### PR TITLE
feat(resource): register external adopting RPC methods

### DIFF
--- a/bldr/resource/resource-rpc-methods.pb.go
+++ b/bldr/resource/resource-rpc-methods.pb.go
@@ -142,5 +142,5 @@ func IsResourceRPCAdoptingUnaryMethod(serviceID, methodID string) bool {
 	case "s4wave.worldop.registry.WorldOpRegistryResourceService/RegisterWorldOp":
 		return true
 	}
-	return false
+	return isExternalResourceRPCAdoptingUnaryMethod(serviceID, methodID)
 }

--- a/bldr/resource/resource-rpc-registry.go
+++ b/bldr/resource/resource-rpc-registry.go
@@ -1,0 +1,27 @@
+package resource
+
+import "sync"
+
+type resourceRPCMethod struct {
+	serviceID string
+	methodID  string
+}
+
+var externalResourceRPCAdoptingUnaryMethods sync.Map
+
+// RegisterResourceRPCAdoptingUnaryMethod registers an adopting unary method
+// implemented outside the Spacewave protobuf tree.
+func RegisterResourceRPCAdoptingUnaryMethod(serviceID, methodID string) {
+	externalResourceRPCAdoptingUnaryMethods.Store(resourceRPCMethod{
+		serviceID: serviceID,
+		methodID:  methodID,
+	}, struct{}{})
+}
+
+func isExternalResourceRPCAdoptingUnaryMethod(serviceID, methodID string) bool {
+	_, ok := externalResourceRPCAdoptingUnaryMethods.Load(resourceRPCMethod{
+		serviceID: serviceID,
+		methodID:  methodID,
+	})
+	return ok
+}

--- a/bldr/resource/resource-rpc-registry_test.go
+++ b/bldr/resource/resource-rpc-registry_test.go
@@ -1,0 +1,33 @@
+package resource
+
+import "testing"
+
+func TestRegisterResourceRPCAdoptingUnaryMethod(t *testing.T) {
+	const (
+		serviceID = "external.fixture.ResourceService"
+		methodID  = "AccessChild"
+	)
+
+	if IsResourceRPCAdoptingUnaryMethod(serviceID, methodID) {
+		t.Fatal("method is registered before RegisterResourceRPCAdoptingUnaryMethod")
+	}
+
+	RegisterResourceRPCAdoptingUnaryMethod(serviceID, methodID)
+	RegisterResourceRPCAdoptingUnaryMethod(serviceID, methodID)
+
+	if !IsResourceRPCAdoptingUnaryMethod(serviceID, methodID) {
+		t.Fatal("method is not registered after RegisterResourceRPCAdoptingUnaryMethod")
+	}
+	if IsResourceRPCAdoptingUnaryMethod(serviceID, "OtherMethod") {
+		t.Fatal("registration matched another method")
+	}
+}
+
+func TestGeneratedResourceRPCAdoptingUnaryMethod(t *testing.T) {
+	if !IsResourceRPCAdoptingUnaryMethod(
+		"s4wave.root.RootResourceService",
+		"AccessStateAtom",
+	) {
+		t.Fatal("generated adopting method is not registered")
+	}
+}

--- a/scripts/postprocess-generated.test.ts
+++ b/scripts/postprocess-generated.test.ts
@@ -190,6 +190,9 @@ message Result {
       'case "fixture.FixtureService/Create":',
     )
     expect(resourceRPCMethods).not.toContain('fixture.FixtureService/Watch')
+    expect(resourceRPCMethods).toContain(
+      'return isExternalResourceRPCAdoptingUnaryMethod(serviceID, methodID)',
+    )
     expect(first.endsWith('\n')).toBe(true)
 
     await generateResourceIDExtractors(root)

--- a/scripts/postprocess-generated.ts
+++ b/scripts/postprocess-generated.ts
@@ -253,7 +253,12 @@ export function generateResourceRPCMethodFile(
       '\t\treturn true',
     )
   }
-  lines.push('\t}', '\treturn false', '}', '')
+  lines.push(
+    '\t}',
+    '\treturn isExternalResourceRPCAdoptingUnaryMethod(serviceID, methodID)',
+    '}',
+    '',
+  )
   return lines.join('\n')
 }
 


### PR DESCRIPTION
Resource clients can adopt held receipts only when the shared classifier recognizes the RPC method. Services defined outside Spacewave cannot enter the generated classifier, which prevents their clients from preserving custody across reconnects.

Add a concurrency-safe runtime registry for external unary methods that support held-receipt adoption. Keep generated classifications authoritative and consult the registry only after the generated switch has no match. Extend the generator regression and add owner-level tests for registration, method isolation, and generated-method behavior.