### PR TITLE
fix(command): adopt registered command resources

### DIFF
--- a/web/command/CommandContext.tsx
+++ b/web/command/CommandContext.tsx
@@ -55,9 +55,8 @@ interface CommandContextValue {
   openCommand: (commandId: string) => void
   // service is the command registry service client.
   service: CommandRegistryResourceService | null
-  // releaseResource releases a server-side resource by ID.
-  // Used to unregister commands when useCommand unmounts.
-  releaseResource: (resourceId: number) => void
+  // adoptResource adopts a pending server resource and returns its release.
+  adoptResource: (resourceId: number) => (() => void) | null
   // attachResource attaches a client-side handler resource to the root client.
   attachResource: (
     label: string,
@@ -127,11 +126,11 @@ export function CommandProvider({
     return new CommandRegistryResourceServiceClient(root.client)
   }, [root])
 
-  const releaseResource = useCallback(
-    (resourceId: number) => {
-      if (!root || resourceId === 0 || root.resourceRef.released) return
+  const adoptResource = useCallback(
+    (resourceId: number): (() => void) | null => {
+      if (!root || resourceId === 0 || root.resourceRef.released) return null
       const ref = root.resourceRef.createRef(resourceId)
-      ref.release()
+      return () => ref.release()
     },
     [root],
   )
@@ -218,7 +217,7 @@ export function CommandProvider({
       invokeCommand,
       openCommand,
       service,
-      releaseResource,
+      adoptResource,
       attachResource,
       getSubItems,
       registerOpenCommand,
@@ -228,7 +227,7 @@ export function CommandProvider({
       invokeCommand,
       openCommand,
       service,
-      releaseResource,
+      adoptResource,
       attachResource,
       getSubItems,
       registerOpenCommand,
@@ -247,7 +246,7 @@ const emptyCommandContext: CommandContextValue = {
   invokeCommand: () => {},
   openCommand: () => {},
   service: null,
-  releaseResource: () => {},
+  adoptResource: () => null,
   attachResource: () => Promise.resolve({ resourceId: 0, cleanup: () => {} }),
   getSubItems: () => Promise.resolve([]),
   registerOpenCommand: () => () => {},

--- a/web/command/useCommand.test.tsx
+++ b/web/command/useCommand.test.tsx
@@ -40,6 +40,7 @@ if (typeof document === 'undefined') {
 const mockRegisterCommand = vi.fn()
 const mockSetActive = vi.fn()
 const mockSetEnabled = vi.fn()
+const mockAdoptResource = vi.fn(() => mockReleaseResource)
 const mockReleaseResource = vi.fn()
 const mockAttachResource = vi.fn()
 const mockCleanup = vi.fn()
@@ -49,7 +50,7 @@ const mockContextValue = {
     SetActive: mockSetActive,
     SetEnabled: mockSetEnabled,
   },
-  releaseResource: mockReleaseResource,
+  adoptResource: mockAdoptResource,
   attachResource: mockAttachResource,
 }
 type AttachedHandlerService = {
@@ -174,10 +175,12 @@ describe('useCommand', () => {
       expect.any(AbortSignal),
     ])
 
+    expect(mockAdoptResource).toHaveBeenCalledWith(41)
+
     view.unmount()
 
     expect(mockCleanup).toHaveBeenCalled()
-    expect(mockReleaseResource).toHaveBeenCalledWith(41)
+    expect(mockReleaseResource).toHaveBeenCalledOnce()
   })
 
   it('registers search aliases on the web surface', async () => {

--- a/web/command/useCommand.ts
+++ b/web/command/useCommand.ts
@@ -55,7 +55,7 @@ interface UseCommandOpts {
 // useCommand registers a command with the command registry and sets up
 // a client-side handler. Manages registration, activation, and cleanup.
 export function useCommand(opts: UseCommandOpts): void {
-  const { service, releaseResource, attachResource } = useCommandContext()
+  const { service, adoptResource, attachResource } = useCommandContext()
   const registrationResourceIdRef = useRef(0)
   const defaultBindingsRef = useRef(opts.defaultBindings)
   defaultBindingsRef.current = opts.defaultBindings
@@ -106,6 +106,7 @@ export function useCommand(opts: UseCommandOpts): void {
     const abort = new AbortController()
     let registrationId = 0
     let detachHandlerResource: (() => void) | null = null
+    let releaseRegistrationResource: (() => void) | null = null
 
     const handlerService: CommandHandlerService = {
       GetSubItems: async (req, signal) => {
@@ -154,8 +155,11 @@ export function useCommand(opts: UseCommandOpts): void {
           abort.signal,
         )
         registrationId = resp.resourceId ?? 0
+        if (registrationId !== 0) {
+          releaseRegistrationResource = adoptResource(registrationId)
+        }
         if (abort.signal.aborted) {
-          if (registrationId !== 0) releaseResource(registrationId)
+          releaseRegistrationResource?.()
           return
         }
 
@@ -177,12 +181,12 @@ export function useCommand(opts: UseCommandOpts): void {
       if (registrationResourceIdRef.current === registrationId) {
         registrationResourceIdRef.current = 0
       }
-      if (registrationId !== 0) releaseResource(registrationId)
+      releaseRegistrationResource?.()
     }
   }, [
     attachResource,
     service,
-    releaseResource,
+    adoptResource,
     opts.commandId,
     opts.label,
     defaultBindingsSignature,


### PR DESCRIPTION
Browser command registration kept only the numeric resource returned by RegisterCommand. Long-lived commands therefore remained pending until unmount and produced adoption warnings after ten seconds.

The command context now creates the client resource reference as soon as registration succeeds and retains its release for effect cleanup. A response racing cancellation is adopted and immediately released, while stale cleanup cannot release a newer registration.

This preserves the command API and resource protocol while giving each registration the lifetime already required by the Resource client.
