### PR TITLE
fix(web): isolate replacement worker generations

### DIFF
--- a/bldr/web/bldr/shared-worker.ts
+++ b/bldr/web/bldr/shared-worker.ts
@@ -86,14 +86,11 @@ if (isPlugin) {
       ),
     })
 
-    const abortController = new AbortController()
-    const abortSignal = abortController.signal
-
     const backendAPI = new BackendApiImpl(
       startInfo,
       transport.openStream,
       handleIncomingStreamCtr,
-      abortSignal,
+      opts.signal,
     )
 
     console.log('shared-worker: starting plugin:', scriptPath)
@@ -115,7 +112,7 @@ if (isPlugin) {
     await startWorkerPluginEntrypoint(
       pluginModule.default,
       backendAPI,
-      abortSignal,
+      opts.signal,
       opts.runtimeWasmEnv,
       (err) => {
         console.warn('shared-worker: plugin runtime failed:', err)

--- a/bldr/web/bldr/web-document-tracker.ts
+++ b/bldr/web/bldr/web-document-tracker.ts
@@ -119,6 +119,9 @@ export class WebDocumentTracker {
     // the bridge. Removing a non-host WebDocument does not fire it, so an
     // unrelated tab close never invalidates a healthy mounted volume's handles.
     private readonly onOpfsBridgeLost?: (() => Promise<void> | void) | null,
+    private readonly onTerminalWebDocumentClose?:
+      | (() => Promise<void> | void)
+      | null,
   ) {
     this.clientUuid = clientUuid
     this.clientType = clientType
@@ -164,6 +167,9 @@ export class WebDocumentTracker {
       }
 
       if (data.close) {
+        if (data.terminal === true) {
+          void this.onTerminalWebDocumentClose?.()
+        }
         const closeErr = new Error(
           `WebDocumentTracker: ${this.clientUuid}: WebDocument ${webDocumentId} closed`,
         )

--- a/bldr/web/bldr/web-document.test.ts
+++ b/bldr/web/bldr/web-document.test.ts
@@ -1307,7 +1307,7 @@ describe('WebDocument plugin generation state', () => {
     expect(replacement.close).toHaveBeenCalledOnce()
   })
 
-  it('retains the SharedWorker construction path behind the hard-disable', async () => {
+  it('scopes SharedWorker identity only when a generation is present', async () => {
     const sharedWorkers = installFakeSharedWorker()
     const doc = buildTestWebDocument()
     doc.forceDedicatedWorkers = false
@@ -1319,14 +1319,49 @@ describe('WebDocument plugin generation state', () => {
         workerMode: WebWorkerMode.WORKER_MODE_SHARED,
       }),
     ).resolves.toEqual({ created: true, shared: true })
+    await expect(
+      WebDocument.prototype.createWebWorker.call(doc, {
+        id: 'worker-shared',
+        generation: 'generation-a',
+        path: '/b/pd/web/web.mjs',
+        workerMode: WebWorkerMode.WORKER_MODE_SHARED,
+      }),
+    ).resolves.toEqual({ created: true, shared: true })
+    await expect(
+      WebDocument.prototype.createWebWorker.call(doc, {
+        id: 'worker-shared',
+        generation: 'generation-a',
+        path: '/b/pd/web/web.mjs',
+        workerMode: WebWorkerMode.WORKER_MODE_SHARED,
+      }),
+    ).resolves.toEqual({ created: true, shared: true })
+    await expect(
+      WebDocument.prototype.createWebWorker.call(doc, {
+        id: 'worker-shared',
+        generation: 'generation-b',
+        path: '/b/pd/web/web.mjs',
+        workerMode: WebWorkerMode.WORKER_MODE_SHARED,
+      }),
+    ).resolves.toEqual({ created: true, shared: true })
 
-    const [worker] = sharedWorkers
-    if (!worker) {
-      throw new Error('expected SharedWorker construction')
+    const [legacyWorker, firstWorker, sameGenerationWorker, replacementWorker] =
+      sharedWorkers
+    if (
+      !legacyWorker ||
+      !firstWorker ||
+      !sameGenerationWorker ||
+      !replacementWorker
+    ) {
+      throw new Error('expected SharedWorker generations')
     }
-    expect(String(worker.url)).toContain('/shw.mjs')
-    expect(worker.options).toMatchObject({ type: 'module' })
-    expect(worker.port.postMessage).toHaveBeenCalledWith(
+    expect(String(firstWorker.url)).toContain('/shw.mjs')
+    expect(firstWorker.options).toMatchObject({ type: 'module' })
+    expect(legacyWorker.options?.name).toBe('worker-shared?s=/b/pd/web/web.mjs')
+    expect(firstWorker.options?.name).toContain('g=generation-a')
+    expect(sameGenerationWorker.options?.name).toBe(firstWorker.options?.name)
+    expect(replacementWorker.options?.name).toContain('g=generation-b')
+    expect(firstWorker.options?.name).not.toBe(replacementWorker.options?.name)
+    expect(replacementWorker.port.postMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         from: 'document-1',
         initPort: expect.any(Object),

--- a/bldr/web/bldr/web-document.ts
+++ b/bldr/web/bldr/web-document.ts
@@ -244,7 +244,12 @@ class WebDocumentWebWorker {
 
       const workerParams = buildWorkerParams(path, !!initData)
       const workerURL = buildWorkerURL(sharedWorkerPath, workerParams)
-      const workerName = `${id}?${workerParams}`
+      // SharedWorker identity includes a runtime-issued generation so a
+      // replacement cannot reconnect to the terminally closing predecessor.
+      // Generation-less requests retain their legacy identity across upgrades.
+      const workerName = generation
+        ? `${id}?${workerParams}&g=${encodeURIComponent(generation)}`
+        : `${id}?${workerParams}`
 
       if (typeof SharedWorker !== 'undefined') {
         this.sharedWorker = new SharedWorker(workerURL.toString(), {

--- a/bldr/web/runtime/plugin-worker.test.ts
+++ b/bldr/web/runtime/plugin-worker.test.ts
@@ -76,6 +76,85 @@ describe('PluginWorker startup shutdown', () => {
     expect(consoleWarn).not.toHaveBeenCalled()
   })
 
+  test('aborts plugin work before terminal close tears down runtime streams', async () => {
+    vi.useFakeTimers()
+    const global = new FakeDedicatedWorkerGlobal()
+    vi.stubGlobal('navigator', {})
+    const events: string[] = []
+    let pluginSignal: AbortSignal | undefined
+    let pluginStarted: (() => void) | undefined
+    const started = new Promise<void>((resolve) => {
+      pluginStarted = resolve
+    })
+    const worker = new PluginWorker(
+      global as unknown as DedicatedWorkerGlobalScope,
+      vi.fn(async (opts) => {
+        pluginSignal = opts.signal
+        opts.signal.addEventListener('abort', () => events.push('abort'))
+        pluginStarted?.()
+      }),
+      null,
+    )
+    vi.spyOn(worker.webDocumentTracker, 'waitConn').mockResolvedValue(undefined)
+    vi.spyOn(
+      worker.webDocumentTracker,
+      'requestWebRtcBridge',
+    ).mockResolvedValue(null)
+    vi.spyOn(worker.webDocumentTracker, 'requestOpfsWorker').mockResolvedValue(
+      null,
+    )
+    vi.spyOn(worker.webDocumentTracker, 'close').mockImplementation(() => {
+      if (!pluginSignal?.aborted) {
+        events.push('retry-error')
+      }
+      events.push('tracker-close')
+    })
+
+    const documentChannel = new MessageChannel()
+    global.dispatchMessage({
+      from: 'document-1',
+      initData: new TextEncoder().encode(btoa('{}')),
+      initPort: documentChannel.port1,
+    })
+    await started
+
+    documentChannel.port2.postMessage({
+      from: 'document-1',
+      close: true,
+      terminal: true,
+    })
+    await vi.waitFor(() => expect(pluginSignal?.aborted).toBe(true))
+
+    expect(events).toEqual(['abort', 'tracker-close'])
+    await vi.runAllTimersAsync()
+    expect(global.close).toHaveBeenCalledOnce()
+  })
+
+  test('keeps plugin work alive across non-terminal WebDocument reloads', async () => {
+    const global = new FakeDedicatedWorkerGlobal()
+    vi.stubGlobal('navigator', {})
+    const worker = new PluginWorker(
+      global as unknown as DedicatedWorkerGlobalScope,
+      vi.fn(),
+      null,
+    )
+    const close = vi.spyOn(worker.webDocumentTracker, 'close')
+
+    const documentChannel = new MessageChannel()
+    worker.webDocumentTracker.handleWebDocumentMessage({
+      from: 'document-1',
+      initPort: documentChannel.port1,
+    })
+    documentChannel.port2.postMessage({
+      from: 'document-1',
+      close: true,
+    })
+    await Promise.resolve()
+
+    expect(close).not.toHaveBeenCalled()
+    expect(global.close).not.toHaveBeenCalled()
+  })
+
   test('reports one runtime failure close before idempotent shutdown', async () => {
     vi.useFakeTimers()
     const global = new FakeDedicatedWorkerGlobal()

--- a/bldr/web/runtime/plugin-worker.ts
+++ b/bldr/web/runtime/plugin-worker.ts
@@ -50,6 +50,7 @@ export function parsePluginWorkerName(name: string): string {
 // PluginStartOpts contains start info and worker communication detection.
 export interface PluginStartOpts {
   startInfo: PluginStartInfo
+  signal: AbortSignal
   workerCommsDetect?: WorkerCommsDetectResult
   runtimeWasmEnv?: Record<string, string>
 }
@@ -86,6 +87,8 @@ export class PluginWorker {
   private pluginStarted?: true
   // startPluginPromise tracks the in-flight startup sequence.
   private startPluginPromise?: Promise<void>
+  // pluginAbortController binds plugin entrypoint work to this worker lifecycle.
+  private readonly pluginAbortController = new AbortController()
   // lockAbortController aborts the worker liveness lock on shutdown.
   private lockAbortController?: AbortController
   // failureCloseReported records that this worker has already published a fatal close.
@@ -115,6 +118,7 @@ export class PluginWorker {
       null,
       undefined,
       this.refreshOpfsBridge.bind(this),
+      this.shutdown.bind(this),
     )
     this.armWorkerLock()
 
@@ -189,6 +193,7 @@ export class PluginWorker {
       return
     }
     this.shuttingDown = true
+    this.pluginAbortController.abort()
     this.lockAbortController?.abort()
     this.lockAbortController = undefined
     this.webDocumentTracker.close()
@@ -278,6 +283,7 @@ export class PluginWorker {
     this.notifyStartupMark('plugin.entrypoint-start')
     await this.startPlugin({
       startInfo,
+      signal: this.pluginAbortController.signal,
       workerCommsDetect,
       runtimeWasmEnv,
     })


### PR DESCRIPTION
A replacement Web worker reused the predecessor's SharedWorker browser identity. Chromium could reconnect the new runtime generation to a terminally closed tracker until it reclaimed the predecessor, making startup require several attempts.

SharedWorker names now include each non-empty runtime generation while preserving the exact generation-less identity for rolling compatibility. Tabs in one generation continue to share their worker, but replacements no longer attach to an older generation.

Plugin entrypoint work now follows PluginWorker shutdown. A terminal document close aborts retry work before tracker streams close, then follows the existing worker shutdown path. Non-terminal reloads retain their rerouting behavior.
