### PR TITLE
fix(shell): collapse empty split panes

### DIFF
--- a/app/ShellFlexLayout.tsx
+++ b/app/ShellFlexLayout.tsx
@@ -603,6 +603,18 @@ function ShellTabStripInner({
   // Handle model changes - sync tabs state, check for grid mode transition
   const handleModelChange = useCallback(
     (newModel: Model) => {
+      // A drag starts in the pinned single-tabset model. Once it creates a
+      // grid, empty tabsets must collapse so later model projection cannot
+      // target a stale pane.
+      if (
+        hasGridLayout(newModel) &&
+        newModel.toJson().global?.tabSetEnableDeleteWhenEmpty === false
+      ) {
+        newModel.doAction(
+          Actions.updateModelAttributes({ tabSetEnableDeleteWhenEmpty: true }),
+        )
+      }
+
       setModel(newModel)
 
       // Save to sessionStorage.

--- a/app/ShellTabStrip.test.tsx
+++ b/app/ShellTabStrip.test.tsx
@@ -257,6 +257,9 @@ vi.mock('@aptre/flex-layout', () => {
 
     toJson() {
       return {
+        global: {
+          tabSetEnableDeleteWhenEmpty: this.tabSetEnableDeleteWhenEmpty,
+        },
         layout: {
           children: [
             {
@@ -521,6 +524,35 @@ describe('ShellTabStrip', () => {
             action.type === 'selectTab' && action.tabId === activeTabId,
         ),
       ).toBe(true)
+    })
+  })
+
+  it('enables empty-tabset deletion when a drag creates a grid', () => {
+    seedShellTabs([{ id: 'home', name: 'Home', path: '/' }])
+
+    render(<ShellTabStrip entry={continuationEntry} />)
+
+    const props = mockOptimizedLayoutProps.mock.calls.at(-1)?.[0]
+    if (!props) throw new Error('shell layout did not render')
+    const model = props.model as unknown as {
+      actions: Array<{
+        attributes?: { tabSetEnableDeleteWhenEmpty?: boolean }
+        type: string
+      }>
+      addExternalSplit: (node: { id: string; name: string }) => void
+      tabSetEnableDeleteWhenEmpty: boolean
+    }
+
+    expect(model.tabSetEnableDeleteWhenEmpty).toBe(false)
+
+    act(() => {
+      model.addExternalSplit({ id: 'right-tab', name: 'Right' })
+    })
+
+    expect(model.tabSetEnableDeleteWhenEmpty).toBe(true)
+    expect(model.actions).toContainEqual({
+      type: 'updateModelAttributes',
+      attributes: { tabSetEnableDeleteWhenEmpty: true },
     })
   })
 

--- a/app/shell-layout-tab-utils.test.ts
+++ b/app/shell-layout-tab-utils.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest'
+import {
+  Actions,
+  DockLocation,
+  Model,
+  type IJsonModel,
+} from '@aptre/flex-layout'
+
+import {
+  addAndSelectShellModelTab,
+  addShellModelTab,
+  getShellTabsetId,
+} from './shell-layout-tab-utils.js'
+
+function getModelTabIds(model: Model): string[] {
+  const ids: string[] = []
+  model.visitNodes((node) => {
+    if (node.getType() === 'tab') ids.push(node.getId())
+  })
+  return ids
+}
+
+const modelJson: IJsonModel = {
+  global: { tabSetEnableDeleteWhenEmpty: false },
+  layout: {
+    type: 'row',
+    children: [
+      {
+        type: 'tabset',
+        id: 'shell-tabset',
+        children: [],
+      },
+    ],
+  },
+}
+
+describe('addShellModelTab', () => {
+  it('projects a committed tab only once in its requested pane', () => {
+    const model = Model.fromJson(modelJson)
+    const tab = { id: 'tab-created', name: 'Created', path: '/created' }
+
+    addShellModelTab(model, 'shell-tabset', tab, 'shell-content')
+    addShellModelTab(model, 'shell-tabset', tab, 'shell-content')
+
+    expect(getModelTabIds(model)).toEqual(['tab-created'])
+    expect(getShellTabsetId(model, tab.id)).toBe('shell-tabset')
+  })
+
+  it('moves an already projected tab to its requested pane', () => {
+    const model = Model.fromJson({
+      ...modelJson,
+      layout: {
+        type: 'row',
+        children: [
+          {
+            type: 'tabset',
+            id: 'left-tabset',
+            children: [],
+          },
+          {
+            type: 'tabset',
+            id: 'right-tabset',
+            children: [
+              { type: 'tab', id: 'right-anchor', name: 'Right anchor' },
+            ],
+          },
+        ],
+      },
+    })
+    const tab = { id: 'tab-created', name: 'Created', path: '/created' }
+
+    addShellModelTab(model, 'left-tabset', tab, 'shell-content')
+    addShellModelTab(model, 'right-tabset', tab, 'shell-content')
+
+    expect(getModelTabIds(model)).toEqual(['right-anchor', 'tab-created'])
+    expect(getShellTabsetId(model, tab.id)).toBe('right-tabset')
+  })
+
+  it('rejects a Shell Tab ID that collides with a structural node', () => {
+    const model = Model.fromJson({
+      ...modelJson,
+      layout: {
+        type: 'row',
+        children: [
+          {
+            type: 'tabset',
+            id: 'shell-tabset',
+            children: [
+              { type: 'tab', id: 'shell-anchor', name: 'Shell anchor' },
+            ],
+          },
+          {
+            type: 'tabset',
+            id: 'tab-created',
+            children: [
+              { type: 'tab', id: 'right-anchor', name: 'Right anchor' },
+            ],
+          },
+        ],
+      },
+    })
+
+    expect(() =>
+      addShellModelTab(
+        model,
+        'shell-tabset',
+        { id: 'tab-created', name: 'Created', path: '/created' },
+        'shell-content',
+      ),
+    ).toThrow('Shell tab ID collides with tabset node: tab-created')
+  })
+
+  it('collapses a closed grid pane before projecting a committed tab twice', () => {
+    const model = Model.fromJson({
+      ...modelJson,
+      layout: {
+        type: 'row',
+        children: [
+          {
+            type: 'tabset',
+            id: 'shell-tabset',
+            children: [
+              { type: 'tab', id: 'left-tab', name: 'Left' },
+              { type: 'tab', id: 'right-tab', name: 'Right' },
+            ],
+          },
+        ],
+      },
+    })
+
+    model.doAction(
+      Actions.moveNode('right-tab', 'shell-tabset', DockLocation.RIGHT, -1),
+    )
+    const rightTabsetId = model.getNodeById('right-tab')?.getParent()?.getId()
+    expect(rightTabsetId).toBeDefined()
+
+    model.doAction(
+      Actions.updateModelAttributes({ tabSetEnableDeleteWhenEmpty: true }),
+    )
+    model.doAction(Actions.deleteTab('right-tab'))
+
+    expect(model.getNodeById(rightTabsetId!)).toBeUndefined()
+    const tab = { id: 'tab-created', name: 'Created', path: '/created' }
+
+    addShellModelTab(model, 'shell-tabset', tab, 'shell-content')
+    addAndSelectShellModelTab(model, 'shell-tabset', tab, 'shell-content')
+
+    expect(getModelTabIds(model)).toEqual(['left-tab', 'tab-created'])
+    expect(getShellTabsetId(model, tab.id)).toBe('shell-tabset')
+  })
+})

--- a/app/shell-layout-tab-utils.ts
+++ b/app/shell-layout-tab-utils.ts
@@ -9,13 +9,32 @@ import {
   getTabNameFromPath,
 } from '@s4wave/app/shell-tab.js'
 
-// addShellModelTab adds a shell tab node to a FlexLayout model.
+// addShellModelTab projects a Shell Tab into its requested FlexLayout tabset.
 export function addShellModelTab(
   model: Model,
   tabsetId: string,
   tab: ShellTab,
   component: string,
 ): void {
+  // Store hydration and a committed tab callback can report the same tab.
+  // Preserve that node and move it to the requested tabset instead of
+  // duplicating it.
+  const existing = model.getNodeById(tab.id)
+  if (existing) {
+    if (existing.getType() !== 'tab') {
+      throw new Error(
+        `Shell tab ID collides with ${existing.getType()} node: ${tab.id}`,
+      )
+    }
+    const parent = existing.getParent()
+    if (parent?.getType() !== 'tabset' || parent.getId() !== tabsetId) {
+      model.doAction(
+        Actions.moveNode(tab.id, tabsetId, DockLocation.CENTER, -1, false),
+      )
+    }
+    return
+  }
+
   model.doAction(
     Actions.addNode(
       {


### PR DESCRIPTION
A Shell grid inherited the single-pane model's empty-tabset retention setting. Closing the final tab in a split therefore left an active empty pane, and concurrent durable-tab projections could ask FlexLayout to insert the same tab ID twice.

The Shell restores empty-tabset deletion when a drag first creates a grid. Its model projection now preserves a tab already in the requested pane, moves it when the committed callback selects another pane, and rejects structural ID collisions.

This keeps the normal empty Shell surface while making grid close and tab projection converge on one valid FlexLayout tree.
