### PR TITLE
fix(prerender): resolve release Bldr sources

### DIFF
--- a/app/prerender/vite-release-source.test.ts
+++ b/app/prerender/vite-release-source.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import type { Alias, UserConfig } from 'vite'
+
+import hydrateConfig from './vite.hydrate.config.js'
+import ssrConfig from './vite.ssr.config.js'
+
+function aliasReplacement(
+  config: UserConfig,
+  find: string,
+): string | undefined {
+  const aliases = config.resolve?.alias as Alias[]
+  return aliases.find((alias) => String(alias.find) === find)?.replacement
+}
+
+describe('release prerender Bldr sources', () => {
+  it.each([
+    ['hydrate', hydrateConfig],
+    ['ssr', ssrConfig],
+  ])('%s resolves Bldr SDK imports from release build output', (_, config) => {
+    expect(
+      aliasReplacement(config, String(/^@aptre\/bldr-sdk\/(.*)$/)),
+    ).toContain('/.bldr-dist/src/sdk/$1')
+  })
+})

--- a/app/prerender/vite.hydrate.config.ts
+++ b/app/prerender/vite.hydrate.config.ts
@@ -13,7 +13,8 @@ import {
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const projectRoot = resolve(__dirname, '../../')
-const goAliases = buildGoAliases(projectRoot)
+const bldrDistRoot = resolve(projectRoot, '.bldr-dist/src')
+const goAliases = buildGoAliases(projectRoot, bldrDistRoot)
 
 // Resolves image imports to /static/assets/<basename> so the hydrate
 // bundle produces the same URLs as the SSR prerender build.
@@ -74,18 +75,15 @@ export default defineConfig({
     alias: [
       {
         find: '@aptre/bldr',
-        replacement: resolve(projectRoot, './.bldr/src/web/bldr/index.js'),
+        replacement: resolve(bldrDistRoot, 'web/bldr/index.js'),
       },
       {
         find: '@aptre/bldr-react',
-        replacement: resolve(
-          projectRoot,
-          './.bldr/src/web/bldr-react/index.js',
-        ),
+        replacement: resolve(bldrDistRoot, 'web/bldr-react/index.js'),
       },
       {
         find: /^@aptre\/bldr-sdk\/(.*)$/,
-        replacement: resolve(projectRoot, './.bldr/src/sdk/$1'),
+        replacement: resolve(bldrDistRoot, 'sdk/$1'),
       },
       ...goAliases,
       {
@@ -123,6 +121,6 @@ export default defineConfig({
     staticAssetPlugin(),
     react(),
     tailwindcss(),
-    goTsResolver(projectRoot),
+    goTsResolver(projectRoot, bldrDistRoot),
   ],
 })

--- a/app/prerender/vite.ssr.config.ts
+++ b/app/prerender/vite.ssr.config.ts
@@ -13,7 +13,8 @@ import {
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const projectRoot = resolve(__dirname, '../../')
-const goAliases = buildGoAliases(projectRoot)
+const bldrDistRoot = resolve(projectRoot, '.bldr-dist/src')
+const goAliases = buildGoAliases(projectRoot, bldrDistRoot)
 
 // Resolves image imports to /static/assets/<basename> URLs during SSR.
 // At runtime Vite/esbuild handles these; during prerender we need
@@ -77,18 +78,15 @@ export default defineConfig({
     alias: [
       {
         find: '@aptre/bldr',
-        replacement: resolve(projectRoot, './.bldr/src/web/bldr/index.js'),
+        replacement: resolve(bldrDistRoot, 'web/bldr/index.js'),
       },
       {
         find: '@aptre/bldr-react',
-        replacement: resolve(
-          projectRoot,
-          './.bldr/src/web/bldr-react/index.js',
-        ),
+        replacement: resolve(bldrDistRoot, 'web/bldr-react/index.js'),
       },
       {
         find: /^@aptre\/bldr-sdk\/(.*)$/,
-        replacement: resolve(projectRoot, './.bldr/src/sdk/$1'),
+        replacement: resolve(bldrDistRoot, 'sdk/$1'),
       },
       ...goAliases,
       {
@@ -126,6 +124,6 @@ export default defineConfig({
     staticAssetPlugin(),
     react(),
     tailwindcss(),
-    goTsResolver(projectRoot),
+    goTsResolver(projectRoot, bldrDistRoot),
   ],
 })


### PR DESCRIPTION
The browser handoff builds Bldr with the isolated `.bldr-dist` state root, which materializes its TypeScript sources under `.bldr-dist/src`. Hydrate and SSR bundling still resolved Bldr packages from `.bldr/src`, so clean release jobs could not load SDK modules after the browser build completed.

This change resolves Bldr, Bldr React, SDK, and Go TypeScript imports from the release state source tree in both prerender bundles. Development configuration remains on its existing default state, while release bundling now consumes the output produced by its preceding build.
