### PR TITLE
fix(device): simplify SSH host setup

### DIFF
--- a/app/device/AddDeviceWizardViewer.test.tsx
+++ b/app/device/AddDeviceWizardViewer.test.tsx
@@ -298,7 +298,7 @@ describe('AddDeviceWizardViewer', () => {
     expect(h.navigateToObjects).toHaveBeenCalledWith(['devices/build-host'])
   })
 
-  it('creates an SSH-only Host with Secret refs and an SSH Host terminal', async () => {
+  it('creates an SSH-only Host without unavailable-install or runtime review copy', async () => {
     h.currentStep = 1
     h.configData = new TextEncoder().encode(
       JSON.stringify({
@@ -315,6 +315,22 @@ describe('AddDeviceWizardViewer', () => {
       }),
     )
     renderViewer()
+
+    expect(screen.getByPlaceholderText('host.example.com')).toHaveProperty(
+      'value',
+      'build.example.com',
+    )
+    expect(screen.getByPlaceholderText('SSH password')).toBeTruthy()
+    expect(
+      screen.getByRole('button', { name: /add ssh host and open terminal/i }),
+    ).toHaveProperty('disabled', false)
+    expect(screen.queryByText('Runtime')).toBeNull()
+    expect(screen.queryByText('Native SSH connector required')).toBeNull()
+    expect(
+      screen.queryByText(
+        'Install Agent is not available until secure bootstrap is configured.',
+      ),
+    ).toBeNull()
 
     fireEvent.change(screen.getByPlaceholderText('SSH password'), {
       target: { value: 'raw-secret-value' },
@@ -645,9 +661,11 @@ describe('AddDeviceWizardViewer', () => {
       expect(finalize).toHaveProperty('disabled', true)
       fireEvent.click(finalize)
 
-      expect(screen.getByRole('alert').textContent).toContain(
-        'Install Agent is not available until secure bootstrap is configured.',
-      )
+      expect(
+        screen.queryByText(
+          'Install Agent is not available until secure bootstrap is configured.',
+        ),
+      ).toBeNull()
       expect(h.toastError).not.toHaveBeenCalled()
       expectNoInstallAgentSideEffects()
     },

--- a/app/device/AddDeviceWizardViewer.tsx
+++ b/app/device/AddDeviceWizardViewer.tsx
@@ -962,13 +962,6 @@ function SshHostSetupForm({
             disabled
           />
         </div>
-        <p
-          className="text-foreground-alt/70 mt-2 text-xs leading-relaxed"
-          role={setupMode === 'install-agent' ? 'alert' : undefined}
-        >
-          Install Agent is not available until secure bootstrap is configured.
-          Add the SSH Host to keep on-demand terminal access.
-        </p>
       </div>
 
       <div className="border-foreground/6 bg-background-card/30 rounded-lg border p-3.5">
@@ -985,7 +978,6 @@ function SshHostSetupForm({
           />
           <ReviewRow label="Credential" value={credentialKind} />
           <ReviewRow label="Trust mode" value={trustMode} />
-          <ReviewRow label="Runtime" value="Native SSH connector required" />
         </dl>
       </div>
     </section>


### PR DESCRIPTION
The SSH Host setup form explained why the separate Install Agent path was unavailable and repeated a native runtime requirement in its review. Those notices distracted from the selected task without changing what the user could do.

This keeps the unavailable Install Agent choice and its secure-bootstrap guards, but removes the explanatory paragraph and runtime review row from the SSH Host path. Host validation, credential handling, SSH Host and Terminal creation, and navigation remain unchanged.