### PR TITLE
fix(terminal): make failed sessions retryable

### DIFF
--- a/app/terminal/TerminalPane.test.tsx
+++ b/app/terminal/TerminalPane.test.tsx
@@ -114,6 +114,7 @@ vi.mock('@xterm/addon-fit', () => ({
 
 import {
   TerminalPane,
+  safeTerminalFailureDetail,
   type TerminalPaneConnector,
   type TerminalPaneProps,
 } from './TerminalPane.js'
@@ -251,7 +252,8 @@ describe('TerminalPane', () => {
       [
         {
           kind: TerminalFrameKind.ERROR,
-          error: 'permission denied',
+          error:
+            'ssh: handshake failed: ssh: unable to authenticate, attempted methods [none password], no supported methods remain',
         },
       ],
       false,
@@ -262,7 +264,7 @@ describe('TerminalPane', () => {
       expect(screen.getByText('CLI session failed')).toBeDefined()
       expect(
         screen.getByText(
-          'The terminal session could not start. Try again from the owning surface.',
+          'The SSH host rejected the username or credentials. Check the host settings, then retry.',
         ),
       ).toBeDefined()
     })
@@ -399,5 +401,100 @@ describe('TerminalPane', () => {
     expect(closeIndex).toBeLessThan(h.events.indexOf('rpc.abort'))
     expect(h.inputDispose).toHaveBeenCalled()
     expect(h.dispose).toHaveBeenCalled()
+  })
+  it.each([
+    [
+      'ssh: handshake failed: ssh: unable to authenticate, attempted methods [none password], no supported methods remain',
+      'The SSH host rejected the username or credentials. Check the host settings, then retry.',
+    ],
+    [
+      'dial tcp 10.0.0.8:22: connect: connection refused',
+      'The SSH host refused the connection. Check that SSH is running and the host and port are correct.',
+    ],
+    [
+      'dial tcp: lookup host.internal: no such host',
+      'The terminal session could not start. Check the host settings, then retry.',
+    ],
+    [
+      'permission denied while reading object',
+      'The terminal session could not start. Check the host settings, then retry.',
+    ],
+  ])('safely classifies SSH producer failure %s', (raw, expected) => {
+    expect(safeTerminalFailureDetail(raw)).toBe(expected)
+  })
+
+  it('lets an explicit retry callback replace the local reconnect', async () => {
+    const onRetry = vi.fn()
+    const connectTerminal = vi.fn<TerminalPaneConnector>(() =>
+      terminalFrames(
+        [{ kind: TerminalFrameKind.ERROR, error: 'connection refused' }],
+        false,
+      ),
+    )
+    render(<TerminalPane connectTerminal={connectTerminal} onRetry={onRetry} />)
+
+    await screen.findByText('CLI session failed')
+    screen.getByRole('button', { name: 'Retry' }).click()
+
+    expect(onRetry).toHaveBeenCalledOnce()
+    await Promise.resolve()
+    expect(connectTerminal).toHaveBeenCalledOnce()
+  })
+
+  it('starts only one connector under StrictMode', async () => {
+    const connectTerminal = vi.fn<TerminalPaneConnector>(() =>
+      terminalFrames([], true),
+    )
+    render(
+      <React.StrictMode>
+        <TerminalPane connectTerminal={connectTerminal} />
+      </React.StrictMode>,
+    )
+
+    await vi.waitFor(() => expect(connectTerminal).toHaveBeenCalledOnce())
+  })
+  it('waits for CLOSE delivery and abort before starting a retry connector', async () => {
+    let releaseClose!: () => void
+    const closeReleased = new Promise<void>((resolve) => {
+      releaseClose = resolve
+    })
+    let calls = 0
+    const connectTerminal: TerminalPaneConnector = (frames, signal) => {
+      calls += 1
+      h.events.push(`connect.${calls}`)
+      signal.addEventListener('abort', () => h.events.push(`abort.${calls}`))
+      void (async () => {
+        const iterator = frames[Symbol.asyncIterator]()
+        if (calls === 1) await closeReleased
+        for (;;) {
+          const next = await iterator.next()
+          if (next.done || signal.aborted) return
+          h.clientFrames.push(next.value)
+          if (next.value.kind === TerminalFrameKind.CLOSE) {
+            h.events.push('client.close')
+            h.resolveClose()
+          }
+        }
+      })()
+      return terminalFrames(
+        [{ kind: TerminalFrameKind.ERROR, error: 'connection refused' }],
+        false,
+      )
+    }
+    render(<TerminalPane connectTerminal={connectTerminal} />)
+
+    await screen.findByText('CLI session failed')
+    screen.getByRole('button', { name: 'Retry' }).click()
+    await Promise.resolve()
+    expect(h.events).toEqual(['connect.1'])
+
+    releaseClose()
+    await vi.waitFor(() => expect(h.events).toContain('connect.2'))
+    expect(h.events.indexOf('client.close')).toBeLessThan(
+      h.events.indexOf('abort.1'),
+    )
+    expect(h.events.indexOf('abort.1')).toBeLessThan(
+      h.events.indexOf('connect.2'),
+    )
   })
 })

--- a/app/terminal/TerminalPane.tsx
+++ b/app/terminal/TerminalPane.tsx
@@ -1,6 +1,13 @@
 import { FitAddon } from '@xterm/addon-fit'
 import { Terminal as XTerm } from '@xterm/xterm'
-import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useReducer,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
 import type { MessageStream } from 'starpc'
 
 import { terminalStatusToLoadingView } from '@s4wave/app/loading/status/terminal.js'
@@ -60,88 +67,115 @@ export function TerminalPane({
 }: TerminalPaneProps) {
   const terminalHostRef = useRef<HTMLDivElement | null>(null)
   const terminalQueueRef = useRef<TerminalFrameQueue | null>(null)
+  const stopTerminalRef = useRef<(() => Promise<void>) | null>(null)
   const [trustChallenge, setTrustChallenge] = useState<TerminalFrame | null>(
     null,
   )
   const [status, setStatus] = useState<TerminalPaneStatus>(connectingStatus)
+  const [connectionAttempt, retryConnection] = useReducer(
+    (attempt: number) => attempt + 1,
+    0,
+  )
+
+  const handleLocalRetry = useCallback(async () => {
+    await stopTerminalRef.current?.()
+    retryConnection()
+  }, [])
 
   useEffect(() => {
-    const host = terminalHostRef.current
-    if (!host) return
-    setStatus(connectingStatus)
-    setTrustChallenge(null)
-    if (!connectTerminal) return
+    let cancelled = false
+    let stopAttempt = async () => {}
+    const previousStopped = stopTerminalRef.current?.() ?? Promise.resolve()
 
-    const rpcAbort = new AbortController()
-    const renderAbort = new AbortController()
-    const queue = createTerminalFrameQueue()
-    terminalQueueRef.current = queue
-    const term = new XTerm({
-      cursorBlink: true,
-      screenReaderMode: true,
-      ...resolveTerminalTheme(host),
-    })
-    const fit = new FitAddon()
-    term.loadAddon(fit)
-    const fitAndReportSize = () => {
-      try {
-        fit.fit()
-      } catch {
-        return
+    void previousStopped.then(() => {
+      if (cancelled) return
+      const host = terminalHostRef.current
+      if (!host) return
+      setStatus(connectingStatus)
+      setTrustChallenge(null)
+      if (!connectTerminal) return
+
+      const rpcAbort = new AbortController()
+      const renderAbort = new AbortController()
+      const queue = createTerminalFrameQueue()
+      terminalQueueRef.current = queue
+      const term = new XTerm({
+        cursorBlink: true,
+        screenReaderMode: true,
+        ...resolveTerminalTheme(host),
+      })
+      const fit = new FitAddon()
+      term.loadAddon(fit)
+      const fitAndReportSize = () => {
+        try {
+          fit.fit()
+        } catch {
+          return
+        }
+        queue.push({
+          kind: TerminalFrameKind.RESIZE,
+          cols: term.cols,
+          rows: term.rows,
+        })
       }
-      queue.push({
-        kind: TerminalFrameKind.RESIZE,
-        cols: term.cols,
-        rows: term.rows,
-      })
-    }
-    term.open(host)
-    fitAndReportSize()
+      term.open(host)
+      fitAndReportSize()
 
-    const disposeInput = term.onData((chunk) => {
-      if (!chunk) return
-      queue.push({
-        kind: TerminalFrameKind.INPUT,
-        data: terminalEncoder.encode(chunk),
+      const disposeInput = term.onData((chunk) => {
+        if (!chunk) return
+        queue.push({
+          kind: TerminalFrameKind.INPUT,
+          data: terminalEncoder.encode(chunk),
+        })
       })
+
+      const resizeObserver =
+        typeof ResizeObserver === 'undefined'
+          ? null
+          : new ResizeObserver(() => fitAndReportSize())
+      resizeObserver?.observe(host)
+
+      const terminalDone = readTerminalFrames(
+        connectTerminal(queue.stream(), rpcAbort.signal),
+        term,
+        renderAbort.signal,
+        setTrustChallenge,
+        {
+          onOutput: () => setStatus({ kind: 'ready' }),
+          onFailure: (detail) => setStatus({ kind: 'failed', detail }),
+          onClosed: () => setStatus({ kind: 'closed' }),
+        },
+      )
+
+      let stopping: Promise<void> | null = null
+      stopAttempt = () => {
+        if (stopping) return stopping
+        stopping = (async () => {
+          renderAbort.abort()
+          if (terminalQueueRef.current === queue) {
+            terminalQueueRef.current = null
+          }
+          const closeDelivered = queue.close()
+          if (queue.started()) {
+            await closeDelivered
+            await terminalDone
+          }
+          rpcAbort.abort()
+          resizeObserver?.disconnect()
+          disposeInput.dispose()
+          term.dispose()
+        })()
+        return stopping
+      }
+      stopTerminalRef.current = stopAttempt
+      if (cancelled) void stopAttempt()
     })
-
-    const resizeObserver =
-      typeof ResizeObserver === 'undefined'
-        ? null
-        : new ResizeObserver(() => fitAndReportSize())
-    resizeObserver?.observe(host)
-
-    const terminalDone = readTerminalFrames(
-      connectTerminal(queue.stream(), rpcAbort.signal),
-      term,
-      renderAbort.signal,
-      setTrustChallenge,
-      {
-        onOutput: () => setStatus({ kind: 'ready' }),
-        onFailure: (detail) => setStatus({ kind: 'failed', detail }),
-        onClosed: () => setStatus({ kind: 'closed' }),
-      },
-    )
 
     return () => {
-      renderAbort.abort()
-      if (terminalQueueRef.current === queue) {
-        terminalQueueRef.current = null
-      }
-      const closeDelivered = queue.close()
-      if (!queue.started()) {
-        rpcAbort.abort()
-      } else {
-        void closeDelivered
-          .then(() => terminalDone)
-          .finally(() => rpcAbort.abort())
-      }
-      resizeObserver?.disconnect()
-      disposeInput.dispose()
-      term.dispose()
+      cancelled = true
+      void stopAttempt()
     }
-  }, [connectTerminal])
+  }, [connectTerminal, connectionAttempt])
 
   const respondToSshTrust = useCallback((accepted: boolean) => {
     const queue = terminalQueueRef.current
@@ -172,7 +206,9 @@ export function TerminalPane({
           <TerminalPaneStatusLayer
             status={status}
             cliSession={!renderTrustChallenge}
-            onRetry={onRetry}
+            onRetry={
+              connectTerminal ? (onRetry ?? handleLocalRetry) : undefined
+            }
             onBackToSettings={onBackToSettings}
           />
         ) : null}
@@ -259,25 +295,61 @@ async function readTerminalFrames(
     if (!signal.aborted && !receivedOutput) {
       handlers.onFailure(safeTerminalFailureDetail())
     }
-  } catch {
+  } catch (error) {
     if (!signal.aborted) {
-      handlers.onFailure(safeTerminalFailureDetail())
+      handlers.onFailure(safeTerminalFailureDetail(errorMessage(error)))
     }
   }
 }
 
-function safeTerminalFailureDetail(rawError?: string): string {
+function errorMessage(error: unknown): string | undefined {
+  return error instanceof Error ? error.message : undefined
+}
+
+export function safeTerminalFailureDetail(rawError?: string): string {
   const normalized = rawError?.toLowerCase() ?? ''
   if (normalized.includes('native runtime')) {
-    return 'SSH needs a native connector. Open this terminal in the desktop/native runtime or use a managed Device.'
+    return 'SSH needs a native connector. Open this terminal in the desktop app or use a managed Device.'
   }
   if (
     normalized.includes('runtime context') ||
     normalized.includes('runtime-unavailable')
   ) {
-    return 'The Spacewave runtime is unavailable in this session. Try again or return to Settings.'
+    return 'The Spacewave runtime is unavailable in this session. Try again.'
   }
-  return 'The terminal session could not start. Try again from the owning surface.'
+  if (
+    normalized.includes('ssh: unable to authenticate') ||
+    normalized.includes('ssh: handshake failed: unable to authenticate')
+  ) {
+    return 'The SSH host rejected the username or credentials. Check the host settings, then retry.'
+  }
+  if (
+    normalized.includes('connection refused') ||
+    normalized.includes('actively refused')
+  ) {
+    return 'The SSH host refused the connection. Check that SSH is running and the host and port are correct.'
+  }
+  if (
+    normalized.includes('no route to host') ||
+    normalized.includes('network is unreachable') ||
+    normalized.includes('i/o timeout') ||
+    normalized.includes('timed out')
+  ) {
+    return 'The SSH host could not be reached. Check its address and network connection, then retry.'
+  }
+  if (
+    normalized.includes('host key') &&
+    (normalized.includes('not pinned') || normalized.includes('not trusted'))
+  ) {
+    return 'The SSH host key was not trusted. Verify the host identity before trying again.'
+  }
+  if (
+    normalized.includes('parse ssh private key') ||
+    (normalized.includes('private key') && normalized.includes('invalid'))
+  ) {
+    return 'The SSH private key could not be used. Check the key and passphrase in the host settings.'
+  }
+  return 'The terminal session could not start. Check the host settings, then retry.'
 }
 
 function createTerminalFrameQueue(): TerminalFrameQueue {

--- a/app/terminal/TerminalViewer.test.tsx
+++ b/app/terminal/TerminalViewer.test.tsx
@@ -29,6 +29,7 @@ const h = vi.hoisted(() => {
     closeSeen: closeWaiter.promise,
     resolveClose: closeWaiter.resolve,
     abortObservedBeforeExit: true,
+    connectCalls: 0,
   }
 })
 
@@ -106,6 +107,7 @@ vi.mock('@s4wave/web/hooks/useAccessTypedHandle.js', () => ({
       watchTerminalState: vi.fn(),
       connectTerminal: vi.fn(
         (frames: AsyncIterable<TerminalFrame>, signal?: AbortSignal) => {
+          h.connectCalls += 1
           void (async () => {
             for await (const frame of frames) {
               if (signal?.aborted) return
@@ -113,7 +115,7 @@ vi.mock('@s4wave/web/hooks/useAccessTypedHandle.js', () => ({
               if (frame.kind === TerminalFrameKind.CLOSE) {
                 h.abortObservedBeforeExit = signal?.aborted === true
                 h.resolveClose()
-                return
+                continue
               }
             }
           })()
@@ -148,6 +150,7 @@ describe('TerminalViewer', () => {
       h.resolveClose = resolve
     })
     h.abortObservedBeforeExit = true
+    h.connectCalls = 0
     currentState = {
       name: 'Build Host Terminal',
       deviceObjectKey: 'devices/build-host',
@@ -184,7 +187,7 @@ describe('TerminalViewer', () => {
     expect(screen.getByText('Build Host Terminal')).toBeTruthy()
     expect(screen.getByText('Disconnected')).toBeTruthy()
     expect(screen.getByText('devices/build-host')).toBeTruthy()
-    expect(h.open).toHaveBeenCalled()
+    await vi.waitFor(() => expect(h.open).toHaveBeenCalled())
     await vi.waitFor(() => expect(h.write).toHaveBeenCalledWith('ready\n'))
     await vi.waitFor(() =>
       expect(h.clientFrames[0]?.kind).toBe(TerminalFrameKind.RESIZE),
@@ -339,6 +342,62 @@ describe('TerminalViewer', () => {
         ),
       ).toBe(true),
     )
+    unmount()
+  })
+  it('shows a safe SSH failure cause and Retry starts a new terminal attempt', async () => {
+    currentState = {
+      name: 'Prod SSH Terminal',
+      sshHostObjectKey: 'hosts/prod',
+      targetKind: TerminalTargetKind.SSH_HOST,
+      state: TerminalSessionState.FAILED,
+      status: 'failed to connect',
+      error:
+        'ssh: handshake failed: unable to authenticate, attempted methods [none password]',
+      cols: 80,
+      rows: 24,
+    }
+    h.serverFrames = [
+      {
+        kind: TerminalFrameKind.ERROR,
+        error:
+          'ssh: handshake failed: unable to authenticate, attempted methods [none password]',
+      },
+    ]
+
+    const { unmount } = render(
+      <TerminalViewer
+        objectInfo={{
+          info: {
+            case: 'worldObjectInfo',
+            value: {
+              objectKey: 'terminal/prod-ssh',
+              objectType: 'spacewave/terminal',
+            },
+          },
+        }}
+        worldState={{
+          value: null,
+          loading: false,
+          error: null,
+          retry: vi.fn(),
+        }}
+      />,
+    )
+
+    await screen.findByText('Terminal session failed')
+    expect(
+      screen.getAllByText(
+        'The SSH host rejected the username or credentials. Check the host settings, then retry.',
+      ),
+    ).toHaveLength(1)
+    expect(screen.queryByText(/unable to authenticate/i)).toBeNull()
+    expect(h.connectCalls).toBe(1)
+
+    h.serverFrames = []
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await vi.waitFor(() => expect(h.connectCalls).toBe(2))
+    await vi.waitFor(() => expect(h.write).toHaveBeenCalledWith('ready\n'))
     unmount()
   })
 })

--- a/app/terminal/TerminalViewer.tsx
+++ b/app/terminal/TerminalViewer.tsx
@@ -18,6 +18,7 @@ import {
 } from '@s4wave/sdk/terminal/terminal.js'
 import {
   TerminalPane,
+  safeTerminalFailureDetail,
   type TerminalPaneConnector,
   type TerminalPaneTrustChallengeRenderer,
 } from './TerminalPane.js'
@@ -95,9 +96,9 @@ export function TerminalViewer({
           />
         </div>
       )}
-      {state?.error && (
+      {state?.error && !connectTerminal && (
         <div className="border-destructive/30 bg-destructive/10 text-destructive border-b px-4 py-2 text-sm">
-          {state.error}
+          {safeTerminalFailureDetail(state.error)}
         </div>
       )}
       <TerminalPane


### PR DESCRIPTION
A failed SSH terminal collapsed useful connection errors into an internal-sounding message and left the object view without a working recovery action. Retrying also needed to replace the complete stream and xterm attempt rather than reset presentation state.

TerminalPane now serializes each connection attempt through cleanup, close delivery, RPC cancellation, and xterm disposal before opening the next attempt. An explicit caller retry remains an override, while object viewers use the local retry owner. Known SSH failures map to safe, actionable guidance and one visible failure surface.

This lets users understand common host, network, key, and runtime failures and retry the complete connection without exposing raw internal errors.