### PR TITLE
fix(chat): settle empty channel history

### DIFF
--- a/app/chat/ChatChannelViewer.test.tsx
+++ b/app/chat/ChatChannelViewer.test.tsx
@@ -1,0 +1,121 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ChatChannelViewer } from './ChatChannelViewer.js'
+
+const retry = vi.fn()
+let streamState: {
+  value: never[] | null
+  loading: boolean
+  error: Error | null
+  retry: () => void
+}
+
+vi.mock('@s4wave/web/hooks/useAccessTypedHandle.js', () => ({
+  useAccessTypedHandle: () => ({
+    value: { watchMessages: vi.fn(), sendMessage: vi.fn() },
+    loading: false,
+    error: null,
+    retry: vi.fn(),
+  }),
+}))
+
+vi.mock('@aptre/bldr-sdk/hooks/useStreamingResource.js', () => ({
+  useStreamingResource: () => streamState,
+}))
+
+const objectInfo = {
+  info: {
+    case: 'worldObjectInfo' as const,
+    value: { objectKey: 'chat/general', objectType: 'spacewave-chat/channel' },
+  },
+}
+
+const worldState = { value: null, loading: false, error: null, retry: vi.fn() }
+
+afterEach(() => {
+  cleanup()
+  retry.mockClear()
+})
+
+describe('ChatChannelViewer', () => {
+  it('settles an empty initial snapshot', () => {
+    streamState = { value: [], loading: false, error: null, retry }
+    render(
+      <ChatChannelViewer
+        objectInfo={objectInfo}
+        worldState={worldState as never}
+      />,
+    )
+    expect(screen.getByText('Start the conversation')).toBeDefined()
+    expect(screen.queryByText('Loading messages')).toBeNull()
+  })
+
+  it('does not carry a populated channel into a newly selected empty channel', async () => {
+    streamState = {
+      value: [
+        {
+          objectKey: 'chat/a/message/0',
+          senderPeerId: 'peer-a',
+          text: 'channel A message',
+          createdAt: new Date(),
+          replyToKey: '',
+        },
+      ] as never[],
+      loading: false,
+      error: null,
+      retry,
+    }
+    const { rerender } = render(
+      <ChatChannelViewer
+        objectInfo={objectInfo}
+        worldState={worldState as never}
+      />,
+    )
+    expect(await screen.findByText('channel A message')).toBeDefined()
+
+    streamState = { value: [] as never[], loading: false, error: null, retry }
+    rerender(
+      <ChatChannelViewer
+        objectInfo={{
+          info: {
+            case: 'worldObjectInfo',
+            value: {
+              objectKey: 'chat/empty',
+              objectType: 'spacewave-chat/channel',
+            },
+          },
+        }}
+        worldState={worldState as never}
+      />,
+    )
+
+    await waitFor(() =>
+      expect(screen.queryByText('channel A message')).toBeNull(),
+    )
+    expect(screen.getByText('Start the conversation')).toBeDefined()
+  })
+
+  it('offers retry when channel history fails', () => {
+    streamState = {
+      value: null,
+      loading: false,
+      error: new Error('offline'),
+      retry,
+    }
+    render(
+      <ChatChannelViewer
+        objectInfo={objectInfo}
+        worldState={worldState as never}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+    expect(retry).toHaveBeenCalledOnce()
+  })
+})

--- a/app/chat/ChatChannelViewer.tsx
+++ b/app/chat/ChatChannelViewer.tsx
@@ -1,95 +1,147 @@
+import { LuCircleAlert, LuHash, LuRefreshCw } from 'react-icons/lu'
 import { useCallback, useEffect, useState } from 'react'
 
 import { useStreamingResource } from '@aptre/bldr-sdk/hooks/useStreamingResource.js'
 import { useAccessTypedHandle } from '@s4wave/web/hooks/useAccessTypedHandle.js'
 import type { ObjectViewerComponentProps } from '@s4wave/web/object/object.js'
 import { getObjectKey } from '@s4wave/web/object/object.js'
-import { LoadingCard } from '@s4wave/web/ui/loading/LoadingCard.js'
 
-import { useRenderDelay } from '@s4wave/app/loading/useRenderDelay.js'
 import { ChatHandle, ChatChannelTypeID } from '@s4wave/sdk/chat/chat.js'
 import type { ChatMessageInfo } from '@s4wave/sdk/chat/rpc/rpc.pb.js'
-import { MessageList } from './MessageList.js'
 import { MessageInput } from './MessageInput.js'
+import { MessageList } from './MessageList.js'
 
 export { ChatChannelTypeID }
 
-// ChatChannelViewer displays a live chat interface for a chat channel object.
-// It streams message batches via WatchMessages and accumulates them for display.
+// ChatChannelViewer displays live channel history and its composer.
 export function ChatChannelViewer({
   objectInfo,
   worldState,
 }: ObjectViewerComponentProps) {
   const objectKey = getObjectKey(objectInfo)
+  return (
+    <ChatChannelContent
+      key={objectKey}
+      objectKey={objectKey}
+      worldState={worldState}
+    />
+  )
+}
 
+function ChatChannelContent({
+  objectKey,
+  worldState,
+}: {
+  objectKey: string
+  worldState: ObjectViewerComponentProps['worldState']
+}) {
   const handle = useAccessTypedHandle(
     worldState,
     objectKey,
     ChatHandle,
     ChatChannelTypeID,
   )
-
-  // Accumulate streamed message batches in state.
-  // Each yield from watchMessages is a delta (new messages only).
   const [messages, setMessages] = useState<ChatMessageInfo[]>([])
 
-  const streamFactory = useCallback((h: ChatHandle, signal: AbortSignal) => {
+  const streamFactory = useCallback((chat: ChatHandle, signal: AbortSignal) => {
     setMessages([])
-    return h.watchMessages(signal)
+    return chat.watchMessages(signal)
   }, [])
-
   const messagesResource = useStreamingResource(handle, streamFactory, [])
 
-  // 300 ms render delay so fast history loads do not flash the card.
-  const showLoadingCard = useRenderDelay(300)
-
-  // Merge each new batch into the accumulator.
-  // This is a synchronous state derivation from streamed values, not async data loading.
   useEffect(() => {
     const batch = messagesResource.value
-    if (!batch || batch.length === 0) return
-    const timer = window.setTimeout(() => {
-      setMessages((prev) => {
-        const existing = new Set(prev.map((m) => m.objectKey))
-        const newMsgs = batch.filter((m) => !existing.has(m.objectKey))
-        if (newMsgs.length === 0) return prev
-        return [...prev, ...newMsgs]
-      })
-    }, 0)
-    return () => window.clearTimeout(timer)
-  }, [messagesResource.value])
+    if (messagesResource.loading || !batch?.length) return
+    setMessages((current) => {
+      const keys = new Set(current.map((message) => message.objectKey))
+      const additions = batch.filter((message) => !keys.has(message.objectKey))
+      return additions.length === 0 ? current : [...current, ...additions]
+    })
+  }, [messagesResource.loading, messagesResource.value])
 
   const handleSend = useCallback(
     async (text: string) => {
-      const h = handle.value
-      if (!h) return
-      await h.sendMessage(text)
+      const chat = handle.value
+      if (!chat) throw new Error('The channel is not connected yet.')
+      await chat.sendMessage(text)
     },
     [handle.value],
   )
 
+  const loading = messagesResource.loading && messages.length === 0
+  const error = messagesResource.error
+
   return (
-    <div className="bg-background-primary flex h-full w-full flex-col">
-      <div className="border-foreground/8 flex h-9 shrink-0 items-center border-b px-4">
-        <span className="text-foreground text-sm font-semibold tracking-tight select-none">
-          Chat
-        </span>
-      </div>
-      {messagesResource.loading && messages.length === 0 && showLoadingCard && (
-        <div className="flex flex-1 items-center justify-center p-6">
-          <div className="w-full max-w-sm">
-            <LoadingCard
-              view={{
-                state: 'active',
-                title: 'Loading messages',
-                detail: 'Reading channel history from the peer group.',
-              }}
-            />
+    <section
+      className="bg-background-primary flex h-full min-h-0 w-full flex-col"
+      aria-label="Chat channel"
+    >
+      <header className="border-foreground/10 bg-background-secondary/60 flex min-h-14 shrink-0 items-center gap-3 border-b px-3 sm:px-5">
+        <div className="bg-background-tertiary text-brand flex size-8 shrink-0 items-center justify-center rounded-sm">
+          <LuHash className="size-4" aria-hidden="true" />
+        </div>
+        <div className="min-w-0">
+          <h1 className="text-foreground truncate text-sm font-semibold">
+            Chat channel
+          </h1>
+          <p className="text-muted-foreground truncate text-xs">
+            {objectKey || 'Conversation'}
+          </p>
+        </div>
+      </header>
+
+      {loading ? (
+        <div
+          className="flex flex-1 items-center justify-center p-6"
+          role="status"
+        >
+          <div className="flex items-center gap-3 text-sm">
+            <div className="border-brand/30 border-t-brand size-5 animate-spin rounded-full border-2" />
+            <div>
+              <div className="text-foreground font-medium">
+                Loading messages
+              </div>
+              <div className="text-muted-foreground text-xs">
+                Reading conversation history…
+              </div>
+            </div>
           </div>
         </div>
+      ) : error ? (
+        <div
+          className="flex flex-1 items-center justify-center p-6"
+          role="alert"
+        >
+          <div className="border-error/30 bg-background-card max-w-sm rounded-md border p-5 text-center">
+            <LuCircleAlert
+              className="text-error-text mx-auto size-6"
+              aria-hidden="true"
+            />
+            <h2 className="text-foreground mt-3 text-sm font-semibold">
+              Messages unavailable
+            </h2>
+            <p className="text-muted-foreground mt-1 text-sm leading-5">
+              The channel history could not be read. Check the connection and
+              try again.
+            </p>
+            <button
+              type="button"
+              onClick={messagesResource.retry}
+              className="border-foreground/15 bg-background-tertiary text-foreground hover:bg-background-panel focus-visible:ring-primary mx-auto mt-4 flex items-center gap-2 rounded-sm border px-3 py-2 text-xs font-semibold focus-visible:ring-2"
+            >
+              <LuRefreshCw className="size-3.5" aria-hidden="true" />
+              Try again
+            </button>
+          </div>
+        </div>
+      ) : (
+        <MessageList messages={messages} />
       )}
-      <MessageList messages={messages} />
-      <MessageInput onSend={handleSend} />
-    </div>
+
+      <MessageInput
+        disabled={loading || Boolean(error) || !handle.value}
+        onSend={handleSend}
+      />
+    </section>
   )
 }

--- a/app/chat/MessageInput.test.tsx
+++ b/app/chat/MessageInput.test.tsx
@@ -1,0 +1,60 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { MessageInput } from './MessageInput.js'
+
+afterEach(cleanup)
+
+describe('MessageInput', () => {
+  it('sends a trimmed message with Enter and clears the successful draft', async () => {
+    const onSend = vi.fn(async () => {})
+    render(<MessageInput onSend={onSend} />)
+    const input = screen.getByRole('textbox', { name: 'Message' })
+    fireEvent.change(input, { target: { value: '  hello channel  ' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => expect(onSend).toHaveBeenCalledWith('hello channel'))
+    await waitFor(() => expect((input as HTMLTextAreaElement).value).toBe(''))
+    expect(document.activeElement).toBe(input)
+  })
+
+  it('keeps a failed draft and lets the reader retry', async () => {
+    const onSend = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Peer unavailable'))
+      .mockResolvedValueOnce(undefined)
+    render(<MessageInput onSend={onSend} />)
+    const input = screen.getByRole('textbox', { name: 'Message' })
+    fireEvent.change(input, { target: { value: 'still here' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
+    expect((await screen.findByRole('alert')).textContent).toContain(
+      'Peer unavailable',
+    )
+    expect((input as HTMLTextAreaElement).value).toBe('still here')
+    await waitFor(() => expect(document.activeElement).toBe(input))
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
+    await waitFor(() => expect(onSend).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect((input as HTMLTextAreaElement).value).toBe(''))
+  })
+
+  it('uses Shift+Enter for a newline and disables empty sends', () => {
+    const onSend = vi.fn(async () => {})
+    render(<MessageInput onSend={onSend} />)
+    const input = screen.getByRole('textbox', { name: 'Message' })
+    expect(
+      (
+        screen.getByRole('button', {
+          name: 'Send message',
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true)
+    fireEvent.change(input, { target: { value: 'line one' } })
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: true })
+    expect(onSend).not.toHaveBeenCalled()
+  })
+})

--- a/app/chat/MessageInput.tsx
+++ b/app/chat/MessageInput.tsx
@@ -1,28 +1,48 @@
-import { useState, useRef, useCallback } from 'react'
+import { LuSendHorizontal } from 'react-icons/lu'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
-// MessageInput provides a textarea for composing and sending chat messages.
-// Enter sends the message, Shift+Enter inserts a newline.
-export function MessageInput({
-  onSend,
-}: {
+interface MessageInputProps {
+  disabled?: boolean
   onSend: (text: string) => Promise<void>
-}) {
-  const [state, setState] = useState({ text: '', sending: false })
+}
+
+// MessageInput provides the channel composer and preserves a failed draft for retry.
+export function MessageInput({ disabled = false, onSend }: MessageInputProps) {
+  const [state, setState] = useState({ text: '', sending: false, error: '' })
   const ref = useRef<HTMLTextAreaElement>(null)
+  const restoreFocusRef = useRef(false)
+  useEffect(() => {
+    if (!state.sending && restoreFocusRef.current) {
+      restoreFocusRef.current = false
+      ref.current?.focus()
+    }
+  }, [state.sending])
+
+  const canSend = state.text.trim().length > 0 && !state.sending && !disabled
 
   const handleSubmit = useCallback(async () => {
     const trimmed = state.text.trim()
-    if (!trimmed || state.sending) return
-    setState({ text: '', sending: true })
-    await onSend(trimmed).catch(() => {})
-    setState((s) => ({ ...s, sending: false }))
-    ref.current?.focus()
-  }, [state.text, state.sending, onSend])
+    if (!trimmed || state.sending || disabled) return
+    setState((current) => ({ ...current, sending: true, error: '' }))
+    try {
+      await onSend(trimmed)
+      restoreFocusRef.current = true
+      setState({ text: '', sending: false, error: '' })
+    } catch (error) {
+      restoreFocusRef.current = true
+      setState((current) => ({
+        ...current,
+        sending: false,
+        error:
+          error instanceof Error ? error.message : 'Message could not be sent.',
+      }))
+    }
+  }, [disabled, onSend, state.sending, state.text])
 
   const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
-        e.preventDefault()
+    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault()
         void handleSubmit()
       }
     },
@@ -30,17 +50,43 @@ export function MessageInput({
   )
 
   return (
-    <div className="border-foreground/8 border-t p-2">
-      <textarea
-        ref={ref}
-        value={state.text}
-        onChange={(e) => setState((s) => ({ ...s, text: e.target.value }))}
-        onKeyDown={handleKeyDown}
-        placeholder="Type a message…"
-        rows={1}
-        disabled={state.sending}
-        className="bg-background-primary text-foreground w-full resize-none rounded border p-2 text-sm"
-      />
+    <div className="border-foreground/10 bg-background-secondary/70 shrink-0 border-t px-3 py-3 sm:px-4">
+      <div className="border-foreground/15 bg-background-primary focus-within:border-primary/60 flex items-end gap-2 rounded-md border p-2 transition-colors">
+        <textarea
+          ref={ref}
+          aria-label="Message"
+          value={state.text}
+          onChange={(event) =>
+            setState((current) => ({
+              ...current,
+              text: event.target.value,
+              error: '',
+            }))
+          }
+          onKeyDown={handleKeyDown}
+          placeholder="Message this channel"
+          rows={1}
+          disabled={state.sending || disabled}
+          className="text-foreground placeholder:text-muted-foreground max-h-32 min-h-9 flex-1 resize-none bg-transparent p-2 text-sm leading-5 outline-none disabled:cursor-not-allowed disabled:opacity-60"
+        />
+        <button
+          type="button"
+          aria-label={state.sending ? 'Sending message' : 'Send message'}
+          disabled={!canSend}
+          onClick={() => void handleSubmit()}
+          className="bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:ring-primary focus-visible:ring-offset-background flex size-9 shrink-0 items-center justify-center rounded-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-35"
+        >
+          <LuSendHorizontal className="size-4" aria-hidden="true" />
+        </button>
+      </div>
+      <div className="mt-1.5 flex min-h-4 items-center justify-between gap-3 px-1 text-xs">
+        <span role="alert" className="text-error-text">
+          {state.error}
+        </span>
+        <span className="text-muted-foreground ml-auto hidden sm:inline">
+          Enter to send · Shift+Enter for a new line
+        </span>
+      </div>
     </div>
   )
 }

--- a/app/chat/MessageList.test.tsx
+++ b/app/chat/MessageList.test.tsx
@@ -1,0 +1,33 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { MessageList } from './MessageList.js'
+
+afterEach(cleanup)
+
+describe('MessageList', () => {
+  it('settles an empty channel with an actionable first-message state', () => {
+    render(<MessageList messages={[]} />)
+    expect(screen.getByText('Start the conversation')).toBeDefined()
+    expect(screen.getByLabelText('Channel messages')).toBeDefined()
+  })
+
+  it('renders persisted sender identity, text, and time', () => {
+    render(
+      <MessageList
+        messages={[
+          {
+            objectKey: 'message/1',
+            senderPeerId: 'peer-123456789012345',
+            text: 'hello',
+            createdAt: new Date('2026-08-11T12:30:00Z'),
+            replyToKey: '',
+          },
+        ]}
+      />,
+    )
+    expect(screen.getByText('peer-12…12345')).toBeDefined()
+    expect(screen.getByText('hello')).toBeDefined()
+    expect(document.querySelector('time')?.textContent).toBeTruthy()
+  })
+})

--- a/app/chat/MessageList.tsx
+++ b/app/chat/MessageList.tsx
@@ -1,26 +1,28 @@
-import { useRef, useEffect, useCallback } from 'react'
+import { LuMessageCircle } from 'react-icons/lu'
+import { useCallback, useEffect, useRef } from 'react'
 
 import type { ChatMessageInfo } from '@s4wave/sdk/chat/rpc/rpc.pb.js'
 
-// truncatePeerId shortens a peer ID for display.
-function truncatePeerId(id: string): string {
-  if (id.length <= 12) return id
-  return id.slice(0, 6) + '...' + id.slice(-4)
+function peerLabel(id: string): string {
+  if (!id) return 'Unknown peer'
+  if (id.length <= 14) return id
+  return `${id.slice(0, 7)}…${id.slice(-5)}`
 }
 
-// formatTime formats a Date for display as HH:MM.
+const timeFormatter = new Intl.DateTimeFormat(undefined, {
+  hour: 'numeric',
+  minute: '2-digit',
+})
+
 function formatTime(date: Date | undefined): string {
-  if (!date) return ''
-  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  return date ? timeFormatter.format(date) : ''
 }
 
-// MessageList renders a scrollable list of chat messages with auto-scroll.
+// MessageList renders channel history and follows new messages while the reader remains at the bottom.
 export function MessageList({ messages }: { messages: ChatMessageInfo[] }) {
   const containerRef = useRef<HTMLDivElement>(null)
   const wasAtBottomRef = useRef(true)
 
-  // Auto-scroll when new messages arrive and user was at the bottom.
-  // This is a DOM side effect (scroll position), so raw useEffect is correct.
   useEffect(() => {
     if (wasAtBottomRef.current && containerRef.current) {
       containerRef.current.scrollTop = containerRef.current.scrollHeight
@@ -28,36 +30,69 @@ export function MessageList({ messages }: { messages: ChatMessageInfo[] }) {
   }, [messages.length])
 
   const handleScroll = useCallback(() => {
-    const el = containerRef.current
-    if (!el) return
+    const element = containerRef.current
+    if (!element) return
     wasAtBottomRef.current =
-      el.scrollHeight - el.scrollTop - el.clientHeight < 40
+      element.scrollHeight - element.scrollTop - element.clientHeight < 40
   }, [])
 
   return (
     <div
       ref={containerRef}
       onScroll={handleScroll}
-      className="flex-1 overflow-y-auto px-4 py-3"
+      aria-label="Channel messages"
+      className="flex-1 overflow-y-auto overscroll-contain px-3 py-4 sm:px-5"
     >
-      {messages.length === 0 && (
-        <div className="text-muted-foreground text-sm">No messages yet.</div>
-      )}
-      {messages.map((msg) => (
-        <div key={msg.objectKey ?? ''} className="mb-2">
-          <div className="flex items-baseline gap-2">
-            <span className="text-foreground/60 text-xs font-medium">
-              {truncatePeerId(msg.senderPeerId ?? '')}
-            </span>
-            <span className="text-foreground/40 text-xs">
-              {formatTime(msg.createdAt)}
-            </span>
+      {messages.length === 0 ? (
+        <div className="mx-auto flex h-full max-w-sm flex-col items-center justify-center px-6 py-12 text-center">
+          <div className="bg-background-tertiary text-brand mb-4 flex size-11 items-center justify-center rounded-full">
+            <LuMessageCircle className="size-5" aria-hidden="true" />
           </div>
-          <p className="text-foreground text-sm whitespace-pre-wrap">
-            {msg.text ?? ''}
+          <h2 className="text-foreground text-sm font-semibold">
+            Start the conversation
+          </h2>
+          <p className="text-muted-foreground mt-1.5 text-sm leading-5">
+            This channel is ready. Send the first message to everyone in the
+            peer group.
           </p>
         </div>
-      ))}
+      ) : (
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-1">
+          {messages.map((message, index) => {
+            const previous = messages[index - 1]
+            const grouped = previous?.senderPeerId === message.senderPeerId
+            return (
+              <article
+                key={message.objectKey}
+                className={
+                  grouped ? 'pt-0.5 pl-11' : 'flex gap-3 pt-4 first:pt-0'
+                }
+              >
+                {!grouped && (
+                  <div className="bg-background-tertiary text-foreground-alt flex size-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold uppercase">
+                    {(message.senderPeerId || '?').slice(0, 1)}
+                  </div>
+                )}
+                <div className="min-w-0 flex-1">
+                  {!grouped && (
+                    <div className="mb-0.5 flex min-w-0 items-baseline gap-2">
+                      <span className="text-foreground-alt truncate text-xs font-semibold">
+                        {peerLabel(message.senderPeerId ?? '')}
+                      </span>
+                      <time className="text-muted-foreground shrink-0 text-xs">
+                        {formatTime(message.createdAt)}
+                      </time>
+                    </div>
+                  )}
+                  <p className="text-foreground text-sm leading-6 break-words whitespace-pre-wrap">
+                    {message.text ?? ''}
+                  </p>
+                </div>
+              </article>
+            )
+          })}
+        </div>
+      )}
     </div>
   )
 }

--- a/sdk/chat/chat-resource.go
+++ b/sdk/chat/chat-resource.go
@@ -118,6 +118,7 @@ func (r *ChatResource) WatchMessages(
 ) error {
 	ctx := strm.Context()
 	nextIndex := uint64(0)
+	initialized := false
 
 	for {
 		if err := ctx.Err(); err != nil {
@@ -136,6 +137,12 @@ func (r *ChatResource) WatchMessages(
 		if nextIndex > messageCount {
 			nextIndex = messageCount
 		}
+		if !initialized && messageCount == 0 {
+			if err := strm.Send(&spacewave_chat_rpc.WatchMessagesResponse{}); err != nil {
+				return err
+			}
+		}
+		initialized = true
 		for nextIndex < messageCount {
 			endIndex := min(nextIndex+defaultMessageListLimit, messageCount)
 			keys, err := r.readMessageKeys(ctx, nextIndex, endIndex)

--- a/sdk/chat/chat-resource_test.go
+++ b/sdk/chat/chat-resource_test.go
@@ -137,6 +137,42 @@ func TestChatResourceSendsListsAndWatchesMessages(t *testing.T) {
 	}
 }
 
+func TestChatResourceWatchMessagesSettlesEmptyChannel(t *testing.T) {
+	ctx := t.Context()
+	wtb, err := db_world_testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(wtb.Release)
+
+	ws := world.NewEngineWorldState(wtb.Engine, true)
+	createChatChannel(t, ctx, ws, GeneralChannelKey, "General")
+	resource := NewChatResource(ws, wtb.Engine, GeneralChannelKey, "peer-local")
+
+	watchCtx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+	stream := newChatMessageStream(watchCtx)
+	done := make(chan error, 1)
+	go func() {
+		done <- resource.WatchMessages(&spacewave_chat_rpc.WatchMessagesRequest{}, stream)
+	}()
+
+	watchResp := recvChatWatchValue(t, stream.sent)
+	if len(watchResp.GetMessages()) != 0 {
+		t.Fatalf("initial watch response has %d messages, want empty snapshot", len(watchResp.GetMessages()))
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil && err != context.Canceled {
+			t.Fatalf("WatchMessages returned %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for WatchMessages to stop")
+	}
+}
+
 func TestChatResourceListMessagesBeforeKeyUsesSortedMessageSet(t *testing.T) {
 	ctx := t.Context()
 	wtb, err := db_world_testbed.Default(ctx)

--- a/sdk/chat/chat.ts
+++ b/sdk/chat/chat.ts
@@ -57,9 +57,7 @@ export class ChatHandle extends Resource implements IChatHandle {
   ): AsyncIterable<ChatMessageInfo[]> {
     const stream = this.service.WatchMessages({}, abortSignal)
     for await (const resp of stream as AsyncIterable<WatchMessagesResponse>) {
-      if (resp.messages && resp.messages.length > 0) {
-        yield resp.messages
-      }
+      yield resp.messages ?? []
     }
   }
 


### PR DESCRIPTION
A newly created Chat Channel never received an initial history value. The server waited for a world change when the channel contained no messages, and the browser discarded empty snapshots, so the viewer remained in its loading state forever.

The watch service now emits one initial empty response and the browser preserves it. The viewer renders an explicit empty conversation, keys its stream and accumulated messages to the selected channel, and provides accessible send, failure, retry, draft-preservation, and focus behavior.

New channels become usable immediately while persisted messages continue through the existing ordered watch contract.