### PR TITLE
feat(secret): add a confidential object viewer

### DIFF
--- a/app/secret/SecretViewer.test.tsx
+++ b/app/secret/SecretViewer.test.tsx
@@ -1,0 +1,140 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { Resource } from '@aptre/bldr-sdk/hooks/useResource.js'
+import { SharedObjectHealthStatus } from '@s4wave/core/sobject/sobject.pb.js'
+import type { SecretState } from '@s4wave/sdk/secret/secret.pb.js'
+import type { IWorldState } from '@s4wave/sdk/world/world-state.js'
+
+import { SecretViewer } from './SecretViewer.js'
+
+const secretValue = 'production-token-must-never-render'
+const { hookState } = vi.hoisted(() => ({
+  hookState: {
+    value: null as SecretState | null,
+    loading: false,
+    error: null as Error | null,
+    retry: vi.fn(),
+  },
+}))
+
+vi.mock('@s4wave/web/hooks/useAccessTypedHandle.js', () => ({
+  useAccessTypedHandle: () => ({ value: {}, loading: false, error: null }),
+}))
+
+vi.mock('@aptre/bldr-sdk/hooks/useStreamingResource.js', () => ({
+  useStreamingResource: () => hookState,
+}))
+
+function worldState(): Resource<IWorldState> {
+  return {
+    value: {} as IWorldState,
+    loading: false,
+    error: null,
+    retry: vi.fn(),
+  }
+}
+
+function renderViewer() {
+  return render(
+    <SecretViewer
+      objectInfo={{
+        info: {
+          case: 'worldObjectInfo',
+          value: {
+            objectKey: 'credentials/matrix-bot',
+            objectType: 'spacewave/secret',
+          },
+        },
+      }}
+      worldState={worldState()}
+    />,
+  )
+}
+
+function readyState(readable: boolean): SecretState {
+  return {
+    secret: {
+      displayName: 'Matrix bot token',
+      kind: 'matrix_access_token',
+      nestedSharedObjectId: 'shared-object-redacted-ref',
+      createdAt: new Date('2026-06-01T10:00:00Z'),
+      updatedAt: new Date('2026-06-02T11:30:00Z'),
+    },
+    grantStatus: {
+      participant: readable,
+      readable,
+      grantCount: readable ? 1 : 0,
+    },
+    health: { status: SharedObjectHealthStatus.READY },
+    payload: { value: new TextEncoder().encode(secretValue) },
+  } as SecretState
+}
+
+describe('SecretViewer', () => {
+  beforeEach(() => {
+    hookState.value = null
+    hookState.loading = false
+    hookState.error = null
+    hookState.retry.mockClear()
+  })
+  afterEach(cleanup)
+
+  it('keeps access unknown while the nested SharedObject is loading', () => {
+    hookState.value = {
+      health: { status: SharedObjectHealthStatus.LOADING },
+      grantStatus: { participant: false, readable: false, grantCount: 0 },
+    }
+    renderViewer()
+
+    expect(screen.getByText('Nested SharedObject status')).toBeDefined()
+    expect(screen.getByText('Loading')).toBeDefined()
+    expect(screen.queryByText('Not readable')).toBeNull()
+    expect(screen.queryByText('Not granted')).toBeNull()
+    expect(screen.queryByText('Active grants')).toBeNull()
+  })
+
+  it.each([
+    [false, 'Not readable', 'Not granted', '0'],
+    [true, 'Readable', 'Granted', '1'],
+  ] as const)(
+    'renders exact ready access state when readability is %s',
+    (readable, readability, participant, grants) => {
+      hookState.value = readyState(readable)
+      renderViewer()
+
+      expect(screen.getByText('Nested SharedObject readability')).toBeDefined()
+      expect(screen.getByText(readability)).toBeDefined()
+      expect(screen.getByText(participant)).toBeDefined()
+      expect(screen.getByText(grants)).toBeDefined()
+      expect(screen.getAllByText('Matrix bot token')).toHaveLength(2)
+      expect(screen.getByText('••••••••••••')).toBeDefined()
+      expect(screen.queryByText(secretValue)).toBeNull()
+      expect(screen.queryByRole('button', { name: /reveal/i })).toBeNull()
+      expect(screen.getByText('Nested SharedObject ID')).toBeDefined()
+    },
+  )
+
+  it('shows retryable unavailable state when the stream completes without state', () => {
+    renderViewer()
+
+    expect(screen.getByText('Secret metadata unavailable')).toBeDefined()
+    expect(
+      screen.getByText('The Secret resource returned no state.'),
+    ).toBeDefined()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(hookState.retry).toHaveBeenCalledTimes(1)
+  })
+
+  it('hides stale metadata behind a retryable stream error', () => {
+    hookState.value = readyState(true)
+    hookState.error = new Error('stream failed')
+    renderViewer()
+
+    expect(screen.getByText('Secret metadata unavailable')).toBeDefined()
+    expect(screen.queryByText('Matrix bot token')).toBeNull()
+    expect(screen.queryByText('stream failed')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(hookState.retry).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/secret/SecretViewer.tsx
+++ b/app/secret/SecretViewer.tsx
@@ -1,0 +1,219 @@
+import { useCallback } from 'react'
+import { LuKeyRound, LuLockKeyhole, LuShieldCheck } from 'react-icons/lu'
+
+import { useStreamingResource } from '@aptre/bldr-sdk/hooks/useStreamingResource.js'
+import { SecretHandle, SecretTypeID } from '@s4wave/sdk/secret/secret.js'
+import type { SecretState } from '@s4wave/sdk/secret/secret.pb.js'
+import { SharedObjectHealthStatus } from '@s4wave/core/sobject/sobject.pb.js'
+import { useAccessTypedHandle } from '@s4wave/web/hooks/useAccessTypedHandle.js'
+import type { ObjectViewerComponentProps } from '@s4wave/web/object/object.js'
+import { getObjectKey } from '@s4wave/web/object/object.js'
+import { cn } from '@s4wave/web/style/utils.js'
+import { CopyableField } from '@s4wave/web/ui/CopyableField.js'
+import { InfoCard } from '@s4wave/web/ui/InfoCard.js'
+import { LoadingCard } from '@s4wave/web/ui/loading/LoadingCard.js'
+
+export { SecretTypeID }
+
+// SecretViewer displays only the browser-safe metadata stream. Payload reads
+// require a separate peer-authenticated challenge and are deliberately absent.
+export function SecretViewer({
+  objectInfo,
+  worldState,
+}: ObjectViewerComponentProps) {
+  const objectKey = getObjectKey(objectInfo)
+  const handle = useAccessTypedHandle(
+    worldState,
+    objectKey,
+    SecretHandle,
+    SecretTypeID,
+  )
+  const streamFactory = useCallback(
+    (secret: SecretHandle, signal: AbortSignal) => secret.watchState(signal),
+    [],
+  )
+  const stateResource = useStreamingResource(handle, streamFactory, [])
+  const state: SecretState | undefined = stateResource.value ?? undefined
+  const secret = state?.secret
+  const grant = state?.grantStatus
+  const healthStatus = state?.health?.status ?? SharedObjectHealthStatus.UNKNOWN
+  const accessReady = healthStatus === SharedObjectHealthStatus.READY
+
+  return (
+    <div className="bg-background-primary flex h-full w-full flex-col">
+      <div className="border-foreground/8 flex h-9 shrink-0 items-center gap-2 border-b px-4">
+        <LuKeyRound className="text-foreground-alt size-4" aria-hidden="true" />
+        <span className="text-foreground truncate text-sm font-semibold tracking-tight">
+          {stateResource.error ? 'Secret' : secret?.displayName || 'Secret'}
+        </span>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto px-4 py-3">
+        {stateResource.error ? (
+          <LoadingCard
+            view={{
+              state: 'error',
+              title: 'Secret metadata unavailable',
+              detail: 'The redacted Secret state stream stopped unexpectedly.',
+              onRetry: stateResource.retry,
+            }}
+          />
+        ) : stateResource.loading && !state ? (
+          <LoadingCard
+            view={{
+              state: 'active',
+              title: 'Loading secret metadata',
+              detail: 'Reading the authorized, redacted Secret state.',
+            }}
+          />
+        ) : !state ? (
+          <LoadingCard
+            view={{
+              state: 'error',
+              title: 'Secret metadata unavailable',
+              detail: 'The Secret resource returned no state.',
+              onRetry: stateResource.retry,
+            }}
+          />
+        ) : (
+          <div className="mx-auto flex w-full max-w-3xl flex-col gap-4">
+            <InfoCard
+              icon={<LuLockKeyhole className="text-brand size-4" />}
+              title="Protected value"
+            >
+              <div className="border-foreground/8 bg-background-dark text-foreground rounded-md border px-3 py-2 font-mono text-sm tracking-[0.2em]">
+                ••••••••••••
+              </div>
+              <p className="text-foreground-alt/60 mt-2 text-xs leading-relaxed">
+                Secret values stay hidden in the object viewer. Use the feature
+                that consumes this credential to verify or replace it.
+              </p>
+            </InfoCard>
+
+            <InfoCard title="Metadata">
+              <div className="grid gap-x-6 gap-y-3 sm:grid-cols-2">
+                <Metadata
+                  label="Name"
+                  value={state.secret?.displayName || 'Unnamed secret'}
+                />
+                <Metadata
+                  label="Kind"
+                  value={state.secret?.kind || 'Unspecified'}
+                  mono
+                />
+                <Metadata
+                  label="Object key"
+                  value={objectKey || 'Unknown'}
+                  mono
+                />
+                {state.secret?.nestedSharedObjectId ? (
+                  <CopyableField
+                    label="Nested SharedObject ID"
+                    value={state.secret.nestedSharedObjectId}
+                  />
+                ) : (
+                  <Metadata
+                    label="Nested SharedObject ID"
+                    value="Unavailable"
+                  />
+                )}
+                <Metadata
+                  label="Created"
+                  value={formatTimestamp(state.secret?.createdAt)}
+                />
+                <Metadata
+                  label="Updated"
+                  value={formatTimestamp(state.secret?.updatedAt)}
+                />
+              </div>
+            </InfoCard>
+
+            <InfoCard
+              icon={<LuShieldCheck className="text-foreground-alt size-4" />}
+              title="Access status"
+            >
+              {accessReady ? (
+                <div className="grid gap-3 sm:grid-cols-3">
+                  <Metadata
+                    label="Nested SharedObject readability"
+                    value={
+                      grant
+                        ? grant.readable
+                          ? 'Readable'
+                          : 'Not readable'
+                        : 'Unknown'
+                    }
+                  />
+                  <Metadata
+                    label="Participant"
+                    value={
+                      grant
+                        ? grant.participant
+                          ? 'Granted'
+                          : 'Not granted'
+                        : 'Unknown'
+                    }
+                  />
+                  <Metadata
+                    label="Active grants"
+                    value={grant ? String(grant.grantCount ?? 0) : 'Unknown'}
+                  />
+                </div>
+              ) : (
+                <Metadata
+                  label="Nested SharedObject status"
+                  value={formatHealthStatus(healthStatus)}
+                />
+              )}
+              <p className="text-foreground-alt/60 mt-3 text-xs leading-relaxed">
+                This status describes nested SharedObject access. It does not
+                reveal or copy the protected value.
+              </p>
+            </InfoCard>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Metadata({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string
+  value: string
+  mono?: boolean
+}) {
+  return (
+    <div className="min-w-0">
+      <p className="text-foreground-alt/60 text-xs">{label}</p>
+      <p
+        className={cn(
+          'text-foreground mt-0.5 break-words text-xs',
+          mono ? 'font-mono' : 'font-medium',
+        )}
+      >
+        {value}
+      </p>
+    </div>
+  )
+}
+
+function formatHealthStatus(status: SharedObjectHealthStatus): string {
+  switch (status) {
+    case SharedObjectHealthStatus.LOADING:
+      return 'Loading'
+    case SharedObjectHealthStatus.DEGRADED:
+      return 'Degraded'
+    case SharedObjectHealthStatus.CLOSED:
+      return 'Unavailable'
+    default:
+      return 'Unknown'
+  }
+}
+
+function formatTimestamp(value: Date | undefined): string {
+  if (!value) return 'Unavailable'
+  return value.toLocaleString()
+}

--- a/app/viewers.test.ts
+++ b/app/viewers.test.ts
@@ -190,4 +190,15 @@ describe('getObjectViewersForType', () => {
       ),
     ).toEqual(['V86', 'Debug Viewer'])
   })
+  it('registers the redacted Secret viewer ahead of the debug fallback', () => {
+    expect(
+      getObjectViewersForType('spacewave/secret').map((viewer) => [
+        viewer.componentID,
+        viewer.name,
+      ]),
+    ).toEqual([
+      ['spacewave.secret.viewer', 'Secret'],
+      ['spacewave.debug.viewer', 'Debug Viewer'],
+    ])
+  })
 })

--- a/app/viewers.tsx
+++ b/app/viewers.tsx
@@ -73,6 +73,7 @@ import {
   TerminalTypeID,
 } from '@s4wave/app/terminal/TerminalViewer.js'
 import { OrgViewer, OrganizationTypeID } from '@s4wave/app/org/OrgViewer.js'
+import { SecretViewer, SecretTypeID } from '@s4wave/app/secret/SecretViewer.js'
 import { KvStoreViewer, KvStoreTypeID } from '@s4wave/app/kv/KvStoreViewer.js'
 import { SqlDbViewer, SqlDbTypeID } from '@s4wave/app/sql/SqlDbViewer.js'
 import {
@@ -234,6 +235,13 @@ const productObjectViewers: ObjectViewerComponent[] = [
     name: 'Organization',
     category: 'Management',
     component: OrgViewer,
+  },
+  {
+    componentID: 'spacewave.secret.viewer',
+    typeID: SecretTypeID,
+    name: 'Secret',
+    category: 'Management',
+    component: SecretViewer,
   },
   {
     componentID: 'spacewave.kv.store',

--- a/web/object/ObjectViewerContent.test.tsx
+++ b/web/object/ObjectViewerContent.test.tsx
@@ -122,10 +122,14 @@ describe('ObjectViewerContent', () => {
     )
 
     expect(screen.getByText("Can't open this object yet")).toBeDefined()
+    expect(screen.getByText('About this object')).toBeDefined()
+    expect(screen.getByText('Object key')).toBeDefined()
+    expect(screen.getByText('glados/bootstrap/llm-session')).toBeDefined()
+    expect(screen.getByText('Object type')).toBeDefined()
     expect(screen.getByText('glados/missing')).toBeDefined()
     expect(screen.getByText(/glados\.custom\.viewer/)).toBeDefined()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Open Debug Viewer' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Open raw object' }))
 
     expect(onSelectComponent).toHaveBeenCalledWith(debugComponent)
   })

--- a/web/object/ObjectViewerContent.tsx
+++ b/web/object/ObjectViewerContent.tsx
@@ -3,6 +3,8 @@ import { WebViewErrorBoundary } from '@aptre/bldr-react'
 
 import { cn } from '@s4wave/web/style/utils.js'
 import { Button } from '@s4wave/web/ui/button.js'
+import { CopyableField } from '@s4wave/web/ui/CopyableField.js'
+import { InfoCard } from '@s4wave/web/ui/InfoCard.js'
 import type { IObjectState } from '@s4wave/sdk/world/object-state.js'
 import type { IWorldState } from '@s4wave/sdk/world/world-state.js'
 import type { Resource } from '@aptre/bldr-sdk/hooks/useResource.js'
@@ -59,33 +61,44 @@ export function ObjectViewerContent({
           ) : !typeID ? (
             <span>Object has no type</span>
           ) : (
-            <div className="flex max-w-md flex-col items-center gap-3">
-              <div>
+            <div className="flex w-full max-w-lg flex-col gap-4 text-left">
+              <div className="text-center">
                 <h2 className="text-foreground text-sm font-semibold">
                   Can't open this object yet
                 </h2>
-                <p className="mt-1 text-xs">
-                  No installed viewer handles this object type.
+                <p className="mt-1 text-xs leading-relaxed">
+                  No installed viewer handles this object type. You can inspect
+                  its object record when the raw viewer is available.
                 </p>
               </div>
-              <div className="border-border bg-background/60 text-foreground rounded-md border px-3 py-2 font-mono text-xs">
-                {typeID}
-              </div>
-              {missingComponentID && missingComponentID !== typeID ? (
-                <p className="text-xs">
-                  The requested viewer is not available: {missingComponentID}
-                </p>
-              ) : null}
+              <InfoCard title="About this object">
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <CopyableField label="Object key" value={objectKey} />
+                  <CopyableField label="Object type" value={typeID} />
+                </div>
+                {missingComponentID && missingComponentID !== typeID ? (
+                  <p className="text-foreground-alt/60 mt-3 text-xs leading-relaxed">
+                    Requested viewer unavailable:{' '}
+                    <span className="font-mono">{missingComponentID}</span>
+                  </p>
+                ) : null}
+              </InfoCard>
               {debugComponent ? (
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={handleOpenDebugViewer}
-                >
-                  Open Debug Viewer
-                </Button>
-              ) : null}
+                <div className="flex justify-center">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={handleOpenDebugViewer}
+                  >
+                    Open raw object
+                  </Button>
+                </div>
+              ) : (
+                <p className="text-center text-xs leading-relaxed">
+                  No raw object viewer is installed.
+                </p>
+              )}
             </div>
           )}
         </div>

--- a/web/object/ObjectViewerDetails.test.tsx
+++ b/web/object/ObjectViewerDetails.test.tsx
@@ -49,6 +49,26 @@ describe('ObjectViewerDetails', () => {
     vi.clearAllMocks()
   })
 
+  it('copies the object key with the shared click-to-copy field', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    })
+
+    render(
+      <ObjectViewerDetails
+        objectKey="glados/workfront/1"
+        typeID="glados/workfront"
+        availableComponents={[]}
+        onComponentSelect={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Click to copy' }))
+    expect(writeText).toHaveBeenCalledWith('glados/workfront/1')
+  })
+
   it('exposes missing requested component IDs in the object internals panel', () => {
     render(
       <ObjectViewerDetails

--- a/web/object/ObjectViewerDetails.tsx
+++ b/web/object/ObjectViewerDetails.tsx
@@ -106,14 +106,7 @@ export function ObjectViewerDetails({
 
                 <InfoCard>
                   <div className="space-y-3">
-                    <div className="min-w-0">
-                      <p className="text-foreground-alt text-xs select-none">
-                        Object key
-                      </p>
-                      <p className="text-foreground text-sm font-medium break-all select-none">
-                        {objectKey}
-                      </p>
-                    </div>
+                    <CopyableField label="Object key" value={objectKey} />
                     {missingComponentID && (
                       <CopyableField
                         label="Missing Component ID"


### PR DESCRIPTION
Secret objects fell through to the generic unsupported-object state even though the browser exposes a redacted metadata stream. The fallback also omitted useful object context, and the standard object details view rendered its key as inert text.

This registers a Secret viewer that consumes only redacted SecretState metadata. Nested SharedObject health remains distinct from resolved grant facts, the value stays masked, and unavailable states are retryable without importing or calling payload APIs. Standard copy fields expose only safe identifiers, while unsupported objects gain concrete type and key context and honest recovery actions.

Secret objects become useful to inspect without widening payload authority, and generic object details consistently provide explicit copy affordances.