### PR TITLE
fix(releases): clarify desktop downloads

### DIFF
--- a/app/download/PrimaryDownloadButton.tsx
+++ b/app/download/PrimaryDownloadButton.tsx
@@ -7,12 +7,16 @@ import type { DownloadEntry } from './manifest.js'
 
 interface PrimaryDownloadButtonProps {
   entry: DownloadEntry | null
+  releaseLabel?: string
 }
 
 // PrimaryDownloadButton renders the hero download CTA for the detected
 // platform. Falls back to a "Pick a build below." headline when detection
 // missed or the detected tuple is absent from the manifest.
-export function PrimaryDownloadButton({ entry }: PrimaryDownloadButtonProps) {
+export function PrimaryDownloadButton({
+  entry,
+  releaseLabel,
+}: PrimaryDownloadButtonProps) {
   if (!entry) {
     return (
       <p className="text-foreground-alt text-center text-base select-none @lg:text-lg">
@@ -33,7 +37,8 @@ export function PrimaryDownloadButton({ entry }: PrimaryDownloadButtonProps) {
     >
       <LuDownload className="size-5" />
       <span>
-        Download for {entry.osLabel} ({entry.archLabel})
+        Download{releaseLabel ? ` ${releaseLabel}` : ''} for {entry.osLabel} (
+        {entry.archLabel}) · {entry.ext}
       </span>
     </ExternalLink>
   )

--- a/app/download/manifest.test.ts
+++ b/app/download/manifest.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   DOWNLOAD_MANIFEST,
+  isReleaseVersion,
   releaseAssetUrl,
   resolveInstallerEntries,
   resolvePrimaryEntry,
@@ -87,11 +88,26 @@ describe('resolvePrimaryEntry', () => {
   })
 })
 
+describe('isReleaseVersion', () => {
+  it('accepts only the changelog major.minor.patch contract', () => {
+    expect(isReleaseVersion('0.53.1')).toBe(true)
+    for (const version of [' 0.53.1', '0.53.1 ', 'v0.53.1', 'garbage']) {
+      expect(isReleaseVersion(version)).toBe(false)
+    }
+  })
+})
+
 describe('releaseAssetUrl', () => {
   it('points at the exact release tag download path', () => {
     expect(releaseAssetUrl('spacewave-macos-arm64.dmg', '0.53.1')).toBe(
       'https://github.com/s4wave/spacewave/releases/download/v0.53.1/spacewave-macos-arm64.dmg',
     )
+  })
+
+  it('rejects an invalid version instead of creating a malformed URL', () => {
+    expect(() =>
+      releaseAssetUrl('spacewave-macos-arm64.dmg', 'v0.53.1'),
+    ).toThrow('invalid release version')
   })
 })
 

--- a/app/download/manifest.ts
+++ b/app/download/manifest.ts
@@ -42,10 +42,19 @@ export function assetUrl(filename: string): string {
   return `${GITHUB_RELEASES_URL}/download/${filename}`
 }
 
-// releaseAssetUrl builds the asset URL for a specific release tag. The
+// isReleaseVersion reports whether version matches the changelog producer's
+// major.minor.patch contract.
+export function isReleaseVersion(version: string): boolean {
+  return /^\d+\.\d+\.\d+$/.test(version)
+}
+
+// releaseAssetUrl builds the asset URL for a validated release tag. The
 // default DOWNLOAD_MANIFEST urls resolve the latest release; the changelog
 // per-release page repoints them at the exact tag through this helper.
 export function releaseAssetUrl(filename: string, version: string): string {
+  if (!isReleaseVersion(version)) {
+    throw new Error(`invalid release version: ${version}`)
+  }
   return `${GITHUB_REPO_URL}/releases/download/v${version}/${filename}`
 }
 

--- a/app/landing/ChangelogReleaseDownloads.test.tsx
+++ b/app/landing/ChangelogReleaseDownloads.test.tsx
@@ -3,46 +3,94 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ChangelogReleaseDownloads } from './ChangelogReleaseDownloads.js'
 
+const platform = vi.hoisted(() => ({
+  detected: { os: 'macos', arch: 'arm64' } as {
+    os: 'macos'
+    arch: 'arm64'
+  } | null,
+}))
+
 vi.mock('@s4wave/web/platform/detect-platform.js', () => ({
-  detectPlatform: () => ({ os: 'macos', arch: 'arm64' }),
+  detectPlatform: () => platform.detected,
 }))
 
 describe('ChangelogReleaseDownloads', () => {
-  beforeEach(() => cleanup())
+  beforeEach(() => {
+    cleanup()
+    platform.detected = { os: 'macos', arch: 'arm64' }
+  })
   afterEach(() => {
     cleanup()
     vi.clearAllMocks()
   })
 
-  it('defaults to the latest release artifacts and highlights the detected platform', () => {
+  it('defaults to the latest release and labels the detected artifact', () => {
     render(<ChangelogReleaseDownloads version="0.53.1" />)
 
+    expect(
+      screen.getByRole('radio', { name: /Latest release/ }),
+    ).toHaveProperty('checked', true)
     const primary = screen.getByRole('link', {
-      name: /Download for macOS \(Apple Silicon\)/,
+      name: 'Download Latest release for macOS (Apple Silicon) · dmg',
     })
     expect(primary.getAttribute('href')).toBe(
       'https://github.com/s4wave/spacewave/releases/latest/download/spacewave-macos-arm64.dmg',
     )
+    expect(primary.getAttribute('download')).not.toBeNull()
+    expect(primary.getAttribute('target')).toBe('_blank')
+    expect(primary.getAttribute('rel')).toBe('noopener noreferrer')
   })
 
-  it('switches every link to the exact version when the checkbox is ticked', () => {
+  it('switches every link to the exact release selected by its radio', () => {
     render(<ChangelogReleaseDownloads version="0.53.1" />)
 
-    fireEvent.click(
-      screen.getByLabelText(/Download this exact version \(v0\.53\.1\)/),
-    )
-
-    const primary = screen.getByRole('link', {
-      name: /Download for macOS \(Apple Silicon\)/,
+    const exactRelease = screen.getByRole('radio', {
+      name: /This release · v0\.53\.1/,
     })
-    expect(primary.getAttribute('href')).toBe(
+    exactRelease.focus()
+    expect(document.activeElement).toBe(exactRelease)
+    fireEvent.click(exactRelease)
+
+    expect(
+      screen.getByRole('link', {
+        name: 'Download v0.53.1 for macOS (Apple Silicon) · dmg',
+      }),
+    ).toHaveProperty(
+      'href',
       'https://github.com/s4wave/spacewave/releases/download/v0.53.1/spacewave-macos-arm64.dmg',
     )
 
     const archTile = screen.getByText('spacewave-linux-amd64.AppImage')
-    const tileLink = archTile.closest('a')
-    expect(tileLink?.getAttribute('href')).toBe(
+    expect(archTile.closest('a')?.getAttribute('href')).toBe(
       'https://github.com/s4wave/spacewave/releases/download/v0.53.1/spacewave-linux-amd64.AppImage',
     )
   })
+
+  it('offers manual builds when platform detection is unsupported', () => {
+    platform.detected = null
+    render(<ChangelogReleaseDownloads version="0.53.1" />)
+
+    expect(
+      screen.queryByRole('link', { name: /Download Latest release for/ }),
+    ).toBeNull()
+    expect(
+      screen.getByText(/could not detect a supported build for this device/i),
+    ).toBeTruthy()
+    expect(screen.getByText('spacewave-linux-amd64.AppImage')).toBeTruthy()
+  })
+
+  it.each(['', ' 0.53.1', '0.53.1 ', 'v0.53.1', 'garbage'])(
+    'disables exact-release selection for invalid version %j',
+    (version) => {
+      render(<ChangelogReleaseDownloads version={version} />)
+
+      expect(
+        screen.getByRole('radio', { name: /This release/ }),
+      ).toHaveProperty('disabled', true)
+      expect(screen.getByText('Selected: Latest release')).toBeTruthy()
+      expect(
+        document.querySelector('a[href*="/releases/download/v"]'),
+      ).toBeNull()
+    },
+  )
 })

--- a/app/landing/ChangelogReleaseDownloads.tsx
+++ b/app/landing/ChangelogReleaseDownloads.tsx
@@ -1,24 +1,28 @@
 import { useCallback, useId, useMemo, useState } from 'react'
 import { LuMonitorDown } from 'react-icons/lu'
 
-import { detectPlatform } from '@s4wave/web/platform/detect-platform.js'
 import {
+  isReleaseVersion,
   resolveInstallerEntries,
   resolvePrimaryEntry,
   type DownloadOS,
 } from '@s4wave/app/download/manifest.js'
 import { PlatformSection } from '@s4wave/app/download/PlatformSection.js'
 import { PrimaryDownloadButton } from '@s4wave/app/download/PrimaryDownloadButton.js'
+import { cn } from '@s4wave/web/style/utils.js'
+import { detectPlatform } from '@s4wave/web/platform/detect-platform.js'
 
 const PLATFORM_ORDER: readonly DownloadOS[] = ['macos', 'windows', 'linux']
+type ReleaseChoice = 'latest' | 'this-release'
 
 // ChangelogReleaseDownloads renders the desktop-app download options for a
-// changelog release page. It defaults to the latest release's artifacts and
-// highlights the detected platform; the "exact version" checkbox repoints
-// every link at the release whose notes are being read.
+// changelog release page. The selected release is the single source for every
+// primary and manual download URL in the section.
 export function ChangelogReleaseDownloads({ version }: { version: string }) {
-  const [exactVersion, setExactVersion] = useState(false)
-  const checkboxId = useId()
+  const [releaseChoice, setReleaseChoice] = useState<ReleaseChoice>('latest')
+  const choiceName = useId()
+  const hasReleaseVersion = isReleaseVersion(version)
+  const exactVersion = releaseChoice === 'this-release' && hasReleaseVersion
 
   const detected = useMemo(() => {
     if (typeof navigator === 'undefined') return null
@@ -37,12 +41,17 @@ export function ChangelogReleaseDownloads({ version }: { version: string }) {
     () =>
       PLATFORM_ORDER.map((os) => ({
         os,
-        entries: entries.filter((e) => e.os === os),
+        entries: entries.filter((entry) => entry.os === os),
       })),
     [entries],
   )
 
-  const toggleExact = useCallback(() => setExactVersion((prev) => !prev), [])
+  const selectLatest = useCallback(() => setReleaseChoice('latest'), [])
+  const selectThisRelease = useCallback(
+    () => setReleaseChoice('this-release'),
+    [],
+  )
+  const releaseLabel = exactVersion ? `v${version}` : 'Latest release'
 
   return (
     <section className="flex w-full flex-col gap-8">
@@ -54,28 +63,89 @@ export function ChangelogReleaseDownloads({ version }: { version: string }) {
           </h2>
         </div>
         <p className="text-foreground-alt text-sm @lg:text-base">
-          The buttons install the latest Spacewave release. Tick the box below
-          to grab the exact build that shipped with v{version}.
+          Choose the newest Spacewave app or the build documented on this page.
         </p>
       </header>
 
-      <PrimaryDownloadButton entry={primary} />
+      <fieldset className="flex flex-col gap-3">
+        <legend className="text-foreground text-sm font-semibold">
+          Choose a release
+        </legend>
+        <div className="grid gap-3 @md:grid-cols-2">
+          <label
+            className={cn(
+              'focus-within:ring-brand/70 flex cursor-pointer gap-3 rounded-lg border p-4 focus-within:ring-2',
+              releaseChoice === 'latest'
+                ? 'border-brand/50 bg-brand/10'
+                : 'border-foreground/10 bg-background-card/30 hover:border-foreground/20',
+            )}
+          >
+            <input
+              type="radio"
+              name={choiceName}
+              value="latest"
+              checked={releaseChoice === 'latest'}
+              onChange={selectLatest}
+              className="accent-brand mt-1 size-4 shrink-0 cursor-pointer"
+            />
+            <span className="flex flex-col gap-1">
+              <span className="text-foreground text-sm font-semibold">
+                Latest release
+              </span>
+              <span className="text-foreground-alt text-xs leading-relaxed">
+                Recommended. Downloads the newest published build.
+              </span>
+            </span>
+          </label>
+          <label
+            className={cn(
+              'focus-within:ring-brand/70 flex gap-3 rounded-lg border p-4 focus-within:ring-2',
+              hasReleaseVersion
+                ? 'cursor-pointer'
+                : 'cursor-not-allowed opacity-50',
+              releaseChoice === 'this-release'
+                ? 'border-brand/50 bg-brand/10'
+                : 'border-foreground/10 bg-background-card/30 hover:border-foreground/20',
+            )}
+          >
+            <input
+              type="radio"
+              name={choiceName}
+              value="this-release"
+              checked={releaseChoice === 'this-release'}
+              onChange={selectThisRelease}
+              disabled={!hasReleaseVersion}
+              className="accent-brand mt-1 size-4 shrink-0 cursor-pointer disabled:cursor-not-allowed"
+            />
+            <span className="flex flex-col gap-1">
+              <span className="text-foreground text-sm font-semibold">
+                This release{hasReleaseVersion ? ` · v${version}` : ''}
+              </span>
+              <span className="text-foreground-alt text-xs leading-relaxed">
+                Downloads the exact build described in these release notes.
+              </span>
+            </span>
+          </label>
+        </div>
+      </fieldset>
 
-      <label
-        htmlFor={checkboxId}
-        className="text-foreground-alt hover:text-foreground flex cursor-pointer items-center gap-2 text-sm select-none"
+      <div className="flex flex-col gap-2">
+        <p className="text-foreground-alt text-xs font-medium tracking-wider uppercase">
+          Selected: {releaseLabel}
+        </p>
+        <PrimaryDownloadButton entry={primary} releaseLabel={releaseLabel} />
+        {!primary && (
+          <p className="text-foreground-alt text-center text-sm">
+            We could not detect a supported build for this device. Choose your
+            platform and architecture below.
+          </p>
+        )}
+      </div>
+
+      <div
+        className="flex w-full flex-col gap-10"
+        aria-label={`${releaseLabel} downloads`}
       >
-        <input
-          id={checkboxId}
-          type="checkbox"
-          checked={exactVersion}
-          onChange={toggleExact}
-          className="accent-brand size-4 cursor-pointer"
-        />
-        Download this exact version (v{version})
-      </label>
-
-      <div className="flex w-full flex-col gap-10">
         {groups.map(({ os, entries }) => (
           <PlatformSection key={os} os={os} entries={entries} />
         ))}

--- a/app/landing/ChangelogReleasePage.test.tsx
+++ b/app/landing/ChangelogReleasePage.test.tsx
@@ -42,7 +42,7 @@ describe('ChangelogReleasePage', () => {
       screen.getByRole('heading', { name: 'Download the desktop app' }),
     ).toBeTruthy()
     expect(
-      screen.getByLabelText(/Download this exact version \(v0\.53\.1\)/),
+      screen.getByRole('radio', { name: /This release · v0\.53\.1/ }),
     ).toBeTruthy()
   })
 })


### PR DESCRIPTION
Release notes used a checkbox to silently switch every desktop artifact between the latest release and the page version. The primary action did not say which release or artifact it would download, and malformed version metadata could construct invalid pinned URLs.

This presents Latest release and This release as explicit native choices, labels the selected platform, architecture, extension, and version, and keeps manual alternatives visible when platform detection is unavailable. Release versions are validated before enabling or constructing exact-version links.

Readers can choose the intended release directly and see exactly which desktop artifact each action downloads.