### PR TITLE
fix(docs): tighten responsive navigation

### DIFF
--- a/app/docs/DocsLayout.test.tsx
+++ b/app/docs/DocsLayout.test.tsx
@@ -12,16 +12,19 @@ describe('DocsLayout', () => {
   it('renders the mobile sheet inside the docs container', async () => {
     const user = userEvent.setup()
     const { container } = render(
-      <DocsLayout sidebar={<div>Sidebar content</div>}>
+      <DocsLayout
+        sidebar={<div>Sidebar content</div>}
+        mobileTitle="Create Your First Space"
+      >
         <div>Page content</div>
       </DocsLayout>,
     )
 
-    expect(
-      screen.getByRole('button', {
-        name: 'Open documentation navigation',
-      }),
-    ).not.toBeNull()
+    const trigger = screen.getByRole('button', {
+      name: 'Open documentation navigation',
+    })
+    expect(trigger).not.toBeNull()
+    expect(screen.getByText('Create Your First Space')).not.toBeNull()
 
     await user.click(
       screen.getByRole('button', {
@@ -43,5 +46,13 @@ describe('DocsLayout', () => {
         name: 'Close documentation navigation',
       }),
     ).not.toBeNull()
+
+    await user.keyboard('{Escape}')
+    expect(
+      screen.queryByRole('button', {
+        name: 'Close documentation navigation',
+      }),
+    ).toBeNull()
+    expect(document.activeElement).toBe(trigger)
   })
 })

--- a/app/docs/DocsLayout.tsx
+++ b/app/docs/DocsLayout.tsx
@@ -15,6 +15,7 @@ interface DocsLayoutProps {
   sidebar: React.ReactNode
   children: React.ReactNode
   currentSlug?: string
+  mobileTitle?: string
   // contentWidth selects the content column measure. 'reading' is the prose
   // measure for article pages; 'wide' is the card-grid measure so hub and
   // section index pages fill a desktop viewport instead of stranding a gutter.
@@ -24,34 +25,41 @@ interface DocsLayoutProps {
 interface DocsMobileNavProps {
   portalContainer: HTMLDivElement | null
   sidebar: React.ReactNode
+  title: string
 }
 
 // DocsMobileNav renders the full-width top bar with the hamburger trigger and
 // the slide-in navigation drawer. It occupies its own row above the content so
 // the trigger spans the viewport rather than sitting beside the content column.
-function DocsMobileNav({ portalContainer, sidebar }: DocsMobileNavProps) {
+function DocsMobileNav({
+  portalContainer,
+  sidebar,
+  title,
+}: DocsMobileNavProps) {
   const [mobileOpen, setMobileOpen] = useState(false)
 
   return (
     <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
-      <div className="border-b border-white/10 px-4 py-2.5 @2xl:hidden">
+      <div className="bg-topbar-back flex h-12 min-w-0 items-center gap-1 border-b border-white/10 px-2 @2xl:hidden">
         <SheetTrigger asChild>
           <button
             type="button"
             aria-label="Open documentation navigation"
-            className="text-foreground-alt hover:text-foreground hover:border-foreground/20 inline-flex items-center gap-2 rounded-md border border-white/10 px-3 py-2 text-sm font-medium transition-colors"
+            className="text-foreground-alt hover:bg-foreground/5 hover:text-foreground focus-visible:ring-brand/30 inline-flex size-11 shrink-0 items-center justify-center rounded-md transition-colors focus-visible:ring-1 focus-visible:outline-none"
           >
             <LuMenu className="size-4" />
-            <span>Navigation</span>
           </button>
         </SheetTrigger>
+        <span className="text-foreground min-w-0 truncate text-sm font-semibold">
+          {title}
+        </span>
       </div>
       <SheetContent
         side="left"
         position="absolute"
         portalContainer={portalContainer}
         showCloseButton={false}
-        className="w-[264px] max-w-[85%] gap-0 p-0"
+        className="w-[280px] max-w-[calc(100%_-_32px)] gap-0 p-0"
       >
         <div className="flex min-h-0 flex-1 flex-col">
           <div className="flex items-center justify-between border-b border-white/10 px-4 py-3">
@@ -62,7 +70,7 @@ function DocsMobileNav({ portalContainer, sidebar }: DocsMobileNavProps) {
               <button
                 type="button"
                 aria-label="Close documentation navigation"
-                className="text-foreground-alt hover:text-foreground rounded-md p-2 transition-colors"
+                className="text-foreground-alt hover:bg-foreground/5 hover:text-foreground focus-visible:ring-brand/30 inline-flex size-11 items-center justify-center rounded-md transition-colors focus-visible:ring-1 focus-visible:outline-none"
               >
                 <LuX className="size-4" />
               </button>
@@ -83,6 +91,7 @@ export function DocsLayout({
   sidebar,
   children,
   currentSlug,
+  mobileTitle = 'Documentation',
   contentWidth = 'reading',
 }: DocsLayoutProps) {
   const [portalContainer, setPortalContainer] = useState<HTMLDivElement | null>(
@@ -100,11 +109,12 @@ export function DocsLayout({
         key={currentSlug ?? 'docs-root'}
         portalContainer={portalContainer}
         sidebar={sidebar}
+        title={mobileTitle}
       />
 
       <div className="flex min-h-0 flex-1 overflow-hidden">
         {/* Sidebar - wide widths only */}
-        <aside className="hidden w-[216px] shrink-0 overflow-y-auto border-r border-white/10 @2xl:block">
+        <aside className="hidden w-[232px] shrink-0 overflow-y-auto border-r border-white/10 @2xl:block">
           {sidebar}
         </aside>
 

--- a/app/docs/DocsPage.tsx
+++ b/app/docs/DocsPage.tsx
@@ -100,7 +100,9 @@ export function DocsPage({ doc, prevDoc, nextDoc }: DocsPageProps) {
             {getSectionLabel(doc.site, doc.section)}
           </span>
           <span className="text-foreground-alt/30 hidden @2xl:inline">/</span>
-          <span className="text-foreground-alt truncate">{doc.title}</span>
+          <span className="text-foreground-alt hidden truncate @2xl:inline">
+            {doc.title}
+          </span>
         </div>
 
         <div className="flex shrink-0 items-center gap-1">

--- a/app/docs/DocsPageRoute.tsx
+++ b/app/docs/DocsPageRoute.tsx
@@ -60,7 +60,7 @@ export function DocsPageRoute() {
   )
 
   return (
-    <DocsLayout sidebar={sidebar} currentSlug={slug}>
+    <DocsLayout sidebar={sidebar} currentSlug={slug} mobileTitle={doc.title}>
       <DocsPage doc={doc} prevDoc={prevDoc} nextDoc={nextDoc} />
     </DocsLayout>
   )

--- a/app/docs/DocsSidebar.test.tsx
+++ b/app/docs/DocsSidebar.test.tsx
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const navigate = vi.fn()
+
+vi.mock('@s4wave/web/router/router.js', () => ({
+  useNavigate: () => navigate,
+}))
+
+import { DocsSidebar } from './DocsSidebar.js'
+import type { DocPage, DocSection } from './types.js'
+
+const currentDoc: DocPage = {
+  slug: 'create-your-first-space',
+  url: '/docs/users/start/create-your-first-space',
+  title: 'Create Your First Space',
+  site: 'users',
+  section: 'start',
+  order: 1,
+  summary: 'Create a Space.',
+  body: 'Body',
+  filename: '01-create-your-first-space.md',
+}
+
+const nextDoc: DocPage = {
+  ...currentDoc,
+  slug: 'invite-collaborators',
+  url: '/docs/users/start/invite-collaborators',
+  title: 'Invite Collaborators',
+  order: 2,
+  filename: '02-invite-collaborators.md',
+}
+
+const sections: DocSection[] = [
+  {
+    id: 'start',
+    label: 'Start',
+    site: 'users',
+    order: 1,
+    pages: [currentDoc, nextDoc],
+  },
+]
+
+describe('DocsSidebar', () => {
+  afterEach(cleanup)
+
+  it('marks the current page and navigates from its button', async () => {
+    const user = userEvent.setup()
+    navigate.mockReset()
+    render(<DocsSidebar sections={sections} currentDoc={currentDoc} />)
+
+    expect(
+      screen
+        .getByRole('button', { name: currentDoc.title })
+        .getAttribute('aria-current'),
+    ).toBe('page')
+    expect(
+      screen
+        .getByRole('button', { name: nextDoc.title })
+        .getAttribute('aria-current'),
+    ).toBeNull()
+
+    await user.click(screen.getByRole('button', { name: nextDoc.title }))
+    expect(navigate).toHaveBeenCalledWith({ path: nextDoc.url })
+  })
+})

--- a/app/docs/DocsSidebar.tsx
+++ b/app/docs/DocsSidebar.tsx
@@ -57,12 +57,13 @@ export function DocsSidebar({ sections, currentDoc }: DocsSidebarProps) {
 
   return (
     <nav aria-label="Documentation navigation" className="flex flex-1 flex-col">
-      <div className="flex flex-col gap-1 p-4">
+      <div className="flex flex-col px-3 py-4">
         <button
           type="button"
           onClick={goToIndex}
+          aria-current={!currentDoc ? 'page' : undefined}
           className={cn(
-            'mb-4 cursor-pointer text-left text-sm font-semibold transition-colors',
+            'mb-4 min-h-11 cursor-pointer @2xl:min-h-9 rounded-md px-2 text-left text-xs font-semibold transition-colors focus-visible:ring-1 focus-visible:ring-brand/30 focus-visible:outline-none',
             !currentDoc
               ? 'text-brand'
               : 'text-foreground hover:text-foreground-alt',
@@ -72,13 +73,13 @@ export function DocsSidebar({ sections, currentDoc }: DocsSidebarProps) {
         </button>
 
         {categories.map((cat) => (
-          <div key={cat.name} className="mb-5">
-            <h2 className="text-foreground-alt/40 mb-2 text-xs font-semibold tracking-widest uppercase">
+          <div key={cat.name} className="mb-4">
+            <h2 className="text-foreground-alt/50 mb-1.5 px-2 text-xs font-semibold tracking-[0.08em] uppercase">
               {cat.name}
             </h2>
             {cat.sections.map((section) => (
-              <div key={`${section.site}/${section.id}`} className="mb-3">
-                <h3 className="text-foreground-alt/50 mb-1.5 text-xs font-semibold tracking-wider uppercase">
+              <div key={`${section.site}/${section.id}`} className="mb-2.5">
+                <h3 className="text-foreground-alt/60 mb-1 px-2 text-xs font-medium tracking-[0.08em] uppercase">
                   {section.label}
                 </h3>
                 <ul className="flex flex-col">
@@ -87,11 +88,14 @@ export function DocsSidebar({ sections, currentDoc }: DocsSidebarProps) {
                       <button
                         type="button"
                         onClick={() => goToPage(page.url)}
+                        aria-current={
+                          currentDoc?.url === page.url ? 'page' : undefined
+                        }
                         className={cn(
-                          'w-full cursor-pointer border-l-2 py-2 pl-3 text-left text-sm transition-colors',
+                          'min-h-11 w-full cursor-pointer @2xl:min-h-9 rounded-r-md border-l-2 px-2 py-1.5 text-left text-xs leading-4 transition-colors focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-brand/30 focus-visible:outline-none',
                           currentDoc?.url === page.url
-                            ? 'border-brand text-brand'
-                            : 'text-foreground-alt/70 hover:text-foreground hover:border-foreground-alt/20 border-transparent',
+                            ? 'border-brand bg-brand/8 text-brand'
+                            : 'text-foreground-alt/70 hover:bg-foreground/5 hover:text-foreground hover:border-foreground-alt/20 border-transparent',
                         )}
                       >
                         {page.title}
@@ -108,14 +112,14 @@ export function DocsSidebar({ sections, currentDoc }: DocsSidebarProps) {
       <div className="mt-auto flex flex-col gap-1.5 border-t border-white/10 p-4">
         <ExternalLink
           href={githubUrl}
-          className="text-foreground-alt/50 hover:text-foreground-alt flex items-center gap-1.5 text-xs transition-colors"
+          className="text-foreground-alt/50 hover:bg-foreground/5 hover:text-foreground-alt focus-visible:ring-brand/30 flex min-h-11 items-center gap-1.5 rounded-md px-2 text-xs transition-colors focus-visible:ring-1 focus-visible:outline-none @2xl:min-h-9"
         >
           <LuExternalLink className="size-3" />
           View on GitHub
         </ExternalLink>
         <button
           onClick={currentDoc ? goToIndex : goHome}
-          className="text-foreground-alt/50 hover:text-foreground-alt flex cursor-pointer items-center gap-1.5 text-left text-xs transition-colors"
+          className="text-foreground-alt/50 hover:bg-foreground/5 hover:text-foreground-alt focus-visible:ring-brand/30 flex min-h-11 cursor-pointer items-center gap-1.5 rounded-md px-2 text-left text-xs transition-colors focus-visible:ring-1 focus-visible:outline-none @2xl:min-h-9"
         >
           <LuArrowLeft className="size-3" />
           {currentDoc ? 'Back to Documentation' : 'Back to Home'}


### PR DESCRIPTION
The documentation drawer used oversized navigation text and a generic mobile title, then repeated the active article title in a separate content toolbar. This weakened hierarchy and consumed scarce space on narrow screens.

The active article title now appears in the mobile top bar while the document heading remains in content. The shared sidebar uses readable compact labels, bounded widths, explicit active states, and consistent focus and touch targets. Radix continues to manage drawer focus, Escape, and trigger restoration.

Documentation navigation keeps the current page visible without duplicate chrome and presents a denser, accessible route hierarchy on desktop and mobile.