### PR TITLE
fix(forge): make cluster workflows usable

### DIFF
--- a/app/configeditors/ForgeJobConfigEditor.test.tsx
+++ b/app/configeditors/ForgeJobConfigEditor.test.tsx
@@ -1,0 +1,197 @@
+import React from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const clusterResource: {
+  value: Array<{ key: string; name: string }>
+  loading: boolean
+  error: Error | null
+  retry: ReturnType<typeof vi.fn>
+} = {
+  value: [{ key: 'cluster-1', name: 'Primary build cluster' }],
+  loading: false,
+  error: null,
+  retry: vi.fn(),
+}
+
+vi.mock('@aptre/bldr-sdk/hooks/useResource.js', () => ({
+  useResource: () => clusterResource,
+}))
+
+vi.mock('@s4wave/web/contexts/SpaceContainerContext.js', () => ({
+  SpaceContainerContext: {
+    useContext: () => ({ spaceWorldResource: {} }),
+  },
+}))
+
+import { ForgeJobCreateOp } from '@s4wave/core/forge/job/job.pb.js'
+import { Cluster } from '@go/github.com/s4wave/spacewave/forge/cluster/cluster.pb.js'
+import type { IWorldState } from '@s4wave/sdk/world/world-state.js'
+import {
+  ForgeJobConfigEditor,
+  loadForgeClusterOptions,
+} from './ForgeJobConfigEditor.js'
+
+describe('loadForgeClusterOptions', () => {
+  it('settles a one-cluster read with its display name and stable key', async () => {
+    const release = vi.fn()
+    const close = vi.fn()
+    const world = {
+      listObjectsWithType: vi.fn().mockResolvedValue(['cluster-1']),
+      getObject: vi.fn().mockResolvedValue({
+        accessWorldState: vi.fn().mockResolvedValue({
+          unmarshal: vi.fn().mockResolvedValue({
+            found: true,
+            data: Cluster.toBinary({ name: 'Primary build cluster' }),
+          }),
+          [Symbol.dispose]: close,
+        }),
+        release,
+      }),
+    } as unknown as IWorldState
+
+    await expect(
+      loadForgeClusterOptions(world, new AbortController().signal),
+    ).resolves.toEqual([{ key: 'cluster-1', name: 'Primary build cluster' }])
+    expect(close).toHaveBeenCalledOnce()
+    expect(release).toHaveBeenCalledOnce()
+  })
+})
+
+describe('ForgeJobConfigEditor', () => {
+  afterEach(() => {
+    cleanup()
+    clusterResource.value = [
+      {
+        key: 'cluster-1',
+        name: 'Primary build cluster',
+      },
+    ]
+    clusterResource.loading = false
+    clusterResource.error = null
+    clusterResource.retry.mockClear()
+  })
+  it('shows a loaded Cluster context and accepts a named initial task', async () => {
+    const user = userEvent.setup()
+    const onValueChange = vi.fn()
+    function Harness() {
+      const [value, setValue] = React.useState<ForgeJobCreateOp>({
+        clusterKey: '',
+        taskDefs: [],
+      })
+      return React.createElement(ForgeJobConfigEditor, {
+        value,
+        onValueChange: (next) => {
+          onValueChange(next)
+          setValue(next)
+        },
+      })
+    }
+    render(React.createElement(Harness))
+
+    expect(screen.queryByText('Loading clusters…')).toBeNull()
+    expect(screen.getByText('Primary build cluster')).toBeTruthy()
+    expect(screen.getByText('cluster-1')).toBeTruthy()
+
+    await user.click(
+      screen.getByRole('button', { name: /primary build cluster/i }),
+    )
+    expect(onValueChange).toHaveBeenCalledWith({
+      clusterKey: 'cluster-1',
+      taskDefs: [],
+    })
+
+    await user.type(screen.getByLabelText('Task 1 name'), 'compile')
+    expect(onValueChange).toHaveBeenLastCalledWith({
+      clusterKey: 'cluster-1',
+      taskDefs: [{ name: 'compile' }],
+    })
+  })
+
+  it('distinguishes cluster loading and failure and retries the failure', async () => {
+    const user = userEvent.setup()
+    clusterResource.value = []
+    clusterResource.loading = true
+    const { rerender } = render(
+      <ForgeJobConfigEditor
+        value={{ clusterKey: '', taskDefs: [] }}
+        onValueChange={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('Loading clusters…')).toBeTruthy()
+
+    clusterResource.loading = false
+    clusterResource.error = new Error('cluster graph unavailable')
+    rerender(
+      <ForgeJobConfigEditor
+        value={{ clusterKey: '', taskDefs: [] }}
+        onValueChange={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('Clusters unavailable')).toBeTruthy()
+    expect(screen.queryByText(/No Clusters are available/)).toBeNull()
+
+    await user.click(screen.getByRole('button', { name: /retry/i }))
+    expect(clusterResource.retry).toHaveBeenCalledOnce()
+  })
+
+  it('preserves task row identity through proto round trips and first, middle, and last edits', async () => {
+    const user = userEvent.setup()
+    function ProtoHarness() {
+      const [value, setValue] = React.useState<ForgeJobCreateOp>({
+        clusterKey: 'cluster-1',
+        taskDefs: [{ name: 'one' }, { name: 'two' }, { name: 'three' }],
+      })
+      return (
+        <ForgeJobConfigEditor
+          value={value}
+          onValueChange={(next) => {
+            const decoded = ForgeJobCreateOp.fromBinary(
+              ForgeJobCreateOp.toBinary(next),
+            )
+            setValue(decoded)
+          }}
+        />
+      )
+    }
+    render(<ProtoHarness />)
+
+    const two = screen.getByLabelText('Task 2 name')
+    const three = screen.getByLabelText('Task 3 name')
+    three.focus()
+    fireEvent.click(screen.getByRole('button', { name: 'Remove task 1' }))
+    await waitFor(() => expect(screen.getByLabelText('Task 1 name')).toBe(two))
+    expect(screen.getByLabelText('Task 2 name')).toBe(three)
+    expect(document.activeElement).toBe(three)
+
+    await user.click(screen.getByRole('button', { name: 'Add Task' }))
+    await waitFor(() => expect(screen.getByLabelText('Task 1 name')).toBe(two))
+    expect(screen.getByLabelText('Task 2 name')).toBe(three)
+    const added = screen.getByLabelText('Task 3 name')
+
+    two.focus()
+    fireEvent.click(screen.getByRole('button', { name: 'Remove task 2' }))
+    await waitFor(() => expect(screen.getByLabelText('Task 1 name')).toBe(two))
+    expect(screen.getByLabelText('Task 2 name')).toBe(added)
+    expect(document.activeElement).toBe(two)
+
+    await user.click(screen.getByRole('button', { name: 'Add Task' }))
+    const last = screen.getByLabelText('Task 3 name')
+    two.focus()
+    fireEvent.click(screen.getByRole('button', { name: 'Remove task 3' }))
+    await waitFor(() =>
+      expect(screen.queryByLabelText('Task 3 name')).toBeNull(),
+    )
+    expect(screen.getByLabelText('Task 1 name')).toBe(two)
+    expect(document.activeElement).toBe(two)
+    expect(last.isConnected).toBe(false)
+  })
+})

--- a/app/configeditors/ForgeJobConfigEditor.tsx
+++ b/app/configeditors/ForgeJobConfigEditor.tsx
@@ -1,6 +1,5 @@
-/* eslint-disable react-doctor/async-await-in-loop */
 import { useCallback, useMemo, useRef } from 'react'
-import { LuPlus, LuServer, LuTrash } from 'react-icons/lu'
+import { LuCheck, LuPlus, LuServer, LuTrash } from 'react-icons/lu'
 
 import type { ConfigEditorProps } from '@s4wave/web/configtype/configtype.js'
 import { SpaceContainerContext } from '@s4wave/web/contexts/SpaceContainerContext.js'
@@ -8,14 +7,39 @@ import { useResource } from '@aptre/bldr-sdk/hooks/useResource.js'
 import { cn } from '@s4wave/web/style/utils.js'
 import { Button } from '@s4wave/web/ui/button.js'
 import { Input } from '@s4wave/web/ui/input.js'
+import { LoadingCard } from '@s4wave/web/ui/loading/LoadingCard.js'
 import type { ForgeJobCreateOp } from '@s4wave/core/forge/job/job.pb.js'
 import { Cluster } from '@go/github.com/s4wave/spacewave/forge/cluster/cluster.pb.js'
 import { listObjectsWithType } from '@s4wave/sdk/world/types/types.js'
 import type { IWorldState } from '@s4wave/sdk/world/world-state.js'
 
-interface ClusterInfo {
+export interface ForgeClusterOption {
   key: string
   name: string
+}
+
+export async function loadForgeClusterOptions(
+  world: IWorldState,
+  signal: AbortSignal,
+): Promise<ForgeClusterOption[]> {
+  const keys = await listObjectsWithType(world, 'forge/cluster', signal)
+  return Promise.all(
+    keys.map(async (key) => {
+      const obj = await world.getObject(key, signal)
+      if (!obj) return { key, name: key }
+      try {
+        using cursor = await obj.accessWorldState(undefined, signal)
+        const resp = await cursor.unmarshal(
+          { blockType: 'forge/cluster' },
+          signal,
+        )
+        if (!resp.found || !resp.data?.length) return { key, name: key }
+        return { key, name: Cluster.fromBinary(resp.data).name || key }
+      } finally {
+        obj.release()
+      }
+    }),
+  )
 }
 
 const inputClassName =
@@ -31,33 +55,8 @@ export function ForgeJobConfigEditor({
 
   const clustersResource = useResource(
     spaceWorldResource,
-    async (world: IWorldState, signal: AbortSignal) => {
-      const keys = await listObjectsWithType(world, 'forge/cluster', signal)
-      const results: ClusterInfo[] = []
-      for (const key of keys) {
-        const obj = await world.getObject(key, signal)
-        if (!obj) {
-          results.push({ key, name: key })
-          continue
-        }
-        try {
-          using cursor = await obj.accessWorldState(undefined, signal)
-          const resp = await cursor.unmarshal(
-            { blockType: 'forge/cluster' },
-            signal,
-          )
-          if (resp.found && resp.data?.length) {
-            const cluster = Cluster.fromBinary(resp.data)
-            results.push({ key, name: cluster.name || key })
-          } else {
-            results.push({ key, name: key })
-          }
-        } finally {
-          obj.release()
-        }
-      }
-      return results
-    },
+    (world: IWorldState, signal: AbortSignal) =>
+      loadForgeClusterOptions(world, signal),
     [],
   )
   const clusters = useMemo(
@@ -66,9 +65,16 @@ export function ForgeJobConfigEditor({
   )
 
   const taskDefs = useMemo(() => value.taskDefs ?? [], [value.taskDefs])
-  const taskKeyMapRef = useRef(new WeakMap<object, string>())
-  const taskKeyCounterRef = useRef(0)
-
+  const displayedTaskDefs = useMemo(
+    () => (taskDefs.length > 0 ? taskDefs : [{ name: '' }]),
+    [taskDefs],
+  )
+  const nextTaskKeyRef = useRef(1)
+  const taskKeysRef = useRef<string[]>([])
+  while (taskKeysRef.current.length < displayedTaskDefs.length) {
+    taskKeysRef.current.push(`task-${nextTaskKeyRef.current++}`)
+  }
+  taskKeysRef.current.length = displayedTaskDefs.length
   const handleSelectCluster = useCallback(
     (clusterKey: string) => {
       onValueChange({ ...value, clusterKey })
@@ -86,12 +92,14 @@ export function ForgeJobConfigEditor({
   )
 
   const handleAddTask = useCallback(() => {
+    taskKeysRef.current.push(`task-${nextTaskKeyRef.current++}`)
     onValueChange({ ...value, taskDefs: [...taskDefs, { name: '' }] })
   }, [taskDefs, value, onValueChange])
 
   const handleRemoveTask = useCallback(
     (index: number) => {
       if (taskDefs.length <= 1) return
+      taskKeysRef.current.splice(index, 1)
       onValueChange({
         ...value,
         taskDefs: taskDefs.filter((_, i) => i !== index),
@@ -99,14 +107,6 @@ export function ForgeJobConfigEditor({
     },
     [taskDefs, value, onValueChange],
   )
-
-  const getTaskKey = useCallback((task: object) => {
-    const existing = taskKeyMapRef.current.get(task)
-    if (existing) return existing
-    const next = `task-${taskKeyCounterRef.current++}`
-    taskKeyMapRef.current.set(task, next)
-    return next
-  }, [])
 
   return (
     <div className="space-y-3">
@@ -117,13 +117,33 @@ export function ForgeJobConfigEditor({
             Target Cluster
           </h3>
         </div>
-        {clusters.length === 0 && (
-          <div className="border-foreground/6 bg-background-card/30 text-foreground-alt/40 flex items-center gap-2 rounded-lg border px-3.5 py-3 text-xs">
-            <LuServer className="size-3.5 shrink-0" />
-            {clustersResource.loading
-              ? 'Loading clusters…'
-              : 'No clusters found. Create a cluster first.'}
+        {clustersResource.error ? (
+          <LoadingCard
+            view={{
+              state: 'error',
+              title: 'Clusters unavailable',
+              detail: 'Forge could not load the available clusters.',
+              error: 'Try again to choose where this Job will run.',
+              onRetry: clustersResource.retry,
+            }}
+          />
+        ) : clustersResource.loading && clusters.length === 0 ? (
+          <LoadingCard
+            view={{
+              state: 'loading',
+              title: 'Loading clusters…',
+              detail: 'Reading the available Forge Clusters.',
+              progressIndeterminate: true,
+            }}
+          />
+        ) : clusters.length === 0 ? (
+          <div className="border-foreground/6 bg-background-card/30 text-foreground-alt/60 rounded-lg border px-3.5 py-3 text-xs leading-relaxed">
+            No Clusters are available. Create a Cluster before creating a Job.
           </div>
+        ) : (
+          <p className="text-foreground-alt/60 mb-2 text-xs leading-relaxed">
+            Choose the Cluster that will schedule this Job.
+          </p>
         )}
         <div className="space-y-2">
           {clusters.map((cluster) => (
@@ -136,13 +156,25 @@ export function ForgeJobConfigEditor({
                   'border-brand/30 bg-brand/5',
               )}
               onClick={() => handleSelectCluster(cluster.key)}
+              aria-pressed={value.clusterKey === cluster.key}
             >
               <span className="bg-foreground/5 flex size-7 shrink-0 items-center justify-center rounded-md">
                 <LuServer className="text-foreground-alt/50 size-3.5" />
               </span>
-              <span className="text-foreground text-xs font-medium">
-                {cluster.name}
+              <span className="min-w-0 flex-1">
+                <span className="text-foreground block truncate text-xs font-medium">
+                  {cluster.name}
+                </span>
+                <span className="text-foreground-alt/50 block truncate text-xs">
+                  {cluster.key}
+                </span>
               </span>
+              {value.clusterKey === cluster.key && (
+                <LuCheck
+                  className="text-brand size-4 shrink-0"
+                  aria-label="Selected"
+                />
+              )}
             </button>
           ))}
         </div>
@@ -164,16 +196,23 @@ export function ForgeJobConfigEditor({
             Add Task
           </Button>
         </div>
+        <p className="text-foreground-alt/60 mb-2 text-xs leading-relaxed">
+          Add at least one named task. Tasks run in the order shown.
+        </p>
         <div className="border-foreground/6 bg-background-card/30 space-y-2 rounded-lg border p-3.5">
-          {taskDefs.map((task, i) => (
-            <div key={getTaskKey(task)} className="flex items-center gap-2">
+          {displayedTaskDefs.map((task, i) => (
+            <div
+              key={taskKeysRef.current[i]}
+              className="flex items-center gap-2"
+            >
               <Input
                 value={task.name ?? ''}
                 onChange={(e) => handleUpdateTaskDef(i, e.target.value)}
                 placeholder={`Task ${i + 1} name...`}
+                aria-label={`Task ${i + 1} name`}
                 className={inputClassName}
               />
-              {taskDefs.length > 1 && (
+              {displayedTaskDefs.length > 1 && (
                 <Button
                   variant="outline"
                   size="sm"

--- a/app/forge/ForgeClusterViewer.test.tsx
+++ b/app/forge/ForgeClusterViewer.test.tsx
@@ -15,14 +15,27 @@ vi.mock('@s4wave/web/forge/ForgeViewerShell.js', () => ({
   ForgeViewerShell: ({
     tabs,
   }: {
-    tabs?: Array<{ id: string; content: React.ReactNode }>
-  }) => (
-    <div data-testid="forge-viewer-shell">
-      {tabs?.map((tab) => (
-        <div key={tab.id}>{tab.content}</div>
-      ))}
-    </div>
-  ),
+    tabs?: Array<{ id: string; label: string; content: React.ReactNode }>
+  }) => {
+    const [activeTab, setActiveTab] = React.useState(tabs?.[0]?.id)
+    return (
+      <div data-testid="forge-viewer-shell">
+        <div role="tablist">
+          {tabs?.map((tab) => (
+            <button
+              key={tab.id}
+              role="tab"
+              aria-selected={activeTab === tab.id}
+              onClick={() => setActiveTab(tab.id)}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+        {tabs?.find((tab) => tab.id === activeTab)?.content}
+      </div>
+    )
+  },
 }))
 
 vi.mock('@s4wave/web/forge/useForgeBlockData.js', () => ({
@@ -36,6 +49,24 @@ vi.mock('@s4wave/web/forge/useForgeLinkedEntities.js', () => ({
   useForgeLinkedEntities: () => ({
     entities: [],
     loading: false,
+  }),
+}))
+
+const mockRetrySnapshot = vi.fn()
+let mockSnapshotError: Error | null = null
+
+vi.mock('./useForgeClusterSnapshot.js', () => ({
+  useForgeClusterSnapshot: () => ({
+    snapshot: {
+      jobs: [],
+      tasks: [],
+      passes: [],
+      executions: [],
+      workers: [],
+    },
+    loading: false,
+    error: mockSnapshotError,
+    retry: mockRetrySnapshot,
   }),
 }))
 
@@ -90,6 +121,7 @@ describe('ForgeClusterViewer', () => {
 
   afterEach(() => {
     cleanup()
+    mockSnapshotError = null
     mockVisibleWizardTypeSet.clear()
     mockVisibleWizardTypeSet.add('forge/job')
     vi.clearAllMocks()
@@ -99,6 +131,7 @@ describe('ForgeClusterViewer', () => {
     const user = userEvent.setup()
     renderViewer()
 
+    await user.click(screen.getByRole('tab', { name: 'Jobs' }))
     await user.click(screen.getByRole('button', { name: /create job/i }))
 
     expect(mockSpaceWorld.applyWorldOp).toHaveBeenCalledTimes(1)
@@ -119,10 +152,52 @@ describe('ForgeClusterViewer', () => {
     expect(mockNavigateToObjects).toHaveBeenCalledWith([decoded.objectKey])
   })
 
-  it('hides the create-job affordance when forge jobs are experimental', () => {
+  it('settles a new empty cluster across each interactive tab', async () => {
+    const user = userEvent.setup()
+    renderViewer()
+
+    expect(screen.queryByText(/Loading task breakdown/i)).toBeNull()
+    expect(screen.getByText('No tasks assigned yet')).toBeTruthy()
+
+    await user.click(screen.getByRole('tab', { name: 'Workers' }))
+    expect(screen.queryByText(/Loading workers/i)).toBeNull()
+    expect(screen.getByText('No workers assigned')).toBeTruthy()
+
+    await user.click(screen.getByRole('tab', { name: 'Jobs' }))
+    expect(screen.queryByText(/Loading jobs/i)).toBeNull()
+    expect(screen.getByText('No jobs in cluster')).toBeTruthy()
+
+    await user.click(screen.getByRole('tab', { name: 'Settings' }))
+    expect(screen.getByText('Cluster identity')).toBeTruthy()
+    expect(screen.getByText('Object Key')).toBeTruthy()
+    expect(screen.getByText('forge/cluster/main')).toBeTruthy()
+  })
+
+  it('shows snapshot failures before empty states and retries from each data tab', async () => {
+    const user = userEvent.setup()
+    mockSnapshotError = new Error('graph unavailable')
+    renderViewer()
+
+    expect(screen.getByText('Task states unavailable')).toBeTruthy()
+    await user.click(screen.getByRole('button', { name: /retry/i }))
+
+    await user.click(screen.getByRole('tab', { name: 'Workers' }))
+    expect(screen.getByText('Workers unavailable')).toBeTruthy()
+    await user.click(screen.getByRole('button', { name: /retry/i }))
+
+    await user.click(screen.getByRole('tab', { name: 'Jobs' }))
+    expect(screen.getByText('Jobs unavailable')).toBeTruthy()
+    await user.click(screen.getByRole('button', { name: /retry/i }))
+
+    expect(mockRetrySnapshot).toHaveBeenCalledTimes(3)
+  })
+
+  it('hides the create-job affordance when forge jobs are experimental', async () => {
     mockVisibleWizardTypeSet.clear()
 
+    const user = userEvent.setup()
     renderViewer()
+    await user.click(screen.getByRole('tab', { name: 'Jobs' }))
 
     expect(screen.queryByRole('button', { name: /create job/i })).toBeNull()
   })

--- a/app/forge/ForgeClusterViewer.tsx
+++ b/app/forge/ForgeClusterViewer.tsx
@@ -34,6 +34,7 @@ import { StateBadge } from '@s4wave/web/forge/StateBadge.js'
 import { InfoCard } from '@s4wave/web/ui/InfoCard.js'
 import { StatCard } from '@s4wave/web/ui/StatCard.js'
 import { CopyableField } from '@s4wave/web/ui/CopyableField.js'
+import { LoadingCard } from '@s4wave/web/ui/loading/LoadingCard.js'
 import { DashboardButton } from '@s4wave/web/ui/DashboardButton.js'
 import { SpaceContainerContext } from '@s4wave/web/contexts/SpaceContainerContext.js'
 import { toast } from '@s4wave/web/ui/toaster.js'
@@ -86,10 +87,12 @@ export function ForgeClusterViewer({
     objectKey,
     PRED_CLUSTER_TO_JOB,
   )
-  const { snapshot, loading: snapshotLoading } = useForgeClusterSnapshot(
-    worldState,
-    [objectKey],
-  )
+  const {
+    snapshot,
+    loading: snapshotLoading,
+    error: snapshotError,
+    retry: retrySnapshot,
+  } = useForgeClusterSnapshot(worldState, [objectKey])
   const taskStateCounts = useMemo(() => {
     const counts: Record<number, number> = {}
     for (const task of snapshot.tasks) {
@@ -178,16 +181,18 @@ export function ForgeClusterViewer({
         label: 'Overview',
         content: (
           <div className="space-y-3">
-            <InfoCard>
-              <div className="space-y-2">
-                {cluster?.name && (
-                  <CopyableField label="Name" value={cluster.name} />
-                )}
-                {cluster?.peerId && (
-                  <CopyableField label="Peer ID" value={cluster.peerId} />
-                )}
-              </div>
-            </InfoCard>
+            {(cluster?.name || cluster?.peerId) && (
+              <InfoCard title="Cluster identity">
+                <div className="space-y-2">
+                  {cluster.name && (
+                    <CopyableField label="Name" value={cluster.name} />
+                  )}
+                  {cluster.peerId && (
+                    <CopyableField label="Peer ID" value={cluster.peerId} />
+                  )}
+                </div>
+              </InfoCard>
+            )}
             <div className="grid grid-cols-2 gap-3">
               <StatCard
                 icon={LuCpu}
@@ -204,17 +209,25 @@ export function ForgeClusterViewer({
               icon={<LuListTodo className="text-foreground-alt/60 size-3.5" />}
               title="Task States"
             >
-              {snapshotLoading && (
+              {snapshotError ? (
+                <LoadingCard
+                  view={{
+                    state: 'error',
+                    title: 'Task states unavailable',
+                    detail: 'Forge could not read this Cluster snapshot.',
+                    error: snapshotError.message,
+                    onRetry: retrySnapshot,
+                  }}
+                />
+              ) : snapshotLoading ? (
                 <div className="text-foreground-alt/50 text-xs">
                   Loading task breakdown…
                 </div>
-              )}
-              {!snapshotLoading && snapshot.tasks.length === 0 && (
+              ) : snapshot.tasks.length === 0 ? (
                 <div className="text-foreground-alt/50 text-xs">
                   No tasks assigned yet
                 </div>
-              )}
-              {!snapshotLoading && snapshot.tasks.length > 0 && (
+              ) : (
                 <div className="grid grid-cols-2 gap-2">
                   {Object.entries(taskStateLabels).map(([state, label]) => (
                     <div
@@ -238,41 +251,50 @@ export function ForgeClusterViewer({
       {
         id: 'workers',
         label: 'Workers',
-        content:
-          snapshot.workers.length === 0 ? (
-            <ForgeEntityList
-              entities={workers}
-              loading={workersLoading || snapshotLoading}
-              icon={<LuCpu className="size-3 shrink-0" />}
-              loadingLabel="Loading workers..."
-              emptyLabel="No workers assigned"
-            />
-          ) : (
-            <div className="space-y-2">
-              {snapshot.workers.map((worker) => (
-                <div
-                  key={worker.objectKey}
-                  className="border-foreground/6 bg-background-card/30 hover:border-foreground/12 hover:bg-background-card/50 space-y-2 rounded-lg border px-3.5 py-2.5 transition duration-150"
-                >
-                  <div className="flex items-center justify-between gap-3">
-                    <ForgeEntityLink
-                      objectKey={worker.objectKey}
-                      className="text-foreground min-w-0 text-sm font-medium"
-                    >
-                      {worker.data.name || worker.objectKey}
-                    </ForgeEntityLink>
-                    <div className="text-foreground-alt/50 text-xs">
-                      {workerExecutionCounts.get(worker.objectKey) ?? 0} active
-                    </div>
-                  </div>
-                  <div className="text-foreground-alt/50 flex flex-wrap gap-3 text-xs">
-                    <span>{worker.peerIds.length} peer IDs</span>
-                    <span>{worker.clusterKeys.length} cluster links</span>
+        content: snapshotError ? (
+          <LoadingCard
+            view={{
+              state: 'error',
+              title: 'Workers unavailable',
+              detail: 'Forge could not read this Cluster snapshot.',
+              error: snapshotError.message,
+              onRetry: retrySnapshot,
+            }}
+          />
+        ) : snapshot.workers.length === 0 ? (
+          <ForgeEntityList
+            entities={workers}
+            loading={workersLoading || snapshotLoading}
+            icon={<LuCpu className="size-3 shrink-0" />}
+            loadingLabel="Loading workers..."
+            emptyLabel="No workers assigned"
+          />
+        ) : (
+          <div className="space-y-2">
+            {snapshot.workers.map((worker) => (
+              <div
+                key={worker.objectKey}
+                className="border-foreground/6 bg-background-card/30 hover:border-foreground/12 hover:bg-background-card/50 space-y-2 rounded-lg border px-3.5 py-2.5 transition duration-150"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <ForgeEntityLink
+                    objectKey={worker.objectKey}
+                    className="text-foreground min-w-0 text-sm font-medium"
+                  >
+                    {worker.data.name || worker.objectKey}
+                  </ForgeEntityLink>
+                  <div className="text-foreground-alt/50 text-xs">
+                    {workerExecutionCounts.get(worker.objectKey) ?? 0} active
                   </div>
                 </div>
-              ))}
-            </div>
-          ),
+                <div className="text-foreground-alt/50 flex flex-wrap gap-3 text-xs">
+                  <span>{worker.peerIds.length} peer IDs</span>
+                  <span>{worker.clusterKeys.length} cluster links</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        ),
       },
       {
         id: 'jobs',
@@ -292,7 +314,17 @@ export function ForgeClusterViewer({
                 </DashboardButton>
               </div>
             )}
-            {snapshot.jobs.length === 0 ? (
+            {snapshotError ? (
+              <LoadingCard
+                view={{
+                  state: 'error',
+                  title: 'Jobs unavailable',
+                  detail: 'Forge could not read this Cluster snapshot.',
+                  error: snapshotError.message,
+                  onRetry: retrySnapshot,
+                }}
+              />
+            ) : snapshot.jobs.length === 0 ? (
               <ForgeEntityList
                 entities={jobs}
                 loading={jobsLoading || snapshotLoading}
@@ -366,11 +398,22 @@ export function ForgeClusterViewer({
         id: 'settings',
         label: 'Settings',
         content: (
-          <InfoCard>
+          <InfoCard title="Cluster identity">
             <div className="space-y-2">
+              <p className="text-foreground-alt/60 text-xs leading-relaxed">
+                The object key identifies this Cluster in the Space graph.
+              </p>
+              {cluster?.name && (
+                <CopyableField label="Name" value={cluster.name} />
+              )}
               <CopyableField label="Object Key" value={objectKey} />
-              {cluster?.peerId && (
+              {cluster?.peerId ? (
                 <CopyableField label="Peer ID" value={cluster.peerId} />
+              ) : (
+                <p className="text-foreground-alt/60 text-xs leading-relaxed">
+                  No peer ID is assigned. Workers can join this Cluster without
+                  a Cluster peer identity.
+                </p>
               )}
             </div>
           </InfoCard>
@@ -386,6 +429,8 @@ export function ForgeClusterViewer({
       jobs,
       jobsLoading,
       objectKey,
+      retrySnapshot,
+      snapshotError,
       snapshot.jobs,
       snapshot.tasks,
       snapshot.workers,

--- a/app/forge/ForgeDashboardViewer.test.tsx
+++ b/app/forge/ForgeDashboardViewer.test.tsx
@@ -218,6 +218,7 @@ describe('ForgeDashboardViewer', () => {
     expect(clusterOp.wizardTypeId).toBe('wizard/forge/cluster')
     expect(clusterOp.targetTypeId).toBe('forge/cluster')
     expect(clusterOp.targetKeyPrefix).toBe('forge/cluster/')
+    expect(clusterOp.name).toBe('cluster')
 
     const [jobOpTypeId, jobOpData] = mockSpaceWorld.applyWorldOp.mock
       .calls[1] as [string, Uint8Array]

--- a/app/forge/ForgeDashboardViewer.tsx
+++ b/app/forge/ForgeDashboardViewer.tsx
@@ -211,7 +211,7 @@ export function ForgeDashboardViewer({
         'wizard/forge/cluster',
         'forge/cluster',
         'forge/cluster/',
-        'Cluster',
+        'cluster',
       )
     } catch {
       const message = 'Cluster creation is unavailable. Try again.'

--- a/app/forge/useForgeClusterSnapshot.test.ts
+++ b/app/forge/useForgeClusterSnapshot.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
 
 import {
   Execution,
@@ -29,7 +30,10 @@ import {
   PRED_PASS_TO_EXECUTION,
   PRED_TASK_TO_PASS,
 } from '@s4wave/web/forge/predicates.js'
-import { buildForgeClusterSnapshot } from './useForgeClusterSnapshot.js'
+import {
+  buildForgeClusterSnapshot,
+  useForgeClusterSnapshot,
+} from './useForgeClusterSnapshot.js'
 
 interface TestEdge {
   predicate: string
@@ -41,6 +45,72 @@ function disposable<T extends object>(value: T): T & Disposable {
     [Symbol.dispose]() {},
   })
 }
+
+describe('useForgeClusterSnapshot', () => {
+  it('settles an empty snapshot when callers recreate an equivalent key list', async () => {
+    const world = {
+      listGraphEdgeBuckets: vi.fn((originObjectKeys: string[]) =>
+        Promise.resolve({
+          buckets: originObjectKeys.map((originObjectKey) => ({
+            originObjectKey,
+            outgoing: [],
+          })),
+        }),
+      ),
+    } as unknown as IWorldState
+    const worldState = {
+      value: world,
+      loading: false,
+      error: null,
+      retry: vi.fn(),
+    }
+
+    const { result, rerender } = renderHook(() =>
+      useForgeClusterSnapshot(worldState, ['forge/cluster/empty']),
+    )
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.snapshot).toEqual({
+      jobs: [],
+      tasks: [],
+      passes: [],
+      executions: [],
+      workers: [],
+    })
+    expect(world.listGraphEdgeBuckets).toHaveBeenCalledTimes(1)
+
+    rerender()
+    expect(result.current.loading).toBe(false)
+    expect(world.listGraphEdgeBuckets).toHaveBeenCalledTimes(1)
+  })
+
+  it('exposes a rejected graph read and retries it', async () => {
+    const graphError = new Error('graph unavailable')
+    const listGraphEdgeBuckets = vi
+      .fn()
+      .mockRejectedValueOnce(graphError)
+      .mockResolvedValueOnce({
+        buckets: [{ originObjectKey: 'forge/cluster/error', outgoing: [] }],
+      })
+    const worldState = {
+      value: { listGraphEdgeBuckets } as unknown as IWorldState,
+      loading: false,
+      error: null,
+      retry: vi.fn(),
+    }
+
+    const { result } = renderHook(() =>
+      useForgeClusterSnapshot(worldState, ['forge/cluster/error']),
+    )
+
+    await waitFor(() => expect(result.current.error).toBe(graphError))
+    expect(result.current.loading).toBe(false)
+    result.current.retry()
+    await waitFor(() => expect(result.current.error).toBeNull())
+    expect(result.current.snapshot.jobs).toEqual([])
+    expect(listGraphEdgeBuckets).toHaveBeenCalledTimes(2)
+  })
+})
 
 describe('buildForgeClusterSnapshot', () => {
   it('uses grouped edge buckets for the first cluster snapshot', async () => {

--- a/app/forge/useForgeClusterSnapshot.ts
+++ b/app/forge/useForgeClusterSnapshot.ts
@@ -347,24 +347,35 @@ export async function buildForgeClusterSnapshot(
 export function useForgeClusterSnapshot(
   worldState: Resource<IWorldState>,
   clusterKeys: string[],
-): { snapshot: ForgeClusterSnapshot; loading: boolean } {
+): {
+  snapshot: ForgeClusterSnapshot
+  loading: boolean
+  error: Error | null
+  retry: () => void
+} {
+  const clusterKeySignature = JSON.stringify([
+    ...new Set(clusterKeys.filter(Boolean)),
+  ])
   const resource = useResource(
     worldState,
     async (world, signal) => {
-      if (!world || clusterKeys.length === 0) {
+      const stableClusterKeys = JSON.parse(clusterKeySignature) as string[]
+      if (!world || stableClusterKeys.length === 0) {
         return emptyForgeClusterSnapshot()
       }
 
-      return buildForgeClusterSnapshot(world, clusterKeys, signal)
+      return buildForgeClusterSnapshot(world, stableClusterKeys, signal)
     },
-    [clusterKeys],
+    [clusterKeySignature],
   )
 
   return useMemo(
     () => ({
       snapshot: resource.value ?? emptyForgeClusterSnapshot(),
       loading: resource.loading,
+      error: resource.error,
+      retry: resource.retry,
     }),
-    [resource.loading, resource.value],
+    [resource.error, resource.loading, resource.retry, resource.value],
   )
 }

--- a/app/space/create-op-builders.test.ts
+++ b/app/space/create-op-builders.test.ts
@@ -1,24 +1,16 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  buildForgeObjectKey,
   buildObjectKey,
   buildWizardObjectKey,
   lookupCreateOpBuilder,
 } from './create-op-builders.js'
 
 describe('buildObjectKey', () => {
-  it('uses simple name-based numbered keys', () => {
+  it('preserves the established numbered convention for non-Forge callers', () => {
     expect(buildObjectKey('canvas/', 'Canvas')).toBe('canvas-1')
-    expect(buildObjectKey('forge/cluster/', 'Forge Cluster')).toBe(
-      'forge-cluster-1',
-    )
-  })
-
-  it('selects the next available numbered key', () => {
     expect(buildObjectKey('canvas/', 'Canvas', ['canvas-1'])).toBe('canvas-2')
-  })
-
-  it('uses the prefix only when the name is empty', () => {
     expect(buildObjectKey('object-layout/', '')).toBe('object-layout-1')
   })
 
@@ -29,6 +21,29 @@ describe('buildObjectKey', () => {
     expect(
       buildWizardObjectKey('Git Repository', ['wizard/git-repository-1']),
     ).toBe('wizard/git-repository-2')
+  })
+})
+
+describe('buildForgeObjectKey', () => {
+  it('uses the normalized requested key when it is free', () => {
+    expect(buildForgeObjectKey('forge/cluster/', 'cluster-1')).toBe('cluster-1')
+    expect(buildForgeObjectKey('forge/job/', 'Build Job')).toBe('build-job')
+  })
+
+  it('numbers only a colliding bare key and tolerates historical numbered keys', () => {
+    expect(
+      buildForgeObjectKey('forge/cluster/', 'cluster', [
+        'cluster',
+        'cluster-1',
+        'cluster-2',
+      ]),
+    ).toBe('cluster-3')
+  })
+
+  it('does not confuse hierarchical graph keys with the bare create key', () => {
+    expect(
+      buildForgeObjectKey('forge/task/', 'compile', ['forge/task/compile']),
+    ).toBe('compile')
   })
 })
 

--- a/app/space/create-op-builders.ts
+++ b/app/space/create-op-builders.ts
@@ -156,6 +156,23 @@ export function buildObjectKey(
   return candidates.find((key) => !existing.has(key)) ?? `${base}-1`
 }
 
+// buildForgeObjectKey preserves a requested Forge key unless it collides.
+export function buildForgeObjectKey(
+  prefix: string,
+  name: string,
+  existingKeys?: Iterable<string | undefined>,
+): string {
+  const base = slugObjectKeySegment(name) || buildObjectKeyBase(prefix)
+  const existing = new Set(existingKeys ?? [])
+  if (!existing.has(base)) return base
+
+  const candidates = Array.from(
+    { length: existing.size + 2 },
+    (_, index) => `${base}-${index + 2}`,
+  )
+  return candidates.find((key) => !existing.has(key)) ?? `${base}-2`
+}
+
 export function buildWizardObjectKey(
   name: string,
   existingKeys?: Iterable<string | undefined>,

--- a/app/wizard/ForgeJobWizardViewer.test.tsx
+++ b/app/wizard/ForgeJobWizardViewer.test.tsx
@@ -121,7 +121,7 @@ describe('ForgeJobWizardViewer', () => {
     expect(sender).toBe('12D3KooWJobPeer')
 
     const decoded = ForgeJobCreateOp.fromBinary(opData)
-    expect(decoded.jobKey).toBe('build-job-1')
+    expect(decoded.jobKey).toBe('build-job')
     expect(decoded.clusterKey).toBe('forge/cluster/main')
     expect(decoded.taskDefs?.map((td) => td.name)).toEqual(['compile', 'test'])
     expect(h.deleteObject).toHaveBeenCalledWith('wizard/forge/job/test')

--- a/app/wizard/ForgeJobWizardViewer.tsx
+++ b/app/wizard/ForgeJobWizardViewer.tsx
@@ -5,7 +5,7 @@ import type { ObjectViewerComponentProps } from '@s4wave/web/object/object.js'
 import { toast } from '@s4wave/web/ui/toaster.js'
 import { LoadingCard } from '@s4wave/web/ui/loading/LoadingCard.js'
 import { ForgeJobCreateOp } from '@s4wave/core/forge/job/job.pb.js'
-import { buildObjectKey } from '../space/create-op-builders.js'
+import { buildForgeObjectKey } from '../space/create-op-builders.js'
 
 import { useWizardState } from './useWizardState.js'
 import { WizardShell } from './WizardShell.js'
@@ -32,13 +32,16 @@ export function ForgeJobWizardViewer(props: ObjectViewerComponentProps) {
   const handleFinalize = useCallback(async () => {
     if (!state || ws.creating || !selectedCluster || !ws.localName.trim())
       return
-    const validTasks = taskDefs.filter((td) => td.name)
+    const validTasks = taskDefs.flatMap((task) => {
+      const name = task.name?.trim()
+      return name ? [{ ...task, name }] : []
+    })
     if (validTasks.length === 0) return
 
     ws.setCreating(true)
     try {
       await ws.persistDraftState()
-      const jobKey = buildObjectKey(
+      const jobKey = buildForgeObjectKey(
         'forge/job/',
         ws.localName,
         ws.existingObjectKeys,
@@ -97,17 +100,24 @@ export function ForgeJobWizardViewer(props: ObjectViewerComponentProps) {
       }
       step={state.step ?? 0}
       totalSteps={2}
+      stepName={(state.step ?? 0) === 0 ? 'Cluster and tasks' : 'Job identity'}
       localName={ws.localName}
       onUpdateName={ws.handleUpdateName}
       onBack={() => void ws.handleBack()}
       onCancel={handleCancel}
       nameLabel="Job Name"
       namePlaceholder="Enter job name..."
+      nameHelp="This display name is separate from the stable Job object key."
       nameStep={1}
       creating={ws.creating}
       onFinalize={handleFinalizeClick}
       onNext={() => void handleNext()}
-      canNext={!!selectedCluster && taskDefs.some((td) => td.name)}
+      canNext={
+        !!selectedCluster && taskDefs.some((task) => !!task.name?.trim())
+      }
+      canFinalize={
+        !!selectedCluster && taskDefs.some((task) => !!task.name?.trim())
+      }
       finalizeStep={1}
     >
       {(state.step ?? 0) === 0 && configEditor.element}

--- a/app/wizard/ForgeTaskWizardViewer.test.tsx
+++ b/app/wizard/ForgeTaskWizardViewer.test.tsx
@@ -100,7 +100,7 @@ describe('ForgeTaskWizardViewer', () => {
     expect(sender).toBe('12D3KooWTaskPeer')
 
     const decoded = ForgeTaskCreateOp.fromBinary(opData)
-    expect(decoded.taskKey).toBe('compile-task-1')
+    expect(decoded.taskKey).toBe('compile-task')
     expect(decoded.name).toBe('Compile Task')
     expect(decoded.jobKey).toBe('forge/job/main')
     expect(h.deleteObject).toHaveBeenCalledWith('wizard/forge/task/test')

--- a/app/wizard/ForgeTaskWizardViewer.tsx
+++ b/app/wizard/ForgeTaskWizardViewer.tsx
@@ -5,7 +5,7 @@ import type { ObjectViewerComponentProps } from '@s4wave/web/object/object.js'
 import { toast } from '@s4wave/web/ui/toaster.js'
 import { LoadingCard } from '@s4wave/web/ui/loading/LoadingCard.js'
 import { ForgeTaskCreateOp } from '@s4wave/core/forge/task/task.pb.js'
-import { buildObjectKey } from '../space/create-op-builders.js'
+import { buildForgeObjectKey } from '../space/create-op-builders.js'
 
 import { useWizardState } from './useWizardState.js'
 import { WizardShell } from './WizardShell.js'
@@ -42,7 +42,7 @@ export function ForgeTaskWizardViewer(props: ObjectViewerComponentProps) {
     ws.setCreating(true)
     try {
       await ws.persistDraftState()
-      const taskKey = buildObjectKey(
+      const taskKey = buildForgeObjectKey(
         'forge/task/',
         ws.localName,
         ws.existingObjectKeys,

--- a/app/wizard/WizardShell.tsx
+++ b/app/wizard/WizardShell.tsx
@@ -28,6 +28,7 @@ export interface WizardShellProps {
   nameLabel?: string
   namePlaceholder?: string
   nameHelp?: string
+  nameError?: string
   // Which step shows the name input. Defaults to 0.
   nameStep?: number
   // Selects the existing default name when the name input receives focus.
@@ -66,6 +67,7 @@ export function WizardShell({
   nameLabel = 'Name',
   namePlaceholder = 'Enter a name...',
   nameHelp,
+  nameError,
   nameStep = 0,
   selectNameOnFocus = false,
   creating,
@@ -146,8 +148,21 @@ export function WizardShell({
                     onChange={(e) => onUpdateName(e.target.value)}
                     placeholder={namePlaceholder}
                     help={nameHelp}
+                    aria-invalid={nameError ? true : undefined}
+                    aria-describedby={
+                      nameError ? 'wizard-name-error' : undefined
+                    }
+                    className={nameError ? 'border-destructive/50' : undefined}
                     onFocus={handleNameFocus}
                   />
+                  {nameError && (
+                    <p
+                      id="wizard-name-error"
+                      className="text-destructive mt-1.5 text-xs"
+                    >
+                      {nameError}
+                    </p>
+                  )}
                 </div>
               </section>
             )}

--- a/app/wizard/WizardViewer.test.tsx
+++ b/app/wizard/WizardViewer.test.tsx
@@ -219,7 +219,7 @@ describe('WizardViewer', () => {
       step: 0,
       targetTypeId: 'forge/cluster',
       targetKeyPrefix: 'forge/cluster/',
-      name: 'Test Cluster',
+      name: 'test-cluster',
     }
     currentWizards = [
       {
@@ -245,12 +245,42 @@ describe('WizardViewer', () => {
     expect(sender).toBe(currentPeerId)
 
     const decoded = ClusterCreateOp.fromBinary(opData)
-    expect(decoded.clusterKey).toBe('test-cluster-1')
-    expect(decoded.name).toBe('Test Cluster')
+    expect(decoded.clusterKey).toBe('test-cluster')
+    expect(decoded.name).toBe('test-cluster')
     expect(decoded.peerId ?? '').toBe('')
     expect(mocks.deleteObject).toHaveBeenCalledWith('wizard/test-canvas')
     expect(mocks.navigateToObjects).toHaveBeenCalledWith([decoded.clusterKey])
-    expect(mocks.toastSuccess).toHaveBeenCalledWith('Created Test Cluster')
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('Created test-cluster')
+  })
+
+  it('blocks an invalid Forge Cluster DNS-1123 name with actionable guidance', async () => {
+    currentState = {
+      step: 0,
+      targetTypeId: 'forge/cluster',
+      targetKeyPrefix: 'forge/cluster/',
+      name: 'Invalid Cluster',
+    }
+    currentWizards = [
+      {
+        typeId: 'forge/cluster',
+        displayName: 'Forge Cluster',
+        createOpId: 'forge/cluster/create',
+        keyPrefix: 'forge/cluster/',
+      },
+    ]
+
+    renderViewer()
+
+    expect(
+      screen.getByText(
+        'Use 1–63 lowercase letters, numbers, or hyphens; start and end with a letter or number.',
+      ),
+    ).toBeTruthy()
+    expect(
+      (screen.getByRole('button', { name: /create/i }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true)
+    expect(mocks.applyWorldOp).not.toHaveBeenCalled()
   })
 
   it('does not finalize an experimental target wizard before browser opt-in', async () => {

--- a/app/wizard/WizardViewer.tsx
+++ b/app/wizard/WizardViewer.tsx
@@ -9,6 +9,7 @@ import { useConfigEditor } from '@s4wave/web/configtype/useConfigEditor.js'
 import { LoadingCard } from '@s4wave/web/ui/loading/LoadingCard.js'
 import {
   lookupCreateOpBuilder,
+  buildForgeObjectKey,
   buildObjectKey,
 } from '../space/create-op-builders.js'
 import { useExperimentalCreatorsEnabled } from '../creator-visibility.js'
@@ -18,6 +19,15 @@ import { useWizardState } from './useWizardState.js'
 import { WizardShell } from './WizardShell.js'
 
 export const WizardTypePrefix = 'wizard/'
+
+const dns1123NamePattern = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/
+
+function validateTargetName(targetTypeId: string | undefined, name: string) {
+  if (targetTypeId !== 'forge/cluster' || dns1123NamePattern.test(name)) {
+    return ''
+  }
+  return 'Use 1–63 lowercase letters, numbers, or hyphens; start and end with a letter or number.'
+}
 
 export function WizardViewer(props: ObjectViewerComponentProps) {
   const spaceResource = SpaceContext.useContext()
@@ -51,6 +61,11 @@ export function WizardViewer(props: ObjectViewerComponentProps) {
     const name = ws.localName || state.name
     const targetKeyPrefix = state.targetKeyPrefix ?? ''
     if (!name) return
+    const nameError = validateTargetName(state.targetTypeId, name)
+    if (nameError) {
+      toast.error(nameError)
+      return
+    }
 
     const builder = lookupCreateOpBuilder(targetWizard.createOpId)
     if (!builder) {
@@ -61,11 +76,11 @@ export function WizardViewer(props: ObjectViewerComponentProps) {
     ws.setCreating(true)
     try {
       await ws.persistDraftState()
-      const targetKey = buildObjectKey(
-        targetKeyPrefix,
-        name,
-        ws.existingObjectKeys,
-      )
+      const targetKey = (
+        state.targetTypeId?.startsWith('forge/')
+          ? buildForgeObjectKey
+          : buildObjectKey
+      )(targetKeyPrefix, name, ws.existingObjectKeys)
       const opData = builder(targetKey, name, state.configData)
       await ws.spaceWorld.applyWorldOp(
         targetWizard.createOpId,
@@ -109,6 +124,7 @@ export function WizardViewer(props: ObjectViewerComponentProps) {
   }
 
   const displayName = targetWizard?.displayName ?? state.targetTypeId
+  const nameError = validateTargetName(state.targetTypeId, ws.localName)
 
   return (
     <WizardShell
@@ -116,10 +132,12 @@ export function WizardViewer(props: ObjectViewerComponentProps) {
       step={state.step ?? 0}
       localName={ws.localName}
       onUpdateName={ws.handleUpdateName}
+      nameError={nameError}
       onBack={() => void ws.handleBack()}
       onCancel={handleCancel}
       creating={ws.creating}
       onFinalize={handleFinalizeClick}
+      canFinalize={!nameError}
     >
       {configEditor.element}
     </WizardShell>

--- a/sdk/world/wizard/registry.go
+++ b/sdk/world/wizard/registry.go
@@ -119,7 +119,7 @@ var ObjectWizards = []*ObjectWizard{
 		Category:           "Forge",
 		IconName:           "LuServer",
 		CreateOpId:         "forge/cluster/create",
-		DefaultNamePattern: "Cluster",
+		DefaultNamePattern: "cluster",
 		KeyPrefix:          "forge/cluster/",
 		Persistent:         true,
 		WizardTypeId:       "wizard/forge/cluster",

--- a/sdk/world/wizard/registry_test.go
+++ b/sdk/world/wizard/registry_test.go
@@ -1,0 +1,13 @@
+package s4wave_wizard
+
+import "testing"
+
+func TestForgeClusterWizardDefaultNameIsDNS1123(t *testing.T) {
+	wizard := LookupObjectWizard("forge/cluster")
+	if wizard == nil {
+		t.Fatal("forge/cluster wizard is not registered")
+	}
+	if got, want := wizard.GetDefaultNamePattern(), "cluster"; got != want {
+		t.Fatalf("default name = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Forge Cluster creation started with an invalid DNS label, always added an unexpected numeric suffix, and repeatedly restarted empty snapshot reads. New clusters therefore failed creation or remained in loading placeholders, while the Job wizard could also remain stuck loading its cluster list.

This validates cluster DNS labels, isolates bare keys to Forge creators, stabilizes snapshot dependencies, and exposes failed reads with retry actions. Cluster tabs now distinguish loading, failure, and empty states and present useful identity context. The Job editor provides reliable cluster selection and keeps task identity and focus through protobuf updates.

The complete persistent key and lifecycle range has independent clean review and focused Go and browser-component regression coverage.