### PR TITLE
fix(device): bootstrap managed device setup

### DIFF
--- a/app/device/AddDeviceWizardViewer.test.tsx
+++ b/app/device/AddDeviceWizardViewer.test.tsx
@@ -1,3 +1,16 @@
+import { spawnSync } from 'child_process'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
 import React from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
@@ -153,6 +166,16 @@ vi.mock('@s4wave/web/ui/toaster.js', () => ({
 
 import { AddDeviceWizardViewer } from './AddDeviceWizardViewer.js'
 
+function installSetupCommand(): string {
+  return `tmp=$(mktemp) || exit; trap 'rm -f "$tmp"' 0 HUP INT TERM; curl -fsSL --output "$tmp" https://raw.githubusercontent.com/s4wave/spacewave/master/scripts/spacewave.sh || exit; sh "$tmp" device setup --label 'Build Host' --target-hint space-1`
+}
+
+function renderedInstallSetupCommand(): string {
+  const command = screen.getByText(installSetupCommand()).textContent
+  if (!command) throw new Error('expected the install setup command')
+  return command
+}
+
 describe('AddDeviceWizardViewer', () => {
   afterEach(() => {
     cleanup()
@@ -168,13 +191,117 @@ describe('AddDeviceWizardViewer', () => {
     ]
   })
 
-  it('renders one setup command when the CLI and container command are identical', () => {
+  it('shows direct and bootstrap setup commands before the Device ticket is available', () => {
     renderViewer()
 
     expect(screen.getByText('Add Device')).toBeTruthy()
     expect(screen.queryByText('Link My Device')).toBeNull()
-    expect(screen.getAllByText(/spacewave device setup/)).toHaveLength(1)
-    expect(screen.getAllByText(/--target-hint space-1/)).toHaveLength(1)
+    expect(screen.getByText('Spacewave already installed')).toBeTruthy()
+    expect(screen.getByText('Install and run')).toBeTruthy()
+    expect(
+      screen.getByText(
+        /^spacewave device setup --label 'Build Host' --target-hint space-1$/,
+      ),
+    ).toBeTruthy()
+    expect(screen.getByText(installSetupCommand())).toBeTruthy()
+    expect(screen.getByText('2. Paste the Device ticket')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /^approve$/i })).toBeNull()
+  })
+
+  it('does not execute a truncated bootstrap when curl fails', () => {
+    renderViewer()
+    const dir = mkdtempSync(join(tmpdir(), 'spacewave-device-bootstrap-'))
+    const bin = join(dir, 'bin')
+    const marker = join(dir, 'script-ran')
+    const curl = join(bin, 'curl')
+    try {
+      mkdirSync(bin)
+      writeFileSync(
+        curl,
+        `#!/bin/sh
+set -eu
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--output" ]; then
+    output="$2"
+    break
+  fi
+  shift
+done
+printf '%s\\n' 'printf "%s\\n" script-ran > "$SPACEWAVE_TEST_MARKER"' > "\${output:?}"
+printf '%s' 'truncated' >> "\${output:?}"
+exit 22
+`,
+      )
+      chmodSync(curl, 0o755)
+
+      const result = spawnSync('sh', ['-c', renderedInstallSetupCommand()], {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${bin}:${process.env.PATH}`,
+          SPACEWAVE_TEST_MARKER: marker,
+        },
+      })
+
+      expect(result.error).toBeUndefined()
+      expect(result.status).not.toBe(0)
+      expect(existsSync(marker)).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('runs the downloaded bootstrap with the displayed setup arguments', () => {
+    renderViewer()
+    const dir = mkdtempSync(join(tmpdir(), 'spacewave-device-bootstrap-'))
+    const bin = join(dir, 'bin')
+    const args = join(dir, 'args')
+    const curl = join(bin, 'curl')
+    try {
+      mkdirSync(bin)
+      writeFileSync(
+        curl,
+        `#!/bin/sh
+set -eu
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--output" ]; then
+    output="$2"
+    break
+  fi
+  shift
+done
+printf '%s\\n' '#!/bin/sh' 'printf "%s\\n" "$@" > "$SPACEWAVE_TEST_ARGS"' > "\${output:?}"
+`,
+      )
+      chmodSync(curl, 0o755)
+
+      const result = spawnSync('sh', ['-c', renderedInstallSetupCommand()], {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${bin}:${process.env.PATH}`,
+          SPACEWAVE_TEST_ARGS: args,
+        },
+      })
+
+      expect(result.error).toBeUndefined()
+      expect(result.status).toBe(0)
+      expect(readFileSync(args, 'utf8')).toBe(
+        'device\nsetup\n--label\nBuild Host\n--target-hint\nspace-1\n',
+      )
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('uses the shared compact input class for the Device name', () => {
+    h.currentStep = 0
+    renderViewer()
+
+    const name = screen.getByLabelText('Device Name')
+    expect(name.className).toContain('text-xs')
+    expect(name.className).not.toMatch(/(^|\s)text-base($|\s)/)
+    expect(name.className).not.toMatch(/(^|\s)text-sm($|\s)/)
   })
 
   it('approves a CLI SpaceLink ticket and persists the completion command', async () => {
@@ -198,6 +325,9 @@ describe('AddDeviceWizardViewer', () => {
     expect(
       screen.getByPlaceholderText(/paste the base64 ticket/i),
     ).toHaveProperty('value', ticket)
+    expect(screen.getByText('Approve Device ticket')).toBeTruthy()
+    expect(screen.queryByText('Spacewave already installed')).toBeNull()
+    expect(screen.queryByText('Install and run')).toBeNull()
     fireEvent.click(screen.getByRole('button', { name: /approve/i }))
 
     await waitFor(() => expect(h.updateState).toHaveBeenCalled())
@@ -242,6 +372,12 @@ describe('AddDeviceWizardViewer', () => {
       ),
     ).toBeTruthy()
     expect(screen.queryByPlaceholderText(/paste the base64 ticket/i)).toBeNull()
+    expect(screen.queryByText('Spacewave already installed')).toBeNull()
+    expect(screen.queryByText('Install and run')).toBeNull()
+    expect(screen.queryByText(/^spacewave device setup/)).toBeNull()
+    expect(
+      screen.queryByText(/raw\.githubusercontent\.com\/s4wave\/spacewave/),
+    ).toBeNull()
     expect(screen.queryByRole('button', { name: /^approve$/i })).toBeNull()
 
     fireEvent.click(

--- a/app/device/AddDeviceWizardViewer.tsx
+++ b/app/device/AddDeviceWizardViewer.tsx
@@ -145,6 +145,10 @@ function useAddDeviceWizardController(props: ObjectViewerComponentProps) {
     ws.localName || 'Device',
     sharedObjectId,
   )
+  const installSetupCommand = buildInstallSetupCommand(
+    ws.localName || 'Device',
+    sharedObjectId,
+  )
   const completeCommand = completion
     ? `spacewave device complete --completion ${quoteShellArg(completion)}`
     : 'spacewave device complete --completion <completion>'
@@ -412,6 +416,7 @@ function useAddDeviceWizardController(props: ObjectViewerComponentProps) {
     handleTicketChange,
     isOpeningStep,
     isSshInstallMode,
+    installSetupCommand,
     mode,
     operationError,
     session,
@@ -456,6 +461,7 @@ function AddDeviceWizardSteps({
     handleSshConfigChange,
     handleTicketChange,
     isOpeningStep,
+    installSetupCommand,
     mode,
     operationError,
     session,
@@ -504,6 +510,8 @@ function AddDeviceWizardSteps({
                 onSignIn={handleSignIn}
                 config={config}
                 ticket={ticket}
+                setupCommand={setupCommand}
+                installSetupCommand={installSetupCommand}
                 busy={busy}
                 error={approvalError}
                 onTicketChange={(value) => {
@@ -524,22 +532,6 @@ function AddDeviceWizardSteps({
                   })
                 }}
               />
-              <div className="space-y-2">
-                <div>
-                  <h3 className="text-foreground text-xs font-medium">
-                    Get a ticket on the Device
-                  </h3>
-                  <p className="text-foreground-alt/70 mt-1 text-xs leading-relaxed">
-                    Run this command with the installed Local CLI or Container
-                    daemon, then paste the ticket above.
-                  </p>
-                </div>
-                <CommandPanel
-                  title="Device setup command"
-                  command={setupCommand}
-                  icon={<LuTerminal className="size-3.5" />}
-                />
-              </div>
             </section>
           )}
           {mode === 'ssh' && (
@@ -1073,6 +1065,8 @@ function CommandPanel({
 function SpaceLinkApprovalPanel({
   config,
   ticket,
+  setupCommand,
+  installSetupCommand,
   busy,
   error,
   supported,
@@ -1083,6 +1077,8 @@ function SpaceLinkApprovalPanel({
 }: {
   config: AddDeviceWizardConfig
   ticket: string
+  setupCommand: string
+  installSetupCommand: string
   busy: boolean
   error?: string
   supported: boolean
@@ -1124,55 +1120,84 @@ function SpaceLinkApprovalPanel({
     )
   }
 
+  const ticketReady = ticket.trim().length > 0
+
   return (
-    <div className="border-foreground/6 bg-background-card/30 rounded-lg border p-3.5">
-      <label className="text-foreground text-xs font-medium select-none">
-        SpaceLink Ticket
-      </label>
-      <p className="text-foreground-alt/70 mt-1 text-xs leading-relaxed">
-        Paste the ticket created by the Device setup command to prepare
-        enrollment.
-      </p>
-      <textarea
-        value={ticket}
-        onChange={(e) => onTicketChange(e.target.value)}
-        placeholder="Paste the base64 ticket from spacewave device setup"
-        disabled={busy}
-        className="border-foreground/10 bg-background/20 text-foreground placeholder:text-foreground-alt/40 focus-visible:border-brand/50 focus-visible:ring-brand/15 mt-2 min-h-24 w-full rounded-md border p-2 font-mono text-xs outline-none disabled:opacity-60"
-      />
-      {config.preview && (
-        <div className="text-foreground-alt/60 mt-2 grid gap-1 text-xs">
-          <span>{config.preview.label || 'Device'}</span>
-          {config.preview.agentPeerId && (
-            <span className="truncate font-mono">
-              {config.preview.agentPeerId}
-            </span>
-          )}
+    <div className="space-y-3">
+      {!ticketReady && (
+        <div>
+          <h3 className="text-foreground text-xs font-medium">
+            1. Run setup on the Device
+          </h3>
+          <p className="text-foreground-alt/70 mt-1 text-xs leading-relaxed">
+            Choose the command that matches the Device. Both print a ticket.
+          </p>
+          <div className="mt-2 space-y-2">
+            <CommandPanel
+              title="Spacewave already installed"
+              command={setupCommand}
+              icon={<LuTerminal className="size-3.5" />}
+            />
+            <CommandPanel
+              title="Install and run"
+              command={installSetupCommand}
+              icon={<LuTerminal className="size-3.5" />}
+            />
+          </div>
         </div>
       )}
-      {busy && (
-        <p className="text-foreground-alt/80 mt-2 text-xs leading-relaxed">
-          Checking ticket and preparing enrollment…
+      <div className="border-foreground/6 bg-background-card/30 rounded-lg border p-3.5">
+        <label className="text-foreground text-xs font-medium select-none">
+          {ticketReady ? 'Approve Device ticket' : '2. Paste the Device ticket'}
+        </label>
+        <p className="text-foreground-alt/70 mt-1 text-xs leading-relaxed">
+          {ticketReady
+            ? 'The ticket is ready. Approve it to create the completion command.'
+            : 'Paste the base64 ticket printed by the Device setup command.'}
         </p>
-      )}
-      {error && (
-        <div
-          className="border-destructive/15 bg-destructive/5 text-destructive mt-2 rounded-md border p-2 text-xs leading-relaxed"
-          role="alert"
-        >
-          <div className="font-medium">Ticket could not be approved</div>
-          <div className="mt-0.5">{error}</div>
-        </div>
-      )}
-      <Button
-        size="sm"
-        onClick={onApprove}
-        disabled={busy || !ticket.trim()}
-        className="border-brand/30 bg-brand/10 hover:border-brand/50 hover:bg-brand/15 text-foreground mt-3 h-7 rounded-md border px-3 text-xs transition duration-150"
-      >
-        <LuClipboardCheck className="size-3.5" />
-        {busy ? 'Checking ticket…' : 'Approve'}
-      </Button>
+        <textarea
+          value={ticket}
+          onChange={(e) => onTicketChange(e.target.value)}
+          placeholder="Paste the base64 ticket from spacewave device setup"
+          disabled={busy}
+          className="border-foreground/10 bg-background/20 text-foreground placeholder:text-foreground-alt/40 focus-visible:border-brand/50 focus-visible:ring-brand/15 mt-2 min-h-24 w-full rounded-md border p-2 font-mono text-xs outline-none disabled:opacity-60"
+        />
+        {config.preview && (
+          <div className="text-foreground-alt/60 mt-2 grid gap-1 text-xs">
+            <span>{config.preview.label || 'Device'}</span>
+            {config.preview.agentPeerId && (
+              <span className="truncate font-mono">
+                {config.preview.agentPeerId}
+              </span>
+            )}
+          </div>
+        )}
+        {busy && (
+          <p className="text-foreground-alt/80 mt-2 text-xs leading-relaxed">
+            Checking ticket and preparing enrollment…
+          </p>
+        )}
+        {error && (
+          <div
+            className="border-destructive/15 bg-destructive/5 text-destructive mt-2 rounded-md border p-2 text-xs leading-relaxed"
+            role="alert"
+          >
+            <div className="font-medium">Ticket could not be approved</div>
+            <div className="mt-0.5">{error}</div>
+          </div>
+        )}
+        {ticketReady && (
+          <Button
+            size="sm"
+            onClick={onApprove}
+            disabled={busy}
+            className="border-brand/30 bg-brand/10 hover:border-brand/50 hover:bg-brand/15 text-foreground mt-3 h-7 rounded-md border px-3 text-xs transition duration-150"
+          >
+            <LuClipboardCheck className="size-3.5" />
+            {busy ? 'Checking ticket…' : 'Approve'}
+          </Button>
+        )}
+      </div>
     </div>
   )
 }
@@ -1493,13 +1518,21 @@ function encodeConfig(config: AddDeviceWizardConfig): Uint8Array {
 }
 
 function buildSetupCommand(label: string, sharedObjectId: string): string {
-  const parts = [
-    'spacewave',
-    'device',
-    'setup',
-    '--label',
-    quoteShellArg(label),
-  ]
+  return ['spacewave', buildDeviceSetupArgs(label, sharedObjectId)].join(' ')
+}
+
+function buildInstallSetupCommand(
+  label: string,
+  sharedObjectId: string,
+): string {
+  return [
+    `tmp=$(mktemp) || exit; trap 'rm -f "$tmp"' 0 HUP INT TERM; curl -fsSL --output "$tmp" https://raw.githubusercontent.com/s4wave/spacewave/master/scripts/spacewave.sh || exit; sh "$tmp"`,
+    buildDeviceSetupArgs(label, sharedObjectId),
+  ].join(' ')
+}
+
+function buildDeviceSetupArgs(label: string, sharedObjectId: string): string {
+  const parts = ['device', 'setup', '--label', quoteShellArg(label)]
   if (sharedObjectId) {
     parts.push('--target-hint', quoteShellArg(sharedObjectId))
   }

--- a/app/space/SpaceObjectContainer.navigation.test.tsx
+++ b/app/space/SpaceObjectContainer.navigation.test.tsx
@@ -1,0 +1,132 @@
+import { useCallback, useState } from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  resolvePath,
+  Route,
+  Router,
+  Routes,
+  type To,
+} from '@s4wave/web/router/router.js'
+
+import { SpaceObjectContainer } from './SpaceObjectContainer.js'
+
+const wizardPath = '/u/1/so/space-1/-/wizard/device-1'
+
+const h = vi.hoisted(() => ({
+  navigateToRoot: vi.fn(),
+  navigateToSubPath: vi.fn(),
+  spaceContentsResource: {
+    value: {},
+    loading: false,
+    error: null,
+    retry: vi.fn(),
+  },
+  spaceContext: {
+    spaceId: 'space-1',
+    objectKey: 'wizard',
+    objectPath: 'device-1',
+    spaceState: {
+      worldContents: {
+        objects: [{ objectKey: 'wizard', objectType: 'spacewave/wizard' }],
+      },
+    },
+    spaceWorldResource: { value: null, loading: false, error: null },
+  },
+}))
+
+vi.mock('@s4wave/web/object/ObjectViewer.js', () => ({
+  ObjectViewer: ({
+    onNavigate,
+  }: {
+    onNavigate?: (to: { path: string }) => void
+  }) => (
+    <button onClick={() => onNavigate?.({ path: '/login' })}>
+      Sign in or create account
+    </button>
+  ),
+}))
+
+vi.mock('@s4wave/web/contexts/contexts.js', () => ({
+  SpaceContentsContext: {
+    useContext: () => h.spaceContentsResource,
+  },
+  useSessionIndex: () => 1,
+}))
+
+vi.mock('@s4wave/web/contexts/SpaceContainerContext.js', () => ({
+  SpaceContainerContext: {
+    useContext: () => ({
+      ...h.spaceContext,
+      navigateToRoot: h.navigateToRoot,
+      navigateToSubPath: h.navigateToSubPath,
+    }),
+  },
+}))
+
+vi.mock('@s4wave/app/quickstart/session-handoff.js', () => ({
+  getQuickstartInitialObjectHandoff: vi.fn(),
+}))
+
+function AppRouteHarness() {
+  const [entries, setEntries] = useState([wizardPath])
+  const [entryIndex, setEntryIndex] = useState(0)
+  const path = entries[entryIndex] ?? wizardPath
+  const navigate = useCallback(
+    (to: To) => {
+      const next = resolvePath(path, to)
+      if (to.replace) {
+        setEntries((current) => current.with(entryIndex, next))
+        return
+      }
+      setEntries((current) => [...current.slice(0, entryIndex + 1), next])
+      setEntryIndex((current) => current + 1)
+    },
+    [entryIndex, path],
+  )
+  const goBack = useCallback(() => {
+    setEntryIndex((current) => Math.max(0, current - 1))
+  }, [])
+
+  return (
+    <>
+      <output data-testid="current-route">{path}</output>
+      <Router path={path} onNavigate={navigate}>
+        <Routes fullPath>
+          <Route path="/u/:sessionIndex/so/:spaceId/-/*">
+            <SpaceObjectContainer />
+          </Route>
+          <Route path="/login">
+            <div>
+              <p>Spacewave Cloud login</p>
+              <button onClick={goBack}>Back to device wizard</button>
+            </div>
+          </Route>
+        </Routes>
+      </Router>
+    </>
+  )
+}
+
+describe('SpaceObjectContainer authentication navigation', () => {
+  it('opens the app login route and keeps the device wizard as the back target', () => {
+    render(<AppRouteHarness />)
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Sign in or create account' }),
+    )
+
+    expect(screen.getByText('Spacewave Cloud login')).toBeTruthy()
+    expect(screen.getByTestId('current-route').textContent).toBe('/login')
+    expect(h.navigateToSubPath).not.toHaveBeenCalled()
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Back to device wizard' }),
+    )
+    expect(
+      screen.getByRole('button', { name: 'Sign in or create account' }),
+    ).toBeTruthy()
+    expect(screen.getByTestId('current-route').textContent).toBe(wizardPath)
+  })
+})

--- a/app/space/SpaceObjectContainer.test.tsx
+++ b/app/space/SpaceObjectContainer.test.tsx
@@ -21,6 +21,7 @@ interface CapturedObjectViewerProps {
 
 const h = vi.hoisted(() => ({
   objectViewer: vi.fn((_props: CapturedObjectViewerProps) => null),
+  navigate: vi.fn(),
   navigateToRoot: vi.fn(),
   navigateToSubPath: vi.fn(),
   getQuickstartInitialObjectHandoff: vi.fn(),
@@ -41,6 +42,14 @@ const h = vi.hoisted(() => ({
     error: null,
     retry: vi.fn(),
   },
+}))
+
+vi.mock('@s4wave/web/router/router.js', () => ({
+  resolvePath: (currentPath: string, to: { path: string }) =>
+    to.path.startsWith('/')
+      ? to.path
+      : `${currentPath.replace(/\/$/, '')}/${to.path}`,
+  useNavigate: () => h.navigate,
 }))
 
 vi.mock('@s4wave/web/object/ObjectViewer.js', () => ({
@@ -74,6 +83,7 @@ vi.mock('@s4wave/app/quickstart/session-handoff.js', () => ({
 describe('SpaceObjectContainer', () => {
   beforeEach(() => {
     h.objectViewer.mockClear()
+    h.navigate.mockClear()
     h.navigateToRoot.mockClear()
     h.navigateToSubPath.mockClear()
     h.getQuickstartInitialObjectHandoff.mockReset()
@@ -138,5 +148,15 @@ describe('SpaceObjectContainer', () => {
     expect(h.navigateToSubPath).toHaveBeenCalledWith(
       'repo/demo/-/docs/readme.md',
     )
+  })
+
+  it('forwards absolute viewer routes to the app router', () => {
+    render(<SpaceObjectContainer />)
+
+    const props = h.objectViewer.mock.calls[0]?.[0]
+    props?.onNavigate?.({ path: '/login' })
+
+    expect(h.navigate).toHaveBeenCalledWith({ path: '/login' })
+    expect(h.navigateToSubPath).not.toHaveBeenCalled()
   })
 })

--- a/app/space/SpaceObjectContainer.tsx
+++ b/app/space/SpaceObjectContainer.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useCallback } from 'react'
-import { resolvePath, type To } from '@s4wave/web/router/router.js'
+import { resolvePath, type To, useNavigate } from '@s4wave/web/router/router.js'
 import { SpaceContainerContext } from '@s4wave/web/contexts/SpaceContainerContext.js'
 import {
   SpaceContentsContext,
@@ -22,19 +22,24 @@ export function SpaceObjectContainer() {
     navigateToSubPath,
   } = SpaceContainerContext.useContext()
   const sessionIndex = useSessionIndex()
+  const navigate = useNavigate()
   const spaceContentsResource = SpaceContentsContext.useContext()
 
   const routerPath = '/' + (objectPath || '')
 
   const handleViewerNavigate = useCallback(
     (to: To) => {
+      if (to.path.startsWith('/')) {
+        navigate(to)
+        return
+      }
       const resolved = resolvePath(routerPath, to)
       const stripped = resolved.replace(/^\//, '')
       const key = objectKey ?? ''
       const full = stripped ? key + '/-/' + stripped : key
       navigateToSubPath(full)
     },
-    [routerPath, objectKey, navigateToSubPath],
+    [navigate, routerPath, objectKey, navigateToSubPath],
   )
 
   const objectType = useMemo(() => {

--- a/app/wizard/wizard-field-styles.ts
+++ b/app/wizard/wizard-field-styles.ts
@@ -1,5 +1,5 @@
 export const wizardInputClassName =
-  'border-foreground/10 bg-background/20 text-foreground placeholder:text-foreground-alt/40 focus-visible:border-brand/50 focus-visible:ring-brand/15 h-9 text-sm'
+  'border-foreground/10 bg-background/20 text-foreground placeholder:text-foreground-alt/40 focus-visible:border-brand/50 focus-visible:ring-brand/15 h-9 text-xs'
 
 export const wizardTextareaClassName =
   'border-foreground/10 bg-background/20 text-foreground placeholder:text-foreground-alt/40 focus-visible:border-brand/50 focus-visible:ring-brand/15 w-full rounded-md border p-2 font-mono text-xs outline-none'

--- a/scripts/spacewave.sh
+++ b/scripts/spacewave.sh
@@ -1,0 +1,133 @@
+#!/bin/sh
+# Install the Spacewave CLI for the current user when it is not already
+# available, then execute the command supplied by the caller.
+set -eu
+
+repo_url="https://github.com/s4wave/spacewave"
+release_url="${repo_url}/releases/latest/download"
+
+if command -v spacewave >/dev/null 2>&1; then
+  exec spacewave "$@"
+fi
+
+if [ -z "${HOME:-}" ]; then
+  echo "HOME is required to install the Spacewave CLI." >&2
+  exit 1
+fi
+install_dir="${HOME}/.local/bin"
+target="${install_dir}/spacewave"
+
+case ":${PATH:-}:" in
+  *":${install_dir}:"*) install_dir_on_path=true ;;
+  *) install_dir_on_path=false ;;
+esac
+
+exec_spacewave() {
+  if [ "${install_dir_on_path}" = false ]; then
+    printf 'Spacewave is installed in %s. Add it to PATH for future shells.\n' \
+      "${install_dir}" >&2
+  fi
+  PATH="${install_dir}:${PATH:-}"
+  export PATH
+  if [ -n "${temp_dir:-}" ]; then
+    cleanup
+  fi
+  exec spacewave "$@"
+}
+
+if [ -x "${target}" ]; then
+  exec_spacewave "$@"
+fi
+
+case "$(uname -s)" in
+  Darwin)
+    os="macos"
+    archive_ext="zip"
+    ;;
+  Linux)
+    os="linux"
+    archive_ext="tar.gz"
+    ;;
+  *)
+    echo "Spacewave CLI is not available for $(uname -s)." >&2
+    exit 1
+    ;;
+esac
+
+case "$(uname -m)" in
+  x86_64 | amd64)
+    arch="amd64"
+    ;;
+  aarch64 | arm64)
+    arch="arm64"
+    ;;
+  *)
+    echo "Spacewave CLI is not available for $(uname -m)." >&2
+    exit 1
+    ;;
+esac
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required to install the Spacewave CLI." >&2
+  exit 1
+fi
+
+archive_name="spacewave-cli-${os}-${arch}.${archive_ext}"
+temp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "${temp_dir}"
+}
+trap cleanup EXIT HUP INT TERM
+
+archive_path="${temp_dir}/${archive_name}"
+checksums_path="${temp_dir}/checksums.txt"
+extract_dir="${temp_dir}/extract"
+curl --fail --location --silent --show-error \
+  --output "${checksums_path}" \
+  "${release_url}/checksums.txt"
+curl --fail --location --silent --show-error \
+  --output "${archive_path}" \
+  "${release_url}/${archive_name}"
+
+expected_checksum="$(awk -v name="${archive_name}" '$2 == name { print $1; exit }' "${checksums_path}")"
+if [ -z "${expected_checksum}" ]; then
+  echo "Release checksums do not include ${archive_name}." >&2
+  exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+  actual_checksum="$(sha256sum "${archive_path}" | awk '{ print $1 }')"
+elif command -v shasum >/dev/null 2>&1; then
+  actual_checksum="$(shasum -a 256 "${archive_path}" | awk '{ print $1 }')"
+else
+  echo "sha256sum or shasum is required to verify the Spacewave CLI." >&2
+  exit 1
+fi
+if [ "${actual_checksum}" != "${expected_checksum}" ]; then
+  echo "Spacewave CLI checksum verification failed." >&2
+  exit 1
+fi
+
+mkdir -p "${extract_dir}" "${install_dir}"
+case "${archive_ext}" in
+  tar.gz)
+    tar -xzf "${archive_path}" -C "${extract_dir}"
+    ;;
+  zip)
+    if ! command -v unzip >/dev/null 2>&1; then
+      echo "unzip is required to install the Spacewave CLI on macOS." >&2
+      exit 1
+    fi
+    unzip -q "${archive_path}" -d "${extract_dir}"
+    ;;
+esac
+
+binary_path="${extract_dir}/spacewave"
+if [ ! -f "${binary_path}" ]; then
+  echo "Spacewave CLI archive did not contain spacewave." >&2
+  exit 1
+fi
+chmod 755 "${binary_path}"
+mv "${binary_path}" "${target}"
+
+exec_spacewave "$@"

--- a/scripts/spacewave.test.sh
+++ b/scripts/spacewave.test.sh
@@ -1,0 +1,105 @@
+#!/bin/sh
+set -eu
+
+repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+script="${repo_dir}/scripts/spacewave.sh"
+temp_dir=$(mktemp -d)
+cleanup() {
+  rm -rf "${temp_dir}"
+}
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p "${temp_dir}/archive" "${temp_dir}/bin" "${temp_dir}/home" \
+  "${temp_dir}/install-tmp"
+cat > "${temp_dir}/archive/spacewave" <<'EOF'
+#!/bin/sh
+if [ -n "${SPACEWAVE_TEST_TMP_ROOT:-}" ]; then
+  for path in "${SPACEWAVE_TEST_TMP_ROOT}"/*; do
+    if [ -d "${path}" ]; then
+      echo "bootstrap temp directory remained before CLI exec" >&2
+      exit 1
+    fi
+  done
+fi
+printf '%s\n' "$@" > "${SPACEWAVE_TEST_ARGS:?}"
+EOF
+chmod 755 "${temp_dir}/archive/spacewave"
+tar -czf "${temp_dir}/spacewave-cli-linux-amd64.tar.gz" \
+  -C "${temp_dir}/archive" spacewave
+if command -v sha256sum >/dev/null 2>&1; then
+  checksum=$(sha256sum "${temp_dir}/spacewave-cli-linux-amd64.tar.gz" | awk '{ print $1 }')
+elif command -v shasum >/dev/null 2>&1; then
+  checksum=$(shasum -a 256 "${temp_dir}/spacewave-cli-linux-amd64.tar.gz" | awk '{ print $1 }')
+else
+  echo "sha256sum or shasum is required for this test." >&2
+  exit 1
+fi
+
+cat > "${temp_dir}/bin/curl" <<'EOF'
+#!/bin/sh
+set -eu
+output=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output)
+      output="$2"
+      shift 2
+      ;;
+    *)
+      url="$1"
+      shift
+      ;;
+  esac
+done
+case "${url}" in
+  */checksums.txt)
+    printf '%s  spacewave-cli-linux-amd64.tar.gz\n' "${SPACEWAVE_TEST_CHECKSUM:?}" > "${output:?}"
+    ;;
+  */spacewave-cli-linux-amd64.tar.gz)
+    cp "${SPACEWAVE_TEST_ARCHIVE:?}" "${output:?}"
+    ;;
+  *)
+    echo "unexpected curl URL: ${url}" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod 755 "${temp_dir}/bin/curl"
+
+cat > "${temp_dir}/bin/uname" <<'EOF'
+#!/bin/sh
+case "${1:-}" in
+  -s) printf '%s\n' Linux ;;
+  -m) printf '%s\n' x86_64 ;;
+  *) printf '%s\n' Linux ;;
+esac
+EOF
+chmod 755 "${temp_dir}/bin/uname"
+
+PATH="${temp_dir}/bin:/usr/bin:/bin" \
+HOME="${temp_dir}/home" \
+TMPDIR="${temp_dir}/install-tmp" \
+SPACEWAVE_TEST_TMP_ROOT="${temp_dir}/install-tmp" \
+SPACEWAVE_TEST_ARCHIVE="${temp_dir}/spacewave-cli-linux-amd64.tar.gz" \
+SPACEWAVE_TEST_CHECKSUM="${checksum}" \
+SPACEWAVE_TEST_ARGS="${temp_dir}/args" \
+"${script}" device setup --label "Build Host" --target-hint "space-1" \
+  2> "${temp_dir}/stderr"
+
+test -x "${temp_dir}/home/.local/bin/spacewave"
+expected_args="$(printf '%s\n' device setup --label "Build Host" --target-hint space-1)"
+test "$(cat "${temp_dir}/args")" = "${expected_args}"
+grep -F "Add it to PATH for future shells." "${temp_dir}/stderr" >/dev/null
+
+if PATH="${temp_dir}/bin:/usr/bin:/bin" \
+  HOME="${temp_dir}/bad-home" \
+  SPACEWAVE_TEST_ARCHIVE="${temp_dir}/spacewave-cli-linux-amd64.tar.gz" \
+  SPACEWAVE_TEST_CHECKSUM="not-a-checksum" \
+  "${script}" version 2> "${temp_dir}/bad-stderr"; then
+  echo "expected checksum mismatch to fail" >&2
+  exit 1
+fi
+test ! -e "${temp_dir}/bad-home/.local/bin/spacewave"
+grep -F "checksum verification failed" "${temp_dir}/bad-stderr" >/dev/null
+
+printf '%s\n' "spacewave.sh test: PASS"


### PR DESCRIPTION
Managed-device setup mixed signed-out, install, and approval actions, offered no practical bootstrap when the CLI was absent, and routed Login through the object-local router. This could leave the wizard with unusable instructions and make its authentication action fail to reach the app route.

The wizard now presents exclusive setup states, provides direct and fail-closed bootstrap commands, and forwards absolute viewer destinations through the app router while preserving relative object navigation. The bootstrap script installs a checksum-verified Linux or macOS release into the user-local bin directory, preserves arbitrary CLI arguments, requires no sudo or shell-profile edits, and removes all temporary files before execution.

The UI and new script are in one commit because the raw master bootstrap URL becomes valid only when the complete change lands.