### PR TITLE
fix(session): make Space actions reliable

### DIFF
--- a/app/session/dashboard/SessionDashboard.test.tsx
+++ b/app/session/dashboard/SessionDashboard.test.tsx
@@ -5,6 +5,7 @@ import {
   screen,
   within,
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ObjectTypeRegistration } from '@s4wave/sdk/objecttype/registry/registry.pb.js'
 
@@ -120,7 +121,8 @@ describe('SessionDashboard', () => {
       writable: true,
       configurable: true,
     })
-    mockClipboard.writeText.mockClear()
+    mockClipboard.writeText.mockReset()
+    mockClipboard.writeText.mockResolvedValue(undefined)
     mockUseVisibleQuickstartOptions.mockReturnValue([
       {
         id: 'account',
@@ -226,6 +228,161 @@ describe('SessionDashboard', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Copy Beta Space ID' }))
     expect(mockClipboard.writeText).toHaveBeenCalledWith(sharedSpaceId)
+  })
+
+  it('opens a Space from its primary row and visible ID', () => {
+    const onSpaceClick = vi.fn()
+    const space = { id: 'space-1', name: 'Alpha Space' }
+    const { rerender } = render(
+      <SessionDashboard spaces={[space]} onSpaceClick={onSpaceClick} />,
+    )
+
+    fireEvent.click(screen.getByText('Alpha Space'))
+    expect(onSpaceClick).toHaveBeenLastCalledWith(space)
+
+    onSpaceClick.mockClear()
+    fireEvent.click(screen.getByText('space-1'))
+    expect(onSpaceClick).toHaveBeenLastCalledWith(space)
+
+    onSpaceClick.mockClear()
+    rerender(<SessionDashboard spaces={[space]} onSpaceClick={onSpaceClick} />)
+    fireEvent.keyDown(screen.getByText('Alpha Space').closest('[cmdk-item]')!, {
+      key: 'Enter',
+    })
+    expect(onSpaceClick).toHaveBeenCalledWith(space)
+  })
+
+  it('copies from the explicit icon without opening the Space', async () => {
+    const onSpaceClick = vi.fn()
+    render(
+      <SessionDashboard
+        spaces={[{ id: 'space-1', name: 'Alpha Space' }]}
+        onSpaceClick={onSpaceClick}
+      />,
+    )
+
+    const copyButton = screen.getByRole('button', {
+      name: 'Copy Alpha Space ID',
+    })
+    expect(copyButton.closest('[cmdk-item]')).toBeNull()
+    expect(copyButton.className).toContain('size-6')
+    copyButton.focus()
+    await userEvent.keyboard('{Enter}')
+    expect(mockClipboard.writeText).toHaveBeenCalledWith('space-1')
+    expect(await screen.findByRole('button', { name: 'Copied' })).toBeDefined()
+    expect(screen.getByRole('status').textContent).toBe('Copied')
+    expect(onSpaceClick).not.toHaveBeenCalled()
+  })
+
+  it('reports clipboard rejection without opening the Space', async () => {
+    mockClipboard.writeText.mockRejectedValueOnce(new Error('denied'))
+    const onSpaceClick = vi.fn()
+    render(
+      <SessionDashboard
+        spaces={[{ id: 'space-1', name: 'Alpha Space' }]}
+        onSpaceClick={onSpaceClick}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy Alpha Space ID' }))
+
+    expect(
+      await screen.findByRole('button', { name: 'Copy failed' }),
+    ).toBeDefined()
+    expect(screen.queryByRole('button', { name: 'Copied' })).toBeNull()
+    expect(onSpaceClick).not.toHaveBeenCalled()
+  })
+
+  it('uses cmdk filtering for Space rows and sibling copy actions', async () => {
+    const onSpaceClick = vi.fn()
+    const { unmount } = render(
+      <SessionDashboard
+        spaces={[
+          { id: 'space-alpha', name: 'Alpha Space' },
+          { id: 'space-beta', name: 'Beta Drive', orgId: 'org-beta' },
+          { id: 'space-gamma', name: 'Gamma Doc', orgId: 'org-gamma' },
+        ]}
+        orgs={[
+          { id: 'org-beta', displayName: 'Builders' },
+          { id: 'org-gamma', displayName: 'Unrelated' },
+        ]}
+        onSpaceClick={onSpaceClick}
+      />,
+    )
+    const input = screen.getByPlaceholderText('Search spaces...')
+
+    await userEvent.type(input, 'Builders')
+    expect(screen.queryByText('Alpha Space')).toBeNull()
+    expect(screen.queryByRole('button', { name: /Unrelated/ })).toBeNull()
+    expect(screen.queryByText('No results')).toBeNull()
+    expect(screen.getByText('Beta Drive')).toBeDefined()
+    expect(
+      screen.getByRole('button', { name: 'Copy Beta Drive ID' }),
+    ).toBeDefined()
+
+    unmount()
+    render(
+      <SessionDashboard
+        spaces={[
+          { id: 'space-alpha', name: 'Alpha Space' },
+          { id: 'space-beta', name: 'Beta Drive' },
+        ]}
+        onSpaceClick={onSpaceClick}
+      />,
+    )
+    const freshInput = screen.getByPlaceholderText('Search spaces...')
+    await userEvent.type(freshInput, 'AS')
+    expect(screen.getByText('Alpha Space')).toBeDefined()
+    expect(
+      screen.getByRole('button', { name: 'Copy Alpha Space ID' }),
+    ).toBeDefined()
+    await userEvent.keyboard('{ArrowDown}{Enter}')
+    expect(onSpaceClick).toHaveBeenCalledWith({
+      id: 'space-beta',
+      name: 'Beta Drive',
+    })
+  })
+
+  it('keeps only the latest clipboard result and ignores unmount completion', async () => {
+    let resolveFirst: (() => void) | undefined
+    mockClipboard.writeText
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveFirst = resolve
+          }),
+      )
+      .mockRejectedValueOnce(new Error('latest denied'))
+    const { unmount } = render(
+      <SessionDashboard
+        spaces={[{ id: 'space-1', name: 'Alpha Space' }]}
+        onSpaceClick={vi.fn()}
+      />,
+    )
+    const copy = screen.getByRole('button', { name: 'Copy Alpha Space ID' })
+
+    fireEvent.click(copy)
+    fireEvent.click(copy)
+    expect(
+      await screen.findByRole('button', { name: 'Copy failed' }),
+    ).toBeDefined()
+    resolveFirst?.()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(screen.getByRole('button', { name: 'Copy failed' })).toBeDefined()
+
+    let resolveUnmounted: (() => void) | undefined
+    mockClipboard.writeText.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveUnmounted = resolve
+        }),
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Copy failed' }))
+    unmount()
+    resolveUnmounted?.()
+    await Promise.resolve()
+    await Promise.resolve()
   })
 
   it('shows an overflow cue and the owner-provided source for every space row', () => {

--- a/app/session/dashboard/SessionDashboard.tsx
+++ b/app/session/dashboard/SessionDashboard.tsx
@@ -890,6 +890,12 @@ function DashboardSpaceItem({
       sublabel={getSpaceSourceLabel(space.source)}
       identifier={space.id}
       orgName={orgName}
+      keywords={[
+        space.id,
+        space.source ?? '',
+        space.objectType ?? '',
+        orgName ?? '',
+      ]}
       onSelect={() => onSelect(space)}
     />
   )
@@ -1142,6 +1148,7 @@ interface DashboardItemProps {
   identifier?: string
   orgName?: string
   onSelect: () => void
+  keywords?: string[]
 }
 
 function DashboardItem({
@@ -1154,11 +1161,16 @@ function DashboardItem({
   experimental,
   orgName,
   onSelect,
+  keywords,
 }: DashboardItemProps) {
-  return (
+  const item = (
     <CommandItem
       value={value}
-      className="group hover:!bg-background-card/30 focus:!bg-background-card/30 focus-visible:!bg-background-card/30 data-[selected=true]:hover:!bg-background-card/30 data-[selected=true]:focus:!bg-background-card/30 data-[selected=true]:focus-visible:!bg-background-card/30 mx-1 flex cursor-pointer items-center gap-3 rounded-md bg-transparent px-3 py-2.5 data-[selected=true]:!bg-transparent"
+      keywords={keywords}
+      className={cn(
+        'group hover:!bg-background-card/30 focus:!bg-background-card/30 focus-visible:!bg-background-card/30 data-[selected=true]:hover:!bg-background-card/30 data-[selected=true]:focus:!bg-background-card/30 data-[selected=true]:focus-visible:!bg-background-card/30 flex cursor-pointer items-center gap-3 rounded-md bg-transparent px-3 py-2.5 data-[selected=true]:!bg-transparent',
+        identifier ? 'mx-0 pr-16' : 'mx-1',
+      )}
       onSelect={onSelect}
     >
       <IconButton icon={icon} tone={iconTone} />
@@ -1183,19 +1195,10 @@ function DashboardItem({
             )}
             {identifier && (
               <span
-                className="flex min-w-0 items-center gap-1 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 group-data-[selected=true]:opacity-100"
+                className="text-foreground-alt/40 max-w-28 truncate font-mono text-xs"
                 title={identifier}
-                onClick={(event) => event.stopPropagation()}
-                onMouseDown={(event) => event.stopPropagation()}
               >
-                <span className="text-foreground-alt/40 max-w-28 truncate font-mono text-xs">
-                  {identifier}
-                </span>
-                <CopyButton
-                  text={identifier}
-                  label={`Copy ${label} ID`}
-                  className="hover:bg-foreground/5 size-5"
-                />
+                {identifier}
               </span>
             )}
           </div>
@@ -1203,5 +1206,18 @@ function DashboardItem({
       </div>
       <LuChevronRight className="text-foreground-alt/40 group-data-[selected=true]:text-foreground-alt size-4 shrink-0 transition-colors" />
     </CommandItem>
+  )
+
+  if (!identifier) return item
+
+  return (
+    <div className="relative mx-1 hidden has-[[cmdk-item]]:block">
+      {item}
+      <CopyButton
+        text={identifier}
+        label={`Copy ${label} ID`}
+        className="hover:bg-foreground/5 absolute right-8 bottom-2 size-6"
+      />
+    </div>
   )
 }

--- a/app/sobject/AddUserDialog.test.tsx
+++ b/app/sobject/AddUserDialog.test.tsx
@@ -1,6 +1,12 @@
 import React from 'react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
 
 import { SessionContext } from '@s4wave/web/contexts/contexts.js'
 import { SpaceContainerContext } from '@s4wave/web/contexts/SpaceContainerContext.js'
@@ -37,6 +43,8 @@ vi.mock('@s4wave/web/ui/tabs.js', () => ({
     <div>{children}</div>
   ),
 }))
+
+const mockClipboard = { writeText: vi.fn() }
 
 const mockSession = {
   spacewave: {
@@ -104,6 +112,17 @@ function renderDialog({ isCloudProvider = true } = {}) {
 }
 
 describe('AddUserDialog', () => {
+  beforeEach(() => {
+    mockClipboard.writeText.mockReset()
+    mockClipboard.writeText.mockResolvedValue(undefined)
+  })
+
+  Object.defineProperty(navigator, 'clipboard', {
+    value: mockClipboard,
+    writable: true,
+    configurable: true,
+  })
+
   afterEach(() => {
     cleanup()
     vi.clearAllMocks()
@@ -165,6 +184,74 @@ describe('AddUserDialog', () => {
     expect(
       mockSession.spacewave.createSpaceTargetedInvitationByUsername,
     ).toHaveBeenCalledWith('casey', 'space-1', 'writer')
+  })
+
+  it('reports clipboard rejection without showing copied success', async () => {
+    mockSession.createSpaceInvite = vi.fn().mockResolvedValue({
+      shortCode: 'ABC123',
+      inviteMessage: {},
+    }) as never
+    mockClipboard.writeText.mockRejectedValue(new Error('denied'))
+    renderDialog()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create Invite Code' }))
+    await waitFor(() => expect(screen.getByText('Copy Code')).toBeDefined())
+    fireEvent.click(screen.getByRole('button', { name: 'Copy Code' }))
+
+    expect(await screen.findByRole('alert')).toBeDefined()
+    expect(screen.getByRole('alert').textContent).toContain(
+      'Could not copy to the clipboard',
+    )
+    expect(screen.queryByText('Copied')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy Link' }))
+    await waitFor(() =>
+      expect(mockClipboard.writeText).toHaveBeenCalledTimes(2),
+    )
+    expect(screen.queryByText('Copied')).toBeNull()
+  })
+
+  it('keeps the latest copy result and ignores completion after unmount', async () => {
+    mockSession.createSpaceInvite = vi.fn().mockResolvedValue({
+      shortCode: 'ABC123',
+      inviteMessage: {},
+    }) as never
+    let rejectFirst: ((error: Error) => void) | undefined
+    mockClipboard.writeText
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((_, reject) => {
+            rejectFirst = reject
+          }),
+      )
+      .mockResolvedValueOnce(undefined)
+    const { unmount } = renderDialog()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create Invite Code' }))
+    await waitFor(() => expect(screen.getByText('Copy Code')).toBeDefined())
+    const copyLink = screen.getByRole('button', { name: 'Copy Link' })
+    fireEvent.click(copyLink)
+    fireEvent.click(copyLink)
+    await waitFor(() =>
+      expect(screen.getAllByText('Copied').length).toBeGreaterThan(0),
+    )
+    rejectFirst?.(new Error('stale denied'))
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(screen.queryByRole('alert')).toBeNull()
+
+    let resolveUnmounted: (() => void) | undefined
+    mockClipboard.writeText.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveUnmounted = resolve
+        }),
+    )
+    fireEvent.click(screen.getAllByText('Copied')[0]!.closest('button')!)
+    unmount()
+    resolveUnmounted?.()
+    await Promise.resolve()
+    await Promise.resolve()
   })
 
   it('hides username invites for local provider sessions', () => {

--- a/app/sobject/AddUserDialog.tsx
+++ b/app/sobject/AddUserDialog.tsx
@@ -1,5 +1,13 @@
 /* eslint-disable react-doctor/no-giant-component */
-import { useCallback, useId, useMemo, useReducer, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from 'react'
 import {
   LuBuilding2,
   LuCheck,
@@ -66,6 +74,7 @@ type InviteAction =
   | { type: 'error'; message: string }
   | { type: 'copied' }
   | { type: 'uncopied' }
+  | { type: 'copy_error' }
   | { type: 'username'; value: string }
   | { type: 'usernameSent' }
 
@@ -89,9 +98,15 @@ function reducer(state: InviteState, action: InviteAction): InviteState {
     case 'error':
       return { ...state, creating: false, error: action.message }
     case 'copied':
-      return { ...state, copied: true }
+      return { ...state, copied: true, error: undefined }
     case 'uncopied':
       return { ...state, copied: false }
+    case 'copy_error':
+      return {
+        ...state,
+        copied: false,
+        error: 'Could not copy to the clipboard',
+      }
     case 'username':
       return {
         ...state,
@@ -130,6 +145,18 @@ export function AddUserDialog({
   const inviteCodeId = useId()
   const usernameInputId = useId()
   const inviteLinkId = useId()
+  const copyGenerationRef = useRef(0)
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      copyGenerationRef.current += 1
+      if (copyTimerRef.current != null) clearTimeout(copyTimerRef.current)
+    }
+  }, [])
 
   const handleOpenChange = useCallback(
     (next: boolean) => {
@@ -186,10 +213,25 @@ export function AddUserDialog({
     return buildInviteLink(cloudProviderConfig?.publicBaseUrl, encoded)
   }, [state.inviteResp, cloudProviderConfig?.publicBaseUrl])
 
-  const handleCopy = useCallback((text: string) => {
-    void navigator.clipboard.writeText(text)
-    dispatch({ type: 'copied' })
-    setTimeout(() => dispatch({ type: 'uncopied' }), 2000)
+  const handleCopy = useCallback(async (text: string) => {
+    const generation = ++copyGenerationRef.current
+    if (copyTimerRef.current != null) clearTimeout(copyTimerRef.current)
+    try {
+      await navigator.clipboard.writeText(text)
+      if (!mountedRef.current || generation !== copyGenerationRef.current)
+        return
+      dispatch({ type: 'copied' })
+      copyTimerRef.current = setTimeout(() => {
+        if (!mountedRef.current || generation !== copyGenerationRef.current)
+          return
+        dispatch({ type: 'uncopied' })
+        copyTimerRef.current = null
+      }, 2000)
+    } catch {
+      if (!mountedRef.current || generation !== copyGenerationRef.current)
+        return
+      dispatch({ type: 'copy_error' })
+    }
   }, [])
 
   const effectiveOrgId = orgId ?? ''
@@ -287,7 +329,7 @@ export function AddUserDialog({
                   onClick={(e) => (e.target as HTMLInputElement).select()}
                 />
                 <button
-                  onClick={() => handleCopy(shortCode)}
+                  onClick={() => void handleCopy(shortCode)}
                   className={cn(
                     actionButtonClass,
                     state.copied && successActionClass,
@@ -366,15 +408,29 @@ export function AddUserDialog({
             </TabsContent>
           )}
 
-          <TabsContent value="link" className="space-y-3 pt-2">
+          <TabsContent value="link" className="space-y-4 pt-3">
+            <div className="border-foreground/8 bg-background-card/20 rounded-lg border p-3">
+              <div className="text-foreground text-sm font-medium">
+                Share a Space invite
+              </div>
+              <p className="text-foreground-alt/60 mt-1 text-xs leading-relaxed">
+                Create one link for this Space, then send it through a trusted
+                channel. The recipient uses Join Space to accept it.
+              </p>
+            </div>
             {state.inviteResp?.inviteMessage ? (
               <div className="space-y-2">
-                <label
-                  htmlFor={inviteLinkId}
-                  className="text-foreground-alt mb-1.5 block text-xs select-none"
-                >
-                  Invite link
-                </label>
+                <div className="flex items-center justify-between">
+                  <label
+                    htmlFor={inviteLinkId}
+                    className="text-foreground-alt text-xs select-none"
+                  >
+                    Invite link
+                  </label>
+                  <span className="bg-success/10 text-success rounded-full px-2 py-0.5 text-xs font-medium">
+                    Ready to share
+                  </span>
+                </div>
                 <input
                   id={inviteLinkId}
                   value={inviteLink}
@@ -383,7 +439,7 @@ export function AddUserDialog({
                   onClick={(e) => (e.target as HTMLInputElement).select()}
                 />
                 <button
-                  onClick={() => handleCopy(inviteLink)}
+                  onClick={() => void handleCopy(inviteLink)}
                   className={cn(
                     actionButtonClass,
                     state.copied && successActionClass,
@@ -408,14 +464,18 @@ export function AddUserDialog({
                 disabled={state.creating || !session}
                 className={actionButtonClass}
               >
-                {state.creating ? 'Creating…' : 'Create Invite Link'}
+                {state.creating
+                  ? 'Creating secure link…'
+                  : 'Create Invite Link'}
               </button>
             )}
           </TabsContent>
         </Tabs>
 
         {state.error && (
-          <p className="text-destructive text-xs">{state.error}</p>
+          <p role="alert" className="text-destructive text-xs">
+            {state.error}
+          </p>
         )}
       </DialogContent>
     </Dialog>

--- a/app/sobject/JoinSpaceDialog.test.tsx
+++ b/app/sobject/JoinSpaceDialog.test.tsx
@@ -46,10 +46,20 @@ vi.mock('@s4wave/web/ui/dialog.js', () => ({
   Dialog: ({
     children,
     open,
+    onOpenChange,
   }: {
     children?: React.ReactNode
     open: boolean
-  }) => (open ? <div>{children}</div> : null),
+    onOpenChange: (open: boolean) => void
+  }) =>
+    open ? (
+      <div>
+        {children}
+        <button type="button" onClick={() => onOpenChange(false)}>
+          Dismiss dialog
+        </button>
+      </div>
+    ) : null,
   DialogContent: ({ children }: { children?: React.ReactNode }) => (
     <div>{children}</div>
   ),
@@ -95,6 +105,184 @@ describe('JoinSpaceDialog', () => {
     )
     fireEvent.click(screen.getByRole('button', { name: 'Join Space' }))
   }
+
+  it('disables invalid input and labels the invite field', () => {
+    render(
+      <JoinSpaceDialog
+        onAccepted={mockAccepted}
+        open={true}
+        onOpenChange={() => {}}
+      />,
+    )
+
+    expect(screen.getByLabelText('Invite code or link')).toBeDefined()
+    expect(
+      (screen.getByRole('button', { name: 'Join Space' }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true)
+  })
+
+  it('shows progress, reports an error, and retries the same invite', async () => {
+    let rejectLookup: ((error: Error) => void) | undefined
+    mockLookupInviteCode
+      .mockImplementationOnce(
+        () =>
+          new Promise((_, reject) => {
+            rejectLookup = reject
+          }),
+      )
+      .mockResolvedValueOnce({ inviteMessage: { inviteId: 'inv-2' } })
+    mockJoinSpaceViaInvite.mockResolvedValue({
+      result: JoinSpaceViaInviteResult.JoinSpaceViaInviteResult_REJECTED,
+    })
+
+    renderDialog()
+    expect(screen.getByText('Looking up invite...')).toBeDefined()
+    rejectLookup?.(new Error('Invite service unavailable'))
+
+    expect((await screen.findByRole('alert')).textContent).toContain(
+      'Invite service unavailable',
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+
+    await waitFor(() => {
+      expect(mockLookupInviteCode).toHaveBeenCalledTimes(2)
+      expect(screen.getByText('Invite rejected')).toBeDefined()
+    })
+  })
+
+  it('invalidates an in-flight invite lookup when closed and reopened', async () => {
+    let resolveLookup: ((value: { inviteMessage: object }) => void) | undefined
+    mockLookupInviteCode.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveLookup = resolve
+        }),
+    )
+    const onOpenChange = vi.fn()
+    const { rerender } = render(
+      <JoinSpaceDialog
+        onAccepted={mockAccepted}
+        open={true}
+        onOpenChange={onOpenChange}
+        initialCode="abc123"
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Join Space' }))
+    rerender(
+      <JoinSpaceDialog
+        onAccepted={mockAccepted}
+        open={false}
+        onOpenChange={onOpenChange}
+      />,
+    )
+    rerender(
+      <JoinSpaceDialog
+        onAccepted={mockAccepted}
+        open={true}
+        onOpenChange={onOpenChange}
+      />,
+    )
+    resolveLookup?.({ inviteMessage: { inviteId: 'stale' } })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    await waitFor(() => {
+      expect(mockJoinSpaceViaInvite).not.toHaveBeenCalled()
+      expect(
+        (screen.getByLabelText('Invite code or link') as HTMLInputElement)
+          .value,
+      ).toBe('')
+    })
+  })
+
+  it('invalidates an in-flight lookup when unmounted', async () => {
+    let resolveLookup: ((value: { inviteMessage: object }) => void) | undefined
+    mockLookupInviteCode.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveLookup = resolve
+        }),
+    )
+    const { unmount } = render(
+      <JoinSpaceDialog
+        onAccepted={mockAccepted}
+        open={true}
+        onOpenChange={() => {}}
+        initialCode="abc123"
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Join Space' }))
+    unmount()
+    resolveLookup?.({ inviteMessage: { inviteId: 'stale' } })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(mockJoinSpaceViaInvite).not.toHaveBeenCalled()
+  })
+
+  it('ignores an in-flight join result after the dialog closes', async () => {
+    let resolveJoin: ((value: object) => void) | undefined
+    mockJoinSpaceViaInvite.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveJoin = resolve
+        }),
+    )
+    const onOpenChange = vi.fn()
+    const { rerender } = render(
+      <JoinSpaceDialog
+        onAccepted={mockAccepted}
+        open={true}
+        onOpenChange={onOpenChange}
+        initialCode="abc123"
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Join Space' }))
+    await waitFor(() => expect(mockJoinSpaceViaInvite).toHaveBeenCalledTimes(1))
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss dialog' }))
+    rerender(
+      <JoinSpaceDialog
+        onAccepted={mockAccepted}
+        open={true}
+        onOpenChange={onOpenChange}
+      />,
+    )
+    resolveJoin?.({
+      result: JoinSpaceViaInviteResult.JoinSpaceViaInviteResult_ACCEPTED,
+      sharedObjectId: 'stale-space',
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    await waitFor(() => {
+      expect(screen.queryByText('Joined successfully!')).toBeNull()
+      expect(
+        (screen.getByLabelText('Invite code or link') as HTMLInputElement)
+          .value,
+      ).toBe('')
+    })
+  })
+
+  it('returns to input state when the invite is edited after a failure', async () => {
+    mockLookupInviteCode.mockRejectedValueOnce(new Error('Invite expired'))
+    renderDialog()
+
+    expect(await screen.findByRole('alert')).toBeDefined()
+    const input = screen.getByLabelText('Invite code or link')
+    fireEvent.change(input, { target: { value: 'replacement' } })
+
+    expect(screen.queryByRole('alert')).toBeNull()
+    expect(input.getAttribute('aria-invalid')).toBe('false')
+    fireEvent.click(screen.getByRole('button', { name: 'Join Space' }))
+
+    await waitFor(() => {
+      expect(mockLookupInviteCode).toHaveBeenLastCalledWith('replacement')
+    })
+  })
 
   it('renders pending owner approval state for cloud mailbox submit', async () => {
     mockJoinSpaceViaInvite.mockResolvedValue({

--- a/app/sobject/JoinSpaceDialog.tsx
+++ b/app/sobject/JoinSpaceDialog.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useReducer } from 'react'
+import { useCallback, useEffect, useId, useReducer, useRef } from 'react'
+import {
+  LuCheck,
+  LuLogIn,
+  LuShieldCheck,
+  LuTriangleAlert,
+} from 'react-icons/lu'
+
 import { Spinner } from '@s4wave/web/ui/loading/Spinner.js'
 
 import { SOInviteMessage } from '@s4wave/core/sobject/sobject.pb.js'
@@ -66,7 +73,13 @@ function reducer(state: JoinState, action: JoinAction): JoinState {
     case 'reset':
       return initialState
     case 'set_code':
-      return { ...state, code: action.code, error: undefined }
+      return {
+        ...state,
+        code: action.code,
+        phase: 'input',
+        error: undefined,
+        spaceId: undefined,
+      }
     case 'resolving':
       return { ...state, phase: 'resolving', error: undefined }
     case 'connecting':
@@ -102,6 +115,8 @@ export function JoinSpaceDialog({
   onAccepted,
   initialCode,
 }: JoinSpaceDialogProps) {
+  const inputId = useId()
+  const submitGenerationRef = useRef(0)
   const session = useResourceValue(SessionContext.useContext())
   const { isCloud } = useSessionInfo(session)
   const [state, dispatch] = useReducer(reducer, {
@@ -109,9 +124,22 @@ export function JoinSpaceDialog({
     code: initialCode ?? '',
   })
 
+  useEffect(() => {
+    if (!open) {
+      submitGenerationRef.current += 1
+      dispatch({ type: 'reset' })
+    }
+    return () => {
+      submitGenerationRef.current += 1
+    }
+  }, [open])
+
   const handleOpenChange = useCallback(
     (next: boolean) => {
-      if (!next) dispatch({ type: 'reset' })
+      if (!next) {
+        submitGenerationRef.current += 1
+        dispatch({ type: 'reset' })
+      }
       onOpenChange(next)
     },
     [onOpenChange],
@@ -120,12 +148,15 @@ export function JoinSpaceDialog({
   const handleSubmit = useCallback(async () => {
     if (!session || !state.code.trim()) return
     const input = state.code.trim()
+    const generation = ++submitGenerationRef.current
 
     dispatch({ type: 'resolving' })
     try {
       const inviteMsg = await resolveInvite(session, input, isCloud)
+      if (generation !== submitGenerationRef.current) return
       dispatch({ type: 'connecting' })
       const resp = await session.joinSpaceViaInvite(inviteMsg)
+      if (generation !== submitGenerationRef.current) return
       switch (
         resp.result ??
         JoinSpaceViaInviteResult.JoinSpaceViaInviteResult_UNSPECIFIED
@@ -151,6 +182,7 @@ export function JoinSpaceDialog({
           throw new Error('Invite join returned an unknown result')
       }
     } catch (err) {
+      if (generation !== submitGenerationRef.current) return
       dispatch({
         type: 'error',
         message: err instanceof Error ? err.message : 'Failed to join space',
@@ -162,36 +194,66 @@ export function JoinSpaceDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Join Space</DialogTitle>
-          <DialogDescription>
-            {isCloud
-              ? 'Enter an invite code or paste an invite link.'
-              : 'Paste an invite link to join a space.'}
-          </DialogDescription>
+      <DialogContent className="border-foreground/10 bg-background-get-started max-w-md overflow-hidden border p-0">
+        <DialogHeader className="border-foreground/8 border-b px-6 py-5 text-left">
+          <div className="flex items-start gap-3">
+            <div className="bg-brand/10 text-brand flex size-10 shrink-0 items-center justify-center rounded-lg">
+              <LuLogIn className="size-4" />
+            </div>
+            <div className="min-w-0">
+              <DialogTitle>Join Space</DialogTitle>
+              <DialogDescription className="mt-1.5 leading-relaxed">
+                {isCloud
+                  ? 'Enter an invite code or paste an invite link.'
+                  : 'Paste an invite link to continue.'}
+              </DialogDescription>
+            </div>
+          </div>
         </DialogHeader>
 
-        <div className="space-y-3 pt-2">
-          <input
-            value={state.code}
-            onChange={(e) =>
-              dispatch({ type: 'set_code', code: e.target.value })
-            }
-            placeholder={isCloud ? 'Invite code or link' : 'Invite link'}
-            disabled={busy || state.phase === 'enrolled'}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' && !busy) void handleSubmit()
-            }}
-            className={cn(
-              'border-foreground/20 bg-background/30 text-foreground placeholder:text-foreground-alt/50 w-full rounded-md border px-3 py-2 font-mono text-sm transition-colors outline-none',
-              'focus:border-foreground/40',
-              'disabled:opacity-50',
-            )}
-          />
+        <form
+          className="space-y-4 px-6 py-5"
+          onSubmit={(event) => {
+            event.preventDefault()
+            if (!busy) void handleSubmit()
+          }}
+        >
+          <div>
+            <label
+              htmlFor={inputId}
+              className="text-foreground mb-1.5 block text-xs font-medium"
+            >
+              {isCloud ? 'Invite code or link' : 'Invite link'}
+            </label>
+            <input
+              id={inputId}
+              value={state.code}
+              onChange={(e) =>
+                dispatch({ type: 'set_code', code: e.target.value })
+              }
+              placeholder={isCloud ? 'Invite code or link' : 'Invite link'}
+              disabled={busy || state.phase === 'enrolled'}
+              aria-invalid={state.phase === 'error'}
+              aria-describedby={`${inputId}-guidance${state.error ? ` ${inputId}-error` : ''}`}
+              className={cn(
+                'border-foreground/20 bg-background/30 text-foreground placeholder:text-foreground-alt/50 w-full rounded-md border px-3 py-2 font-mono text-sm transition-colors outline-none',
+                'focus:border-brand/50 focus:ring-brand/20 focus:ring-2',
+                'disabled:opacity-50',
+              )}
+            />
+            <p
+              id={`${inputId}-guidance`}
+              className="text-foreground-alt/50 mt-2 flex items-start gap-1.5 text-xs leading-relaxed"
+            >
+              <LuShieldCheck className="mt-0.5 size-3.5 shrink-0" />
+              The invite determines which Space you can access. It does not link
+              devices or accounts.
+            </p>
+          </div>
 
           {state.phase === 'enrolled' ? (
-            <div className="text-center">
+            <div className="border-success/20 bg-success/5 rounded-lg border p-4 text-center">
+              <LuCheck className="text-success mx-auto mb-2 size-5" />
               <p className="text-foreground text-sm font-medium">
                 Joined successfully!
               </p>
@@ -199,6 +261,7 @@ export function JoinSpaceDialog({
                 Your shared Space is ready.
               </p>
               <button
+                type="button"
                 onClick={() => {
                   if (state.spaceId) onAccepted(state.spaceId)
                 }}
@@ -220,6 +283,7 @@ export function JoinSpaceDialog({
                 shared Space. Return here to retry after approval.
               </p>
               <button
+                type="button"
                 onClick={() => handleOpenChange(false)}
                 className={cn(
                   'mt-3 flex w-full items-center justify-center gap-2 rounded-md border px-4 py-2 text-sm transition-all',
@@ -240,6 +304,7 @@ export function JoinSpaceDialog({
                 link again.
               </p>
               <button
+                type="button"
                 onClick={() => handleOpenChange(false)}
                 className={cn(
                   'mt-3 flex w-full items-center justify-center gap-2 rounded-md border px-4 py-2 text-sm transition-all',
@@ -258,6 +323,7 @@ export function JoinSpaceDialog({
                 This invite was denied or is no longer valid.
               </p>
               <button
+                type="button"
                 onClick={() => handleOpenChange(false)}
                 className={cn(
                   'mt-3 flex w-full items-center justify-center gap-2 rounded-md border px-4 py-2 text-sm transition-all',
@@ -279,24 +345,32 @@ export function JoinSpaceDialog({
               )}
               {!busy && (
                 <button
-                  onClick={() => void handleSubmit()}
+                  type="submit"
                   disabled={!state.code.trim() || !session}
                   className={cn(
                     'flex w-full items-center justify-center gap-2 rounded-md border px-4 py-2 text-sm transition-all',
-                    'border-foreground/20 hover:border-foreground/40 hover:bg-foreground/5',
+                    'border-brand/30 bg-brand/10 text-foreground hover:border-brand/40 hover:bg-brand/15',
+                    'focus-visible:ring-brand/40 focus-visible:ring-2 focus-visible:outline-none',
                     'disabled:cursor-not-allowed disabled:opacity-50',
                   )}
                 >
-                  Join Space
+                  {state.phase === 'error' ? 'Try again' : 'Join Space'}
                 </button>
               )}
             </>
           )}
 
           {state.error && (
-            <p className="text-destructive text-xs">{state.error}</p>
+            <div
+              id={`${inputId}-error`}
+              role="alert"
+              className="border-destructive/20 bg-destructive/5 text-destructive flex items-start gap-2 rounded-md border px-3 py-2.5 text-xs leading-relaxed"
+            >
+              <LuTriangleAlert className="mt-0.5 size-3.5 shrink-0" />
+              <span>{state.error}</span>
+            </div>
           )}
-        </div>
+        </form>
       </DialogContent>
     </Dialog>
   )

--- a/web/ui/CopyButton.tsx
+++ b/web/ui/CopyButton.tsx
@@ -1,5 +1,11 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { LuCheck, LuCopy } from 'react-icons/lu'
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type MouseEvent,
+} from 'react'
+import { LuCheck, LuCopy, LuTriangleAlert } from 'react-icons/lu'
 
 import { cn } from '@s4wave/web/style/utils.js'
 
@@ -27,23 +33,41 @@ export function CopyButton({
   label = 'Copy',
   size = 'sm',
 }: CopyButtonProps) {
-  const [copied, setCopied] = useState(false)
+  const [status, setStatus] = useState<'idle' | 'copied' | 'error'>('idle')
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const generationRef = useRef(0)
+  const mountedRef = useRef(true)
 
-  const handleCopy = useCallback(() => {
-    void navigator.clipboard.writeText(text)
-    setCopied(true)
-    if (timerRef.current != null) {
-      clearTimeout(timerRef.current)
-    }
-    timerRef.current = setTimeout(() => {
-      setCopied(false)
-      timerRef.current = null
-    }, COPIED_RESET_MS)
-  }, [text])
+  const handleCopy = useCallback(
+    async (event: MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault()
+      event.stopPropagation()
+      const generation = ++generationRef.current
+      if (timerRef.current != null) {
+        clearTimeout(timerRef.current)
+      }
+      try {
+        await navigator.clipboard.writeText(text)
+        if (!mountedRef.current || generation !== generationRef.current) return
+        setStatus('copied')
+      } catch {
+        if (!mountedRef.current || generation !== generationRef.current) return
+        setStatus('error')
+      }
+      timerRef.current = setTimeout(() => {
+        if (!mountedRef.current || generation !== generationRef.current) return
+        setStatus('idle')
+        timerRef.current = null
+      }, COPIED_RESET_MS)
+    },
+    [text],
+  )
 
   useEffect(() => {
+    mountedRef.current = true
     return () => {
+      mountedRef.current = false
+      generationRef.current += 1
       if (timerRef.current != null) {
         clearTimeout(timerRef.current)
         timerRef.current = null
@@ -58,15 +82,34 @@ export function CopyButton({
     <button
       type="button"
       onClick={handleCopy}
-      aria-label={copied ? 'Copied' : label}
+      onMouseDown={(event) => event.stopPropagation()}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') event.stopPropagation()
+      }}
+      aria-label={
+        status === 'copied'
+          ? 'Copied'
+          : status === 'error'
+            ? 'Copy failed'
+            : label
+      }
       className={cn(
         'text-foreground-alt hover:text-foreground flex shrink-0 items-center justify-center rounded transition-colors',
         boxCls,
         className,
       )}
     >
-      {copied ? (
+      <span className="sr-only" role="status" aria-live="polite">
+        {status === 'copied'
+          ? 'Copied'
+          : status === 'error'
+            ? 'Copy failed'
+            : ''}
+      </span>
+      {status === 'copied' ? (
         <LuCheck className={cn(iconCls, 'text-emerald-500')} />
+      ) : status === 'error' ? (
+        <LuTriangleAlert className={cn(iconCls, 'text-destructive')} />
       ) : (
         <LuCopy className={iconCls} />
       )}


### PR DESCRIPTION
Session Space rows displayed identifiers that neither opened nor copied reliably, while Join and Link dialogs obscured their primary actions and could retain stale asynchronous results after close. Clipboard failures also reported success or raced newer attempts.

Each Space row remains the cmdk selection action and its explicit copy control is a semantic sibling whose visibility follows the filtered item. Native cmdk filtering and keyboard selection remain intact. Copy completion is attempt-scoped, clipboard errors are visible, and invite lookup and join work are invalidated when the controlled dialog closes or unmounts.

Space identifiers open by default and copy only from the copy action. Join and Link flows now provide clear validation, progress, recovery, and completion states without stale operations.