### PR TITLE
fix(bldr): stabilize Vite startup cache inputs

### DIFF
--- a/bldr/web/pkg/esbuild/determine-cjs-exports/analyze.go
+++ b/bldr/web/pkg/esbuild/determine-cjs-exports/analyze.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/aperturerobotics/esbuild/pkg/cjsexports"
@@ -149,37 +150,61 @@ type requireItem struct {
 // nodeEnv controls which branch is followed for conditional require() calls
 // (e.g., "production" or "development").
 func AnalyzeCjsExports(codeRootPath, importPath string, nodePaths []string, nodeEnv string) (*CjsExportsResult, error) {
+	result, _, err := AnalyzeCjsExportsWithProvenance(codeRootPath, importPath, nodePaths, nodeEnv)
+	return result, err
+}
+
+// AnalyzeCjsExportsWithProvenance analyzes CJS exports and reports every file
+// consulted while resolving and parsing the selected module.
+func AnalyzeCjsExportsWithProvenance(codeRootPath, importPath string, nodePaths []string, nodeEnv string) (*CjsExportsResult, []string, error) {
 	// Resolve the entry file.
-	entry, err := ResolveModuleWithNodePaths(codeRootPath, importPath, nodePaths)
+	entry, resolutionFiles, err := ResolveModuleWithProvenance(codeRootPath, importPath, nodePaths)
 	if err != nil {
-		return nil, errors.Wrap(err, "resolve "+importPath)
+		return nil, nil, errors.Wrap(err, "resolve "+importPath)
 	}
 
 	// Handle JSON files: extract top-level object keys.
 	if strings.HasSuffix(entry, ".json") {
 		keys, err := getJSONKeys(entry)
 		if err != nil {
-			return nil, errors.Wrap(err, "read json "+entry)
+			return nil, nil, errors.Wrap(err, "read json "+entry)
 		}
-		return verifyExports(keys), nil
+		result := verifyExports(keys)
+		return result, append(resolutionFiles, entry), nil
 	}
 
 	// Only process .js, .cjs, .mjs files.
 	if !strings.HasSuffix(entry, ".js") && !strings.HasSuffix(entry, ".cjs") && !strings.HasSuffix(entry, ".mjs") {
-		return verifyExports(nil), nil
+		result := verifyExports(nil)
+		return result, append(resolutionFiles, entry), nil
 	}
 
 	// Process the requires queue.
 	var collected []string
+	sourceFiles := slices.Clone(resolutionFiles)
+	visited := make(map[requireItem]struct{})
 	requires := []requireItem{{path: entry, callMode: false}}
 	for len(requires) > 0 {
 		// Pop from queue.
 		req := requires[len(requires)-1]
 		requires = requires[:len(requires)-1]
+		canonicalPath, canonicalErr := filepath.EvalSymlinks(req.path)
+		if canonicalErr != nil {
+			canonicalPath, canonicalErr = filepath.Abs(req.path)
+			if canonicalErr != nil {
+				return nil, nil, canonicalErr
+			}
+		}
+		identity := requireItem{path: canonicalPath, callMode: req.callMode}
+		if _, ok := visited[identity]; ok {
+			continue
+		}
+		visited[identity] = struct{}{}
 
+		sourceFiles = append(sourceFiles, canonicalPath)
 		code, readErr := os.ReadFile(req.path)
 		if readErr != nil {
-			return nil, errors.Wrap(readErr, "read "+req.path)
+			return nil, nil, errors.Wrap(readErr, "read "+req.path)
 		}
 
 		result, parseErr := cjsexports.Parse(string(code), req.path, cjsexports.Options{
@@ -187,7 +212,7 @@ func AnalyzeCjsExports(codeRootPath, importPath string, nodePaths []string, node
 			CallMode: req.callMode,
 		})
 		if parseErr != nil {
-			return nil, errors.Wrap(parseErr, "parse "+req.path)
+			return nil, nil, errors.Wrap(parseErr, "parse "+req.path)
 		}
 
 		// Optimization: single reexport with no local exports and nothing collected yet.
@@ -199,11 +224,12 @@ func AnalyzeCjsExports(codeRootPath, importPath string, nodePaths []string, node
 				!builtinNodeModules[reexp] &&
 				len(reexp) > 0 &&
 				(reexp[0] >= 'a' && reexp[0] <= 'z' || reexp[0] >= 'A' && reexp[0] <= 'Z' || reexp[0] == '@') {
+				slices.Sort(sourceFiles)
 				return &CjsExportsResult{
 					Reexport:      reexp,
 					ExportDefault: false,
 					Exports:       []string{},
-				}, nil
+				}, slices.Compact(sourceFiles), nil
 			}
 		}
 
@@ -220,16 +246,18 @@ func AnalyzeCjsExports(codeRootPath, importPath string, nodePaths []string, node
 				continue
 			}
 
-			resolved, resolveErr := ResolveModuleWithNodePaths(filepath.Dir(req.path), reexp, nodePaths)
+			resolved, resolutionFiles, resolveErr := ResolveModuleWithProvenance(filepath.Dir(req.path), reexp, nodePaths)
+			sourceFiles = append(sourceFiles, resolutionFiles...)
 			if resolveErr != nil {
-				return nil, errors.Wrap(resolveErr, "resolve reexport "+reexp)
+				return nil, nil, errors.Wrap(resolveErr, "resolve reexport "+reexp)
 			}
 
 			if strings.HasSuffix(resolved, ".json") {
 				keys, jsonErr := getJSONKeys(resolved)
 				if jsonErr != nil {
-					return nil, errors.Wrap(jsonErr, "read json "+resolved)
+					return nil, nil, errors.Wrap(jsonErr, "read json "+resolved)
 				}
+				sourceFiles = append(sourceFiles, resolved)
 				collected = append(collected, keys...)
 				continue
 			}
@@ -238,7 +266,9 @@ func AnalyzeCjsExports(codeRootPath, importPath string, nodePaths []string, node
 		}
 	}
 
-	return verifyExports(collected), nil
+	result := verifyExports(collected)
+	slices.Sort(sourceFiles)
+	return result, slices.Compact(sourceFiles), nil
 }
 
 // verifyExports filters and deduplicates export names.

--- a/bldr/web/pkg/esbuild/determine-cjs-exports/analyze_test.go
+++ b/bldr/web/pkg/esbuild/determine-cjs-exports/analyze_test.go
@@ -1,12 +1,21 @@
 package determine_cjs_exports
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"slices"
 	"sort"
 	"testing"
+	"time"
 )
+
+func TestCjsExportsResultRetainsFiveFieldCompositeShape(t *testing.T) {
+	result := CjsExportsResult{"pkg", true, []string{"named"}, "error", "stack"}
+	if result.Reexport != "pkg" || !result.ExportDefault || len(result.Exports) != 1 || result.Error != "error" || result.Stack != "stack" {
+		t.Fatalf("unexpected unkeyed result: %#v", result)
+	}
+}
 
 func TestAnalyzeCjsExports_JSON(t *testing.T) {
 	// Create a temp directory with a JSON file.
@@ -66,12 +75,20 @@ if (process.env.NODE_ENV !== "production") {
 		t.Fatal(err)
 	}
 
-	prodResult, err := AnalyzeCjsExports(dir, "./index.js", nil, "production")
+	prodResult, prodSources, err := AnalyzeCjsExportsWithProvenance(dir, "./index.js", nil, "production")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !slices.Contains(prodResult.Exports, "prodOnly") || slices.Contains(prodResult.Exports, "devOnly") {
 		t.Fatalf("unexpected production exports: %v", prodResult.Exports)
+	}
+	canonicalDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantProdSources := []string{filepath.Join(canonicalDir, "index.js"), filepath.Join(canonicalDir, "prod.js")}
+	if !slices.Equal(prodSources, wantProdSources) {
+		t.Fatalf("unexpected production sources: got %v want %v", prodSources, wantProdSources)
 	}
 
 	devResult, err := AnalyzeCjsExports(dir, "./index.js", nil, "development")
@@ -200,5 +217,159 @@ func TestResolveModule_BarePackage(t *testing.T) {
 	expected := filepath.Join(libDir, "index.js")
 	if resolved != expected {
 		t.Fatalf("expected %s, got %s", expected, resolved)
+	}
+}
+
+func TestAnalyzeCjsExportsPackageMainProvenance(t *testing.T) {
+	dir := t.TempDir()
+	pkgDir := filepath.Join(dir, "node_modules", "redirect-pkg")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	packageJSON := filepath.Join(pkgDir, "package.json")
+	first := filepath.Join(pkgDir, "first.js")
+	second := filepath.Join(pkgDir, "second.js")
+	if err := os.WriteFile(first, []byte("exports.first = true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(second, []byte("exports.second = true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(packageJSON, []byte(`{"main":"first.js"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	firstResult, firstSources, err := AnalyzeCjsExportsWithProvenance(dir, "redirect-pkg", nil, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(packageJSON, []byte(`{"main":"second.js"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	secondResult, secondSources, err := AnalyzeCjsExportsWithProvenance(dir, "redirect-pkg", nil, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonicalPackageJSON, err := filepath.EvalSymlinks(packageJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(firstSources, canonicalPackageJSON) || !slices.Contains(secondSources, canonicalPackageJSON) {
+		t.Fatalf("package manifest missing from provenance: first=%v second=%v", firstSources, secondSources)
+	}
+	if !slices.Contains(firstResult.Exports, "first") || !slices.Contains(secondResult.Exports, "second") {
+		t.Fatalf("package main redirect did not change exports: first=%v second=%v", firstResult.Exports, secondResult.Exports)
+	}
+}
+
+func TestResolveModuleProvenancePreservesPrimaryBareError(t *testing.T) {
+	dir := t.TempDir()
+	failedNodePath := filepath.Join(dir, "extra", "node_modules")
+	failedPkg := filepath.Join(failedNodePath, "missing-package")
+	if err := os.MkdirAll(failedPkg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(failedPkg, "package.json"), []byte(`{"main":"also-missing.js"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := ResolveModuleWithProvenance(dir, "missing-package", []string{failedNodePath})
+	var notFound *ModuleNotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("resolution error = %v, want ModuleNotFoundError", err)
+	}
+	if notFound.Path != "missing-package" {
+		t.Fatalf("unresolved path = %q, want primary import", notFound.Path)
+	}
+}
+
+func TestResolveModulePreservesAbsentAbsoluteExtension(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "absent.js")
+	resolved, err := ResolveModule(t.TempDir(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved != path {
+		t.Fatalf("resolved path = %q, want %q", resolved, path)
+	}
+	provenanceResolved, provenance, err := ResolveModuleWithProvenance(t.TempDir(), path, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if provenanceResolved != path || len(provenance) != 0 {
+		t.Fatalf("provenance resolution = %q %v, want absent path and no manifests", provenanceResolved, provenance)
+	}
+}
+
+func TestResolveModuleProvenanceIncludesFailedPackageCandidates(t *testing.T) {
+	dir := t.TempDir()
+	failedNodePath := filepath.Join(dir, "failed", "node_modules")
+	goodNodePath := filepath.Join(dir, "good", "node_modules")
+	failedPkg := filepath.Join(failedNodePath, "candidate")
+	goodPkg := filepath.Join(goodNodePath, "candidate")
+	for _, pkg := range []string{failedPkg, goodPkg} {
+		if err := os.MkdirAll(pkg, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	failedManifest := filepath.Join(failedPkg, "package.json")
+	goodManifest := filepath.Join(goodPkg, "package.json")
+	if err := os.WriteFile(failedManifest, []byte(`{"main":"missing.js"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(goodManifest, []byte(`{"main":"index.js"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(goodPkg, "index.js"), []byte("exports.ok = true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, provenance, err := ResolveModuleWithProvenance(filepath.Join(dir, "source"), "candidate", []string{failedNodePath, goodNodePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonicalFailed, err := filepath.EvalSymlinks(failedManifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonicalGood, err := filepath.EvalSymlinks(goodManifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{canonicalFailed, canonicalGood}
+	if !slices.Equal(provenance, want) {
+		t.Fatalf("resolution provenance = %v, want %v", provenance, want)
+	}
+}
+
+func TestAnalyzeCjsExportsRelativeReexportCycles(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		files map[string]string
+	}{
+		{name: "self", files: map[string]string{"a.js": `module.exports = require("./a.js")`}},
+		{name: "two-file", files: map[string]string{
+			"a.js": `module.exports = require("./b.js")`,
+			"b.js": `module.exports = require("./a.js")`,
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for name, content := range test.files {
+				if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			done := make(chan error, 1)
+			go func() {
+				_, err := AnalyzeCjsExports(dir, "./a.js", nil, "production")
+				done <- err
+			}()
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatal(err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("cyclic CJS reexport analysis did not terminate")
+			}
+		})
 	}
 }

--- a/bldr/web/pkg/esbuild/determine-cjs-exports/resolve.go
+++ b/bldr/web/pkg/esbuild/determine-cjs-exports/resolve.go
@@ -9,180 +9,164 @@ import (
 	"github.com/aperturerobotics/fastjson"
 )
 
-// resolveExtensions is the ordered list of extensions to try when resolving.
 var resolveExtensions = []string{".cjs", ".js", ".json", ".node", ".es"}
 
+type moduleResolver struct {
+	manifests []string
+}
+
 // ResolveModule resolves a module import path to an absolute file path.
-// baseDir is the directory to resolve from (for relative imports).
-// importPath is the import specifier (e.g., "./lib", "react", "/abs/path.js").
 func ResolveModule(baseDir, importPath string) (string, error) {
-	// Absolute path with supported extension: return directly.
-	if strings.HasPrefix(importPath, "/") {
-		if hasExtension(importPath) {
-			return importPath, nil
-		}
-		return resolveFile(importPath)
-	}
-
-	// Relative path: resolve relative to baseDir.
-	if strings.HasPrefix(importPath, "./") || strings.HasPrefix(importPath, "../") {
-		abs := filepath.Join(baseDir, importPath)
-		return resolveFile(abs)
-	}
-
-	// Bare specifier: walk up looking for node_modules.
-	return resolveBarePath(baseDir, importPath)
+	return new(moduleResolver).resolveModule(baseDir, importPath)
 }
 
 // ResolveModuleWithNodePaths resolves a module, trying extra node paths if needed.
 func ResolveModuleWithNodePaths(baseDir, importPath string, nodePaths []string) (string, error) {
-	resolved, err := ResolveModule(baseDir, importPath)
-	if err == nil {
-		return resolved, nil
-	}
+	resolved, _, err := ResolveModuleWithProvenance(baseDir, importPath, nodePaths)
+	return resolved, err
+}
 
-	// Try each extra node path as a base directory for bare specifiers.
-	if !strings.HasPrefix(importPath, "./") && !strings.HasPrefix(importPath, "../") && !strings.HasPrefix(importPath, "/") {
-		for _, np := range nodePaths {
-			// nodePaths entries are node_modules directories themselves.
-			pkgDir := filepath.Join(np, importPath)
-			resolved, tryErr := resolvePackageDir(pkgDir)
-			if tryErr == nil {
-				return resolved, nil
+// ResolveModuleWithProvenance resolves a module and reports package manifests consulted during resolution.
+func ResolveModuleWithProvenance(baseDir, importPath string, nodePaths []string) (string, []string, error) {
+	r := new(moduleResolver)
+	resolved, err := r.resolveModule(baseDir, importPath)
+	primaryErr := err
+	if err != nil && !isRelativeOrAbsoluteImport(importPath) {
+		for _, nodePath := range nodePaths {
+			resolved, err = r.resolvePackageDir(filepath.Join(nodePath, importPath))
+			if err == nil {
+				break
 			}
 		}
-	}
-
-	return "", err
-}
-
-// resolveFile tries to resolve a path as a file or directory.
-func resolveFile(abs string) (string, error) {
-	// Try exact path.
-	if isFile(abs) {
-		return abs, nil
-	}
-
-	// Try with each extension.
-	for _, ext := range resolveExtensions {
-		p := abs + ext
-		if isFile(p) {
-			return p, nil
+		if err != nil {
+			err = primaryErr
 		}
 	}
-
-	// Try as directory with index file.
-	return resolveIndex(abs)
+	for i, manifest := range r.manifests {
+		if canonical, canonicalErr := filepath.EvalSymlinks(manifest); canonicalErr == nil {
+			r.manifests[i] = canonical
+		}
+	}
+	slices.Sort(r.manifests)
+	return resolved, slices.Compact(r.manifests), err
 }
 
-// resolveIndex tries to resolve a directory by looking for index files.
-func resolveIndex(dir string) (string, error) {
+func (r *moduleResolver) resolveModule(baseDir, importPath string) (string, error) {
+	if filepath.IsAbs(importPath) {
+		if hasExtension(importPath) {
+			return importPath, nil
+		}
+		return r.resolveFile(importPath)
+	}
+	if strings.HasPrefix(importPath, "./") || strings.HasPrefix(importPath, "../") {
+		return r.resolveFile(filepath.Join(baseDir, importPath))
+	}
+	return r.resolveBarePath(baseDir, importPath)
+}
+
+func (r *moduleResolver) resolveFile(candidate string) (string, error) {
+	if isFile(candidate) {
+		return candidate, nil
+	}
 	for _, ext := range resolveExtensions {
-		p := filepath.Join(dir, "index"+ext)
-		if isFile(p) {
-			return p, nil
+		path := candidate + ext
+		if isFile(path) {
+			return path, nil
+		}
+	}
+	return r.resolveIndex(candidate)
+}
+
+func (r *moduleResolver) resolveIndex(dir string) (string, error) {
+	for _, ext := range resolveExtensions {
+		path := filepath.Join(dir, "index"+ext)
+		if isFile(path) {
+			return path, nil
 		}
 	}
 	return "", &ModuleNotFoundError{Path: dir}
 }
 
-// resolveBarePath resolves a bare module specifier by walking up node_modules.
-func resolveBarePath(baseDir, importPath string) (string, error) {
-	dir := baseDir
-	for {
-		nmDir := filepath.Join(dir, "node_modules")
-		if isDir(nmDir) {
-			pkgDir := filepath.Join(nmDir, importPath)
-			resolved, err := resolvePackageDir(pkgDir)
+func (r *moduleResolver) resolveBarePath(baseDir, importPath string) (string, error) {
+	for dir := baseDir; ; dir = filepath.Dir(dir) {
+		nodeModules := filepath.Join(dir, "node_modules")
+		if isDir(nodeModules) {
+			resolved, err := r.resolvePackageDir(filepath.Join(nodeModules, importPath))
 			if err == nil {
 				return resolved, nil
 			}
 		}
-
 		parent := filepath.Dir(dir)
 		if parent == dir {
 			break
 		}
-		dir = parent
 	}
 	return "", &ModuleNotFoundError{Path: importPath}
 }
 
-// resolvePackageDir resolves a package directory using package.json main field.
-func resolvePackageDir(pkgDir string) (string, error) {
-	// If pkgDir is actually a file (or resolvable as one), use it directly.
-	if isFile(pkgDir) {
-		return pkgDir, nil
+func (r *moduleResolver) resolvePackageDir(packageDir string) (string, error) {
+	if isFile(packageDir) {
+		return packageDir, nil
 	}
 	for _, ext := range resolveExtensions {
-		p := pkgDir + ext
-		if isFile(p) {
-			return p, nil
+		path := packageDir + ext
+		if isFile(path) {
+			return path, nil
 		}
 	}
 
-	// Read package.json for main field.
-	pkgJSON := filepath.Join(pkgDir, "package.json")
-	if isFile(pkgJSON) {
-		main, err := readPackageMain(pkgJSON)
+	packageJSON := filepath.Join(packageDir, "package.json")
+	if isFile(packageJSON) {
+		r.manifests = append(r.manifests, packageJSON)
+		main, err := readPackageMain(packageJSON)
 		if err == nil && main != "" {
-			resolved, err := resolveFile(filepath.Join(pkgDir, main))
-			if err == nil {
+			if resolved, resolveErr := r.resolveFile(filepath.Join(packageDir, main)); resolveErr == nil {
 				return resolved, nil
 			}
 		}
 	}
-
-	// Fall back to index files.
-	return resolveIndex(pkgDir)
+	return r.resolveIndex(packageDir)
 }
 
-// readPackageMain reads the "main" field from a package.json file.
+func isRelativeOrAbsoluteImport(importPath string) bool {
+	return filepath.IsAbs(importPath) || strings.HasPrefix(importPath, "./") || strings.HasPrefix(importPath, "../")
+}
+
 func readPackageMain(path string) (string, error) {
 	// #nosec G703 -- path is resolved from the package graph under analysis, not user input.
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
 	}
-	var p fastjson.Parser
-	v, err := p.ParseBytes(data)
+	var parser fastjson.Parser
+	value, err := parser.ParseBytes(data)
 	if err != nil {
 		return "", err
 	}
-	return string(v.GetStringBytes("main")), nil
+	return string(value.GetStringBytes("main")), nil
 }
 
-// hasExtension checks if the path has one of the supported extensions.
-func hasExtension(p string) bool {
-	ext := filepath.Ext(p)
-	return slices.Contains(resolveExtensions, ext)
+func hasExtension(path string) bool {
+	return slices.Contains(resolveExtensions, filepath.Ext(path))
 }
 
-// isFile checks if the path is a regular file.
-func isFile(p string) bool {
-	// #nosec G703 -- p is resolved from the package graph under analysis, not user input.
-	info, err := os.Stat(p)
-	if err != nil {
-		return false
-	}
-	return !info.IsDir()
+func isFile(path string) bool {
+	// #nosec G703 -- path is resolved from the package graph under analysis, not user input.
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
 }
 
-// isDir checks if the path is a directory.
-func isDir(p string) bool {
-	info, err := os.Stat(p)
-	if err != nil {
-		return false
-	}
-	return info.IsDir()
+func isDir(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
 }
 
-// ModuleNotFoundError is returned when a module cannot be resolved.
+// ModuleNotFoundError reports the unresolved import path.
 type ModuleNotFoundError struct {
 	Path string
 }
 
-// Error returns the error message.
+// Error returns the unresolved-module message.
 func (e *ModuleNotFoundError) Error() string {
 	return "cannot resolve module: " + e.Path
 }

--- a/bldr/web/pkg/vite/vite.go
+++ b/bldr/web/pkg/vite/vite.go
@@ -42,6 +42,14 @@ func BuildWebPkgsVite(
 	viteBundler bldr_vite.SRPCViteBundlerClient,
 	cacheDir string,
 ) (webPkgIDs, sourcePaths []string, importMapEntries []ImportMapEntry, err error) {
+	canonicalCodeRoot, err := filepath.Abs(codeRootPath)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if resolvedRoot, resolveErr := filepath.EvalSymlinks(canonicalCodeRoot); resolveErr == nil {
+		canonicalCodeRoot = resolvedRoot
+	}
+
 	// Build list of web pkg IDs.
 	for _, ref := range webPkgsRefs {
 		webPkgIDs = append(webPkgIDs, ref.GetWebPkgId())
@@ -70,7 +78,7 @@ func BuildWebPkgsVite(
 		pkgRoot := webPkgRef.GetWebPkgRoot()
 		imports := webPkgRef.GetImports()
 		wrapperDir := filepath.Join(outputPath, ".cjs-wrappers")
-		imports, wrapperErr := generateCjsWrappers(le, pkgRoot, imports, wrapperDir, isRelease)
+		imports, wrapperSources, generatedWrappers, wrapperErr := generateCjsWrappers(le, pkgRoot, imports, wrapperDir, isRelease)
 		if wrapperErr != nil {
 			return nil, nil, nil, errors.Wrapf(wrapperErr, "generate cjs wrappers for %s", webPkgID)
 		}
@@ -97,15 +105,20 @@ func BuildWebPkgsVite(
 			return nil, nil, nil, errors.Errorf("vite build web pkg %s failed: %s", webPkgID, resp.GetError())
 		}
 
-		// Collect source files, making paths relative to codeRootPath.
-		for _, srcFile := range resp.GetSourceFiles() {
-			relPath := srcFile
-			if filepath.IsAbs(srcFile) {
-				var relErr error
-				relPath, relErr = filepath.Rel(codeRootPath, srcFile)
-				if relErr != nil {
-					continue
-				}
+		// Collect stable source inputs without recording generated CJS wrappers.
+		// Wrapper provenance remains cache input even when Vite reports only the
+		// generated module that imported it.
+		for _, srcFile := range append(resp.GetSourceFiles(), wrapperSources...) {
+			canonicalPath, pathErr := canonicalSourcePath(canonicalCodeRoot, srcFile)
+			if pathErr != nil {
+				continue
+			}
+			if _, generated := generatedWrappers[canonicalPath]; generated {
+				continue
+			}
+			relPath, relErr := filepath.Rel(canonicalCodeRoot, canonicalPath)
+			if relErr != nil {
+				continue
 			}
 			sourceFilesList = append(sourceFilesList, relPath)
 		}
@@ -128,6 +141,28 @@ func BuildWebPkgsVite(
 	return webPkgIDs, sourceFilesList, importMapEntries, nil
 }
 
+func canonicalSourcePath(rootPath, sourcePath string) (string, error) {
+	rootAbs, err := filepath.Abs(rootPath)
+	if err != nil {
+		return "", err
+	}
+	if canonicalRoot, canonicalErr := filepath.EvalSymlinks(rootAbs); canonicalErr == nil {
+		rootAbs = canonicalRoot
+	}
+	path := sourcePath
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(rootAbs, path)
+	}
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	if canonicalPath, canonicalErr := filepath.EvalSymlinks(path); canonicalErr == nil {
+		path = canonicalPath
+	}
+	return path, nil
+}
+
 // generateCjsWrappers analyzes each import file and generates ESM wrappers
 // for CJS modules. Returns a new imports list where CJS entries point to
 // wrapper .mjs files with named re-exports.
@@ -137,8 +172,10 @@ func generateCjsWrappers(
 	imports []string,
 	wrapperDir string,
 	isRelease bool,
-) ([]string, error) {
+) ([]string, []string, map[string]struct{}, error) {
 	result := make([]string, len(imports))
+	var sources []string
+	generated := make(map[string]struct{})
 	copy(result, imports)
 
 	for i, imp := range imports {
@@ -152,11 +189,12 @@ func generateCjsWrappers(
 		if isRelease {
 			nodeEnv = "production"
 		}
-		cjsResult, err := determine_cjs_exports.AnalyzeCjsExports(pkgRoot, "./"+imp, nil, nodeEnv)
+		cjsResult, analysisSources, err := determine_cjs_exports.AnalyzeCjsExportsWithProvenance(pkgRoot, "./"+imp, nil, nodeEnv)
 		if err != nil {
 			le.WithError(err).WithField("file", absPath).Debug("skipping cjs analysis")
 			continue
 		}
+		sources = append(sources, analysisSources...)
 		if len(cjsResult.Exports) == 0 && !cjsResult.ExportDefault && cjsResult.Reexport == "" {
 			continue
 		}
@@ -167,17 +205,21 @@ func generateCjsWrappers(
 		// Rolldown encountering require() calls in the conditional entry.
 		wrapperImportPath := absPath
 		if cjsResult.Reexport != "" {
-			resolved, resolveErr := determine_cjs_exports.ResolveModuleWithNodePaths(
+			resolved, resolutionFiles, resolveErr := determine_cjs_exports.ResolveModuleWithProvenance(
 				filepath.Dir(absPath), cjsResult.Reexport, nil,
 			)
+			sources = append(sources, resolutionFiles...)
 			if resolveErr == nil {
 				wrapperImportPath = resolved
 				// Re-analyze the resolved file for its actual exports.
-				resolvedResult, reErr := determine_cjs_exports.AnalyzeCjsExports(
+				resolvedResult, resolvedSources, reErr := determine_cjs_exports.AnalyzeCjsExportsWithProvenance(
 					filepath.Dir(resolved), "./"+filepath.Base(resolved), nil, nodeEnv,
 				)
-				if reErr == nil && (len(resolvedResult.Exports) > 0 || resolvedResult.ExportDefault) {
-					cjsResult = resolvedResult
+				if reErr == nil {
+					sources = append(sources, resolvedSources...)
+					if len(resolvedResult.Exports) > 0 || resolvedResult.ExportDefault {
+						cjsResult = resolvedResult
+					}
 				}
 			}
 		}
@@ -193,11 +235,17 @@ func generateCjsWrappers(
 		}
 
 		if err := os.MkdirAll(filepath.Dir(wrapperPath), 0o755); err != nil {
-			return nil, err
+			return nil, nil, nil, err
 		}
 		if err := os.WriteFile(wrapperPath, []byte(wrapperContent), 0o644); err != nil {
-			return nil, err
+			return nil, nil, nil, err
 		}
+		canonicalWrapper, err := canonicalSourcePath("", wrapperPath)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		wrapperPath = canonicalWrapper
+		generated[wrapperPath] = struct{}{}
 
 		le.WithFields(logrus.Fields{
 			"file":    imp,
@@ -209,5 +257,5 @@ func generateCjsWrappers(
 		result[i] = wrapperPath
 	}
 
-	return result, nil
+	return result, sources, generated, nil
 }

--- a/bldr/web/pkg/vite/vite_test.go
+++ b/bldr/web/pkg/vite/vite_test.go
@@ -17,8 +17,9 @@ import (
 )
 
 type fakeViteBundlerClient struct {
-	resp     *bldr_vite.BuildWebPkgResponse
-	requests []*bldr_vite.BuildWebPkgRequest
+	resp      *bldr_vite.BuildWebPkgResponse
+	buildResp func(*bldr_vite.BuildWebPkgRequest) *bldr_vite.BuildWebPkgResponse
+	requests  []*bldr_vite.BuildWebPkgRequest
 }
 
 func (f *fakeViteBundlerClient) SRPCClient() srpc.Client { return nil }
@@ -29,6 +30,9 @@ func (f *fakeViteBundlerClient) Build(context.Context, *bldr_vite.BuildRequest) 
 
 func (f *fakeViteBundlerClient) BuildWebPkg(_ context.Context, req *bldr_vite.BuildWebPkgRequest) (*bldr_vite.BuildWebPkgResponse, error) {
 	f.requests = append(f.requests, req)
+	if f.buildResp != nil {
+		return f.buildResp(req), nil
+	}
 	return f.resp, nil
 }
 
@@ -36,6 +40,17 @@ func TestBuildWebPkgsViteKeepsRelativeSourceFiles(t *testing.T) {
 	codeRootPath := t.TempDir()
 	pkgRoot := filepath.Join(codeRootPath, "node_modules", "@aptre", "it-ws")
 	outDir := filepath.Join(t.TempDir(), "out")
+	for _, source := range []string{
+		filepath.Join(pkgRoot, "dist/src/duplex.js"),
+		filepath.Join(pkgRoot, "dist/src/socket.js"),
+	} {
+		if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(source, []byte("export {}\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
 
 	client := &fakeViteBundlerClient{
 		resp: &bldr_vite.BuildWebPkgResponse{
@@ -74,6 +89,213 @@ func TestBuildWebPkgsViteKeepsRelativeSourceFiles(t *testing.T) {
 	}
 	if !slices.Equal(srcFiles, expected) {
 		t.Fatalf("unexpected source files: got %v want %v", srcFiles, expected)
+	}
+}
+
+func TestBuildWebPkgsViteUsesOneAbsoluteWrapperIdentity(t *testing.T) {
+	codeRootPath := t.TempDir()
+	workingDir := t.TempDir()
+	oldWorkingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(workingDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWorkingDir) })
+
+	pkgRoot := filepath.Join(codeRootPath, "node_modules", "stable-cjs")
+	if err := os.MkdirAll(pkgRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgRoot, "index.cjs"), []byte("exports.stable = true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outputPath := filepath.Join("relative-output", "plugin-C2-b7nSr")
+	var wrapperPath string
+	client := &fakeViteBundlerClient{buildResp: func(req *bldr_vite.BuildWebPkgRequest) *bldr_vite.BuildWebPkgResponse {
+		wrapperPath = req.GetImports()[0]
+		return &bldr_vite.BuildWebPkgResponse{Success: true, SourceFiles: []string{wrapperPath}}
+	}}
+	_, sourceFiles, _, err := BuildWebPkgsVite(
+		context.Background(), logrus.NewEntry(logrus.New()), codeRootPath,
+		[]*web_pkg.WebPkgRef{{WebPkgId: "stable-cjs", WebPkgRoot: pkgRoot, Imports: []string{"index.cjs"}}},
+		outputPath, "/b/pkg/", true, false, true, client, filepath.Join(t.TempDir(), "cache"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !filepath.IsAbs(wrapperPath) {
+		t.Fatalf("wrapper path = %q, want absolute", wrapperPath)
+	}
+	if _, err := os.Stat(wrapperPath); err != nil {
+		t.Fatalf("generated wrapper does not exist: %v", err)
+	}
+	if want := []string{"node_modules/stable-cjs/index.cjs"}; !slices.Equal(sourceFiles, want) {
+		t.Fatalf("source files = %v, want %v", sourceFiles, want)
+	}
+	if err := os.RemoveAll(filepath.Join(workingDir, "relative-output")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(wrapperPath); !os.IsNotExist(err) {
+		t.Fatalf("generated wrapper survived cleanup: %v", err)
+	}
+}
+
+func TestBuildWebPkgsViteIgnoresGeneratedOutputSources(t *testing.T) {
+	codeRootPath := t.TempDir()
+	oldWorkingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(codeRootPath); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWorkingDir) })
+	pkgRoot := filepath.Join(codeRootPath, "node_modules", "stable-pkg")
+	stableSource := filepath.Join(pkgRoot, "index.cjs")
+	if err := os.MkdirAll(pkgRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(stableSource, []byte("exports.stable = true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	build := func(outputName string, outputThroughSymlink, reportThroughSymlink bool) []string {
+		realOutput := filepath.Join(codeRootPath, ".bldr", "build", outputName)
+		aliasOutput := filepath.Join(codeRootPath, ".bldr", "aliases", outputName)
+		if err := os.MkdirAll(filepath.Dir(aliasOutput), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(realOutput, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(realOutput, aliasOutput); err != nil {
+			t.Fatal(err)
+		}
+		outputPath := realOutput
+		if outputThroughSymlink {
+			outputPath = aliasOutput
+		}
+		relativeOutput := filepath.Join(".bldr", "build", outputName)
+		if outputThroughSymlink {
+			relativeOutput = filepath.Join(".bldr", "aliases", outputName)
+		}
+		var generatedPath string
+		client := &fakeViteBundlerClient{
+			buildResp: func(req *bldr_vite.BuildWebPkgRequest) *bldr_vite.BuildWebPkgResponse {
+				generatedPath = req.GetImports()[0]
+				generatedAbs, absErr := filepath.Abs(generatedPath)
+				if absErr != nil {
+					t.Fatal(absErr)
+				}
+				reportedGenerated := generatedAbs
+				if reportThroughSymlink != outputThroughSymlink {
+					rel, relErr := filepath.Rel(outputPath, generatedAbs)
+					if relErr != nil {
+						t.Fatal(relErr)
+					}
+					if reportThroughSymlink {
+						reportedGenerated = filepath.Join(aliasOutput, rel)
+					} else {
+						reportedGenerated = filepath.Join(realOutput, rel)
+					}
+				}
+				return &bldr_vite.BuildWebPkgResponse{
+					Success:     true,
+					SourceFiles: []string{stableSource, reportedGenerated},
+				}
+			},
+		}
+		_, sourceFiles, _, err := BuildWebPkgsVite(
+			context.Background(),
+			logrus.NewEntry(logrus.New()),
+			codeRootPath,
+			[]*web_pkg.WebPkgRef{{
+				WebPkgId:   "stable-pkg",
+				WebPkgRoot: pkgRoot,
+				Imports:    []string{"index.cjs"},
+			}},
+			relativeOutput,
+			"/b/pkg/",
+			false,
+			false,
+			true,
+			client,
+			filepath.Join(t.TempDir(), "cache"),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Stat(generatedPath); err != nil {
+			t.Fatalf("generated wrapper was not created: %v", err)
+		}
+		if err := os.RemoveAll(realOutput); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Stat(generatedPath); !os.IsNotExist(err) {
+			t.Fatalf("generated wrapper survived output cleanup: %v", err)
+		}
+		return sourceFiles
+	}
+
+	first := build("plugin-C2-b7nSr", true, false)
+	second := build("plugin-B9-x4kLm", false, true)
+	want := []string{"node_modules/stable-pkg/index.cjs"}
+	if !slices.Equal(first, want) || !slices.Equal(second, want) {
+		t.Fatalf("startup sources changed with generated output: first=%v second=%v want=%v", first, second, want)
+	}
+}
+
+func TestBuildWebPkgsViteTracksConditionalReexportSources(t *testing.T) {
+	codeRootPath := t.TempDir()
+	pkgRoot := filepath.Join(codeRootPath, "node_modules", "conditional-pkg")
+	if err := os.MkdirAll(pkgRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgRoot, "index.js"), []byte(`
+if (process.env.NODE_ENV === "production") {
+  module.exports = require("bare-target")
+} else {
+  module.exports = require("./dev.js")
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	bareTargetRoot := filepath.Join(codeRootPath, "node_modules", "bare-target")
+	if err := os.MkdirAll(bareTargetRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bareTargetRoot, "package.json"), []byte(`{"main":"index.js"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bareTargetRoot, "index.js"), []byte("exports.production = true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgRoot, "dev.js"), []byte("exports.development = true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := &fakeViteBundlerClient{buildResp: func(req *bldr_vite.BuildWebPkgRequest) *bldr_vite.BuildWebPkgResponse {
+		return &bldr_vite.BuildWebPkgResponse{Success: true, SourceFiles: req.GetImports()}
+	}}
+	_, sourceFiles, _, err := BuildWebPkgsVite(
+		context.Background(), logrus.NewEntry(logrus.New()), codeRootPath,
+		[]*web_pkg.WebPkgRef{{WebPkgId: "conditional-pkg", WebPkgRoot: pkgRoot, Imports: []string{"index.js"}}},
+		filepath.Join(codeRootPath, ".bldr", "output"), "/b/pkg/", true, false, true,
+		client, filepath.Join(t.TempDir(), "cache"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	slices.Sort(sourceFiles)
+	want := []string{
+		"node_modules/bare-target/index.js",
+		"node_modules/bare-target/package.json",
+		"node_modules/conditional-pkg/index.js",
+	}
+	if !slices.Equal(sourceFiles, want) {
+		t.Fatalf("conditional wrapper sources = %v, want %v", sourceFiles, want)
 	}
 }
 
@@ -132,7 +354,11 @@ func TestBuildWebPkgsViteKeepsCjsWrappersOutsideOutDir(t *testing.T) {
 	if strings.HasPrefix(wrapperPath, outPrefix) {
 		t.Fatalf("wrapper path %s is inside outDir %s", wrapperPath, req.GetOutDir())
 	}
-	expectedPrefix := filepath.Join(outDir, ".cjs-wrappers") + string(os.PathSeparator)
+	expectedPrefix, err := filepath.EvalSymlinks(filepath.Join(outDir, ".cjs-wrappers"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedPrefix += string(os.PathSeparator)
 	if !strings.HasPrefix(wrapperPath, expectedPrefix) {
 		t.Fatalf("wrapper path %s does not use wrapper dir prefix %s", wrapperPath, expectedPrefix)
 	}


### PR DESCRIPTION
Vite reports generated CommonJS wrappers as package source files. Release builds clean these wrappers between profile and publication builds, causing startup-cache misses and new hashed plugin paths that stale recorded browser access order.

This change tracks every source file and package manifest consulted while resolving CommonJS exports. Generated wrappers use one canonical absolute identity, and only those exact wrapper files are excluded from cache inputs. The existing export-analysis API and module-resolution behavior remain compatible.

Startup cache reuse now depends on stable package provenance rather than transient bundle output. Conditional reexports, package redirects, cycles, relative output roots, and symlink aliases retain deterministic inputs.
