### PR TITLE
fix(deps): update GoScript WebKit disposal runtime

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 tool github.com/s4wave/goscript/cmd/goscript
 
-require github.com/s4wave/goscript v0.2.25 // master
+require github.com/s4wave/goscript v0.2.26-0.20260812073206-25935cfaf438 // master
 
 replace (
 	// aperture: use compatibility forks

--- a/go.sum
+++ b/go.sum
@@ -320,8 +320,8 @@ github.com/restic/chunker v0.5.0/go.mod h1:z0cH2BejpW636LXw0R/BGyv+Ey8+m9QGiOanD
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/s4wave/goscript v0.2.25 h1:cR0fTBHZ2iuRwA4T+cK9rnqdg/bZ7g9RrC+K6iwDBBs=
-github.com/s4wave/goscript v0.2.25/go.mod h1:2PkLvl4v5IXRzAh+HpOQymrS7Z6mNmAOKY89EoAhv8A=
+github.com/s4wave/goscript v0.2.26-0.20260812073206-25935cfaf438 h1:Q2Ywt/VOFsZDlTS0N5ITGOcfmIoL9AcbtnuR7y/bgXQ=
+github.com/s4wave/goscript v0.2.26-0.20260812073206-25935cfaf438/go.mod h1:2PkLvl4v5IXRzAh+HpOQymrS7Z6mNmAOKY89EoAhv8A=
 github.com/sasha-s/go-deadlock v0.3.9 h1:fiaT9rB7g5sr5ddNZvlwheclN9IP86eFW9WgqlEQV+w=
 github.com/sasha-s/go-deadlock v0.3.9/go.mod h1:KuZj51ZFmx42q/mPaYbRk0P1xcwe697zsJKE03vD4/Y=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=


### PR DESCRIPTION
Spacewave still resolves GoScript v0.2.25, whose disposable stack methods require native symbols. WebKit has no disposal symbols, so Bun lowered `using` declarations throw before application startup.

This pins GoScript at 25935cfa. That runtime resolves native or registry symbols and includes focused Chromium and WebKit browser coverage. The module checksum records the exact source while Chromium behavior and public APIs remain unchanged.

The next generated Spacewave browser can use the WebKit fallback.