### PR TITLE
fix(bldr): exclude Vite worktree from source paths

### DIFF
--- a/bldr/plugin/compiler/build-web-pkgs.go
+++ b/bldr/plugin/compiler/build-web-pkgs.go
@@ -68,10 +68,11 @@ func BuildDirectWebPkgs(
 	var importMapEntries []web_pkg_vite.ImportMapEntry
 	var srcFiles []string
 	err = web_pkg_vite.RunOneShot(ctx, le, distSourcePath, sourcePath, viteWorkingPath, func(ctx context.Context, client bldr_vite.SRPCViteBundlerClient) error {
-		_, builtSrcFiles, entries, buildErr := web_pkg_vite.BuildWebPkgsVite(
+		_, builtSrcFiles, entries, buildErr := web_pkg_vite.BuildWebPkgsViteWithManagedRoot(
 			ctx,
 			le,
 			sourcePath,
+			workingPath,
 			refs,
 			outWebPkgsPath,
 			bldr_plugin.PluginWebPkgHttpPrefix,

--- a/bldr/prototypes/build-web-pkg/main.go
+++ b/bldr/prototypes/build-web-pkg/main.go
@@ -57,10 +57,11 @@ func run(ctx context.Context, le *logrus.Entry) error {
 	distSourcePath := filepath.Join(rootDir, ".bldr", "src")
 
 	return web_pkg_vite.RunOneShot(ctx, le, distSourcePath, rootDir, workingDir, func(ctx context.Context, client bldr_vite.SRPCViteBundlerClient) error {
-		webPkgIds, srcPaths, importMapEntries, buildErr := web_pkg_vite.BuildWebPkgsVite(
+		webPkgIds, srcPaths, importMapEntries, buildErr := web_pkg_vite.BuildWebPkgsViteWithManagedRoot(
 			ctx,
 			le,
 			rootDir,
+			workingDir,
 			refs,
 			outDir,
 			bldr_plugin.PluginWebPkgHttpPrefix,

--- a/bldr/web/bundler/esbuild/compiler/compiler.go
+++ b/bldr/web/bundler/esbuild/compiler/compiler.go
@@ -325,10 +325,11 @@ func (c *Controller) BuildManifest(
 		if len(buildableWebPkgRefs) != 0 {
 			viteWorkingPath := filepath.Join(workingPath, "vite-web-pkgs")
 			err = web_pkg_vite.RunOneShot(ctx, le, distSourcePath, sourcePath, viteWorkingPath, func(ctx context.Context, client bldr_vite.SRPCViteBundlerClient) error {
-				_, srcFiles, _, buildErr := web_pkg_vite.BuildWebPkgsVite(
+				_, srcFiles, _, buildErr := web_pkg_vite.BuildWebPkgsViteWithManagedRoot(
 					ctx,
 					le,
 					sourcePath,
+					workingPath,
 					buildableWebPkgRefs,
 					outWebPkgsPath,
 					bldr_plugin.PluginWebPkgHttpPrefix,

--- a/bldr/web/bundler/vite/compiler/compiler.go
+++ b/bldr/web/bundler/vite/compiler/compiler.go
@@ -817,10 +817,11 @@ func (c *Controller) performFullRebuild(
 			return nil, errors.Wrap(awaitErr, "await vite bundler for web pkgs")
 		}
 
-		_, webPkgSrcFiles, _, err = web_pkg_vite.BuildWebPkgsVite(
+		_, webPkgSrcFiles, _, err = web_pkg_vite.BuildWebPkgsViteWithManagedRoot(
 			ctx,
 			le,
 			sourcePath,
+			workingPath,
 			buildableWebPkgRefs,
 			outWebPkgsPath,
 			bldr_plugin.PluginWebPkgHttpPrefix,

--- a/bldr/web/entrypoint/browser/bundle/bundle.go
+++ b/bldr/web/entrypoint/browser/bundle/bundle.go
@@ -1082,10 +1082,11 @@ func BuildWebPkgsBundle(ctx context.Context, le *logrus.Entry, stateDir string, 
 	var importMap web_entrypoint_index.ImportMap
 	viteWorkingPath := filepath.Join(stateDir, "vite-web-pkgs")
 	err = web_pkg_vite.RunOneShot(ctx, le, bldrDistRoot, bldrDistRoot, viteWorkingPath, func(ctx context.Context, client bldr_vite.SRPCViteBundlerClient) error {
-		_, _, mapEntries, buildErr := web_pkg_vite.BuildWebPkgsVite(
+		_, _, mapEntries, buildErr := web_pkg_vite.BuildWebPkgsViteWithManagedRoot(
 			ctx,
 			le,
 			buildDir,
+			stateDir,
 			refs,
 			outDir,
 			pathPrefix+"/pkgs/",

--- a/bldr/web/pkg/vite/managed-source-root.go
+++ b/bldr/web/pkg/vite/managed-source-root.go
@@ -1,0 +1,48 @@
+//go:build !js
+
+package web_pkg_vite
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// managedSourceRoot identifies one compiler-managed filesystem tree.
+type managedSourceRoot struct {
+	// path is the canonical lexical path to the managed filesystem tree.
+	path string
+	// info is the filesystem identity of the existing managed root.
+	info os.FileInfo
+}
+
+func newManagedSourceRoot(codeRootPath, managedRootPath string) (*managedSourceRoot, error) {
+	path, err := canonicalSourcePath(codeRootPath, managedRootPath)
+	if err != nil {
+		return nil, err
+	}
+	info, err := os.Stat(path)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	return &managedSourceRoot{path: path, info: info}, nil
+}
+
+// Contains reports whether path is inside the managed filesystem tree.
+func (r *managedSourceRoot) Contains(path string) bool {
+	if r.info != nil {
+		for ancestor := path; ; ancestor = filepath.Dir(ancestor) {
+			info, err := os.Stat(ancestor)
+			if err == nil && os.SameFile(r.info, info) {
+				return true
+			}
+			next := filepath.Dir(ancestor)
+			if next == ancestor {
+				break
+			}
+		}
+	}
+
+	relPath, err := filepath.Rel(r.path, path)
+	return err == nil && relPath != ".." && !strings.HasPrefix(relPath, ".."+string(os.PathSeparator))
+}

--- a/bldr/web/pkg/vite/managed-source-root_test.go
+++ b/bldr/web/pkg/vite/managed-source-root_test.go
@@ -1,0 +1,49 @@
+//go:build !js
+
+package web_pkg_vite
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestManagedSourceRootUsesFilesystemIdentity(t *testing.T) {
+	rootPath := filepath.Join(t.TempDir(), "state")
+	if err := os.Mkdir(rootPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	aliasPath := filepath.Join(t.TempDir(), "case-equivalent-state")
+	if err := os.Symlink(rootPath, aliasPath); err != nil {
+		t.Fatal(err)
+	}
+	sourcePath := filepath.Join(aliasPath, "build", "input.js")
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(sourcePath, []byte("export {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	root, err := newManagedSourceRoot("", rootPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !root.Contains(sourcePath) {
+		t.Fatalf("filesystem-equivalent source %q is outside %q", sourcePath, rootPath)
+	}
+}
+
+func TestManagedSourceRootContainsNonexistentLexicalDescendant(t *testing.T) {
+	rootPath := filepath.Join(t.TempDir(), "state")
+	root, err := newManagedSourceRoot("", rootPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !root.Contains(filepath.Join(rootPath, "build", "missing.js")) {
+		t.Fatal("nonexistent lexical descendant is outside managed root")
+	}
+	if root.Contains(filepath.Join(filepath.Dir(rootPath), "state-other", "missing.js")) {
+		t.Fatal("sibling with matching prefix is inside managed root")
+	}
+}

--- a/bldr/web/pkg/vite/vite.go
+++ b/bldr/web/pkg/vite/vite.go
@@ -42,12 +42,41 @@ func BuildWebPkgsVite(
 	viteBundler bldr_vite.SRPCViteBundlerClient,
 	cacheDir string,
 ) (webPkgIDs, sourcePaths []string, importMapEntries []ImportMapEntry, err error) {
+	return BuildWebPkgsViteWithManagedRoot(
+		ctx, le, codeRootPath, "", webPkgsRefs, outputPath, webPkgBasePath,
+		isRelease, jsMinification, jsSourcemaps, viteBundler, cacheDir,
+	)
+}
+
+// BuildWebPkgsViteWithManagedRoot builds web packages without retaining
+// compiler-managed files as durable source provenance.
+func BuildWebPkgsViteWithManagedRoot(
+	ctx context.Context,
+	le *logrus.Entry,
+	codeRootPath string,
+	managedRootPath string,
+	webPkgsRefs []*web_pkg.WebPkgRef,
+	outputPath string,
+	webPkgBasePath string,
+	isRelease bool,
+	jsMinification bool,
+	jsSourcemaps bool,
+	viteBundler bldr_vite.SRPCViteBundlerClient,
+	cacheDir string,
+) (webPkgIDs, sourcePaths []string, importMapEntries []ImportMapEntry, err error) {
 	canonicalCodeRoot, err := filepath.Abs(codeRootPath)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 	if resolvedRoot, resolveErr := filepath.EvalSymlinks(canonicalCodeRoot); resolveErr == nil {
 		canonicalCodeRoot = resolvedRoot
+	}
+	var managedRoot *managedSourceRoot
+	if managedRootPath != "" {
+		managedRoot, err = newManagedSourceRoot(canonicalCodeRoot, managedRootPath)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 	}
 
 	// Build list of web pkg IDs.
@@ -120,7 +149,10 @@ func BuildWebPkgsVite(
 			if relErr != nil {
 				continue
 			}
-			sourceFilesList = append(sourceFilesList, relPath)
+			if managedRoot != nil && managedRoot.Contains(canonicalPath) {
+				continue
+			}
+			sourceFilesList = append(sourceFilesList, filepath.ToSlash(relPath))
 		}
 
 		// Collect import map entries, prefixing output paths with the web pkg base path.

--- a/bldr/web/pkg/vite/vite_test.go
+++ b/bldr/web/pkg/vite/vite_test.go
@@ -62,10 +62,11 @@ func TestBuildWebPkgsViteKeepsRelativeSourceFiles(t *testing.T) {
 		},
 	}
 
-	_, srcFiles, _, err := BuildWebPkgsVite(
+	_, srcFiles, _, err := BuildWebPkgsViteWithManagedRoot(
 		context.Background(),
 		logrus.NewEntry(logrus.New()),
 		codeRootPath,
+		filepath.Join(codeRootPath, ".state"),
 		[]*web_pkg.WebPkgRef{{
 			WebPkgId:   "@aptre/it-ws",
 			WebPkgRoot: pkgRoot,
@@ -102,7 +103,11 @@ func TestBuildWebPkgsViteUsesOneAbsoluteWrapperIdentity(t *testing.T) {
 	if err := os.Chdir(workingDir); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = os.Chdir(oldWorkingDir) })
+	t.Cleanup(func() {
+		if err := os.Chdir(oldWorkingDir); err != nil {
+			t.Errorf("restore working directory: %v", err)
+		}
+	})
 
 	pkgRoot := filepath.Join(codeRootPath, "node_modules", "stable-cjs")
 	if err := os.MkdirAll(pkgRoot, 0o755); err != nil {
@@ -117,8 +122,8 @@ func TestBuildWebPkgsViteUsesOneAbsoluteWrapperIdentity(t *testing.T) {
 		wrapperPath = req.GetImports()[0]
 		return &bldr_vite.BuildWebPkgResponse{Success: true, SourceFiles: []string{wrapperPath}}
 	}}
-	_, sourceFiles, _, err := BuildWebPkgsVite(
-		context.Background(), logrus.NewEntry(logrus.New()), codeRootPath,
+	_, sourceFiles, _, err := BuildWebPkgsViteWithManagedRoot(
+		context.Background(), logrus.NewEntry(logrus.New()), codeRootPath, filepath.Join(codeRootPath, ".state"),
 		[]*web_pkg.WebPkgRef{{WebPkgId: "stable-cjs", WebPkgRoot: pkgRoot, Imports: []string{"index.cjs"}}},
 		outputPath, "/b/pkg/", true, false, true, client, filepath.Join(t.TempDir(), "cache"),
 	)
@@ -151,7 +156,11 @@ func TestBuildWebPkgsViteIgnoresGeneratedOutputSources(t *testing.T) {
 	if err := os.Chdir(codeRootPath); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = os.Chdir(oldWorkingDir) })
+	t.Cleanup(func() {
+		if err := os.Chdir(oldWorkingDir); err != nil {
+			t.Errorf("restore working directory: %v", err)
+		}
+	})
 	pkgRoot := filepath.Join(codeRootPath, "node_modules", "stable-pkg")
 	stableSource := filepath.Join(pkgRoot, "index.cjs")
 	if err := os.MkdirAll(pkgRoot, 0o755); err != nil {
@@ -207,10 +216,11 @@ func TestBuildWebPkgsViteIgnoresGeneratedOutputSources(t *testing.T) {
 				}
 			},
 		}
-		_, sourceFiles, _, err := BuildWebPkgsVite(
+		_, sourceFiles, _, err := BuildWebPkgsViteWithManagedRoot(
 			context.Background(),
 			logrus.NewEntry(logrus.New()),
 			codeRootPath,
+			filepath.Join(codeRootPath, ".state"),
 			[]*web_pkg.WebPkgRef{{
 				WebPkgId:   "stable-pkg",
 				WebPkgRoot: pkgRoot,
@@ -247,6 +257,80 @@ func TestBuildWebPkgsViteIgnoresGeneratedOutputSources(t *testing.T) {
 	}
 }
 
+func TestBuildWebPkgsViteLegacyCall(t *testing.T) {
+	client := &fakeViteBundlerClient{resp: &bldr_vite.BuildWebPkgResponse{Success: true}}
+	_, _, _, err := BuildWebPkgsVite(
+		context.Background(), logrus.NewEntry(logrus.New()), t.TempDir(), nil,
+		t.TempDir(), "/b/pkg/", false, false, true, client, t.TempDir(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuildWebPkgsViteIgnoresManagedStateSources(t *testing.T) {
+	const managedSuffix = "build/js/spacewave-app/sub/vite/build/web-pkgs/node_modules/@aptre/protobuf-es-lite/dist/assert.js"
+
+	run := func(t *testing.T, codeRootPath, managedRootPath, managedSource string) {
+		pkgRoot := filepath.Join(codeRootPath, "node_modules", "stable-pkg")
+		stableSource := filepath.Join(pkgRoot, "index.js")
+		for _, source := range []string{stableSource, managedSource} {
+			if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(source, []byte("export {}\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		client := &fakeViteBundlerClient{resp: &bldr_vite.BuildWebPkgResponse{
+			Success:     true,
+			SourceFiles: []string{stableSource, managedSource},
+		}}
+		_, sourceFiles, _, err := BuildWebPkgsViteWithManagedRoot(
+			context.Background(), logrus.NewEntry(logrus.New()), codeRootPath, managedRootPath,
+			[]*web_pkg.WebPkgRef{{WebPkgId: "stable-pkg", WebPkgRoot: pkgRoot}},
+			filepath.Join(t.TempDir(), "assets"),
+			"/b/pkg/", true, false, true, client, filepath.Join(t.TempDir(), "cache"),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := []string{"node_modules/stable-pkg/index.js"}; !slices.Equal(sourceFiles, want) {
+			t.Fatalf("source files = %v, want %v", sourceFiles, want)
+		}
+	}
+
+	t.Run("default", func(t *testing.T) {
+		codeRootPath := t.TempDir()
+		managedRootPath := filepath.Join(codeRootPath, ".bldr")
+		run(t, codeRootPath, managedRootPath, filepath.Join(managedRootPath, managedSuffix))
+	})
+
+	t.Run("custom-relative", func(t *testing.T) {
+		codeRootPath := t.TempDir()
+		oldWorkingDir, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(codeRootPath); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			if err := os.Chdir(oldWorkingDir); err != nil {
+				t.Errorf("restore working directory: %v", err)
+			}
+		})
+		run(t, codeRootPath, ".state", filepath.Join(codeRootPath, ".state", managedSuffix))
+	})
+
+	t.Run("absolute", func(t *testing.T) {
+		codeRootPath := t.TempDir()
+		managedRootPath := t.TempDir()
+		run(t, codeRootPath, managedRootPath, filepath.Join(managedRootPath, managedSuffix))
+	})
+}
+
 func TestBuildWebPkgsViteTracksConditionalReexportSources(t *testing.T) {
 	codeRootPath := t.TempDir()
 	pkgRoot := filepath.Join(codeRootPath, "node_modules", "conditional-pkg")
@@ -279,8 +363,8 @@ if (process.env.NODE_ENV === "production") {
 	client := &fakeViteBundlerClient{buildResp: func(req *bldr_vite.BuildWebPkgRequest) *bldr_vite.BuildWebPkgResponse {
 		return &bldr_vite.BuildWebPkgResponse{Success: true, SourceFiles: req.GetImports()}
 	}}
-	_, sourceFiles, _, err := BuildWebPkgsVite(
-		context.Background(), logrus.NewEntry(logrus.New()), codeRootPath,
+	_, sourceFiles, _, err := BuildWebPkgsViteWithManagedRoot(
+		context.Background(), logrus.NewEntry(logrus.New()), codeRootPath, filepath.Join(codeRootPath, ".state"),
 		[]*web_pkg.WebPkgRef{{WebPkgId: "conditional-pkg", WebPkgRoot: pkgRoot, Imports: []string{"index.js"}}},
 		filepath.Join(codeRootPath, ".bldr", "output"), "/b/pkg/", true, false, true,
 		client, filepath.Join(t.TempDir(), "cache"),
@@ -318,10 +402,11 @@ func TestBuildWebPkgsViteKeepsCjsWrappersOutsideOutDir(t *testing.T) {
 		resp: &bldr_vite.BuildWebPkgResponse{Success: true},
 	}
 
-	_, _, _, err := BuildWebPkgsVite(
+	_, _, _, err := BuildWebPkgsViteWithManagedRoot(
 		context.Background(),
 		logrus.NewEntry(logrus.New()),
 		codeRootPath,
+		filepath.Join(codeRootPath, ".state"),
 		[]*web_pkg.WebPkgRef{{
 			WebPkgId:   "cjs-pkg",
 			WebPkgRoot: pkgRoot,
@@ -378,10 +463,11 @@ func TestBuildWebPkgsVitePropagatesJavaScriptPolicy(t *testing.T) {
 		resp: &bldr_vite.BuildWebPkgResponse{Success: true},
 	}
 
-	_, _, _, err := BuildWebPkgsVite(
+	_, _, _, err := BuildWebPkgsViteWithManagedRoot(
 		context.Background(),
 		logrus.NewEntry(logrus.New()),
 		codeRootPath,
+		filepath.Join(codeRootPath, ".state"),
 		[]*web_pkg.WebPkgRef{{
 			WebPkgId:   "policy-pkg",
 			WebPkgRoot: pkgRoot,


### PR DESCRIPTION
Vite reports generated web-package files as source paths when a compiler worktree is below the code root. The manifest then records cache output as durable source provenance, so cache cleanup or a fresh startup can invalidate the build.

The Vite web-package builder now accepts the compiler-managed root and filters files in that tree by filesystem identity, with a lexical fallback for paths that do not exist yet. Compiler callers supply their work or state root, while the existing function preserves behavior for callers without one.

The filter retains genuine package sources, handles symlink aliases, and does not require the managed root to exist before source collection. Manifests track source inputs rather than ephemeral Vite cache output.