### PR TITLE
fix(bldr): wait for admitted JavaScript builds during release

### DIFF
--- a/bldr/plugin/compiler/js/compiler.go
+++ b/bldr/plugin/compiler/js/compiler.go
@@ -10,13 +10,13 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/aperturerobotics/controllerbus/bus"
 	"github.com/aperturerobotics/controllerbus/controller"
 	"github.com/aperturerobotics/controllerbus/controller/configset"
 	configset_proto "github.com/aperturerobotics/controllerbus/controller/configset/proto"
 	protobuf_go_lite_json "github.com/aperturerobotics/protobuf-go-lite/json"
+	"github.com/aperturerobotics/util/broadcast"
 	"github.com/aperturerobotics/util/fsutil"
 	"github.com/pkg/errors"
 	bldr "github.com/s4wave/spacewave/bldr"
@@ -54,73 +54,44 @@ type Controller struct {
 	*bus.BusController[*Config]
 	preBuildHooks []preBuildHookEntry
 
-	workDirMtx    sync.Mutex
-	ownedWorkDirs map[string]string
-	buildWg       sync.WaitGroup
-	closing       bool
+	// bcast guards build admission and completion.
+	bcast broadcast.Broadcast
+	// activeBuilds is the number of admitted builds that have not returned.
+	activeBuilds int
+	// closing rejects new builds after Close starts.
+	closing bool
 }
 
-func (c *Controller) acquireWorkingPath(originalWorkingPath string) (string, func(), error) {
-	c.workDirMtx.Lock()
-	defer c.workDirMtx.Unlock()
-
+func (c *Controller) admitBuild() (func(), error) {
+	locked := c.bcast.Lock()
 	if c.closing {
-		return "", nil, errors.New("js compiler is closed")
+		locked.Unlock()
+		return nil, errors.New("js compiler is closed")
 	}
-	if c.ownedWorkDirs == nil {
-		c.ownedWorkDirs = make(map[string]string)
-	}
+	c.activeBuilds++
+	locked.Unlock()
 
-	originalWorkingPath = filepath.Clean(originalWorkingPath)
-	workingPath := c.ownedWorkDirs[originalWorkingPath]
-	if workingPath == "" {
-		workingRoot, err := os.MkdirTemp("", "spacewave-js-build-")
-		if err != nil {
-			return "", nil, errors.Wrap(err, "create js builder working directory")
-		}
-		workingPath = filepath.Join(workingRoot, "work")
-		if filepath.IsAbs(originalWorkingPath) {
-			err = os.Rename(originalWorkingPath, workingPath)
-			if err != nil && !os.IsNotExist(err) {
-				_ = os.RemoveAll(workingRoot)
-				return "", nil, errors.Wrap(err, "take ownership of js builder working directory")
-			}
-		}
-		if err := os.MkdirAll(workingPath, 0o755); err != nil {
-			_ = os.RemoveAll(workingRoot)
-			return "", nil, errors.Wrap(err, "create js builder working directory")
-		}
-		c.ownedWorkDirs[originalWorkingPath] = workingPath
-	}
-	c.buildWg.Add(1)
-	return workingPath, c.buildWg.Done, nil
+	return func() {
+		locked := c.bcast.Lock()
+		c.activeBuilds--
+		locked.Broadcast()
+		locked.Unlock()
+	}, nil
 }
 
-// Close releases owned build directories after active builds have stopped.
+// Close rejects new builds and waits for admitted builds to finish.
 func (c *Controller) Close() error {
-	c.workDirMtx.Lock()
-	if c.closing {
-		c.workDirMtx.Unlock()
-		return nil
-	}
-	c.closing = true
-	c.workDirMtx.Unlock()
-
-	c.buildWg.Wait()
-
-	c.workDirMtx.Lock()
-	workingPaths := make([]string, 0, len(c.ownedWorkDirs))
-	for originalWorkingPath, workingPath := range c.ownedWorkDirs {
-		workingPaths = append(workingPaths, workingPath)
-		delete(c.ownedWorkDirs, originalWorkingPath)
-	}
-	c.workDirMtx.Unlock()
-	for _, workingPath := range workingPaths {
-		if err := os.RemoveAll(filepath.Dir(workingPath)); err != nil {
-			return err
+	for {
+		locked := c.bcast.Lock()
+		c.closing = true
+		if c.activeBuilds == 0 {
+			locked.Unlock()
+			return nil
 		}
+		waitCh := locked.WaitCh()
+		locked.Unlock()
+		<-waitCh
 	}
-	return nil
 }
 
 // preBuildHookEntry pairs a pre-build hook with its optional provenance declaration.
@@ -252,18 +223,15 @@ func (c *Controller) BuildManifest(
 		le.Warnf("skipping build for non-js platform: %v", buildPlatform.GetInputPlatformID())
 		return nil, nil
 	}
-	// BuildManifest may outlive the controller reference that supplied the
-	// workspace, so mutable outputs live under a builder-owned root.
-	builderConf = builderConf.CloneVT()
-	workingPath, releaseWorkingPath, err := c.acquireWorkingPath(builderConf.GetWorkingPath())
+	releaseBuild, err := c.admitBuild()
 	if err != nil {
 		return nil, err
 	}
-	defer releaseWorkingPath()
-	builderConf.WorkingPath = workingPath
+	defer releaseBuild()
 	le.Debug("building js plugin")
 
 	// output paths, dist is unused for JS compiler
+	workingPath := builderConf.GetWorkingPath()
 	// Note: outDistPath is not typically used by the JS compiler itself,
 	// but we create it for consistency and potential future use.
 	outDistPath := filepath.Join(workingPath, "dist")

--- a/bldr/plugin/compiler/js/compiler_test.go
+++ b/bldr/plugin/compiler/js/compiler_test.go
@@ -9,12 +9,15 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
+	"github.com/aperturerobotics/controllerbus/bus/inmem"
 	"github.com/aperturerobotics/controllerbus/controller/configset"
 	configset_proto "github.com/aperturerobotics/controllerbus/controller/configset/proto"
 	"github.com/aperturerobotics/controllerbus/controller/loader"
 	"github.com/aperturerobotics/controllerbus/controller/resolver"
+	directivecontroller "github.com/aperturerobotics/controllerbus/directive/controller"
 	starpc_mock "github.com/aperturerobotics/starpc/mock"
 	"github.com/aperturerobotics/util/promise"
 	bldr_manifest "github.com/s4wave/spacewave/bldr/manifest"
@@ -219,60 +222,111 @@ func TestPluginCompilerJs(t *testing.T) {
 	le.Infof("plugin successfully called host rpc with message: %v", string(calledMsgDat))
 }
 
-func TestPluginCompilerJsOwnsWorkingPathDuringBuild(t *testing.T) {
-	ctrl, err := bldr_plugin_compiler_js.NewController(logrus.NewEntry(logrus.New()), nil, &bldr_plugin_compiler_js.Config{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	workDir := t.TempDir()
-	args := &bldr_manifest_builder.BuildManifestArgs{
-		BuilderConfig: &bldr_manifest_builder.BuilderConfig{
-			ManifestMeta:   bldr_manifest.NewManifestMeta("test-plugin", bldr_manifest.BuildType_DEV, "js", 1),
-			SourcePath:     t.TempDir(),
-			DistSourcePath: t.TempDir(),
-			WorkingPath:    workDir,
-		},
-	}
-	buildStarted := make(chan struct{})
-	continueBuild := make(chan struct{})
-	sentinelErr := errors.New("stop after working-directory ownership check")
-	ctrl.AddPreBuildHook(func(
-		_ context.Context,
-		builderConf *bldr_manifest_builder.BuilderConfig,
-		_ world.Engine,
-	) (*bldr_plugin_compiler_js.PreBuildHookResult, error) {
-		close(buildStarted)
-		<-continueBuild
-		if err := os.WriteFile(filepath.Join(builderConf.GetWorkingPath(), "marker"), []byte("builder-owned"), 0o644); err != nil {
-			return nil, err
+func TestPluginCompilerJsReleaseWaitsForAdmittedBuild(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		le := logrus.NewEntry(logrus.New())
+		dc := directivecontroller.NewController(t.Context(), le)
+		b := inmem.NewBus(dc)
+		ctrl, err := bldr_plugin_compiler_js.NewController(le, b, &bldr_plugin_compiler_js.Config{})
+		if err != nil {
+			t.Fatal(err)
 		}
-		return nil, sentinelErr
+		release, err := b.AddController(t.Context(), ctrl, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		workDir := t.TempDir()
+		args := &bldr_manifest_builder.BuildManifestArgs{
+			BuilderConfig: &bldr_manifest_builder.BuilderConfig{
+				ManifestMeta:   bldr_manifest.NewManifestMeta("test-plugin", bldr_manifest.BuildType_DEV, "js", 1),
+				SourcePath:     t.TempDir(),
+				DistSourcePath: t.TempDir(),
+				WorkingPath:    workDir,
+			},
+		}
+		buildStarted := make(chan struct{})
+		continueBuild := make(chan struct{})
+		sentinelErr := errors.New("stop after release ordering check")
+		ctrl.AddPreBuildHook(func(
+			_ context.Context,
+			builderConf *bldr_manifest_builder.BuilderConfig,
+			_ world.Engine,
+		) (*bldr_plugin_compiler_js.PreBuildHookResult, error) {
+			close(buildStarted)
+			<-continueBuild
+			if err := os.WriteFile(filepath.Join(builderConf.GetWorkingPath(), "marker"), []byte("configured-path"), 0o644); err != nil {
+				return nil, err
+			}
+			return nil, sentinelErr
+		})
+
+		buildErr := make(chan error, 1)
+		go func() {
+			_, err := ctrl.BuildManifest(t.Context(), args, nil)
+			buildErr <- err
+		}()
+		<-buildStarted
+
+		releaseReturned := make(chan struct{})
+		go func() {
+			release()
+			close(releaseReturned)
+		}()
+		synctest.Wait()
+		releasedEarly := false
+		select {
+		case <-releaseReturned:
+			releasedEarly = true
+		default:
+		}
+		secondCloseReturned := make(chan struct{})
+		go func() {
+			_ = ctrl.Close()
+			close(secondCloseReturned)
+		}()
+		synctest.Wait()
+		select {
+		case <-secondCloseReturned:
+			t.Fatal("concurrent Close returned before the admitted build finished")
+		default:
+		}
+
+		close(continueBuild)
+		synctest.Wait()
+		if err := <-buildErr; !errors.Is(err, sentinelErr) {
+			t.Fatalf("BuildManifest error = %v, want sentinel", err)
+		}
+		select {
+		case <-releaseReturned:
+		default:
+			t.Fatal("controller release did not return after the admitted build finished")
+		}
+		select {
+		case <-secondCloseReturned:
+		default:
+			t.Fatal("concurrent Close did not return after the admitted build finished")
+		}
+		marker, err := os.ReadFile(filepath.Join(workDir, "marker"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(marker) != "configured-path" {
+			t.Fatalf("marker = %q, want configured-path", marker)
+		}
+		if releasedEarly {
+			t.Error("controller release returned before the admitted build finished")
+		}
+		if _, err := ctrl.BuildManifest(t.Context(), args, nil); err == nil || err.Error() != "js compiler is closed" {
+			t.Fatalf("BuildManifest after release error = %v, want closed", err)
+		}
+		if err := os.RemoveAll(workDir); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Stat(workDir); !os.IsNotExist(err) {
+			t.Fatalf("configured working path still exists after removal: %v", err)
+		}
 	})
-
-	buildErr := make(chan error, 1)
-	go func() {
-		_, err := ctrl.BuildManifest(context.Background(), args, nil)
-		buildErr <- err
-	}()
-
-	<-buildStarted
-	if err := os.RemoveAll(workDir); err != nil {
-		t.Fatal(err)
-	}
-	close(continueBuild)
-
-	select {
-	case err := <-buildErr:
-		if !errors.Is(err, sentinelErr) {
-			t.Fatalf("BuildManifest error = %v, want sentinel after builder-owned write", err)
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("BuildManifest did not finish after releasing the build seam")
-	}
-	if err := ctrl.Close(); err != nil {
-		t.Fatal(err)
-	}
 }
 
 func TestPluginCompilerJsStartupCacheRequiresStaticInputs(t *testing.T) {


### PR DESCRIPTION
ControllerBus release could return while JavaScript compiler directive work was still using a configured working path. That allowed callers to remove the path before BuildManifest returned and left release ordering dependent on the controller bus implementation.

The JavaScript compiler now admits each supported BuildManifest call under a broadcast-guarded lifecycle count. Close rejects new builds and waits for every admitted build to return, while builds continue to write directly to their configured working paths. The ControllerBus dependency is pinned to the merged release implementation, and the go-git main reference is refreshed to the exact commit required by the repository pin check.

The release-ordering regression test attaches the compiler to an in-memory bus, gates a build, and verifies both release and concurrent Close remain blocked until the build finishes. Focused ordinary and race tests, vet, module tidy, and the Go module pin check pass.