### PR TITLE
fix(plugin): mount QuickJS web packages

### DIFF
--- a/bldr/plugin/host/wazero-quickjs/plugin-quickjs-web-pkg_test.ts
+++ b/bldr/plugin/host/wazero-quickjs/plugin-quickjs-web-pkg_test.ts
@@ -1,0 +1,30 @@
+import type { BackendAPI } from '../../../sdk/plugin.js'
+import { AsyncDisposableStack } from '../../../sdk/defer.js'
+import * as mock from 'starpc/mock'
+// @ts-expect-error QuickJS resolves this absolute module from plugin assets.
+import { Counter } from '/b/pkg/@aptre/protobuf-es-lite/message.mjs'
+
+export default async function main(backendAPI: BackendAPI) {
+  const counter = new Counter()
+  if (counter.next() !== 1) throw new Error('web package module did not load')
+  // test that we can use the new AsyncDisposableStack w/ the Symbol polyfills
+  await using __defer = new AsyncDisposableStack()
+  __defer.defer(() => console.log('deferred function run'))
+
+  console.log('waiting for plugin info...')
+  const pluginInfo = await backendAPI.pluginHost.GetPluginInfo({})
+  console.log(
+    'loaded plugin info',
+    backendAPI.protos.GetPluginInfoResponse.toJsonString(pluginInfo),
+  )
+
+  // build a client for the mock service
+  const mockClient = new mock.MockClient(backendAPI.client)
+  const resp = await mockClient.MockRequest({
+    body: 'hello from the quickjs test plugin',
+  })
+  console.log(
+    'received response from MockRequest',
+    mock.MockMsg.toJsonString(resp),
+  )
+}

--- a/bldr/plugin/host/wazero-quickjs/plugin-quickjs_test.go
+++ b/bldr/plugin/host/wazero-quickjs/plugin-quickjs_test.go
@@ -24,6 +24,20 @@ import (
 )
 
 func TestPluginHostWazeroQuickjs(t *testing.T) {
+	t.Run("without web packages", func(t *testing.T) {
+		testPluginHostWazeroQuickjs(t, "plugin-quickjs_test.ts", nil, false)
+	})
+	t.Run("with web package", func(t *testing.T) {
+		testPluginHostWazeroQuickjs(
+			t,
+			"plugin-quickjs-web-pkg_test.ts",
+			[]string{"/b/pkg/@aptre/protobuf-es-lite/message.mjs"},
+			true,
+		)
+	})
+}
+
+func testPluginHostWazeroQuickjs(t *testing.T, inputFile string, external []string, withWebPkg bool) {
 	ctx := context.Background()
 	log := logrus.New()
 	log.SetLevel(logrus.DebugLevel)
@@ -48,7 +62,7 @@ func TestPluginHostWazeroQuickjs(t *testing.T) {
 			BldrDistRoot: bldrRoot,
 			Entrypoints: []*bldr_web_bundler_rolldown.Entrypoint{{
 				Name:      "plugin-quickjs-test",
-				InputPath: filepath.Join(workingDir, "plugin-quickjs_test.ts"),
+				InputPath: filepath.Join(workingDir, inputFile),
 			}},
 			Format:         "es",
 			Platform:       "browser",
@@ -58,6 +72,7 @@ func TestPluginHostWazeroQuickjs(t *testing.T) {
 			AssetFileNames: "[name]-[hash][extname]",
 			Sourcemap:      "none",
 			TreeShaking:    true,
+			External:       external,
 		},
 	)
 	if err != nil {
@@ -124,6 +139,17 @@ func TestPluginHostWazeroQuickjs(t *testing.T) {
 	err = billy_util.WriteFile(distFS, scriptPath, []byte(scriptContents), 0o644)
 	if err != nil {
 		t.Fatal(err.Error())
+	}
+	if withWebPkg {
+		const webPkgPath = "bldr-web-pkgs/@aptre/protobuf-es-lite/message.mjs"
+		if err := billy_util.WriteFile(
+			assetsFS,
+			webPkgPath,
+			[]byte("export class Counter { constructor() { this.value = 0 } next() { return ++this.value } }"),
+			0o644,
+		); err != nil {
+			t.Fatal(err.Error())
+		}
 	}
 
 	// create a basic plugin manifest

--- a/bldr/plugin/host/wazero-quickjs/quickjs.go
+++ b/bldr/plugin/host/wazero-quickjs/quickjs.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/base64"
 	"io"
+	"io/fs"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -301,6 +302,21 @@ func (h *WazeroQuickJsHost) ExecutePlugin(
 		fsConfig := wazero.NewFSConfig().
 			WithFSMount(pluginDistIofs, DistFsMount).
 			WithFSMount(pluginAssetsIoFs, AssetsFsMount)
+
+		webPkgsInfo, err := fs.Stat(pluginAssetsIoFs, plugin.PluginAssetsWebPkgsDir)
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return errors.Wrap(err, "stat project plugin web packages")
+		}
+		if err == nil {
+			if !webPkgsInfo.IsDir() {
+				return errors.Errorf("project plugin web packages %q is not a directory", plugin.PluginAssetsWebPkgsDir)
+			}
+			pluginWebPkgsIoFs, err := fs.Sub(pluginAssetsIoFs, plugin.PluginAssetsWebPkgsDir)
+			if err != nil {
+				return errors.Wrap(err, "project plugin web packages")
+			}
+			fsConfig = fsConfig.WithFSMount(pluginWebPkgsIoFs, path.Join(BDirMount, BDirWebPkgsMount))
+		}
 
 		// script is within dist
 		scriptPath := path.Join(DistFsMount, entrypoint)


### PR DESCRIPTION
QuickJS plugins could import manifest assets through `/assets`, but compiler-emitted web package imports use `/b/pkg`. These absolute imports failed in the module loader before plugin startup and prevented RPC registration.

This checks the read-only manifest assets filesystem for a real `bldr-web-pkgs` directory and mounts that subtree at `/b/pkg` only when it exists. Missing subtrees leave the preopen absent, non-directory subtrees fail explicitly, other filesystem errors propagate, and the complete assets mount remains available at `/assets`.

The Wazero QuickJS host integration test now runs both the existing no-web-package fixture and a separate external `/b/pkg/@aptre/protobuf-es-lite/message.mjs` fixture through plugin startup and the host RPC exchange. This covers the compatibility path, runtime resolution, module execution, and RPC together.
