### PR TITLE
fix(v86): register home mount before first runtime load

### DIFF
--- a/core/resource/world/vm-v86_test.go
+++ b/core/resource/world/vm-v86_test.go
@@ -250,6 +250,129 @@ func TestVmV86TypedObject(t *testing.T) {
 		}
 	})
 
+	t.Run("ConcurrentExecuteStreamsShareHomeMount", func(t *testing.T) {
+		resClient, engine, cleanup := setupVmV86WorldEngineWithClient(ctx, t, tb)
+		defer cleanup()
+
+		pluginCtrl := newTestV86PluginLoadController()
+		releasePluginCtrl, err := tb.Bus.AddController(ctx, pluginCtrl, nil)
+		if err != nil {
+			t.Fatalf("AddController(plugin load): %v", err)
+		}
+		defer releasePluginCtrl()
+
+		vmKey := "vm-v86-test-home-mount/vm"
+		rootfsKey := "vm-v86-test-home-mount/rootfs"
+		createVmV86WithRootfs(ctx, t, engine, vmKey, rootfsKey)
+
+		readTx, err := engine.NewTransaction(ctx, false)
+		if err != nil {
+			t.Fatalf("NewTransaction failed: %v", err)
+		}
+		defer readTx.Release()
+		srpcClient, err := readTx.GetResourceRef().GetClient()
+		if err != nil {
+			t.Fatalf("GetClient failed: %v", err)
+		}
+		typedSvc := s4wave_world.NewSRPCTypedObjectResourceServiceClient(srpcClient)
+		resp, err := typedSvc.AccessTypedObject(ctx, &s4wave_world.AccessTypedObjectRequest{ObjectKey: vmKey})
+		if err != nil {
+			t.Fatalf("AccessTypedObject failed: %v", err)
+		}
+		vmRef := resClient.CreateResourceReference(resp.ResourceId)
+		defer vmRef.Release()
+		vmClient, err := vmRef.GetClient()
+		if err != nil {
+			t.Fatalf("GetClient for vm resource failed: %v", err)
+		}
+
+		v86fsSvc := unixfs_v86fs.NewSRPCV86FsServiceClient(vmClient)
+		v86fsCtx, v86fsCancel := context.WithTimeout(ctx, 10*time.Second)
+		defer v86fsCancel()
+		v86fsStream, err := v86fsSvc.RelayV86Fs(v86fsCtx)
+		if err != nil {
+			t.Fatalf("RelayV86Fs failed: %v", err)
+		}
+		mountHome := func(tag uint32) {
+			t.Helper()
+			if err := v86fsStream.Send(&unixfs_v86fs.V86FsMessage{
+				Tag: tag,
+				Body: &unixfs_v86fs.V86FsMessage_MountRequest{
+					MountRequest: &unixfs_v86fs.V86FsMountRequest{Name: "home"},
+				},
+			}); err != nil {
+				t.Fatalf("Send MOUNT home failed: %v", err)
+			}
+			reply, err := v86fsStream.Recv()
+			if err != nil {
+				t.Fatalf("Recv MOUNT home reply failed: %v", err)
+			}
+			if reply.GetTag() != tag || reply.GetMountReply() == nil || reply.GetMountReply().GetStatus() != 0 {
+				t.Fatalf("MOUNT home reply = %#v, want successful tag %d reply", reply, tag)
+			}
+		}
+
+		applySetV86State(ctx, t, engine, vmKey, s4wave_vm.VmState_VmState_STARTING, "")
+		execSvc := s4wave_process.NewSRPCPersistentExecutionServiceClient(vmClient)
+		firstCtx, cancelFirst := context.WithCancel(ctx)
+		firstStream, err := execSvc.Execute(firstCtx, &s4wave_process.ExecuteRequest{})
+		if err != nil {
+			t.Fatalf("first Execute failed: %v", err)
+		}
+		expectStatusSequence(t, firstStream, s4wave_process.ExecutionState_ExecutionState_STARTING)
+
+		notify, err := v86fsStream.Recv()
+		if err != nil {
+			t.Fatalf("Recv first-start home MOUNT_NOTIFY failed: %v", err)
+		}
+		if home := notify.GetMountNotify(); home == nil || home.GetName() != "home" || home.GetMountPath() != "/home" {
+			t.Fatalf("first-start notification = %#v, want home /home MOUNT_NOTIFY", notify)
+		}
+		pluginCtrl.expectLoad(t, ctx)
+
+		secondCtx, cancelSecond := context.WithCancel(ctx)
+		secondStream, err := execSvc.Execute(secondCtx, &s4wave_process.ExecuteRequest{})
+		if err != nil {
+			t.Fatalf("second Execute failed: %v", err)
+		}
+		expectStatusSequence(t, secondStream, s4wave_process.ExecutionState_ExecutionState_STARTING)
+		mountHome(1)
+
+		cancelFirst()
+		if _, err := firstStream.Recv(); err == nil {
+			t.Fatal("first Execute remained open after cancellation")
+		}
+		mountHome(2)
+
+		cancelSecond()
+		if _, err := secondStream.Recv(); err == nil {
+			t.Fatal("second Execute remained open after cancellation")
+		}
+		unmount, err := v86fsStream.Recv()
+		if err != nil {
+			t.Fatalf("Recv final home UMOUNT_NOTIFY failed: %v", err)
+		}
+		if home := unmount.GetUmountNotify(); home == nil || home.GetMountPath() != "/home" {
+			t.Fatalf("final notification = %#v, want /home UMOUNT_NOTIFY", unmount)
+		}
+
+		restartCtx, cancelRestart := context.WithCancel(ctx)
+		defer cancelRestart()
+		restartStream, err := execSvc.Execute(restartCtx, &s4wave_process.ExecuteRequest{})
+		if err != nil {
+			t.Fatalf("restart Execute failed: %v", err)
+		}
+		expectStatusSequence(t, restartStream, s4wave_process.ExecutionState_ExecutionState_STARTING)
+		restartNotify, err := v86fsStream.Recv()
+		if err != nil {
+			t.Fatalf("Recv restarted home MOUNT_NOTIFY failed: %v", err)
+		}
+		if home := restartNotify.GetMountNotify(); home == nil || home.GetName() != "home" || home.GetMountPath() != "/home" {
+			t.Fatalf("restart notification = %#v, want home /home MOUNT_NOTIFY", restartNotify)
+		}
+		pluginCtrl.expectLoad(t, ctx)
+	})
+
 	t.Run("SetV86ConfigOpApplies", func(t *testing.T) {
 		engine, cleanup := setupVmV86WorldEngine(ctx, t, tb)
 		defer cleanup()

--- a/sdk/vm/world/v86-mounts.go
+++ b/sdk/vm/world/v86-mounts.go
@@ -22,7 +22,8 @@ import (
 const homeMountPath = "/home"
 
 // registerV86ConfigMounts reads V86Config.Mounts on the VmV86 at objectKey
-// and registers each mount on the v86fs server. The guest is notified of the
+// and registers each non-home mount on the v86fs server. The v86 resource
+// registers /home only while a runtime uses it. The guest is notified of the
 // mount set via MOUNT_NOTIFY frames on session join (seeded by the server).
 //
 // Returns a cleanup closure that releases every opened FSHandle. Callers must
@@ -78,6 +79,9 @@ func registerV86ConfigMounts(
 	for _, mnt := range cfg.GetMounts() {
 		path := mnt.GetPath()
 		objKey := mnt.GetObjectKey()
+		if path == homeMountPath {
+			continue
+		}
 		if path == "" || objKey == "" {
 			continue
 		}
@@ -113,31 +117,26 @@ func deriveV86MountName(path string) string {
 }
 
 // ensureHomeMount guarantees the VmV86 at =vmObjectKey= carries a writable
-// home mount. If the stored V86Config.Mounts list already contains an entry
-// for =/home=, nothing happens. Otherwise a fresh empty UnixFS FS-node world
-// object is created at a deterministic key (=<vm>-home=), registered as
-// =unixfs/fs-node=, and appended to Mounts via SetV86ConfigOp so the host
-// factory picks it up on the next boot and subsequent boots reuse the same
-// object so writes persist across VM restarts.
-//
-// Intended to run once per VM start, before the plugin backend is loaded.
-// Returns nil on success (including the already-provisioned case) and
-// propagates any error from the backing world state.
+// home mount and registers it on the current v86fs server before runtime load.
+// Repeated starts reuse the deterministic =<vm>-home= UnixFS object. The
+// caller keeps the returned registration for the shared runtime lifetime.
 func ensureHomeMount(
 	ctx context.Context,
+	le *logrus.Entry,
 	ws world.WorldState,
 	vmObjectKey string,
-) error {
+	srv *unixfs_v86fs.Server,
+) (func(), error) {
 	if vmObjectKey == "" {
-		return errors.New("vm object key is required")
+		return nil, errors.New("vm object key is required")
 	}
 
 	vmObjState, found, err := ws.GetObject(ctx, vmObjectKey)
 	if err != nil {
-		return errors.Wrap(err, "get vm object")
+		return nil, errors.Wrap(err, "get vm object")
 	}
 	if !found {
-		return errors.Errorf("vm-v86 object %q not found", vmObjectKey)
+		return nil, errors.Errorf("vm-v86 object %q not found", vmObjectKey)
 	}
 
 	var cfg *s4wave_vm.V86Config
@@ -154,33 +153,46 @@ func ensureHomeMount(
 		return nil
 	})
 	if err != nil {
-		return errors.Wrap(err, "read v86 config")
+		return nil, errors.Wrap(err, "read v86 config")
 	}
 	if cfg == nil {
 		cfg = &s4wave_vm.V86Config{}
 	}
-	for _, mnt := range cfg.GetMounts() {
-		if mnt.GetPath() == homeMountPath {
-			return nil
+
+	homeObjectKey := ""
+	for _, mount := range cfg.GetMounts() {
+		if mount.GetPath() == homeMountPath {
+			homeObjectKey = mount.GetObjectKey()
+			break
+		}
+	}
+	if homeObjectKey == "" {
+		homeObjectKey = vmObjectKey + "-home"
+		if err := ensureEmptyFSNodeObject(ctx, ws, homeObjectKey); err != nil {
+			return nil, errors.Wrap(err, "provision home unixfs object")
+		}
+
+		cfg.Mounts = append(cfg.GetMounts(), &s4wave_vm.VmMount{
+			Path:      homeMountPath,
+			ObjectKey: homeObjectKey,
+			Writable:  true,
+		})
+		op := s4wave_vm.NewSetV86ConfigOp(vmObjectKey, cfg)
+		if _, _, err := ws.ApplyWorldOp(ctx, op, ""); err != nil {
+			return nil, errors.Wrap(err, "apply set-config op with home mount")
 		}
 	}
 
-	homeObjectKey := vmObjectKey + "-home"
-	if err := ensureEmptyFSNodeObject(ctx, ws, homeObjectKey); err != nil {
-		return errors.Wrap(err, "provision home unixfs object")
+	mountName := deriveV86MountName(homeMountPath)
+	handle, err := openFSHandleForObject(ctx, le, ws, homeObjectKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "open v86 home mount")
 	}
-
-	cfg.Mounts = append(cfg.GetMounts(), &s4wave_vm.VmMount{
-		Path:      homeMountPath,
-		ObjectKey: homeObjectKey,
-		Writable:  true,
-	})
-
-	op := s4wave_vm.NewSetV86ConfigOp(vmObjectKey, cfg)
-	if _, _, err := ws.ApplyWorldOp(ctx, op, ""); err != nil {
-		return errors.Wrap(err, "apply set-config op with home mount")
-	}
-	return nil
+	srv.AddMount(mountName, homeMountPath, handle)
+	return func() {
+		srv.RemoveMount(mountName)
+		handle.Release()
+	}, nil
 }
 
 // ensureEmptyFSNodeObject creates an empty UnixFS FS-node world object at

--- a/sdk/vm/world/v86-resource.go
+++ b/sdk/vm/world/v86-resource.go
@@ -3,6 +3,7 @@ package s4wave_vm_world
 import (
 	"context"
 	"regexp"
+	"sync"
 
 	"github.com/aperturerobotics/controllerbus/bus"
 	"github.com/aperturerobotics/controllerbus/controller"
@@ -34,12 +35,47 @@ type v86Resource struct {
 	objectKey   string
 	ws          world.WorldState
 	b           bus.Bus
-	v86fsServer unixfs_v86fs.SRPCV86FsServiceServer
+	v86fsServer *unixfs_v86fs.Server
+
+	homeMountMtx     sync.Mutex
+	homeMountRefs    uint
+	homeMountCleanup func()
 }
 
 // newV86Resource constructs a new v86Resource.
-func newV86Resource(le *logrus.Entry, objectKey string, ws world.WorldState, b bus.Bus, v86fsServer unixfs_v86fs.SRPCV86FsServiceServer) *v86Resource {
+func newV86Resource(le *logrus.Entry, objectKey string, ws world.WorldState, b bus.Bus, v86fsServer *unixfs_v86fs.Server) *v86Resource {
 	return &v86Resource{le: le, objectKey: objectKey, ws: ws, b: b, v86fsServer: v86fsServer}
+}
+
+// acquireHomeMount keeps the run-scoped home mount registered until every
+// Execute stream using the runtime releases it.
+func (r *v86Resource) acquireHomeMount(ctx context.Context) (func(), error) {
+	r.homeMountMtx.Lock()
+	defer r.homeMountMtx.Unlock()
+
+	if r.homeMountRefs == 0 {
+		cleanup, err := ensureHomeMount(ctx, r.le, r.ws, r.objectKey, r.v86fsServer)
+		if err != nil {
+			return nil, err
+		}
+		r.homeMountCleanup = cleanup
+	}
+	r.homeMountRefs++
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			r.homeMountMtx.Lock()
+			defer r.homeMountMtx.Unlock()
+
+			r.homeMountRefs--
+			if r.homeMountRefs != 0 {
+				return
+			}
+			r.homeMountCleanup()
+			r.homeMountCleanup = nil
+		})
+	}, nil
 }
 
 // Execute reconciles desired VM state with the instanced runtime plugin.
@@ -57,6 +93,7 @@ func (r *v86Resource) Execute(req *s4wave_process.ExecuteRequest, stream s4wave_
 	var rpRef directive.Reference
 	var v86fsRouteRelease func()
 	var statusRouteRelease func()
+	var homeMountRelease func()
 	releaseRuntime := func() {
 		if rpRef != nil {
 			rpRef.Release()
@@ -69,6 +106,10 @@ func (r *v86Resource) Execute(req *s4wave_process.ExecuteRequest, stream s4wave_
 		if v86fsRouteRelease != nil {
 			v86fsRouteRelease()
 			v86fsRouteRelease = nil
+		}
+		if homeMountRelease != nil {
+			homeMountRelease()
+			homeMountRelease = nil
 		}
 	}
 	defer releaseRuntime()
@@ -172,38 +213,51 @@ func (r *v86Resource) Execute(req *s4wave_process.ExecuteRequest, stream s4wave_
 					continue
 				}
 			}
-			if err := emit(mapVmState(observed), ""); err != nil {
-				return err
-			}
 			if rpRef == nil {
 				if mountErr := r.verifyBootMounts(ctx); mountErr != nil {
+					if err := emit(mapVmState(observed), ""); err != nil {
+						return err
+					}
 					_, _, err := r.updateObservedState(ctx, generation, s4wave_vm.VmState_VmState_ERROR, mountErr.Error())
 					if err != nil {
 						return err
 					}
 					continue
 				}
-				if homeErr := ensureHomeMount(ctx, r.ws, r.objectKey); homeErr != nil {
-					_, _, err := r.updateObservedState(ctx, generation, s4wave_vm.VmState_VmState_ERROR, homeErr.Error())
+				var mountErr error
+				homeMountRelease, mountErr = r.acquireHomeMount(ctx)
+				if mountErr != nil {
+					if err := emit(mapVmState(observed), ""); err != nil {
+						return err
+					}
+					_, _, err := r.updateObservedState(ctx, generation, s4wave_vm.VmState_VmState_ERROR, mountErr.Error())
 					if err != nil {
 						return err
 					}
 					continue
 				}
-				newV86fsRouteRelease, routeErr := r.exposeV86fsToRuntimePlugin(ctx, runtimePluginID)
-				if routeErr != nil {
-					_, _, err := r.updateObservedState(ctx, generation, s4wave_vm.VmState_VmState_ERROR, routeErr.Error())
-					if err != nil {
-						return err
+
+				v86fsRouteRelease, err = r.exposeV86fsToRuntimePlugin(ctx, runtimePluginID)
+				if err != nil {
+					releaseRuntime()
+					if emitErr := emit(mapVmState(observed), ""); emitErr != nil {
+						return emitErr
+					}
+					_, _, updateErr := r.updateObservedState(ctx, generation, s4wave_vm.VmState_VmState_ERROR, err.Error())
+					if updateErr != nil {
+						return updateErr
 					}
 					continue
 				}
-				newStatusRouteRelease, statusErr := r.exposeV86RuntimeStatus(ctx, runtimePluginID, generation)
-				if statusErr != nil {
-					newV86fsRouteRelease()
-					_, _, err := r.updateObservedState(ctx, generation, s4wave_vm.VmState_VmState_ERROR, statusErr.Error())
-					if err != nil {
-						return err
+				statusRouteRelease, err = r.exposeV86RuntimeStatus(ctx, runtimePluginID, generation)
+				if err != nil {
+					releaseRuntime()
+					if emitErr := emit(mapVmState(observed), ""); emitErr != nil {
+						return emitErr
+					}
+					_, _, updateErr := r.updateObservedState(ctx, generation, s4wave_vm.VmState_VmState_ERROR, err.Error())
+					if updateErr != nil {
+						return updateErr
 					}
 					continue
 				}
@@ -213,8 +267,10 @@ func (r *v86Resource) Execute(req *s4wave_process.ExecuteRequest, stream s4wave_
 					if newRef != nil {
 						newRef.Release()
 					}
-					newStatusRouteRelease()
-					newV86fsRouteRelease()
+					releaseRuntime()
+					if emitErr := emit(mapVmState(observed), ""); emitErr != nil {
+						return emitErr
+					}
 					errMsg := "v86 runtime plugin unavailable"
 					if loadErr != nil {
 						errMsg = loadErr.Error()
@@ -226,9 +282,8 @@ func (r *v86Resource) Execute(req *s4wave_process.ExecuteRequest, stream s4wave_
 					continue
 				}
 				rpRef = newRef
-				v86fsRouteRelease = newV86fsRouteRelease
-				statusRouteRelease = newStatusRouteRelease
 			}
+
 			if err := emit(mapVmState(observed), ""); err != nil {
 				return err
 			}


### PR DESCRIPTION
A newly provisioned home mount was written into V86Config after the v86fs server had already loaded its configured mounts. The first runtime start therefore missed /home even though later resource construction could mount it.

Register the deterministic home object on the current v86fs server before loading the runtime plugin. Release the run-scoped mount together with its routes and runtime reference so stops and failed starts unmount cleanly, while servers that already loaded the configured mount keep their existing handle.

Exercise the first start, stop, and restart sequence through the typed VM resource and v86fs notification stream. Fresh V86 VMs now receive /home on their first boot and continue to reuse its persisted UnixFS object.
