### PR TITLE
test(spacewave): add native provider endpoint harness

### DIFF
--- a/cmd/spacewave/native-provider-harness.go
+++ b/cmd/spacewave/native-provider-harness.go
@@ -5,7 +5,11 @@ package main
 import (
 	"context"
 	"math"
+	"net"
+	"net/url"
 	"os"
+	"strconv"
+	"strings"
 
 	aperture_cli "github.com/aperturerobotics/cli"
 	"github.com/aperturerobotics/controllerbus/bus"
@@ -21,6 +25,18 @@ import (
 // provider tests. Production builds exclude this file.
 var nativeProviderHarnessEndpoint string
 
+type nativeProviderHarnessEnvValue struct {
+	value string
+	set   bool
+}
+
+var nativeProviderHarnessEndpointEnv = []string{
+	"SPACEWAVE_CLOUD_BASE_URL",
+	"SPACEWAVE_CLOUD_ACCOUNT_BASE_URL",
+	"SPACEWAVE_CLOUD_PUBLIC_BASE_URL",
+	"SPACEWAVE_CLOUD_SIGNING_ENV_PREFIX",
+}
+
 func init() {
 	if nativeProviderHarnessEndpoint != "" {
 		configSets = append(configSets, nativeProviderHarnessConfigSet)
@@ -33,15 +49,89 @@ func nativeProviderHarnessConfigSet(
 	_ bus.Bus,
 	_ *logrus.Entry,
 ) ([]configset.ConfigSet, error) {
+	endpoint, err := validateNativeProviderHarnessEndpoint(nativeProviderHarnessEndpoint)
+	if err != nil {
+		return nil, err
+	}
 	conf := &provider_spacewave.Config{
-		Endpoint:         nativeProviderHarnessEndpoint,
-		AccountEndpoint:  nativeProviderHarnessEndpoint,
-		PublicBaseUrl:    nativeProviderHarnessEndpoint,
+		Endpoint:         endpoint,
+		AccountEndpoint:  endpoint,
+		PublicBaseUrl:    endpoint,
 		SigningEnvPrefix: "spacewave",
 	}
 	return []configset.ConfigSet{{
 		"provider-spacewave": configset.NewControllerConfig(math.MaxUint64, conf),
 	}}, nil
+}
+
+func validateNativeProviderHarnessEndpoint(endpoint string) (string, error) {
+	if endpoint == "" {
+		return "", errors.New("native provider harness endpoint is required")
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", errors.Wrap(err, "parse native provider harness endpoint")
+	}
+	if u.Scheme != "http" {
+		return "", errors.New("native provider harness endpoint must use http")
+	}
+	if u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return "", errors.New("native provider harness endpoint must not contain credentials, query, or fragment")
+	}
+	host := u.Hostname()
+	if host == "" || u.Port() == "" {
+		return "", errors.New("native provider harness endpoint must include a host and port")
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if !ip.IsLoopback() {
+			return "", errors.New("native provider harness endpoint must be loopback or localhost")
+		}
+	} else if !strings.EqualFold(host, "localhost") {
+		return "", errors.New("native provider harness endpoint must be loopback or localhost")
+	}
+	if u.Path != "" && u.Path != "/" {
+		return "", errors.New("native provider harness endpoint must not contain a path")
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil || port < 1 || port > 65535 {
+		return "", errors.New("native provider harness endpoint must contain a valid port")
+	}
+	return endpoint, nil
+}
+
+// withNativeProviderHarnessEndpoint makes the linker-selected endpoint win over
+// inherited provider environment variables for the duration of one lookup.
+func withNativeProviderHarnessEndpoint(endpoint string, fn func() error) error {
+	endpoint, err := validateNativeProviderHarnessEndpoint(endpoint)
+	if err != nil {
+		return err
+	}
+
+	old := make(map[string]nativeProviderHarnessEnvValue, len(nativeProviderHarnessEndpointEnv))
+	for _, key := range nativeProviderHarnessEndpointEnv {
+		value, set := os.LookupEnv(key)
+		old[key] = nativeProviderHarnessEnvValue{value: value, set: set}
+		value = endpoint
+		if key == "SPACEWAVE_CLOUD_SIGNING_ENV_PREFIX" {
+			value = "spacewave"
+		}
+		if err := os.Setenv(key, value); err != nil {
+			restoreNativeProviderHarnessEnv(old)
+			return errors.Wrapf(err, "set %s", key)
+		}
+	}
+	defer restoreNativeProviderHarnessEnv(old)
+	return fn()
+}
+
+func restoreNativeProviderHarnessEnv(old map[string]nativeProviderHarnessEnvValue) {
+	for key, env := range old {
+		if env.set {
+			_ = os.Setenv(key, env.value)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	}
 }
 
 func newNativeProviderHarnessCommand(getBus func() cli_entrypoint.CliBus) []*aperture_cli.Command {
@@ -52,36 +142,45 @@ func newNativeProviderHarnessCommand(getBus func() cli_entrypoint.CliBus) []*ape
 			&aperture_cli.BoolFlag{Name: "fetch-cloud-config"},
 		},
 		Action: func(c *aperture_cli.Context) error {
-			cb := getBus()
-			prov, provRef, err := provider.ExLookupProvider(c.Context, cb.GetBus(), "spacewave", false, nil)
+			endpoint, err := validateNativeProviderHarnessEndpoint(nativeProviderHarnessEndpoint)
 			if err != nil {
-				return errors.Wrap(err, "lookup native Spacewave provider")
-			}
-			defer provRef.Release()
-
-			swProv, ok := prov.(*provider_spacewave.Provider)
-			if !ok {
-				return errors.Errorf("native Spacewave provider has type %T", prov)
-			}
-			if _, err := os.Stdout.WriteString(
-				"endpoint=" + swProv.GetEndpoint() + "\n" +
-					"account_endpoint=" + swProv.GetAccountEndpoint() + "\n" +
-					"public_base_url=" + swProv.GetPublicBaseURL() + "\n",
-			); err != nil {
 				return err
 			}
-			if !c.Bool("fetch-cloud-config") {
-				return nil
-			}
-			_, release, err := swProv.GetCloudConfig(c.Context)
-			if err != nil {
-				return errors.Wrap(err, "fetch native provider cloud config")
-			}
-			if release != nil {
-				defer release()
-			}
-			_, err = os.Stdout.WriteString("cloud_config=ok\n")
-			return err
+			return withNativeProviderHarnessEndpoint(endpoint, func() error {
+				cb := getBus()
+				if cb == nil {
+					return errors.New("native provider harness bus is unavailable")
+				}
+				prov, provRef, err := provider.ExLookupProvider(c.Context, cb.GetBus(), "spacewave", false, nil)
+				if err != nil {
+					return errors.Wrap(err, "lookup native Spacewave provider")
+				}
+				defer provRef.Release()
+
+				swProv, ok := prov.(*provider_spacewave.Provider)
+				if !ok {
+					return errors.Errorf("native Spacewave provider has type %T", prov)
+				}
+				if _, err := os.Stdout.WriteString(
+					"endpoint=" + swProv.GetEndpoint() + "\n" +
+						"account_endpoint=" + swProv.GetAccountEndpoint() + "\n" +
+						"public_base_url=" + swProv.GetPublicBaseURL() + "\n",
+				); err != nil {
+					return err
+				}
+				if !c.Bool("fetch-cloud-config") {
+					return nil
+				}
+				_, release, err := swProv.GetCloudConfig(c.Context)
+				if err != nil {
+					return errors.Wrap(err, "fetch native provider cloud config")
+				}
+				if release != nil {
+					defer release()
+				}
+				_, err = os.Stdout.WriteString("cloud_config=ok\n")
+				return err
+			})
 		},
 	}}
 }

--- a/cmd/spacewave/native-provider-harness.go
+++ b/cmd/spacewave/native-provider-harness.go
@@ -1,0 +1,87 @@
+//go:build native_provider_harness && !js
+
+package main
+
+import (
+	"context"
+	"math"
+	"os"
+
+	aperture_cli "github.com/aperturerobotics/cli"
+	"github.com/aperturerobotics/controllerbus/bus"
+	"github.com/aperturerobotics/controllerbus/controller/configset"
+	"github.com/pkg/errors"
+	cli_entrypoint "github.com/s4wave/spacewave/bldr/cli/entrypoint"
+	provider "github.com/s4wave/spacewave/core/provider"
+	provider_spacewave "github.com/s4wave/spacewave/core/provider/spacewave"
+	"github.com/sirupsen/logrus"
+)
+
+// nativeProviderHarnessEndpoint is set with the Go linker for isolated native
+// provider tests. Production builds exclude this file.
+var nativeProviderHarnessEndpoint string
+
+func init() {
+	if nativeProviderHarnessEndpoint != "" {
+		configSets = append(configSets, nativeProviderHarnessConfigSet)
+	}
+	cliCommands = append(cliCommands, newNativeProviderHarnessCommand)
+}
+
+func nativeProviderHarnessConfigSet(
+	_ context.Context,
+	_ bus.Bus,
+	_ *logrus.Entry,
+) ([]configset.ConfigSet, error) {
+	conf := &provider_spacewave.Config{
+		Endpoint:         nativeProviderHarnessEndpoint,
+		AccountEndpoint:  nativeProviderHarnessEndpoint,
+		PublicBaseUrl:    nativeProviderHarnessEndpoint,
+		SigningEnvPrefix: "spacewave",
+	}
+	return []configset.ConfigSet{{
+		"provider-spacewave": configset.NewControllerConfig(math.MaxUint64, conf),
+	}}, nil
+}
+
+func newNativeProviderHarnessCommand(getBus func() cli_entrypoint.CliBus) []*aperture_cli.Command {
+	return []*aperture_cli.Command{{
+		Name:  "native-provider-harness",
+		Usage: "inspect the native Spacewave provider in an isolated test build",
+		Flags: []aperture_cli.Flag{
+			&aperture_cli.BoolFlag{Name: "fetch-cloud-config"},
+		},
+		Action: func(c *aperture_cli.Context) error {
+			cb := getBus()
+			prov, provRef, err := provider.ExLookupProvider(c.Context, cb.GetBus(), "spacewave", false, nil)
+			if err != nil {
+				return errors.Wrap(err, "lookup native Spacewave provider")
+			}
+			defer provRef.Release()
+
+			swProv, ok := prov.(*provider_spacewave.Provider)
+			if !ok {
+				return errors.Errorf("native Spacewave provider has type %T", prov)
+			}
+			if _, err := os.Stdout.WriteString(
+				"endpoint=" + swProv.GetEndpoint() + "\n" +
+					"account_endpoint=" + swProv.GetAccountEndpoint() + "\n" +
+					"public_base_url=" + swProv.GetPublicBaseURL() + "\n",
+			); err != nil {
+				return err
+			}
+			if !c.Bool("fetch-cloud-config") {
+				return nil
+			}
+			_, release, err := swProv.GetCloudConfig(c.Context)
+			if err != nil {
+				return errors.Wrap(err, "fetch native provider cloud config")
+			}
+			if release != nil {
+				defer release()
+			}
+			_, err = os.Stdout.WriteString("cloud_config=ok\n")
+			return err
+		},
+	}}
+}

--- a/cmd/spacewave/native-provider-harness_test.go
+++ b/cmd/spacewave/native-provider-harness_test.go
@@ -4,12 +4,36 @@ package main
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
+	aperture_cli "github.com/aperturerobotics/cli"
+	cli_entrypoint "github.com/s4wave/spacewave/bldr/cli/entrypoint"
 	provider_spacewave "github.com/s4wave/spacewave/core/provider/spacewave"
+	"github.com/sirupsen/logrus"
 )
 
-func TestNativeProviderHarnessConfigSet(t *testing.T) {
+func TestNativeProviderHarnessRequiresEndpointBeforeLookup(t *testing.T) {
+	original := nativeProviderHarnessEndpoint
+	nativeProviderHarnessEndpoint = ""
+	t.Cleanup(func() { nativeProviderHarnessEndpoint = original })
+	t.Setenv("SPACEWAVE_CLOUD_BASE_URL", "https://cloud.example.invalid")
+
+	lookupCalled := false
+	commands := newNativeProviderHarnessCommand(func() cli_entrypoint.CliBus {
+		lookupCalled = true
+		return nil
+	})
+	ctx := aperture_cli.NewContext(aperture_cli.NewApp(), nil, nil)
+	if err := commands[0].Action(ctx); err == nil {
+		t.Fatal("missing endpoint unexpectedly succeeded")
+	}
+	if lookupCalled {
+		t.Fatal("bus lookup started without an explicit endpoint")
+	}
+}
+
+func TestNativeProviderHarnessConfigSetLoopbackEndpoint(t *testing.T) {
 	const endpoint = "http://127.0.0.1:43127"
 	original := nativeProviderHarnessEndpoint
 	nativeProviderHarnessEndpoint = endpoint
@@ -35,4 +59,86 @@ func TestNativeProviderHarnessConfigSet(t *testing.T) {
 		conf.GetPublicBaseUrl() != endpoint {
 		t.Fatalf("provider endpoints = %q, %q, %q; want %q", conf.GetEndpoint(), conf.GetAccountEndpoint(), conf.GetPublicBaseUrl(), endpoint)
 	}
+}
+
+func TestNativeProviderHarnessEndpointShapes(t *testing.T) {
+	for _, endpoint := range []string{
+		"http://127.0.0.1:43127",
+		"http://[::1]:43127",
+		"http://localhost:43127",
+	} {
+		if _, err := validateNativeProviderHarnessEndpoint(endpoint); err != nil {
+			t.Errorf("valid endpoint %q rejected: %v", endpoint, err)
+		}
+	}
+	for _, endpoint := range []string{
+		"",
+		"https://127.0.0.1:43127",
+		"http://192.0.2.1:43127",
+		"http://127.0.0.1",
+		"http://127.0.0.1:43127/path",
+		"http://user@127.0.0.1:43127",
+		"http://127.0.0.1:43127?cloud=true",
+	} {
+		if _, err := validateNativeProviderHarnessEndpoint(endpoint); err == nil {
+			t.Errorf("hostile endpoint %q unexpectedly accepted", endpoint)
+		}
+	}
+}
+
+func TestNativeProviderHarnessEndpointIsolation(t *testing.T) {
+	const endpoint = "http://127.0.0.1:43127"
+	original := nativeProviderHarnessEndpoint
+	nativeProviderHarnessEndpoint = endpoint
+	t.Cleanup(func() { nativeProviderHarnessEndpoint = original })
+	for _, key := range nativeProviderHarnessEndpointEnv {
+		t.Setenv(key, "https://cloud.example.invalid")
+	}
+
+	requests := 0
+	lookupCalled := false
+	commands := newNativeProviderHarnessCommand(func() cli_entrypoint.CliBus {
+		lookupCalled = true
+		conf := &provider_spacewave.Config{
+			Endpoint:         endpoint,
+			AccountEndpoint:  endpoint,
+			PublicBaseUrl:    endpoint,
+			SigningEnvPrefix: "spacewave",
+		}
+		prov := provider_spacewave.NewProvider(
+			logrus.NewEntry(logrus.New()),
+			nil,
+			conf,
+			provider_spacewave.NewProviderInfo("spacewave"),
+			nil,
+			nil,
+		)
+		prov.GetHTTPClient().Transport = roundTripFunc(func(*http.Request) (*http.Response, error) {
+			requests++
+			t.Fatal("provider attempted HTTP during endpoint resolution")
+			return nil, nil
+		})
+		if prov.GetEndpoint() != endpoint ||
+			prov.GetAccountEndpoint() != endpoint ||
+			prov.GetPublicBaseURL() != endpoint {
+			t.Fatalf("provider endpoints displaced by environment: %q, %q, %q", prov.GetEndpoint(), prov.GetAccountEndpoint(), prov.GetPublicBaseURL())
+		}
+		return nil
+	})
+	ctx := aperture_cli.NewContext(aperture_cli.NewApp(), nil, nil)
+	if err := commands[0].Action(ctx); err == nil {
+		t.Fatal("harness unexpectedly succeeded without a bus")
+	}
+	if !lookupCalled {
+		t.Fatal("harness did not reach the provider lookup boundary")
+	}
+	if requests != 0 {
+		t.Fatalf("HTTP requests = %d, want 0", requests)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
 }

--- a/cmd/spacewave/native-provider-harness_test.go
+++ b/cmd/spacewave/native-provider-harness_test.go
@@ -1,0 +1,38 @@
+//go:build native_provider_harness && !js
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	provider_spacewave "github.com/s4wave/spacewave/core/provider/spacewave"
+)
+
+func TestNativeProviderHarnessConfigSet(t *testing.T) {
+	const endpoint = "http://127.0.0.1:43127"
+	original := nativeProviderHarnessEndpoint
+	nativeProviderHarnessEndpoint = endpoint
+	t.Cleanup(func() { nativeProviderHarnessEndpoint = original })
+
+	sets, err := nativeProviderHarnessConfigSet(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatalf("build native provider harness config set: %v", err)
+	}
+	if len(sets) != 1 {
+		t.Fatalf("config set count = %d, want 1", len(sets))
+	}
+	entry := sets[0]["provider-spacewave"]
+	if entry == nil {
+		t.Fatal("provider-spacewave config missing")
+	}
+	conf, ok := entry.GetConfig().(*provider_spacewave.Config)
+	if !ok {
+		t.Fatalf("provider-spacewave config has type %T", entry.GetConfig())
+	}
+	if conf.GetEndpoint() != endpoint ||
+		conf.GetAccountEndpoint() != endpoint ||
+		conf.GetPublicBaseUrl() != endpoint {
+		t.Fatalf("provider endpoints = %q, %q, %q; want %q", conf.GetEndpoint(), conf.GetAccountEndpoint(), conf.GetPublicBaseUrl(), endpoint)
+	}
+}


### PR DESCRIPTION
The Computers testbed needs its native Spacewave provider to use the same isolated Cloud worker as the browser harness. This change adds a test-build-only native endpoint adapter behind the `native_provider_harness` build tag. A linker value selects all three provider endpoints, and the tagged command can exercise the ordinary `GetCloudConfig` path. Production binaries contain neither the adapter nor its command.

Tagged ordinary and race tests and vet pass. A loopback run observed `GET /api/auth/config` with the binary protobuf accept header and returned `cloud_config=ok`; production symbol and help checks found no harness surface.

The joined Cloud proof is separately blocked on the Cloud harness dependency and startup work. This pull request does not claim Device enrollment or a live Cloud journey.