### PR TITLE
test(resource): cover retained two-hop child lifetime

### DIFF
--- a/bldr/resource/cross-runtime_test.go
+++ b/bldr/resource/cross-runtime_test.go
@@ -398,7 +398,7 @@ func TestGoClientResourceLifecycleAgainstPythonServer(t *testing.T) {
 	server.waitExit(t, ctx)
 }
 
-func TestGoAttachedResourceTreeLifetimeAgainstTypeScriptServer(t *testing.T) {
+func TestGoAttachedResourceTwoHopLifecycleAgainstTypeScriptServer(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), crossRuntimeFixtureTimeout)
 	defer cancel()
 	server := startCrossRuntimeProcess(
@@ -419,59 +419,70 @@ func TestGoAttachedResourceTreeLifetimeAgainstTypeScriptServer(t *testing.T) {
 		t.Fatalf("start Go ResourceClient: %v", err)
 	}
 
-	var childInvoked atomic.Bool
 	var childReleaseCount atomic.Int32
+	var childAbortCount atomic.Int32
+	childIDCh := make(chan uint32, 1)
+	blockActive := make(chan struct{}, 1)
+	childAborted := make(chan struct{}, 1)
 	childReleased := make(chan struct{}, 1)
-	releaseOrder := make(chan error, 1)
 	attachedMux := srpc.InvokerFunc(func(serviceID, methodID string, strm srpc.Stream) (bool, error) {
-		if serviceID == "test.AttachedEngine" && methodID == "Construct" {
+		if serviceID != "test.AttachedEngine" || methodID != "Construct" {
+			return false, nil
+		}
+		request := srpc.NewRawMessage(nil, true)
+		if err := strm.MsgRecv(request); err != nil {
+			return true, err
+		}
+		if string(request.GetData()) != "construct" {
+			return true, errors.New("attached construct request mismatch")
+		}
+		owner, err := resource_server.MustGetResourceClientContext(strm.Context())
+		if err != nil {
+			return true, err
+		}
+		childID, err := owner.AddResource(srpc.InvokerFunc(func(serviceID, methodID string, strm srpc.Stream) (bool, error) {
+			if serviceID != "test.AttachedChild" {
+				return false, nil
+			}
 			request := srpc.NewRawMessage(nil, true)
 			if err := strm.MsgRecv(request); err != nil {
 				return true, err
 			}
-			if string(request.GetData()) != "construct" {
-				return true, errors.New("attached construct request mismatch")
-			}
-			owner, err := resource_server.MustGetResourceClientContext(strm.Context())
-			if err != nil {
-				return true, err
-			}
-			childID, err := owner.AddResource(srpc.InvokerFunc(func(serviceID, methodID string, strm srpc.Stream) (bool, error) {
-				if serviceID != "test.AttachedChild" || methodID != "Invoke" {
-					return false, nil
-				}
-				request := srpc.NewRawMessage(nil, true)
-				if err := strm.MsgRecv(request); err != nil {
-					return true, err
-				}
+			switch methodID {
+			case "Invoke":
 				if string(request.GetData()) != "invoke" {
 					return true, errors.New("attached child invoke request mismatch")
 				}
-				childInvoked.Store(true)
+				return true, strm.MsgSend(srpc.NewRawMessage([]byte("nested-success"), true))
+			case "Block":
+				if string(request.GetData()) != "block" {
+					return true, errors.New("attached child block request mismatch")
+				}
 				if err := strm.MsgSend(srpc.NewRawMessage([]byte("active"), true)); err != nil {
 					return true, err
 				}
+				blockActive <- struct{}{}
 				<-strm.Context().Done()
+				childAbortCount.Add(1)
+				childAborted <- struct{}{}
 				return true, context.Cause(strm.Context())
-			}), func() {
-				if !childInvoked.Load() {
-					releaseOrder <- errors.New("attached child released before invocation started")
-				}
-				childReleaseCount.Add(1)
-				childReleased <- struct{}{}
-			})
-			if err != nil {
-				return true, err
+			default:
+				return false, nil
 			}
-			return true, strm.MsgSend(srpc.NewRawMessage(encodeCrossRuntimeID(childID), true))
+		}), func() {
+			childReleaseCount.Add(1)
+			childReleased <- struct{}{}
+		})
+		if err != nil {
+			return true, err
 		}
-		return false, nil
+		childIDCh <- childID
+		return true, strm.MsgSend(srpc.NewRawMessage(encodeCrossRuntimeID(childID), true))
 	})
 	attachedRootID, err := client.AttachResourceTree(ctx, "fake-engine", attachedMux)
 	if err != nil {
 		t.Fatalf("attach fake Engine tree: %v\n%s", err, server.logs())
 	}
-
 	if attachedRootID == 0 {
 		t.Fatal("AddAck returned an empty attached root ID")
 	}
@@ -481,96 +492,118 @@ func TestGoAttachedResourceTreeLifetimeAgainstTypeScriptServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get TypeScript root client: %v", err)
 	}
-	callResult := make(chan struct {
-		data []byte
-		err  error
-	}, 1)
-	go func() {
-		data, callErr := crossRuntimeCall(
-			ctx,
-			rootClient,
-			"test.Root",
-			"UseAttached",
-			encodeCrossRuntimeID(attachedRootID),
-		)
-		callResult <- struct {
-			data []byte
-			err  error
-		}{data, callErr}
-	}()
+	objectData, err := crossRuntimeCall(
+		ctx,
+		rootClient,
+		"test.Root",
+		"ConstructAttachedObject",
+		encodeCrossRuntimeID(attachedRootID),
+	)
+	if err != nil {
+		t.Fatalf("construct TypeScript ObjectType-like child: %v\n%s", err, server.logs())
+	}
+	if len(objectData) != 4 {
+		t.Fatalf("object ID length = %d, want 4", len(objectData))
+	}
+	objectID := binary.BigEndian.Uint32(objectData)
+	addAck := server.waitLine(t, ctx, "ATTACHED_ADD_ACK ")
+	if strings.TrimPrefix(addAck, "ATTACHED_ADD_ACK ") != strconv.FormatUint(uint64(attachedRootID), 10) {
+		t.Fatalf("TypeScript AddAck ID marker = %q, Go AddAck ID = %d", addAck, attachedRootID)
+	}
+	childMarker := server.waitLine(t, ctx, "ATTACHED_CHILD_ADDED ")
+	var childID uint32
+	select {
+	case childID = <-childIDCh:
+	case <-ctx.Done():
+		t.Fatalf("timed out receiving attached child ID after %q", childMarker)
+	}
+	if strings.TrimPrefix(childMarker, "ATTACHED_CHILD_ADDED ") != strconv.FormatUint(uint64(childID), 10) {
+		t.Fatalf("TypeScript child ID marker = %q, Go child ID = %d", childMarker, childID)
+	}
+	object := client.CreateResourceReference(objectID)
+	objectClient, err := object.GetClient()
+	if err != nil {
+		t.Fatalf("get constructed object client: %v", err)
+	}
+	data, err := crossRuntimeCall(ctx, objectClient, "test.AttachedObject", "Use", []byte("use"))
+	if err != nil {
+		t.Fatalf("use nested attached Go child after construction: %v\n%s", err, server.logs())
+	}
+	if string(data) != "nested-success" {
+		t.Fatalf("nested response = %q, want nested-success", data)
+	}
+	server.waitLine(t, ctx, "ATTACHED_USE_COMPLETE")
+	if got := childReleaseCount.Load(); got != 0 {
+		t.Fatalf("attached child detached before response: release count = %d", got)
+	}
+	server.send(t, "CHECK_LIVE")
+	server.waitLine(t, ctx, "ATTACHED_LIVE_NO_CANCEL")
+	select {
+	case <-client.Done():
+		t.Fatal("ResourceClient generation retired after successful two-hop call")
+	default:
+	}
 
-	generation := server.waitLine(t, ctx, "ATTACHED_GENERATION ")
-	fields := strings.Fields(generation)
-	if len(fields) != 3 || fields[1] == "0" {
-		t.Fatalf("invalid attached generation marker %q", generation)
+	blockResult := make(chan error, 1)
+	go func() {
+		_, callErr := crossRuntimeCall(ctx, objectClient, "test.AttachedObject", "Block", []byte("block"))
+		blockResult <- callErr
+	}()
+	select {
+	case <-blockActive:
+	case <-ctx.Done():
+		t.Fatalf("nested attached method did not become active\n%s", server.logs())
 	}
-	if fields[2] != strconv.FormatUint(uint64(attachedRootID), 10) {
-		t.Fatalf("TypeScript AddAck ID = %s, Go AddAck ID = %d", fields[2], attachedRootID)
-	}
-	server.waitLine(t, ctx, "ATTACHED_CHILD_ADDED ")
-	server.waitLine(t, ctx, "ATTACHED_CHILD_INVOKE_ACTIVE")
+	server.send(t, "DETACH_ATTACHED_CHILD")
 	server.waitLine(t, ctx, "ATTACHED_CHILD_DETACHED")
 	select {
 	case <-childReleased:
 	case <-ctx.Done():
-		t.Fatal("attached child detach was not acknowledged")
+		t.Fatal("nested attached child detach was not acknowledged")
 	}
-	server.send(t, "ASSERT_ABORT")
-	callCompleted := false
-invokeLoop:
-	for {
-		select {
-		case line := <-server.lines:
-			if line == "ATTACHED_CHILD_INVOKE_ABORTED" {
-				break invokeLoop
-			}
-		case result := <-callResult:
-			if result.err != nil {
-				t.Fatalf("attached child detach did not abort invocation: %q/%v\n%s", result.data, result.err, server.logs())
-			}
-			if string(result.data) != "attached-complete" {
-				t.Fatalf("attached result = %q, want attached-complete", result.data)
-			}
-			callCompleted = true
-		case <-server.done:
-			t.Fatalf("TypeScript fixture exited before attached invocation aborted: %v\n%s", server.err, server.logs())
-		case <-ctx.Done():
-			t.Fatalf("timed out waiting for attached invocation abort\n%s", server.logs())
+	server.waitLine(t, ctx, "ATTACHED_BLOCK_ABORTED")
+	select {
+	case <-childAborted:
+	case <-ctx.Done():
+		t.Fatal("nested attached Go handler did not observe detach")
+	}
+	select {
+	case err := <-blockResult:
+		if err == nil {
+			t.Fatal("detached nested attached method returned success")
 		}
+	case <-ctx.Done():
+		t.Fatal("detached nested attached method did not return")
 	}
-
-	server.waitLine(t, ctx, "ATTACHED_ROOT_DETACHED")
-	if !callCompleted {
-		select {
-		case result := <-callResult:
-			if result.err != nil {
-				t.Fatalf("invoke attached Resource tree: %v", result.err)
-			}
-			if string(result.data) != "attached-complete" {
-				t.Fatalf("attached result = %q, want attached-complete", result.data)
-			}
-		case <-ctx.Done():
-			t.Fatal("timed out invoking attached Resource tree")
-		}
+	if got := childAbortCount.Load(); got != 1 {
+		t.Fatalf("attached child abort count = %d, want 1", got)
 	}
+	if got := childReleaseCount.Load(); got != 1 {
+		t.Fatalf("attached child release count = %d, want 1", got)
+	}
+	server.send(t, "CHECK_ABORT_ONCE")
+	server.waitLine(t, ctx, "ATTACHED_ABORT_ONCE")
 
+	object.Release()
+	root.Release()
 	client.Release()
 	select {
 	case <-client.Done():
 	case <-ctx.Done():
 		t.Fatal("timed out ending Go ResourceClient generation")
 	}
-	select {
-	case err := <-releaseOrder:
-		t.Fatal(err)
-	default:
-	}
 	if got := childReleaseCount.Load(); got != 1 {
-		t.Fatalf("attached child release count = %d, want 1", got)
+		t.Fatalf("attached child release count after client Done = %d, want 1", got)
 	}
-	root.Release()
+	server.send(t, "CHECK_CLEAN")
 	server.waitLine(t, ctx, "TS_SERVER_OWNER_ZERO")
+	if got := childReleaseCount.Load(); got != 1 {
+		t.Fatalf("attached child release count after TypeScript owner zero = %d, want 1", got)
+	}
 	server.waitExit(t, ctx)
+	if got := childReleaseCount.Load(); got != 1 {
+		t.Fatalf("attached child release count after server exit = %d, want 1", got)
+	}
 }
 
 func encodeCrossRuntimeID(id uint32) []byte {

--- a/bldr/resource/testdata/cross-runtime-ts-core-server.ts
+++ b/bldr/resource/testdata/cross-runtime-ts-core-server.ts
@@ -27,8 +27,11 @@ type FixtureState = {
   routeBeforeAdoptAck: boolean
   resolveAdopt: () => void
   adoptAllowedPromise: Promise<void>
-  assertAbort: () => void
-  assertAbortPromise: Promise<void>
+  callCancelsFromClient: number
+  callCancelsFromServer: number
+  attachedBlockAborts: number
+  attachedObjectReleases: number
+  detachAttachedChild?: () => void
 }
 
 function report(marker: string): void {
@@ -69,23 +72,42 @@ function waitForAbort(signal: AbortSignal): Promise<void> {
   })
 }
 
-function tcpPacketStream(socket: net.Socket): PacketStream {
+function tcpPacketStream(
+  socket: net.Socket,
+  state?: FixtureState,
+): PacketStream {
   const source = (async function* (): AsyncGenerator<Uint8Array> {
     const packets = pushable<Uint8Array>({ objectMode: true })
     socket.on('data', (data: Buffer) => packets.push(new Uint8Array(data)))
     socket.on('end', () => packets.end())
     socket.on('error', (error) => packets.end(error))
     socket.on('close', () => packets.end())
-    yield* pipe(
+    for await (const data of pipe(
       packets,
       parseLengthPrefixTransform(),
       combineUint8ArrayListTransform(),
-    )
+    )) {
+      if (state && Packet.fromBinary(data).body?.case === 'callCancel') {
+        state.callCancelsFromClient++
+      }
+      yield data
+    }
   })()
   return {
     source,
     sink: async (input: Source<Uint8Array>): Promise<void> => {
-      for await (const chunk of pipe(input, prependLengthPrefixTransform())) {
+      const observed = (async function* (): AsyncGenerator<Uint8Array> {
+        for await (const data of input) {
+          if (state && Packet.fromBinary(data).body?.case === 'callCancel') {
+            state.callCancelsFromServer++
+          }
+          yield data
+        }
+      })()
+      for await (const chunk of pipe(
+        observed,
+        prependLengthPrefixTransform(),
+      )) {
         const data =
           chunk instanceof Uint8Array
             ? chunk
@@ -137,32 +159,27 @@ function delayedResourceClientStream(
 }
 
 class AttachedChild extends Resource {
-  async invokeUntilDetached(assertAbort: Promise<void>): Promise<void> {
+  async invoke(): Promise<Uint8Array> {
+    return await this.client.request(
+      'test.AttachedChild',
+      'Invoke',
+      bytes('invoke'),
+    )
+  }
+
+  async block(): Promise<void> {
     const responses = this.client
-      .serverStreamingRequest('test.AttachedChild', 'Invoke', bytes('invoke'))
+      .serverStreamingRequest('test.AttachedChild', 'Block', bytes('block'))
       [Symbol.asyncIterator]()
     const active = await responses.next()
     if (active.done || new TextDecoder().decode(active.value) !== 'active') {
-      throw new Error('attached child did not enter invocation')
+      throw new Error('attached child did not enter blocking invocation')
     }
-    report('ATTACHED_CHILD_INVOKE_ACTIVE')
-    this.release()
-    report('ATTACHED_CHILD_DETACHED')
     try {
-      const result = await Promise.race([
-        responses.next(),
-        assertAbort.then(() => {
-          throw new Error('attached child invocation was not aborted by detach')
-        }),
-      ])
-      throw new Error(
-        `attached child invocation completed after detach: done=${result.done}`,
-      )
+      await responses.next()
+      throw new Error('attached child invocation completed without detach')
     } catch (error) {
-      if (error instanceof Error && error.message.includes('RPC_ABORT')) {
-        report('ATTACHED_CHILD_INVOKE_ABORTED')
-        return
-      }
+      if (error instanceof Error && error.message.includes('RPC_ABORT')) return
       throw error
     }
   }
@@ -189,22 +206,11 @@ function rootMux(state: FixtureState) {
         )
         await sink(single(encodeID(child.resourceId)))
       },
-      UseAttached: async (source, sink, context: ServerContext) => {
+      ConstructAttachedObject: async (source, sink, context: ServerContext) => {
         const attachedRootID = decodeID(await readOne(source))
         const resourceCall = getResourceCall(context)
-        const init = Reflect.get(resourceCall, 'init') as {
-          client: {
-            clientID: number
-            attachedResources: Map<number, unknown>
-          }
-        }
-        if (!init.client.attachedResources.has(attachedRootID)) {
-          throw new Error(
-            `attached AddAck ID ${attachedRootID} missing from client ${init.client.clientID}`,
-          )
-        }
-        report(`ATTACHED_GENERATION ${init.client.clientID} ${attachedRootID}`)
         const attachedRoot = resourceCall.getAttachedRef(attachedRootID)
+        report(`ATTACHED_ADD_ACK ${attachedRootID}`)
         const childID = decodeID(
           await attachedRoot.client.request(
             'test.AttachedEngine',
@@ -214,10 +220,57 @@ function rootMux(state: FixtureState) {
         )
         report(`ATTACHED_CHILD_ADDED ${childID}`)
         const child = attachedRoot.createResource(childID, AttachedChild)
-        await child.invokeUntilDetached(state.assertAbortPromise)
-        attachedRoot.release()
-        report('ATTACHED_ROOT_DETACHED')
-        await sink(single(bytes('attached-complete')))
+        state.detachAttachedChild = () => {
+          state.detachAttachedChild = undefined
+          child.release()
+          report('ATTACHED_CHILD_DETACHED')
+        }
+        const object = resourceCall.constructChildResource(() => {
+          const mux = createMux()
+          mux.register(
+            new StaticHandler('test.AttachedObject', {
+              Use: async (objectSource, objectSink) => {
+                if (
+                  new TextDecoder().decode(await readOne(objectSource)) !==
+                  'use'
+                ) {
+                  throw new Error('attached object use request mismatch')
+                }
+                await objectSink(single(await child.invoke()))
+                report('ATTACHED_USE_COMPLETE')
+              },
+              Block: async (objectSource) => {
+                if (
+                  new TextDecoder().decode(await readOne(objectSource)) !==
+                  'block'
+                ) {
+                  throw new Error('attached object block request mismatch')
+                }
+                try {
+                  await child.block()
+                  throw new Error(
+                    'attached object block returned without detach',
+                  )
+                } catch (error) {
+                  state.attachedBlockAborts++
+                  report('ATTACHED_BLOCK_ABORTED')
+                  throw error
+                }
+              },
+            } satisfies Record<string, InvokeFn>),
+          )
+          return {
+            mux,
+            result: undefined,
+            releaseFn: () => {
+              state.attachedObjectReleases++
+              child.release()
+              attachedRoot.release()
+            },
+          }
+        })
+        await sink(single(encodeID(object.resourceId)))
+        report(`ATTACHED_OBJECT_CONSTRUCTED ${object.resourceId}`)
       },
       Echo: async (source, sink) => {
         await sink(single(await readOne(source)))
@@ -277,7 +330,6 @@ async function main(): Promise<void> {
     throw new Error(`invalid address: ${requested}`)
   }
   let resolveAdopt!: () => void
-  let resolveAssertAbort!: () => void
   const state: FixtureState = {
     adoptAllowed: false,
     releaseCount: 0,
@@ -287,10 +339,10 @@ async function main(): Promise<void> {
     adoptAllowedPromise: new Promise<void>((resolve) => {
       resolveAdopt = resolve
     }),
-    assertAbort: () => resolveAssertAbort(),
-    assertAbortPromise: new Promise<void>((resolve) => {
-      resolveAssertAbort = resolve
-    }),
+    callCancelsFromClient: 0,
+    callCancelsFromServer: 0,
+    attachedBlockAborts: 0,
+    attachedObjectReleases: 0,
   }
   const resources = new ResourceServer(rootMux(state))
   const outerMux = createMux()
@@ -302,31 +354,18 @@ async function main(): Promise<void> {
     resolveClean = resolve
   })
   let cleaned = false
+  let cleanRequested = false
   const verifyClean = () => {
-    if (cleaned) return
-    const clients = Reflect.get(resources, 'clients') as Map<
-      number,
-      {
-        released: boolean
-        resources: Map<number, unknown>
-        attachedResources: Map<number, unknown>
-      }
-    >
-    if (
-      state.activeHandlers !== 0 ||
-      [...clients.values()].some(
-        (client) =>
-          !client.released ||
-          client.resources.size !== 0 ||
-          client.attachedResources.size !== 0,
-      )
-    ) {
-      return
-    }
+    if (cleaned || state.activeHandlers !== 0) return
     const expectedReleaseCount = fixtureMode === 'attached' ? 0 : 1
     if (state.releaseCount !== expectedReleaseCount) {
       throw new Error(
         `release count = ${state.releaseCount}, want ${expectedReleaseCount}`,
+      )
+    }
+    if (fixtureMode === 'attached' && state.attachedObjectReleases !== 1) {
+      throw new Error(
+        `attached object releases = ${state.attachedObjectReleases}, want 1`,
       )
     }
     if (state.routeBeforeAdoptAck) {
@@ -340,11 +379,11 @@ async function main(): Promise<void> {
     sockets.add(socket)
     socket.once('close', () => {
       sockets.delete(socket)
-      queueMicrotask(verifyClean)
+      if (cleanRequested && sockets.size === 0) queueMicrotask(verifyClean)
     })
     rpcServer.handlePacketStream(
       fixtureMode === 'attached'
-        ? tcpPacketStream(socket)
+        ? tcpPacketStream(socket, state)
         : delayedResourceClientStream(socket, state),
     )
   })
@@ -365,16 +404,55 @@ async function main(): Promise<void> {
       state.resolveAdopt()
       return
     }
-    if (line === 'ASSERT_ABORT') {
-      state.assertAbort()
+    if (line === 'CHECK_LIVE') {
+      if (
+        state.callCancelsFromClient !== 0 ||
+        state.callCancelsFromServer !== 0
+      ) {
+        throw new Error(
+          `two-hop lifecycle canceled before detach: client-to-server=${state.callCancelsFromClient} server-to-client=${state.callCancelsFromServer}`,
+        )
+      }
+      report('ATTACHED_LIVE_NO_CANCEL')
+      return
+    }
+    if (line === 'CHECK_CLEAN') {
+      verifyClean()
+      if (!cleaned) {
+        throw new Error(
+          `server still has ${state.activeHandlers} active handlers after ResourceClient completion`,
+        )
+      }
+      return
+    }
+    if (line === 'DETACH_ATTACHED_CHILD') {
+      if (!state.detachAttachedChild) {
+        throw new Error('no retained attached child is available to detach')
+      }
+      state.detachAttachedChild()
+      return
+    }
+    if (line === 'CHECK_ABORT_ONCE') {
+      if (state.callCancelsFromClient !== 0) {
+        throw new Error(
+          `retained child detach emitted ${state.callCancelsFromClient} unexpected client-to-server outer CallCancel packets`,
+        )
+      }
+      if (state.callCancelsFromServer !== 0) {
+        throw new Error(
+          `retained child detach emitted ${state.callCancelsFromServer} unexpected server-to-client outer CallCancel packets`,
+        )
+      }
+      if (state.attachedBlockAborts !== 1) {
+        throw new Error(
+          `attached block aborts = ${state.attachedBlockAborts}, want 1`,
+        )
+      }
+      report('ATTACHED_ABORT_ONCE')
       return
     }
     if (line === 'INVALIDATE') {
-      const clients = Reflect.get(resources, 'clients') as Map<
-        number,
-        { releaseAll(): void }
-      >
-      for (const client of clients.values()) client.releaseAll()
+      cleanRequested = true
       for (const socket of sockets) socket.destroy()
       queueMicrotask(verifyClean)
       return


### PR DESCRIPTION
The existing cross-runtime Resource test released the attached child inside its constructing call, leaving a gap around retained two-hop lifetime behavior.

This test-only change constructs a TypeScript child Resource that retains the attached Go child after construction returns. It exercises a successful nested call, observes both outer packet directions, then detaches the child during a blocking call and requires one abort and one release.

The retained TypeScript child two-hop Resource lifetime is green and emits no outer CallCancel, excluding this boundary as the Counter CallCancel source. This pull request makes no production fix claim.