### PR TITLE
fix(router): preserve object-local history targets

### DIFF
--- a/app/space/SpaceObjectContainer.test.tsx
+++ b/app/space/SpaceObjectContainer.test.tsx
@@ -15,7 +15,7 @@ interface CapturedObjectViewerProps {
     }
   }
   path?: string
-  onNavigate?: (to: { path: string }) => void
+  onNavigate?: (to: { path: string; history?: 'local' }) => void
   stateNamespace?: string[]
 }
 
@@ -149,6 +149,22 @@ describe('SpaceObjectContainer', () => {
       'repo/demo/-/docs/readme.md',
     )
   })
+
+  it.each([
+    ['/', 'repo/demo'],
+    ['/docs/readme.md', 'repo/demo/-/docs/readme.md'],
+  ])(
+    'keeps local history target %s scoped under the current object key',
+    (path, expectedSubpath) => {
+      render(<SpaceObjectContainer />)
+
+      const props = h.objectViewer.mock.calls[0]?.[0]
+      props?.onNavigate?.({ path, history: 'local' })
+
+      expect(h.navigateToSubPath).toHaveBeenCalledWith(expectedSubpath)
+      expect(h.navigate).not.toHaveBeenCalled()
+    },
+  )
 
   it('forwards absolute viewer routes to the app router', () => {
     render(<SpaceObjectContainer />)

--- a/app/space/SpaceObjectContainer.tsx
+++ b/app/space/SpaceObjectContainer.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useCallback } from 'react'
 import { resolvePath, type To, useNavigate } from '@s4wave/web/router/router.js'
+import { isLocalHistoryNavigation } from '@s4wave/web/router/HistoryRouter.js'
 import { SpaceContainerContext } from '@s4wave/web/contexts/SpaceContainerContext.js'
 import {
   SpaceContentsContext,
@@ -29,7 +30,7 @@ export function SpaceObjectContainer() {
 
   const handleViewerNavigate = useCallback(
     (to: To) => {
-      if (to.path.startsWith('/')) {
+      if (to.path.startsWith('/') && !isLocalHistoryNavigation(to)) {
         navigate(to)
         return
       }

--- a/web/router/HistoryRouter.test.tsx
+++ b/web/router/HistoryRouter.test.tsx
@@ -1,0 +1,65 @@
+import { useCallback, useState } from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { resolvePath, type To, useNavigate } from '@s4wave/web/router/router.js'
+
+import { HistoryRouter, useHistory } from './HistoryRouter.js'
+
+vi.mock('@aptre/bldr', () => ({
+  cleanPath: (path: string) => path.replace(/\/{2,}/g, '/'),
+  joinPath: (parts: string[], absolute: boolean) =>
+    `${absolute ? '/' : ''}${parts.filter(Boolean).join('/')}`,
+  splitPath: (path: string) => ({
+    pathParts: path.split('/').filter(Boolean),
+    isAbsolute: path.startsWith('/'),
+  }),
+}))
+
+function HistoryControls() {
+  const navigate = useNavigate()
+  const history = useHistory()
+
+  return (
+    <>
+      <button onClick={() => navigate({ path: 'video.mp4' })} type="button">
+        Open video
+      </button>
+      <button onClick={() => history?.goBack()} type="button">
+        Back
+      </button>
+    </>
+  )
+}
+
+function HistoryHarness({ onNavigate }: { onNavigate: (to: To) => void }) {
+  const [path, setPath] = useState('/')
+  const handleNavigate = useCallback(
+    (to: To) => {
+      onNavigate(to)
+      setPath((current) => resolvePath(current, to))
+    },
+    [onNavigate],
+  )
+
+  return (
+    <HistoryRouter path={path} onNavigate={handleNavigate}>
+      <HistoryControls />
+    </HistoryRouter>
+  )
+}
+
+describe('HistoryRouter', () => {
+  it('marks Back targets as local history navigation', () => {
+    const onNavigate = vi.fn()
+    render(<HistoryHarness onNavigate={onNavigate} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open video' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+
+    expect(onNavigate).toHaveBeenLastCalledWith({
+      path: '/',
+      history: 'local',
+    })
+  })
+})

--- a/web/router/HistoryRouter.tsx
+++ b/web/router/HistoryRouter.tsx
@@ -31,10 +31,20 @@ interface HistoryContextType {
 
 const HistoryContext = createContext<HistoryContextType | null>(null)
 
+// LocalHistoryNavigation identifies a target restored from this router's private stack.
+export interface LocalHistoryNavigation extends To {
+  history: 'local'
+}
+
+// isLocalHistoryNavigation reports whether navigation restores private router history.
+export function isLocalHistoryNavigation(to: To): to is LocalHistoryNavigation {
+  return (to as Partial<LocalHistoryNavigation>).history === 'local'
+}
+
 interface HistoryRouterProps {
   children: ReactNode
   path: string
-  onNavigate: (to: To) => void
+  onNavigate: (to: To | LocalHistoryNavigation) => void
 }
 
 // HistoryRouter wraps RouterProvider with back/forward history tracking.
@@ -99,7 +109,7 @@ export function HistoryRouter({
     isHistoryNavRef.current = true
     setCanGoBack(newIndex > 0)
     setCanGoForward(newIndex < history.stack.length - 1)
-    onNavigateRef.current({ path: targetPath })
+    onNavigateRef.current({ path: targetPath, history: 'local' })
   }, [])
 
   const goBackTo = useCallback((targetPath: string) => {
@@ -111,7 +121,11 @@ export function HistoryRouter({
       stack[history.index] = targetPath
       historyRef.current = { stack, index: history.index }
       isHistoryNavRef.current = true
-      onNavigateRef.current({ path: targetPath, replace: true })
+      onNavigateRef.current({
+        path: targetPath,
+        replace: true,
+        history: 'local',
+      })
       return
     }
 
@@ -119,7 +133,7 @@ export function HistoryRouter({
     isHistoryNavRef.current = true
     setCanGoBack(newIndex > 0)
     setCanGoForward(newIndex < history.stack.length - 1)
-    onNavigateRef.current({ path: targetPath })
+    onNavigateRef.current({ path: targetPath, history: 'local' })
   }, [])
 
   const enterFlow = useCallback(
@@ -157,7 +171,7 @@ export function HistoryRouter({
     isHistoryNavRef.current = true
     setCanGoBack(newIndex > 0)
     setCanGoForward(newIndex < history.stack.length - 1)
-    onNavigateRef.current({ path: targetPath })
+    onNavigateRef.current({ path: targetPath, history: 'local' })
   }, [])
 
   const historyValue = useMemo(


### PR DESCRIPTION
HistoryRouter returned absolute paths for private Back and Forward entries without identifying their local origin. Nested ObjectViewers therefore treated a return to their root as app navigation and could leave the current Space.

Private history restores now carry an explicit local marker. SpaceObjectContainer uses it to map both root and nested targets beneath the current object, while ordinary absolute routes such as login continue through the app router.
