### PR TITLE
fix(web): classify plugin shutdown by lifecycle

### DIFF
--- a/bldr/web/runtime/plugin-worker.test.ts
+++ b/bldr/web/runtime/plugin-worker.test.ts
@@ -155,6 +155,36 @@ describe('PluginWorker startup shutdown', () => {
     expect(global.close).not.toHaveBeenCalled()
   })
 
+  test('reports startup errors by lifecycle state instead of message text', async () => {
+    vi.useFakeTimers()
+    const global = new FakeDedicatedWorkerGlobal()
+    vi.stubGlobal('navigator', {})
+    const worker = new PluginWorker(
+      global as unknown as DedicatedWorkerGlobalScope,
+      vi.fn(),
+      null,
+    )
+    vi.spyOn(worker.webDocumentTracker, 'waitConn').mockRejectedValue(
+      new Error('closed while waiting for WebDocument'),
+    )
+    const postMessage = vi.spyOn(worker.webDocumentTracker, 'postMessage')
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    global.dispatchMessage({
+      initData: new TextEncoder().encode(btoa('{}')),
+    })
+    await vi.waitFor(() =>
+      expect(postMessage).toHaveBeenCalledWith({
+        from: 'plugin/spacewave-core',
+        close: true,
+        failureReason: 'closed while waiting for WebDocument',
+      }),
+    )
+
+    await vi.runAllTimersAsync()
+    expect(global.close).toHaveBeenCalledOnce()
+  })
+
   test('reports one runtime failure close before idempotent shutdown', async () => {
     vi.useFakeTimers()
     const global = new FakeDedicatedWorkerGlobal()

--- a/bldr/web/runtime/plugin-worker.ts
+++ b/bldr/web/runtime/plugin-worker.ts
@@ -375,7 +375,7 @@ export class PluginWorker {
         data.workerCommsDetect,
         data.runtimeWasmEnv,
       ).catch((err) => {
-        if (isExpectedPluginWorkerShutdownError(err)) {
+        if (this.shuttingDown) {
           console.warn(
             `PluginWorker: ${this.workerId}: startup canceled because WebDocument closed`,
           )
@@ -398,11 +398,6 @@ function isAbortError(err: unknown): boolean {
     'name' in err &&
     (err as { name?: string }).name === 'AbortError'
   )
-}
-
-function isExpectedPluginWorkerShutdownError(err: unknown): boolean {
-  const msg = err instanceof Error ? err.message : String(err)
-  return msg.includes('closed while waiting for WebDocument')
 }
 
 function stringifyError(err: unknown): string {


### PR DESCRIPTION
## Summary
- classify canceled plugin startup from the worker lifecycle instead of matching an error message
- preserve real startup failures whose text resembles a tracker shutdown

## Verification
- `bun run vitest run --config bldr/vitest.config.ts bldr/web/runtime/plugin-worker.test.ts bldr/web/bldr/web-document.test.ts` (57 tests)
- `bun run bldr:typecheck`

## Acceptance limit
Live Chromium startup acceptance remains pending.