### PR TITLE
fix(bldr): resolve relative startup chunk paths

### DIFF
--- a/bldr/devtool/profile-access-order.go
+++ b/bldr/devtool/profile-access-order.go
@@ -25,7 +25,7 @@ import (
 	unixfs_block "github.com/s4wave/spacewave/db/unixfs/block"
 )
 
-var chunkImportPattern = regexp.MustCompile(`(?:\./)?chunks/[^"'` + "`" + `)]+\.mjs`)
+var dynamicImportPattern = regexp.MustCompile("import\\(\\s*[\"'`]([^\"'`]+)[\"'`]\\s*\\)")
 
 // BuildProfileAccessOrderCommand builds the profile-access-order command.
 func (a *DevtoolArgs) BuildProfileAccessOrderCommand() *cli.Command {
@@ -328,8 +328,20 @@ func recordDynamicImportsFromFile(ctx context.Context, r *startupAccessRecorder,
 		return errors.Wrap(err, "read startup module")
 	}
 	baseDir := path.Dir(filePath)
-	for _, match := range chunkImportPattern.FindAllString(string(dat), -1) {
-		r.add(packfile_order.AccessOrderFilesystem_ACCESS_ORDER_FILESYSTEM_DIST, path.Join(baseDir, match), packfile_order.AccessOrderReason_ACCESS_ORDER_REASON_DYNAMIC_IMPORT, match)
+	for _, match := range dynamicImportPattern.FindAllStringSubmatch(string(dat), -1) {
+		specifier := match[1]
+		modulePath := specifier
+		if suffix := strings.IndexAny(modulePath, "?#"); suffix >= 0 {
+			modulePath = modulePath[:suffix]
+		}
+		resolvedPath := path.Clean(path.Join(baseDir, modulePath))
+		if path.Ext(modulePath) != ".mjs" ||
+			strings.HasPrefix(modulePath, "/") ||
+			strings.HasPrefix(resolvedPath, "../") ||
+			!strings.HasPrefix(resolvedPath, "chunks/") && !strings.Contains(resolvedPath, "/chunks/") {
+			continue
+		}
+		r.add(packfile_order.AccessOrderFilesystem_ACCESS_ORDER_FILESYSTEM_DIST, resolvedPath, packfile_order.AccessOrderReason_ACCESS_ORDER_REASON_DYNAMIC_IMPORT, specifier)
 	}
 	return nil
 }

--- a/bldr/devtool/profile-access-order_test.go
+++ b/bldr/devtool/profile-access-order_test.go
@@ -64,6 +64,38 @@ import("chunks/not-js.css");
 	assertProfileAccessEntry(t, entries[7], 7, "chunks/beta.mjs", packfile_order.AccessOrderReason_ACCESS_ORDER_REASON_DYNAMIC_IMPORT, "chunks/beta.mjs", 1)
 }
 
+func TestRecordDynamicImportsResolvesRelativeChunkSpecifiers(t *testing.T) {
+	ctx := context.Background()
+	distFS := newProfileAccessOrderTestFS(t, map[string][]byte{
+		"entrypoint/a/b/runtime.mjs": []byte(`
+import("../../chunks/parent.mjs");
+import("../chunks/sibling.mjs?worker#startup");
+import("./chunks/local.mjs");
+import("chunks/bare.mjs");
+import("../../../chunks/outside.mjs");
+import("/chunks/absolute.mjs");
+import("../styles/not-a-chunk.mjs");
+import("../chunks/not-module.js");
+`),
+	})
+	defer distFS.Release()
+
+	recorder := newStartupAccessRecorder()
+	if err := recordDynamicImportsFromFile(ctx, recorder, distFS, "entrypoint/a/b/runtime.mjs"); err != nil {
+		t.Fatalf("recordDynamicImportsFromFile: %v", err)
+	}
+
+	entries := recorder.entries
+	if len(entries) != 5 {
+		t.Fatalf("got %d entries, want 5: %v", len(entries), entries)
+	}
+	assertProfileAccessEntry(t, entries[0], 0, "entrypoint/chunks/parent.mjs", packfile_order.AccessOrderReason_ACCESS_ORDER_REASON_DYNAMIC_IMPORT, "../../chunks/parent.mjs", 1)
+	assertProfileAccessEntry(t, entries[1], 1, "entrypoint/a/chunks/sibling.mjs", packfile_order.AccessOrderReason_ACCESS_ORDER_REASON_DYNAMIC_IMPORT, "../chunks/sibling.mjs?worker#startup", 1)
+	assertProfileAccessEntry(t, entries[2], 2, "entrypoint/a/b/chunks/local.mjs", packfile_order.AccessOrderReason_ACCESS_ORDER_REASON_DYNAMIC_IMPORT, "./chunks/local.mjs", 1)
+	assertProfileAccessEntry(t, entries[3], 3, "entrypoint/a/b/chunks/bare.mjs", packfile_order.AccessOrderReason_ACCESS_ORDER_REASON_DYNAMIC_IMPORT, "chunks/bare.mjs", 1)
+	assertProfileAccessEntry(t, entries[4], 4, "chunks/outside.mjs", packfile_order.AccessOrderReason_ACCESS_ORDER_REASON_DYNAMIC_IMPORT, "../../../chunks/outside.mjs", 1)
+}
+
 func TestResolveStartupAccessRefsPopulatesResolvedRefsForRecordedDistAndAssetsEntries(t *testing.T) {
 	ctx := context.Background()
 	const sharedPath = "shared.txt"


### PR DESCRIPTION
Startup profile ownership only recognized direct chunk specifiers, so relative dynamic imports such as `../chunk-name.mjs` were omitted from the startup order and could leave generated worlds with incomplete preload sequencing.

The profile parser now reads complete dynamic-import specifiers, resolves relative paths against the importing chunk, removes query and fragment suffixes for lookup, and accepts only normalized generated chunk modules. Absolute, non-chunk, and non-module paths remain excluded.

This keeps startup ordering aligned with the module graph while preserving the existing profile boundary and filtering behavior.