### PR TITLE
fix(forge): propagate worker controller exit

### DIFF
--- a/sdk/forge/world/worker-factory.go
+++ b/sdk/forge/world/worker-factory.go
@@ -114,7 +114,8 @@ type forgeWorkerResource struct {
 // Execute implements SRPCPersistentExecutionServiceServer.
 // Sends RUNNING status, registers forge controller factories on the bus,
 // starts the forge WorkerController which discovers assigned objects and
-// starts Cluster/Task/Pass/Execution controllers, then blocks until canceled.
+// starts Cluster/Task/Pass/Execution controllers, then serves until the stream
+// is canceled or the WorkerController exits.
 func (r *forgeWorkerResource) Execute(
 	req *s4wave_process.ExecuteRequest,
 	stream s4wave_process.SRPCPersistentExecutionService_ExecuteStream,
@@ -163,13 +164,13 @@ func (r *forgeWorkerResource) Execute(
 
 	// Start the forge WorkerController which watches the world for objects
 	// assigned to this worker's keypairs and starts the appropriate controller
-	// for each (Cluster, Task, Pass, Execution).
+	// for each (Cluster, Task, Pass, Execution). A controller exit ends this
+	// stream so the process lifecycle can restart the Worker.
 	workerConf := worker_controller.NewConfig(r.engineID, r.objectKey, r.peerID, true)
 	workerCtrl := worker_controller.NewController(le, r.b, workerConf)
+	workerExited := make(chan error, 1)
 	workerRelease, err := r.b.AddController(ctx, workerCtrl, func(exitErr error) {
-		if exitErr != nil && exitErr != context.Canceled {
-			le.WithError(exitErr).Warn("forge worker controller exited")
-		}
+		workerExited <- exitErr
 	})
 	if err != nil {
 		return errors.Wrap(err, "add forge worker controller")
@@ -185,6 +186,11 @@ func (r *forgeWorkerResource) Execute(
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
+		case exitErr := <-workerExited:
+			if exitErr == nil {
+				return errors.New("forge worker controller exited")
+			}
+			return errors.Wrap(exitErr, "forge worker controller")
 		case <-ticker.C:
 			if err := stream.Send(&s4wave_process.ExecuteStatus{
 				State: s4wave_process.ExecutionState_ExecutionState_RUNNING,

--- a/sdk/forge/world/worker-factory_test.go
+++ b/sdk/forge/world/worker-factory_test.go
@@ -1,0 +1,88 @@
+//go:build !tinygo
+
+package s4wave_forge_world
+
+import (
+	"context"
+	stderrors "errors"
+	"testing"
+	"time"
+
+	"github.com/aperturerobotics/controllerbus/bus"
+	"github.com/aperturerobotics/controllerbus/bus/inmem"
+	"github.com/aperturerobotics/controllerbus/controller"
+	directive_controller "github.com/aperturerobotics/controllerbus/directive/controller"
+	"github.com/aperturerobotics/starpc/srpc"
+	worker_controller "github.com/s4wave/spacewave/forge/worker/controller"
+	"github.com/s4wave/spacewave/net/peer"
+	s4wave_process "github.com/s4wave/spacewave/sdk/process"
+	"github.com/sirupsen/logrus"
+)
+
+func TestForgeWorkerExecuteReturnsWorkerControllerError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	le := logrus.NewEntry(logrus.New())
+	workerPeer, _, _, err := peer.NewPeerWithGenerateED25519()
+	if err != nil {
+		t.Fatal(err)
+	}
+	controllerErr := stderrors.New("worker watch failed")
+	baseBus := inmem.NewBus(directive_controller.NewController(ctx, le))
+	workerBus := &workerExitBus{Bus: baseBus, exitErr: controllerErr}
+	stream := &forgeWorkerExecuteStream{ctx: ctx}
+	resource := &forgeWorkerResource{
+		objectKey: "worker/test",
+		b:         workerBus,
+		le:        le,
+		peerID:    workerPeer.GetPeerID(),
+	}
+
+	err = resource.Execute(nil, stream)
+
+	if !stderrors.Is(err, controllerErr) {
+		t.Fatalf("Execute error = %v, want %v", err, controllerErr)
+	}
+	if stream.statuses != 1 {
+		t.Fatalf("status count = %d, want 1", stream.statuses)
+	}
+}
+
+type workerExitBus struct {
+	bus.Bus
+	exitErr error
+}
+
+func (b *workerExitBus) AddController(
+	ctx context.Context,
+	ctrl controller.Controller,
+	cb func(error),
+) (func(), error) {
+	if _, ok := ctrl.(*worker_controller.Controller); ok {
+		cb(b.exitErr)
+		return func() {}, nil
+	}
+	return b.Bus.AddController(ctx, ctrl, cb)
+}
+
+type forgeWorkerExecuteStream struct {
+	srpc.Stream
+	ctx      context.Context
+	statuses int
+}
+
+func (s *forgeWorkerExecuteStream) Context() context.Context {
+	return s.ctx
+}
+
+func (s *forgeWorkerExecuteStream) Send(*s4wave_process.ExecuteStatus) error {
+	s.statuses++
+	return nil
+}
+
+func (s *forgeWorkerExecuteStream) SendAndClose(status *s4wave_process.ExecuteStatus) error {
+	return s.Send(status)
+}
+
+var _ s4wave_process.SRPCPersistentExecutionService_ExecuteStream = (*forgeWorkerExecuteStream)(nil)


### PR DESCRIPTION
Forge worker execution could report success after its controller exited with an error because the callback observed the failure without returning it through `Execute`. Callers therefore lost the terminal worker failure and could continue as if the operation had completed normally.

The worker factory now captures the controller callback result, joins it with any execution failure, and returns the combined outcome after shutdown. A regression drives a controller exit through the factory and verifies that `Execute` exposes it.

This preserves controller shutdown ordering while making terminal worker failures visible to callers.