### PR TITLE
fix(daemon): wait for core resource generation

### DIFF
--- a/cmd/spacewave/cli/device-capability-projection.go
+++ b/cmd/spacewave/cli/device-capability-projection.go
@@ -38,14 +38,14 @@ func startDevicePolicyCapabilityProjection(
 	if b == nil || invoker == nil || store == nil {
 		return
 	}
-	client, err := buildSDKClientFromInvoker(ctx, invoker)
-	if err != nil {
-		if ctx.Err() == nil {
-			le.WithError(err).Warn("device policy capability projection unavailable")
-		}
-		return
-	}
 	go func() {
+		client, err := buildSDKClientFromInvoker(ctx, invoker)
+		if err != nil {
+			if ctx.Err() == nil {
+				le.WithError(err).Warn("device policy capability projection unavailable")
+			}
+			return
+		}
 		defer client.close()
 		if err := runDevicePolicyCapabilityProjection(ctx, le, statePath, client, store); err != nil && ctx.Err() == nil {
 			le.WithError(err).Warn("device policy capability projection stopped")

--- a/cmd/spacewave/cli/device-update-projection.go
+++ b/cmd/spacewave/cli/device-update-projection.go
@@ -29,14 +29,14 @@ func startDeviceLauncherUpdateProjection(
 	if b == nil || invoker == nil {
 		return
 	}
-	client, err := buildSDKClientFromInvoker(ctx, invoker)
-	if err != nil {
-		if ctx.Err() == nil {
-			le.WithError(err).Warn("device update projection unavailable")
-		}
-		return
-	}
 	go func() {
+		client, err := buildSDKClientFromInvoker(ctx, invoker)
+		if err != nil {
+			if ctx.Err() == nil {
+				le.WithError(err).Warn("device update projection unavailable")
+			}
+			return
+		}
 		defer client.close()
 		if err := runDeviceLauncherUpdateProjection(ctx, le, statePath, b, client); err != nil && ctx.Err() == nil {
 			le.WithError(err).Warn("device update projection stopped")

--- a/cmd/spacewave/cli/serve.go
+++ b/cmd/spacewave/cli/serve.go
@@ -8,26 +8,25 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/aperturerobotics/cli"
+	"github.com/aperturerobotics/controllerbus/bus"
 	"github.com/aperturerobotics/controllerbus/directive"
 	"github.com/aperturerobotics/starpc/srpc"
 	"github.com/pkg/errors"
 	cli_entrypoint "github.com/s4wave/spacewave/bldr/cli/entrypoint"
 	bldr_manifest_world "github.com/s4wave/spacewave/bldr/manifest/world"
+	bldr_plugin "github.com/s4wave/spacewave/bldr/plugin"
 	plugin_host_default "github.com/s4wave/spacewave/bldr/plugin/host/default"
 	resource "github.com/s4wave/spacewave/bldr/resource"
 	device_policy "github.com/s4wave/spacewave/core/device/policy"
-	spacewave_launcher "github.com/s4wave/spacewave/core/provider/spacewave/launcher"
 	resource_listener "github.com/s4wave/spacewave/core/resource/listener"
 	resource_root "github.com/s4wave/spacewave/core/resource/root"
 	terminal_remoteshell "github.com/s4wave/spacewave/core/terminal/remoteshell"
 	trace_service "github.com/s4wave/spacewave/core/trace/service"
 	db_world "github.com/s4wave/spacewave/db/world"
-	bifrost_rpc "github.com/s4wave/spacewave/net/rpc"
 	s4wave_trace "github.com/s4wave/spacewave/sdk/trace"
 )
 
@@ -141,22 +140,18 @@ func runServeCommand(
 	leaseOwned = false
 	serveCtx, serveCancel := context.WithCancel(ctx)
 	defer serveCancel()
-	releasePluginRuntime, err := startDaemonPluginRuntime(serveCtx, resolved, cliBus)
-	if err != nil {
-		return err
+	releasePluginRuntime := func() {}
+	if cliBus.GetPluginHostObjectKey() == "" {
+		releasePluginRuntime, err = startDaemonPluginRuntime(serveCtx, resolved, cliBus)
+		if err != nil {
+			return err
+		}
 	}
 	defer releasePluginRuntime()
 
-	le.Info("waiting for resource service")
-	invoker, invokerRef, err := waitForResourceService(
-		serveCtx,
-		cliBus,
-		cliBus.GetPluginHostObjectKey() != "",
-	)
-	if err != nil {
-		return err
-	}
-	defer invokerRef.Release()
+	// The socket is the stable transport boundary. Each Resource RPC waits for
+	// the current spacewave-core generation after its stream is opened.
+	invoker := newDaemonResourceInvoker(cliBus.GetBus())
 	devicePolicy, err := device_policy.NewPolicyStore(resolved)
 	if err != nil {
 		return err
@@ -287,83 +282,34 @@ func startDaemonPluginRuntime(
 	return rel, nil
 }
 
-// waitForResourceService waits for the resource service to appear, and on dist
-// runtimes surfaces launcher bootstrap failures when no usable DistConfig exists.
-func waitForResourceService(
-	ctx context.Context,
-	busCtx cli_entrypoint.CliBus,
-	watchLauncher bool,
-) (srpc.Invoker, directive.Reference, error) {
-	b := busCtx.GetBus()
-	serviceID := resource.SRPCResourceServiceServiceID
-	resourceCh := make(chan srpc.Invoker, 1)
-	resourceHandler := directive.NewTypedCallbackHandler[srpc.Invoker](
-		func(v directive.TypedAttachedValue[srpc.Invoker]) {
-			select {
-			case resourceCh <- v.GetValue():
-			default:
-			}
+// daemonPluginClientLoader waits for the current spacewave-core generation.
+type daemonPluginClientLoader func(context.Context) (srpc.Client, directive.Reference, error)
+
+type daemonResourceInvoker struct {
+	loadClient daemonPluginClientLoader
+}
+
+// newDaemonResourceInvoker routes each Resource RPC stream to the current
+// spacewave-core plugin generation.
+func newDaemonResourceInvoker(b bus.Bus) srpc.Invoker {
+	return &daemonResourceInvoker{
+		loadClient: func(ctx context.Context) (srpc.Client, directive.Reference, error) {
+			return bldr_plugin.ExPluginLoadWaitClient(ctx, b, "spacewave-core", nil)
 		},
-		nil,
-		nil,
-		nil,
-	)
-	_, resourceRef, err := b.AddDirective(
-		bifrost_rpc.NewLookupRpcService(serviceID, ""),
-		resourceHandler,
-	)
-	if err != nil {
-		return nil, nil, err
 	}
+}
 
-	if !watchLauncher {
-		select {
-		case <-ctx.Done():
-			resourceRef.Release()
-			return nil, nil, ctx.Err()
-		case invoker := <-resourceCh:
-			return invoker, resourceRef, nil
-		}
+func (i *daemonResourceInvoker) InvokeMethod(
+	serviceID, methodID string,
+	strm srpc.Stream,
+) (bool, error) {
+	if serviceID != resource.SRPCResourceServiceServiceID {
+		return false, nil
 	}
-
-	launcherErrCh := make(chan error, 1)
-	fetchHandler := directive.NewTypedCallbackHandler[*spacewave_launcher.FetchStatus](
-		func(v directive.TypedAttachedValue[*spacewave_launcher.FetchStatus]) {
-			st := v.GetValue()
-			if st == nil || st.Fetching || st.HasConfig || st.LastErr == "" {
-				return
-			}
-			err := errors.Errorf(
-				"launcher bootstrap failed: %s",
-				strings.TrimSpace(st.LastErr),
-			)
-			select {
-			case launcherErrCh <- err:
-			default:
-			}
-		},
-		nil,
-		nil,
-		nil,
-	)
-	_, fetchRef, err := b.AddDirective(
-		spacewave_launcher.NewWatchLauncherFetchStatus(projectID),
-		fetchHandler,
-	)
-	if err != nil {
-		resourceRef.Release()
-		return nil, nil, errors.Wrap(err, "watch launcher fetch status")
+	client, clientRef, err := i.loadClient(strm.Context())
+	if err != nil || clientRef == nil {
+		return false, err
 	}
-	defer fetchRef.Release()
-
-	select {
-	case <-ctx.Done():
-		resourceRef.Release()
-		return nil, nil, ctx.Err()
-	case err := <-launcherErrCh:
-		resourceRef.Release()
-		return nil, nil, err
-	case invoker := <-resourceCh:
-		return invoker, resourceRef, nil
-	}
+	defer clientRef.Release()
+	return srpc.NewClientInvoker(client).InvokeMethod(serviceID, methodID, strm)
 }

--- a/cmd/spacewave/cli/serve_test.go
+++ b/cmd/spacewave/cli/serve_test.go
@@ -3,12 +3,20 @@
 package spacewave_cli
 
 import (
+	"context"
 	"flag"
 	"io"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/aperturerobotics/cli"
+	"github.com/aperturerobotics/controllerbus/directive"
+	"github.com/aperturerobotics/starpc/srpc"
+	resource "github.com/s4wave/spacewave/bldr/resource"
+	resource_client "github.com/s4wave/spacewave/bldr/resource/client"
+	resource_server "github.com/s4wave/spacewave/bldr/resource/server"
 )
 
 func TestServeCommandTraceFlag(t *testing.T) {
@@ -89,4 +97,162 @@ func findServeIdleTimeoutFlag(t *testing.T, cmd *cli.Command) *cli.DurationFlag 
 	}
 	t.Fatal("idle-timeout flag missing")
 	return nil
+}
+
+type daemonTestReference struct {
+	once     sync.Once
+	released chan struct{}
+}
+
+func (r *daemonTestReference) Release() {
+	r.once.Do(func() { close(r.released) })
+}
+
+func newDaemonTestResourceClient(t *testing.T) srpc.Client {
+	t.Helper()
+	mux := srpc.NewMux()
+	if err := resource_server.NewResourceServer(srpc.NewMux()).Register(mux); err != nil {
+		t.Fatal(err)
+	}
+	return srpc.NewClient(srpc.NewServerPipe(srpc.NewServer(mux)))
+}
+
+func TestDaemonResourceInvokerRoutesOnlyResourceService(t *testing.T) {
+	loadCalled := false
+	invoker := &daemonResourceInvoker{loadClient: func(context.Context) (srpc.Client, directive.Reference, error) {
+		loadCalled = true
+		return nil, nil, nil
+	}}
+	found, err := invoker.InvokeMethod("other.Service", "Method", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found || loadCalled {
+		t.Fatal("daemon forwarded a non-Resource service to spacewave-core")
+	}
+}
+
+func TestDaemonResourceStreamWaitsForCurrentCoreGeneration(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	loadStarted := make(chan int, 2)
+	generationReady := []chan struct{}{make(chan struct{}), make(chan struct{})}
+	clients := []srpc.Client{newDaemonTestResourceClient(t), newDaemonTestResourceClient(t)}
+	references := []*daemonTestReference{
+		{released: make(chan struct{})},
+		{released: make(chan struct{})},
+	}
+	var loadMtx sync.Mutex
+	loadCount := 0
+	invoker := &daemonResourceInvoker{loadClient: func(loadCtx context.Context) (srpc.Client, directive.Reference, error) {
+		loadMtx.Lock()
+		generation := loadCount
+		loadCount++
+		loadMtx.Unlock()
+		loadStarted <- generation
+		select {
+		case <-loadCtx.Done():
+			return nil, nil, loadCtx.Err()
+		case <-generationReady[generation]:
+			return clients[generation], references[generation], nil
+		}
+	}}
+
+	open := func() <-chan *resource_client.Client {
+		clientCh := make(chan *resource_client.Client, 1)
+		service := resource.NewSRPCResourceServiceClient(
+			srpc.NewClient(srpc.NewServerPipe(srpc.NewServer(invoker))),
+		)
+		go func() {
+			client, err := resource_client.NewClient(ctx, service)
+			if err != nil {
+				t.Errorf("open Resource client: %v", err)
+				clientCh <- nil
+				return
+			}
+			clientCh <- client
+		}()
+		return clientCh
+	}
+
+	firstCh := open()
+	if generation := <-loadStarted; generation != 0 {
+		t.Fatalf("first lookup generation = %d, want 0", generation)
+	}
+	select {
+	case client := <-firstCh:
+		if client != nil {
+			client.Release()
+		}
+		t.Fatal("Resource client opened before its plugin generation was released")
+	default:
+	}
+	close(generationReady[0])
+	first := <-firstCh
+	if first == nil {
+		t.Fatal("first Resource generation did not open")
+	}
+	first.Release()
+	select {
+	case <-references[0].released:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+
+	secondCh := open()
+	if generation := <-loadStarted; generation != 1 {
+		t.Fatalf("second lookup generation = %d, want 1", generation)
+	}
+	close(generationReady[1])
+	second := <-secondCh
+	if second == nil {
+		t.Fatal("replacement Resource generation did not open")
+	}
+	second.Release()
+	select {
+	case <-references[1].released:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	loadMtx.Lock()
+	defer loadMtx.Unlock()
+	if loadCount != 2 {
+		t.Fatalf("plugin generation lookups = %d, want 2", loadCount)
+	}
+}
+
+func TestDaemonResourceStreamCancellationStopsPluginWait(t *testing.T) {
+	loadStarted := make(chan struct{})
+	loadExited := make(chan struct{})
+	invoker := &daemonResourceInvoker{loadClient: func(ctx context.Context) (srpc.Client, directive.Reference, error) {
+		close(loadStarted)
+		<-ctx.Done()
+		close(loadExited)
+		return nil, nil, ctx.Err()
+	}}
+	service := resource.NewSRPCResourceServiceClient(
+		srpc.NewClient(srpc.NewServerPipe(srpc.NewServer(invoker))),
+	)
+	clientCtx, cancelClient := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := resource_client.NewClient(clientCtx, service)
+		errCh <- err
+	}()
+	<-loadStarted
+	cancelClient()
+
+	select {
+	case err := <-errCh:
+		if err == nil || !strings.Contains(err.Error(), context.Canceled.Error()) {
+			t.Fatalf("Resource client error = %v, want context canceled", err)
+		}
+		select {
+		case <-loadExited:
+		case <-time.After(5 * time.Second):
+			t.Fatal("plugin wait remained active after Resource stream cancellation")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Resource client did not cancel its spacewave-core wait")
+	}
 }

--- a/core/resource/listener/execute.go
+++ b/core/resource/listener/execute.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aperturerobotics/util/gitroot"
 	"github.com/pkg/errors"
 	entrypoint_fatal "github.com/s4wave/spacewave/bldr/entrypoint/fatal"
+	bldr_plugin "github.com/s4wave/spacewave/bldr/plugin"
 	resource "github.com/s4wave/spacewave/bldr/resource"
 	listener_control "github.com/s4wave/spacewave/core/resource/listener/control"
 	yield_policy "github.com/s4wave/spacewave/core/resource/listener/yieldpolicy"
@@ -37,6 +38,12 @@ const RequesterNameDefault = "spacewave serve"
 
 // Execute executes the controller.
 func (c *Controller) Execute(ctx context.Context) error {
+	// A hosted plugin publishes its Resource service through the process host.
+	// The outer application owns the machine-local daemon socket.
+	if bldr_plugin.GetPluginContextInfo(ctx) != nil {
+		return nil
+	}
+
 	// Resolve the configured socket and stop cleanly when it is disabled.
 	le := c.GetLogger()
 	b := c.GetBus()

--- a/core/resource/listener/execute_test.go
+++ b/core/resource/listener/execute_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/aperturerobotics/starpc/srpc"
+	bldr_plugin "github.com/s4wave/spacewave/bldr/plugin"
 	resource "github.com/s4wave/spacewave/bldr/resource"
 	listener_control "github.com/s4wave/spacewave/core/resource/listener/control"
 	yield_policy "github.com/s4wave/spacewave/core/resource/listener/yieldpolicy"
@@ -23,6 +24,16 @@ const (
 	listenerTestPingMethodID  = "Ping"
 	listenerTestWatchMethodID = "Watch"
 )
+
+func TestExecuteSkipsMachineSocketInHostedPlugin(t *testing.T) {
+	ctx := bldr_plugin.WithPluginContextInfo(
+		t.Context(),
+		new(bldr_plugin.PluginContextInfo),
+	)
+	if err := (&Controller{}).Execute(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
 
 func TestHandoffBlocksActiveListener(t *testing.T) {
 	const socketPath = "/tmp/spacewave.sock"


### PR DESCRIPTION
The daemon previously selected one Resource service before binding its socket. That made transport readiness depend on plugin startup and left clients coupled to a bootstrap or stale plugin generation.

Keep the Unix socket as the stable transport boundary. Each Resource RPC now waits under its stream context for the current spacewave-core plugin, forwards through that generation, and releases the generation when the stream ends. Cancellation stops the wait, while a later stream can select a replacement after plugin restart.

Hosted plugins no longer bind the machine-local socket. Device projections open their Resource clients asynchronously so they cannot delay socket readiness. This leaves one external Resource authority without a bootstrap switching proxy.