### PR TITLE
fix(drive): keep startup navigation on fresh state

### DIFF
--- a/app/space/SpaceObjectContainer.test.tsx
+++ b/app/space/SpaceObjectContainer.test.tsx
@@ -15,7 +15,11 @@ interface CapturedObjectViewerProps {
     }
   }
   path?: string
-  onNavigate?: (to: { path: string; history?: 'local' }) => void
+  onNavigate?: (to: {
+    path: string
+    history?: 'local'
+    navigation?: 'local'
+  }) => void
   stateNamespace?: string[]
 }
 
@@ -165,6 +169,16 @@ describe('SpaceObjectContainer', () => {
       expect(h.navigate).not.toHaveBeenCalled()
     },
   )
+
+  it('keeps an explicit local navigation target under the current object key', () => {
+    render(<SpaceObjectContainer />)
+
+    const props = h.objectViewer.mock.calls[0]?.[0]
+    props?.onNavigate?.({ path: '/', navigation: 'local' })
+
+    expect(h.navigateToSubPath).toHaveBeenCalledWith('repo/demo')
+    expect(h.navigate).not.toHaveBeenCalled()
+  })
 
   it('forwards absolute viewer routes to the app router', () => {
     render(<SpaceObjectContainer />)

--- a/app/space/SpaceObjectContainer.tsx
+++ b/app/space/SpaceObjectContainer.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useCallback } from 'react'
 import { resolvePath, type To, useNavigate } from '@s4wave/web/router/router.js'
-import { isLocalHistoryNavigation } from '@s4wave/web/router/HistoryRouter.js'
+import { isLocalNavigation } from '@s4wave/web/router/HistoryRouter.js'
 import { SpaceContainerContext } from '@s4wave/web/contexts/SpaceContainerContext.js'
 import {
   SpaceContentsContext,
@@ -30,7 +30,7 @@ export function SpaceObjectContainer() {
 
   const handleViewerNavigate = useCallback(
     (to: To) => {
-      if (to.path.startsWith('/') && !isLocalHistoryNavigation(to)) {
+      if (to.path.startsWith('/') && !isLocalNavigation(to)) {
         navigate(to)
         return
       }

--- a/app/unixfs/UnixFSBrowser.test.tsx
+++ b/app/unixfs/UnixFSBrowser.test.tsx
@@ -97,6 +97,7 @@ interface MockFileListProps {
 
 interface MockToolbarProps {
   onNewFolder?: () => void
+  onNavigate?: (path: string) => void
 }
 
 const h = vi.hoisted(() => ({
@@ -220,9 +221,16 @@ vi.mock('@s4wave/web/editors/file-browser/FileList.js', () => ({
 }))
 
 vi.mock('@s4wave/web/editors/file-browser/Toolbar.js', () => ({
-  Toolbar: ({ onNewFolder }: MockToolbarProps) => (
+  Toolbar: ({ onNewFolder, onNavigate }: MockToolbarProps) => (
     <div>
       Toolbar
+      <button
+        aria-label="Navigate to root"
+        onClick={() => onNavigate?.('/')}
+        type="button"
+      >
+        Root
+      </button>
       <button onClick={onNewFolder} title="New folder" type="button">
         New folder
       </button>
@@ -280,6 +288,7 @@ vi.mock('@s4wave/web/router/router.js', () => ({
 }))
 
 vi.mock('@s4wave/web/router/HistoryRouter.js', () => ({
+  localNavigation: (to: { path: string }) => ({ ...to, navigation: 'local' }),
   useHistory: () => null,
 }))
 
@@ -696,6 +705,25 @@ describe('UnixFSBrowser drag gating', () => {
       expect(h.mockMkdirAll).toHaveBeenCalledWith(['Projects'])
     })
   })
+  it('marks breadcrumb root navigation as object-local', async () => {
+    const user = userEvent.setup()
+    render(
+      <UnixFSBrowser
+        unixfsId="files"
+        basePath="/"
+        currentPath="/docs/images"
+        worldState={buildResource({} as IWorldState)}
+      />,
+    )
+
+    await user.click(screen.getByLabelText('Navigate to root'))
+
+    expect(h.mockNavigate).toHaveBeenCalledWith({
+      path: '/',
+      navigation: 'local',
+    })
+  })
+
   it('disables navigate up at the UnixFS root and enables it in subdirectories', () => {
     const view = render(
       <UnixFSBrowser
@@ -721,7 +749,10 @@ describe('UnixFSBrowser drag gating', () => {
     expect(navigateUp?.enabled).toBe(true)
     if (!navigateUp?.handler) throw new Error('navigate up handler missing')
     navigateUp.handler()
-    expect(h.mockNavigate).toHaveBeenCalledWith({ path: '/docs' })
+    expect(h.mockNavigate).toHaveBeenCalledWith({
+      path: '/docs',
+      navigation: 'local',
+    })
   })
 
   it('renders owner-provided directory headers above the file list', () => {

--- a/app/unixfs/UnixFSBrowser.tsx
+++ b/app/unixfs/UnixFSBrowser.tsx
@@ -24,7 +24,10 @@ import { toast } from '@s4wave/web/ui/toaster.js'
 import { useTabContext } from '@s4wave/web/object/TabContext.js'
 import { UnixFSPathLoadingCard } from '@s4wave/app/loading/wrappers/UnixFSPathLoadingCard.js'
 import { useNavigate } from '@s4wave/web/router/router.js'
-import { useHistory } from '@s4wave/web/router/HistoryRouter.js'
+import {
+  localNavigation,
+  useHistory,
+} from '@s4wave/web/router/HistoryRouter.js'
 import { SpaceContainerContext } from '@s4wave/web/contexts/SpaceContainerContext.js'
 import { useSessionIndex } from '@s4wave/web/contexts/contexts.js'
 import { useSessionUploadManager } from '@s4wave/app/session/SessionUploadManagerContext.js'
@@ -355,14 +358,14 @@ function useUnixFSBrowserElement({
   const handleUp = useCallback(() => {
     if (!canGoUp) return
     dispatch({ type: 'set-pending-name', name: null })
-    navigate({ path: getUnixFSParentPath(displayPath) })
+    navigate(localNavigation({ path: getUnixFSParentPath(displayPath) }))
   }, [canGoUp, displayPath, navigate])
 
   // Handle path change from toolbar (user edited path directly)
   const handlePathChange = useCallback(
     (newPath: string) => {
       dispatch({ type: 'set-pending-name', name: null })
-      navigate({ path: newPath })
+      navigate(localNavigation({ path: newPath }))
     },
     [navigate],
   )

--- a/app/unixfs/UnixFSFileViewer.test.tsx
+++ b/app/unixfs/UnixFSFileViewer.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { UnixFSFileViewer } from './UnixFSFileViewer.js'
@@ -12,8 +12,13 @@ function buildResource<T>(value: T) {
   }
 }
 
+const h = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  symlinkTarget: null as string | null,
+}))
+
 vi.mock('@aptre/bldr-sdk/hooks/useResource.js', () => ({
-  useResource: () => buildResource(null),
+  useResource: () => buildResource(h.symlinkTarget),
 }))
 
 vi.mock('@s4wave/web/hooks/useUnixFSHandle.js', () => ({
@@ -26,10 +31,11 @@ vi.mock('@s4wave/web/hooks/useUnixFSHandle.js', () => ({
 }))
 
 vi.mock('@s4wave/web/router/router.js', () => ({
-  useNavigate: () => vi.fn(),
+  useNavigate: () => h.navigate,
 }))
 
 vi.mock('@s4wave/web/router/HistoryRouter.js', () => ({
+  localNavigation: (to: { path: string }) => ({ ...to, navigation: 'local' }),
   useHistory: () => null,
 }))
 
@@ -88,6 +94,8 @@ vi.mock('./UnixFSVideoFileViewer.js', () => ({
 describe('UnixFSFileViewer image preview', () => {
   afterEach(() => {
     cleanup()
+    h.navigate.mockClear()
+    h.symlinkTarget = null
   })
 
   it('renders an image tag for image mime types when an inline raw url is provided', () => {
@@ -160,6 +168,32 @@ describe('UnixFSFileViewer image preview', () => {
 
     expect(screen.getByText('Symbolic link')).toBeDefined()
   })
+
+  it.each(['/shared/target.txt', '../shared/target.txt'])(
+    'normalizes symlink target %s as object-local',
+    (target) => {
+      h.symlinkTarget = target
+      render(
+        <UnixFSFileViewer
+          path="/nested/link"
+          stat={{
+            info: { isDir: false, name: 'link' },
+            fileKind: 'symlink',
+            mimeType: 'text/plain',
+          }}
+          rootHandle={buildResource(null)}
+          hideToolbar
+        />,
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'Go to target' }))
+
+      expect(h.navigate).toHaveBeenCalledWith({
+        path: '/shared/target.txt',
+        navigation: 'local',
+      })
+    },
+  )
 
   it('renders a pdf viewer for pdf mime types when an inline raw url is provided', () => {
     render(

--- a/app/unixfs/UnixFSFileViewer.tsx
+++ b/app/unixfs/UnixFSFileViewer.tsx
@@ -22,7 +22,10 @@ import {
 import type { FSHandle } from '@s4wave/sdk/unixfs/handle.js'
 import { getUnixFSFileInfoKind } from '@s4wave/sdk/unixfs/file-kind.js'
 import { useNavigate } from '@s4wave/web/router/router.js'
-import { useHistory } from '@s4wave/web/router/HistoryRouter.js'
+import {
+  localNavigation,
+  useHistory,
+} from '@s4wave/web/router/HistoryRouter.js'
 import { Toolbar } from '@s4wave/web/editors/file-browser/Toolbar.js'
 import { UnixFSAudioFileViewer } from './UnixFSAudioFileViewer.js'
 import { UnixFSPdfFileViewer } from './UnixFSPdfFileViewer.js'
@@ -247,7 +250,7 @@ export function UnixFSFileViewer({
 
   const handlePathChange = useCallback(
     (newPath: string) => {
-      navigate({ path: newPath })
+      navigate(localNavigation({ path: newPath }))
     },
     [navigate],
   )
@@ -278,8 +281,10 @@ export function UnixFSFileViewer({
     // Resolve relative target against the symlink's parent directory.
     const parent = path.replace(/\/[^/]*$/, '') || '/'
     const parts = (
-      parent === '/' ? [] : parent.split('/').filter(Boolean)
-    ).concat(target.split('/'))
+      target.startsWith('/') || parent === '/'
+        ? []
+        : parent.split('/').filter(Boolean)
+    ).concat(target.split('/').filter(Boolean))
     const resolved: string[] = []
     for (const part of parts) {
       if (part === '..') {
@@ -293,7 +298,7 @@ export function UnixFSFileViewer({
 
   const handleNavigateSymlink = useCallback(() => {
     if (resolvedTarget) {
-      navigate({ path: resolvedTarget })
+      navigate(localNavigation({ path: resolvedTarget }))
     }
   }, [resolvedTarget, navigate])
 

--- a/core/session/controller/controller.go
+++ b/core/session/controller/controller.go
@@ -165,36 +165,39 @@ func (c *Controller) ListSessions(ctx context.Context) ([]*session.SessionListEn
 		return nil, err
 	}
 
-	// Retry classification: external to RunTransaction. Invalid-entry warnings
-	// are emitted from the transaction callback.
-
-	otx, err := objStore.NewTransaction(ctx, false)
-	if err != nil {
-		return nil, err
-	}
-	defer otx.Discard()
-
-	size, err := otx.Size(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if size == 0 {
-		return nil, nil
-	}
-
 	var elems []*session.SessionListEntry
-	err = otx.ScanPrefix(ctx, sessionListPrefix, func(key, value []byte) error {
-		entry := &session.SessionListEntry{}
-		if err := entry.UnmarshalVT(value); err != nil {
-			c.GetLogger().WithError(err).Warn("ignoring invalid session list entry")
-			return nil
-		}
+	var invalidEntryErrs []error
+	err = kvtx.RunTransaction(ctx, false,
+		func(ctx context.Context) (kvtx.Tx, error) {
+			return objStore.NewTransaction(ctx, false)
+		},
+		func(ctx context.Context, otx kvtx.Tx) error {
+			elems = nil
+			invalidEntryErrs = nil
+			size, err := otx.Size(ctx)
+			if err != nil {
+				return err
+			}
+			if size == 0 {
+				return nil
+			}
 
-		elems = append(elems, entry)
-		return nil
-	})
+			return otx.ScanPrefix(ctx, sessionListPrefix, func(_ []byte, value []byte) error {
+				entry := &session.SessionListEntry{}
+				if err := entry.UnmarshalVT(value); err != nil {
+					invalidEntryErrs = append(invalidEntryErrs, err)
+					return nil
+				}
+				elems = append(elems, entry)
+				return nil
+			})
+		},
+	)
 	if err != nil {
 		return nil, err
+	}
+	for _, invalidEntryErr := range invalidEntryErrs {
+		c.GetLogger().WithError(invalidEntryErr).Warn("ignoring invalid session list entry")
 	}
 	return elems, nil
 }

--- a/core/session/controller/controller_retry_test.go
+++ b/core/session/controller/controller_retry_test.go
@@ -1,0 +1,130 @@
+package session_controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/s4wave/spacewave/core/session"
+	"github.com/s4wave/spacewave/db/kvtx"
+	store_kvtx_inmem "github.com/s4wave/spacewave/db/store/kvtx/inmem"
+)
+
+type scanConflictStore struct {
+	kvtx.Store
+	opened int
+}
+
+func (s *scanConflictStore) NewTransaction(ctx context.Context, write bool) (kvtx.Tx, error) {
+	tx, err := s.Store.NewTransaction(ctx, write)
+	if err != nil {
+		return nil, err
+	}
+	s.opened++
+	return &scanConflictTx{Tx: tx, failScan: !write && s.opened == 1}, nil
+}
+
+type scanConflictTx struct {
+	kvtx.Tx
+	failScan bool
+}
+
+func (t *scanConflictTx) ScanPrefix(ctx context.Context, prefix []byte, cb func([]byte, []byte) error) error {
+	if err := t.Tx.ScanPrefix(ctx, prefix, cb); err != nil {
+		return err
+	}
+	if t.failScan {
+		return kvtx.ErrInvalidSnapshot
+	}
+	return nil
+}
+
+func TestListSessionsRetriesGenerationChangeBetweenSizeAndScan(t *testing.T) {
+	ctx := context.Background()
+	store := store_kvtx_inmem.NewStore()
+	writeTx, err := store.NewTransaction(ctx, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := &session.SessionListEntry{SessionIndex: 7}
+	data, err := entry.MarshalVT()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeTx.Set(ctx, sessionListEntryKey(7), data); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeTx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	writeTx.Discard()
+
+	conflicts := &scanConflictStore{Store: store}
+	controller := &Controller{objStore: conflicts}
+	entries, err := controller.ListSessions(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conflicts.opened != 2 {
+		t.Fatalf("opened transactions = %d, want 2", conflicts.opened)
+	}
+	if len(entries) != 1 || entries[0].GetSessionIndex() != 7 {
+		t.Fatalf("entries = %v, want session 7", entries)
+	}
+}
+
+type partialScanFailureStore struct {
+	kvtx.Store
+	err error
+}
+
+func (s *partialScanFailureStore) NewTransaction(ctx context.Context, write bool) (kvtx.Tx, error) {
+	tx, err := s.Store.NewTransaction(ctx, write)
+	if err != nil {
+		return nil, err
+	}
+	return &partialScanFailureTx{Tx: tx, err: s.err}, nil
+}
+
+type partialScanFailureTx struct {
+	kvtx.Tx
+	err error
+}
+
+func (t *partialScanFailureTx) ScanPrefix(ctx context.Context, prefix []byte, cb func([]byte, []byte) error) error {
+	if err := t.Tx.ScanPrefix(ctx, prefix, cb); err != nil {
+		return err
+	}
+	return t.err
+}
+
+func TestListSessionsReturnsNilAfterPartialScanFailure(t *testing.T) {
+	ctx := context.Background()
+	store := store_kvtx_inmem.NewStore()
+	writeTx, err := store.NewTransaction(ctx, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := &session.SessionListEntry{SessionIndex: 7}
+	data, err := entry.MarshalVT()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeTx.Set(ctx, sessionListEntryKey(7), data); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeTx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	writeTx.Discard()
+
+	scanErr := errors.New("scan failed")
+	controller := &Controller{objStore: &partialScanFailureStore{Store: store, err: scanErr}}
+	entries, err := controller.ListSessions(ctx)
+	if !errors.Is(err, scanErr) {
+		t.Fatalf("error = %v, want %v", err, scanErr)
+	}
+	if entries != nil {
+		t.Fatalf("entries = %v, want nil", entries)
+	}
+}

--- a/web/router/HistoryRouter.tsx
+++ b/web/router/HistoryRouter.tsx
@@ -31,9 +31,28 @@ interface HistoryContextType {
 
 const HistoryContext = createContext<HistoryContextType | null>(null)
 
+// LocalNavigation identifies a path within the current nested router.
+export interface LocalNavigation {
+  path: string
+  navigation: 'local'
+}
+
+// localNavigation marks a path as local to the current nested router.
+export function localNavigation(to: Pick<To, 'path'>): LocalNavigation {
+  return { ...to, navigation: 'local' }
+}
+
 // LocalHistoryNavigation identifies a target restored from this router's private stack.
 export interface LocalHistoryNavigation extends To {
   history: 'local'
+}
+
+// isLocalNavigation reports whether a target stays within the current nested router.
+export function isLocalNavigation(
+  to: To,
+): to is LocalNavigation | LocalHistoryNavigation {
+  const target = to as Partial<LocalNavigation & LocalHistoryNavigation>
+  return target.navigation === 'local' || target.history === 'local'
 }
 
 // isLocalHistoryNavigation reports whether navigation restores private router history.


### PR DESCRIPTION
UnixFS absolute root, path, and symlink navigation escaped the nested Drive router and was interpreted as an application route. Mark those path-only operations as object-local, including correct root-relative and parent-relative symlink resolution, while preserving genuine global navigation.

A separate production trace showed Quickstart stopping before Drive mounted when `ListSessions` observed an OPFS generation change between `Size` and `ScanPrefix`. Replay that read-only census through the existing transaction helper, keep attempt-local results and warnings, and return no partial list on terminal failure.

The navigation-only Chromium journey passes both nested Home and history scenarios. Focused component, type, controller, race, and vet checks pass.
