### PR TITLE
fix(cdn): coalesce root pointer refreshes

### DIFF
--- a/core/cdn/bstore/block-store.go
+++ b/core/cdn/bstore/block-store.go
@@ -61,6 +61,13 @@ type CdnBlockStore struct {
 	pointerTime     time.Time
 	pointerEpoch    uint64
 	writebackTarget block.StoreOps
+	pointerLoad     *rootPointerLoad
+}
+
+type rootPointerLoad struct {
+	done chan struct{}
+	ptr  *cdn.CdnRootPointer
+	err  error
 }
 
 // NewCdnBlockStore constructs a new CdnBlockStore. The pointer is fetched
@@ -267,22 +274,7 @@ func (s *CdnBlockStore) Pointer() *cdn.CdnRootPointer {
 // Refresh forces a re-fetch of the root pointer and updates the manifest.
 // Returns the new pointer (nil if the CDN Space is empty).
 func (s *CdnBlockStore) Refresh(ctx context.Context) (*cdn.CdnRootPointer, error) {
-	var closed bool
-	s.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
-		closed = s.closed
-	})
-	if closed {
-		return nil, packfile_store.ErrPackfileStoreClosed
-	}
-
-	ptr, err := FetchRootPointer(ctx, s.cli, s.opts.CdnBaseURL, s.opts.SpaceID)
-	if err != nil {
-		return nil, err
-	}
-	if _, published := s.setPointer(ctx, ptr); !published {
-		return nil, packfile_store.ErrPackfileStoreClosed
-	}
-	return ptr, nil
+	return s.loadPointer(ctx)
 }
 
 // Invalidate drops the cached pointer so the next read re-fetches.
@@ -322,6 +314,14 @@ func (s *CdnBlockStore) setPointer(ctx context.Context, ptr *cdn.CdnRootPointer)
 	var published bool
 	s.bcast.HoldLock(func(broadcastFn func(), _ func() <-chan struct{}) {
 		if s.closed {
+			return
+		}
+		if (ptr == nil && s.pointer == nil) ||
+			(ptr != nil && s.pointer != nil && ptr.EqualVT(s.pointer)) {
+			s.pointer = ptr
+			s.pointerTime = time.Now()
+			epoch = s.pointerEpoch
+			published = true
 			return
 		}
 		if s.memCache != nil {
@@ -371,15 +371,80 @@ func (s *CdnBlockStore) ensurePointer(ctx context.Context) (*cdn.CdnRootPointer,
 	if !fetchedAt.IsZero() && (ttl < 0 || time.Since(fetchedAt) < ttl) {
 		return cached, epoch, nil
 	}
-	ptr, err := FetchRootPointer(ctx, s.cli, s.opts.CdnBaseURL, s.opts.SpaceID)
+	ptr, err := s.loadPointer(ctx)
 	if err != nil {
 		return nil, 0, err
 	}
-	epoch, published := s.setPointer(ctx, ptr)
-	if !published {
-		return nil, 0, packfile_store.ErrPackfileStoreClosed
-	}
+	s.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		epoch = s.pointerEpoch
+	})
 	return ptr, epoch, nil
+}
+
+// loadPointer folds concurrent refreshes onto one root-pointer request.
+func (s *CdnBlockStore) loadPointer(ctx context.Context) (*cdn.CdnRootPointer, error) {
+	for {
+		var load *rootPointerLoad
+		var leader bool
+		var storeChanged <-chan struct{}
+		s.bcast.HoldLock(func(_ func(), wait func() <-chan struct{}) {
+			if s.closed {
+				return
+			}
+			load = s.pointerLoad
+			if load == nil {
+				load = &rootPointerLoad{done: make(chan struct{})}
+				s.pointerLoad = load
+				leader = true
+			}
+			storeChanged = wait()
+		})
+		if load == nil {
+			return nil, packfile_store.ErrPackfileStoreClosed
+		}
+		if !leader {
+		waitForLoad:
+			for {
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-load.done:
+					if errors.Is(load.err, context.Canceled) || errors.Is(load.err, context.DeadlineExceeded) {
+						break waitForLoad
+					}
+					return load.ptr, load.err
+				case <-storeChanged:
+					var closed bool
+					s.bcast.HoldLock(func(_ func(), wait func() <-chan struct{}) {
+						closed = s.closed
+						storeChanged = wait()
+					})
+					if closed {
+						return nil, packfile_store.ErrPackfileStoreClosed
+					}
+				}
+			}
+			continue
+		}
+
+		ptr, err := FetchRootPointer(ctx, s.cli, s.opts.CdnBaseURL, s.opts.SpaceID)
+		if err == nil {
+			if _, published := s.setPointer(ctx, ptr); !published {
+				ptr = nil
+				err = packfile_store.ErrPackfileStoreClosed
+			}
+		}
+		s.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+			load.ptr = ptr
+			load.err = err
+			if s.pointerLoad == load {
+				s.pointerLoad = nil
+			}
+			close(load.done)
+			broadcast()
+		})
+		return ptr, err
+	}
 }
 
 func (s *CdnBlockStore) withCurrentManifest(ctx context.Context, read func() error) error {

--- a/core/cdn/bstore/block-store_test.go
+++ b/core/cdn/bstore/block-store_test.go
@@ -35,6 +35,19 @@ type testPack struct {
 	bloom []byte
 }
 
+type doneObservedContext struct {
+	context.Context
+	observed chan struct{}
+}
+
+func (c doneObservedContext) Done() <-chan struct{} {
+	select {
+	case c.observed <- struct{}{}:
+	default:
+	}
+	return c.Context.Done()
+}
+
 func buildSinglePack(t *testing.T, id string, blocks map[string][]byte) testPack {
 	t.Helper()
 
@@ -469,27 +482,35 @@ func TestCdnBlockStoreSharesNonContextPointerError(t *testing.T) {
 	defer bs.Close()
 
 	const readers = 32
-	start := make(chan struct{})
 	done := make(chan error, readers)
-	for range readers {
-		go func() {
-			<-start
-			_, err := bs.Refresh(t.Context())
-			done <- err
-		}()
-	}
-	close(start)
+	go func() {
+		_, err := bs.Refresh(t.Context())
+		done <- err
+	}()
 	select {
 	case <-requestStarted:
 	case <-t.Context().Done():
 		t.Fatal(t.Context().Err())
 	}
 
-	select {
-	case <-time.After(50 * time.Millisecond):
-	case <-t.Context().Done():
-		t.Fatal(t.Context().Err())
+	admitted := make([]chan struct{}, 0, readers-1)
+	for range readers - 1 {
+		observed := make(chan struct{}, 1)
+		admitted = append(admitted, observed)
+		go func() {
+			ctx := doneObservedContext{Context: t.Context(), observed: observed}
+			_, err := bs.Refresh(ctx)
+			done <- err
+		}()
 	}
+	for _, observed := range admitted {
+		select {
+		case <-observed:
+		case <-t.Context().Done():
+			t.Fatal(t.Context().Err())
+		}
+	}
+
 	close(releaseRequest)
 	for range readers {
 		if err := <-done; err == nil || !strings.Contains(err.Error(), "status 503") {
@@ -537,37 +558,43 @@ func TestCdnBlockStoreCoalescesUnchangedPointerRefreshes(t *testing.T) {
 	}
 
 	const readers = 32
-	start := make(chan struct{})
 	done := make(chan error, readers)
-	for range readers {
-		go func() {
-			<-start
-			_, err := bs.Refresh(t.Context())
-			done <- err
-		}()
-	}
-	close(start)
+	go func() {
+		_, err := bs.Refresh(t.Context())
+		done <- err
+	}()
 	select {
 	case <-refreshStarted:
 	case <-t.Context().Done():
 		t.Fatal(t.Context().Err())
 	}
 
-	// The blocked leader leaves every other refresh enough time to fold onto it.
-	select {
-	case <-time.After(50 * time.Millisecond):
-	case <-t.Context().Done():
-		t.Fatal(t.Context().Err())
+	admitted := make([]chan struct{}, 0, readers-1)
+	for range readers - 1 {
+		observed := make(chan struct{}, 1)
+		admitted = append(admitted, observed)
+		go func() {
+			ctx := doneObservedContext{Context: t.Context(), observed: observed}
+			_, err := bs.Refresh(ctx)
+			done <- err
+		}()
 	}
-	if got := requests.Load(); got != 2 {
-		close(releaseRefresh)
-		t.Fatalf("root pointer requests = %d, want initial plus one shared refresh", got)
+	for _, observed := range admitted {
+		select {
+		case <-observed:
+		case <-t.Context().Done():
+			t.Fatal(t.Context().Err())
+		}
 	}
+
 	close(releaseRefresh)
 	for range readers {
 		if err := <-done; err != nil {
 			t.Fatal(err)
 		}
+	}
+	if got := requests.Load(); got != 2 {
+		t.Fatalf("root pointer requests = %d, want initial plus one shared refresh", got)
 	}
 
 	bs.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
@@ -749,12 +776,14 @@ func TestCdnBlockStoreCloseFencesBlockedRefresh(t *testing.T) {
 	}
 
 	followerDone := make(chan error, 1)
+	followerAdmitted := make(chan struct{}, 1)
 	go func() {
-		_, err := bs.Refresh(t.Context())
+		ctx := doneObservedContext{Context: t.Context(), observed: followerAdmitted}
+		_, err := bs.Refresh(ctx)
 		followerDone <- err
 	}()
 	select {
-	case <-time.After(50 * time.Millisecond):
+	case <-followerAdmitted:
 	case <-t.Context().Done():
 		t.Fatal(t.Context().Err())
 	}

--- a/core/cdn/bstore/block-store_test.go
+++ b/core/cdn/bstore/block-store_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -353,6 +354,229 @@ func TestCdnBlockStoreInvalidateClearsDecodedBlockCache(t *testing.T) {
 	}
 }
 
+func TestCdnBlockStoreCanceledPointerLeaderDoesNotPoisonFollower(t *testing.T) {
+	ptr := &cdn.CdnRootPointer{SpaceId: testSpaceID}
+	pointerBytes := encodePointer(t, ptr)
+	var requests atomic.Int64
+	leaderStarted := make(chan struct{})
+	hs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/"+testSpaceID+"/root.packedmsg" {
+			http.NotFound(w, r)
+			return
+		}
+		if requests.Add(1) == 1 {
+			close(leaderStarted)
+			<-r.Context().Done()
+			return
+		}
+		_, _ = w.Write(pointerBytes)
+	}))
+	defer hs.Close()
+
+	bs, err := NewCdnBlockStore(Options{
+		CdnBaseURL: hs.URL,
+		SpaceID:    testSpaceID,
+		HttpClient: hs.Client(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer bs.Close()
+
+	leaderCtx, cancelLeader := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer cancelLeader()
+	leaderDone := make(chan error, 1)
+	go func() {
+		_, err := bs.Refresh(leaderCtx)
+		leaderDone <- err
+	}()
+	select {
+	case <-leaderStarted:
+	case <-t.Context().Done():
+		t.Fatal(t.Context().Err())
+	}
+
+	followerDone := make(chan error, 1)
+	go func() {
+		_, err := bs.Refresh(t.Context())
+		followerDone <- err
+	}()
+
+	callerCtx, cancelCaller := context.WithCancel(t.Context())
+	callerDone := make(chan error, 1)
+	go func() {
+		_, err := bs.Refresh(callerCtx)
+		callerDone <- err
+	}()
+	cancelCaller()
+	select {
+	case err := <-callerDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("canceled follower error = %v, want %v", err, context.Canceled)
+		}
+	case <-t.Context().Done():
+		t.Fatal(t.Context().Err())
+	}
+
+	select {
+	case err := <-leaderDone:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("leader error = %v, want %v", err, context.DeadlineExceeded)
+		}
+	case <-t.Context().Done():
+		t.Fatal(t.Context().Err())
+	}
+	select {
+	case err := <-followerDone:
+		if err != nil {
+			t.Fatalf("healthy follower refresh: %v", err)
+		}
+	case <-t.Context().Done():
+		t.Fatal(t.Context().Err())
+	}
+	if got := requests.Load(); got != 2 {
+		t.Fatalf("root pointer requests = %d, want canceled leader plus replacement", got)
+	}
+	if got := bs.Pointer(); got == nil || !got.EqualVT(ptr) {
+		t.Fatalf("root pointer = %#v, want %#v", got, ptr)
+	}
+}
+
+func TestCdnBlockStoreSharesNonContextPointerError(t *testing.T) {
+	var requests atomic.Int64
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	hs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/"+testSpaceID+"/root.packedmsg" {
+			http.NotFound(w, r)
+			return
+		}
+		requests.Add(1)
+		close(requestStarted)
+		<-releaseRequest
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	defer hs.Close()
+
+	bs, err := NewCdnBlockStore(Options{
+		CdnBaseURL: hs.URL,
+		SpaceID:    testSpaceID,
+		HttpClient: hs.Client(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer bs.Close()
+
+	const readers = 32
+	start := make(chan struct{})
+	done := make(chan error, readers)
+	for range readers {
+		go func() {
+			<-start
+			_, err := bs.Refresh(t.Context())
+			done <- err
+		}()
+	}
+	close(start)
+	select {
+	case <-requestStarted:
+	case <-t.Context().Done():
+		t.Fatal(t.Context().Err())
+	}
+
+	select {
+	case <-time.After(50 * time.Millisecond):
+	case <-t.Context().Done():
+		t.Fatal(t.Context().Err())
+	}
+	close(releaseRequest)
+	for range readers {
+		if err := <-done; err == nil || !strings.Contains(err.Error(), "status 503") {
+			t.Fatalf("shared root pointer error = %v, want status 503", err)
+		}
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("root pointer requests = %d, want one shared request", got)
+	}
+}
+
+func TestCdnBlockStoreCoalescesUnchangedPointerRefreshes(t *testing.T) {
+	ptr := &cdn.CdnRootPointer{SpaceId: testSpaceID}
+	pointerBytes := encodePointer(t, ptr)
+	var requests atomic.Int64
+	refreshStarted := make(chan struct{})
+	releaseRefresh := make(chan struct{})
+	hs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/"+testSpaceID+"/root.packedmsg" {
+			http.NotFound(w, r)
+			return
+		}
+		request := requests.Add(1)
+		if request == 2 {
+			close(refreshStarted)
+		}
+		if request > 1 {
+			<-releaseRefresh
+		}
+		_, _ = w.Write(pointerBytes)
+	}))
+	defer hs.Close()
+
+	bs, err := NewCdnBlockStore(Options{
+		CdnBaseURL: hs.URL,
+		SpaceID:    testSpaceID,
+		HttpClient: hs.Client(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer bs.Close()
+	if _, err := bs.Refresh(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	const readers = 32
+	start := make(chan struct{})
+	done := make(chan error, readers)
+	for range readers {
+		go func() {
+			<-start
+			_, err := bs.Refresh(t.Context())
+			done <- err
+		}()
+	}
+	close(start)
+	select {
+	case <-refreshStarted:
+	case <-t.Context().Done():
+		t.Fatal(t.Context().Err())
+	}
+
+	// The blocked leader leaves every other refresh enough time to fold onto it.
+	select {
+	case <-time.After(50 * time.Millisecond):
+	case <-t.Context().Done():
+		t.Fatal(t.Context().Err())
+	}
+	if got := requests.Load(); got != 2 {
+		close(releaseRefresh)
+		t.Fatalf("root pointer requests = %d, want initial plus one shared refresh", got)
+	}
+	close(releaseRefresh)
+	for range readers {
+		if err := <-done; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	bs.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		if bs.pointerEpoch != 1 {
+			t.Fatalf("unchanged pointer epoch = %d, want 1", bs.pointerEpoch)
+		}
+	})
+}
+
 func TestCdnBlockStorePointerTTLRefreshClearsDecodedBlockCache(t *testing.T) {
 	ctx := context.Background()
 
@@ -524,6 +748,17 @@ func TestCdnBlockStoreCloseFencesBlockedRefresh(t *testing.T) {
 		t.Fatalf("Refresh did not reach the root pointer request: %v", t.Context().Err())
 	}
 
+	followerDone := make(chan error, 1)
+	go func() {
+		_, err := bs.Refresh(t.Context())
+		followerDone <- err
+	}()
+	select {
+	case <-time.After(50 * time.Millisecond):
+	case <-t.Context().Done():
+		t.Fatal(t.Context().Err())
+	}
+
 	closeDone := make(chan struct{})
 	go func() {
 		bs.Close()
@@ -539,6 +774,14 @@ func TestCdnBlockStoreCloseFencesBlockedRefresh(t *testing.T) {
 	}
 	if got := bs.pfs.SnapshotStats().ManifestEntries; got != 0 {
 		t.Fatalf("manifest entries after Close = %d, want 0", got)
+	}
+	select {
+	case err := <-followerDone:
+		if !errors.Is(err, packfile_store.ErrPackfileStoreClosed) {
+			t.Fatalf("Refresh follower after Close error = %v, want %v", err, packfile_store.ErrPackfileStoreClosed)
+		}
+	case <-t.Context().Done():
+		t.Fatalf("Refresh follower did not observe Close: %v", t.Context().Err())
 	}
 
 	close(releaseRefresh)


### PR DESCRIPTION
Concurrent cold reads fetched the same CDN root pointer independently and repeatedly reset manifest state. This multiplied startup requests and made healthy readers repeat work when another reader finished first.

CdnBlockStore now coordinates one in-flight root pointer load and shares its result with concurrent waiters. A waiter with a live context retries after a canceled leader, while close and caller cancellation still terminate waits.

An unchanged pointer refreshes its timestamp without advancing the pointer epoch or clearing caches. Cold startup performs one fetch and keeps healthy readers on the current manifest.
