### PR TITLE
fix(cli): clean up failed daemon starts

### DIFF
--- a/cmd/spacewave/cli/client.go
+++ b/cmd/spacewave/cli/client.go
@@ -7,9 +7,11 @@ import (
 	stderrors "errors"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"syscall"
+	"time"
 
 	"github.com/aperturerobotics/cli"
 	"github.com/aperturerobotics/starpc/srpc"
@@ -48,12 +50,14 @@ var socketPathEnvVars = []string{"SPACEWAVE_SOCKET_PATH"}
 // socketName is the name of the Unix socket within the state path.
 const socketName = "spacewave.sock"
 
-// sdkClient wraps the Resource SDK connection to a running daemon.
+// sdkClient wraps the Resource SDK connection to a running daemon. A
+// successfully connected client does not retain the daemon process handle.
 type sdkClient struct {
-	conn      net.Conn
-	srpc      srpc.Client
-	resClient *resource_client.Client
-	root      *s4wave_root.Root
+	conn         net.Conn
+	srpc         srpc.Client
+	resClient    *resource_client.Client
+	root         *s4wave_root.Root
+	clientCancel context.CancelFunc
 }
 
 type nativeClientFactory struct{}
@@ -92,8 +96,10 @@ func connectDaemon(ctx context.Context, statePath string) (*sdkClient, error) {
 	return client, nil
 }
 
-// connectDaemonWithAutostart connects to a running daemon or starts a
-// CLI-owned daemon in statePath when no daemon is reachable.
+// connectDaemonWithAutostart connects to a running daemon or starts one in
+// statePath when no daemon is reachable. The parent keeps the child process
+// handle until Resource Init succeeds so startup failure can stop and wait for
+// the child. A successful connection releases the handle before returning.
 func connectDaemonWithAutostart(ctx context.Context, statePath string) (*sdkClient, error) {
 	sockPath := filepath.Join(statePath, socketName)
 	_, statErr := os.Stat(sockPath)
@@ -107,10 +113,33 @@ func connectDaemonWithAutostart(ctx context.Context, statePath string) (*sdkClie
 				return nil, errors.Wrap(err, "remove stale daemon socket")
 			}
 		}
-		if err := connectDaemonStart(ctx, statePath); err != nil {
-			return nil, errors.Wrap(err, "start daemon")
+		daemonCmd, startErr := connectDaemonStart(ctx, statePath)
+		if startErr != nil {
+			return nil, errors.Wrap(startErr, "start daemon")
 		}
 		conn, err = connectDaemonDial(ctx, sockPath)
+		if err != nil {
+			stopErr := terminateDaemonCmd(daemonCmd, statePath)
+			if stopErr != nil {
+				return nil, errors.Wrapf(err, "connect to %s; stop started daemon: %v", sockPath, stopErr)
+			}
+			return nil, errors.Wrapf(err, "connect to %s", sockPath)
+		}
+		client, buildErr := connectDaemonBuildClient(ctx, conn)
+		if buildErr != nil {
+			conn.Close()
+			stopErr := terminateDaemonCmd(daemonCmd, statePath)
+			if stopErr != nil {
+				return nil, errors.Wrapf(buildErr, "stop started daemon: %v", stopErr)
+			}
+			return nil, buildErr
+		}
+		// The daemon is self-sustaining after the client handshake succeeds.
+		// Release the process handle so the daemon persists for subsequent
+		// commands; do not store it on the client, since close must not kill
+		// a healthy daemon.
+		releaseDaemonCmd(daemonCmd)
+		return client, nil
 	}
 	if err != nil {
 		return nil, errors.Wrapf(err, "connect to %s", sockPath)
@@ -176,7 +205,12 @@ func connectDaemonNotListeningError(sockPath string) error {
 	)
 }
 
-// buildSDKClient constructs the Resource SDK client over an accepted daemon connection.
+// buildSDKClient constructs the Resource SDK client over an accepted daemon
+// connection. The initial ResourceClient Init handshake is bounded by the
+// daemon startup timeout so it cannot block forever when the core plugin
+// has not loaded yet. On success the client's stream lifetime is tied to
+// the caller's context via a cancel stored on sdkClient, so subsequent RPCs
+// remain valid after the handshake bound expires.
 func buildSDKClient(ctx context.Context, conn net.Conn) (*sdkClient, error) {
 	srpcClient, err := srpc.NewClientWithConn(conn, true, nil)
 	if err != nil {
@@ -184,27 +218,71 @@ func buildSDKClient(ctx context.Context, conn net.Conn) (*sdkClient, error) {
 		return nil, errors.Wrap(err, "create srpc client")
 	}
 
+	// Bound the initial ResourceClient handshake without canceling the
+	// client's lifetime on success. NewClient derives its stream context
+	// from the passed context; a timeout context would cancel the stream
+	// after the deadline even on success. Instead, use a manual cancel
+	// context and a select: on timeout, cancel and fail; on success, keep
+	// the context alive and store the cancel for close.
+	handshakeTimeout, err := getDaemonStartupTimeout()
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	clientCtx, clientCancel := context.WithCancel(ctx)
+
 	resourceSvc := resource.NewSRPCResourceServiceClient(srpcClient)
-	resClient, err := resource_client.NewClient(ctx, resourceSvc)
-	if err != nil {
-		conn.Close()
-		return nil, errors.Wrap(err, "resource client")
+	type buildResult struct {
+		client *resource_client.Client
+		root   *s4wave_root.Root
+		err    error
 	}
+	resultCh := make(chan buildResult, 1)
+	go func() {
+		resClient, err := resource_client.NewClient(clientCtx, resourceSvc)
+		if err != nil {
+			resultCh <- buildResult{err: err}
+			return
+		}
+		rootRef := resClient.AccessRootResource()
+		root, err := s4wave_root.NewRoot(resClient, rootRef)
+		if err != nil {
+			resClient.Release()
+			resultCh <- buildResult{err: err}
+			return
+		}
+		resultCh <- buildResult{client: resClient, root: root}
+	}()
 
-	rootRef := resClient.AccessRootResource()
-	root, err := s4wave_root.NewRoot(resClient, rootRef)
-	if err != nil {
-		resClient.Release()
+	select {
+	case <-time.After(handshakeTimeout):
+		clientCancel()
 		conn.Close()
-		return nil, errors.Wrap(err, "root resource")
+		// Join the NewClient goroutine. After canceling the context
+		// and closing the conn, NewClient must return promptly. If it
+		// produces a client despite the cancel, release root before
+		// client to drop the root reference first.
+		if res := <-resultCh; res.client != nil {
+			if res.root != nil {
+				res.root.Release()
+			}
+			res.client.Release()
+		}
+		return nil, errors.New("resource client: init handshake timed out")
+	case res := <-resultCh:
+		if res.err != nil {
+			clientCancel()
+			conn.Close()
+			return nil, errors.Wrap(res.err, "resource client")
+		}
+		return &sdkClient{
+			conn:         conn,
+			srpc:         srpcClient,
+			resClient:    res.client,
+			root:         res.root,
+			clientCancel: clientCancel,
+		}, nil
 	}
-
-	return &sdkClient{
-		conn:      conn,
-		srpc:      srpcClient,
-		resClient: resClient,
-		root:      root,
-	}, nil
 }
 
 func buildSDKClientFromInvoker(ctx context.Context, invoker srpc.Invoker) (*sdkClient, error) {
@@ -421,7 +499,8 @@ func (c *sdkClient) accessWorldEngineWithRef(ctx context.Context, spaceSvc s4wav
 	return engine, engineRef, cleanup, nil
 }
 
-// close releases all resources and closes the connection.
+// close releases all resources, closes the connection, and cancels the
+// Resource client context.
 func (c *sdkClient) close() {
 	if c.root != nil {
 		c.root.Release()
@@ -429,9 +508,91 @@ func (c *sdkClient) close() {
 	if c.resClient != nil {
 		c.resClient.Release()
 	}
+	if c.clientCancel != nil {
+		c.clientCancel()
+	}
 	if c.conn != nil {
 		c.conn.Close()
 	}
+}
+
+var daemonShutdownGracePeriod = 2 * time.Second
+
+var daemonForcedShutdownTimeout = 2 * time.Second
+
+// terminateDaemonCmd asks the daemon control service to stop, then falls back
+// to the platform interrupt. It waits for normal cleanup and kills any process
+// left in the started tree only after the grace period. cmd.Wait reaps the
+// leader exactly once.
+func terminateDaemonCmd(cmd *exec.Cmd, statePath string) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	pid := cmd.Process.Pid
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- cmd.Wait() }()
+
+	shutdownErr := requestStartedDaemonShutdown(statePath)
+	if shutdownErr != nil {
+		shutdownErr = stderrors.Join(shutdownErr, interruptDaemon(pid))
+	}
+	graceTimer := time.NewTimer(daemonShutdownGracePeriod)
+	select {
+	case <-waitCh:
+		graceTimer.Stop()
+		return killDaemonTree(pid)
+	case <-graceTimer.C:
+	}
+
+	killErr := killDaemonTree(pid)
+	var cleanupErr error
+	if killErr != nil {
+		select {
+		case <-waitCh:
+			return nil
+		default:
+		}
+		leaderKillErr := cmd.Process.Kill()
+		cleanupErr = stderrors.Join(killErr, leaderKillErr)
+	}
+
+	forceTimer := time.NewTimer(daemonForcedShutdownTimeout)
+	defer forceTimer.Stop()
+	select {
+	case <-waitCh:
+		return cleanupErr
+	case <-forceTimer.C:
+		return stderrors.Join(
+			shutdownErr,
+			cleanupErr,
+			errors.New("timed out waiting for started daemon to stop"),
+		)
+	}
+}
+
+func requestStartedDaemonShutdown(statePath string) error {
+	if statePath == "" {
+		return errors.New("daemon state path is empty")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), daemonShutdownGracePeriod)
+	defer cancel()
+	conn, err := (&net.Dialer{}).DialContext(ctx, "unix", filepath.Join(statePath, socketName))
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	return requestDaemonShutdown(ctx, conn)
+}
+
+// releaseDaemonCmd releases the process handle and any platform process-tree
+// handle without killing the child. It is called after Resource Init succeeds
+// so later commands can reuse the daemon.
+func releaseDaemonCmd(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = releaseDaemonTree(cmd.Process.Pid)
+	_ = cmd.Process.Release()
 }
 
 // resolveStatePath resolves the state path, making it absolute if needed.

--- a/cmd/spacewave/cli/client_test.go
+++ b/cmd/spacewave/cli/client_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -31,9 +32,9 @@ func TestConnectDaemonDoesNotAutostartAfterDialFailure(t *testing.T) {
 		dialCalls++
 		return nil, context.DeadlineExceeded
 	}
-	connectDaemonStart = func(ctx context.Context, statePath string) error {
+	connectDaemonStart = func(ctx context.Context, statePath string) (*exec.Cmd, error) {
 		t.Fatal("connectDaemon must not autostart")
-		return nil
+		return nil, nil
 	}
 	connectDaemonBuildClient = func(ctx context.Context, conn net.Conn) (*sdkClient, error) {
 		t.Fatal("unexpected build client call")
@@ -80,9 +81,9 @@ func TestConnectDaemonWithAutostartStartsDaemonAfterDialFailure(t *testing.T) {
 		}
 		return connA, nil
 	}
-	connectDaemonStart = func(ctx context.Context, statePath string) error {
+	connectDaemonStart = func(ctx context.Context, statePath string) (*exec.Cmd, error) {
 		startStatePath = statePath
-		return nil
+		return nil, nil
 	}
 	connectDaemonBuildClient = func(ctx context.Context, conn net.Conn) (*sdkClient, error) {
 		if conn != connA {
@@ -125,9 +126,9 @@ func TestConnectDaemonWithAutostartDoesNotAutostartOverExistingSocketAfterTransi
 	connectDaemonDial = func(ctx context.Context, sockPath string) (net.Conn, error) {
 		return nil, context.DeadlineExceeded
 	}
-	connectDaemonStart = func(ctx context.Context, statePath string) error {
+	connectDaemonStart = func(ctx context.Context, statePath string) (*exec.Cmd, error) {
 		t.Fatal("must not autostart while an existing daemon socket may still be live")
-		return nil
+		return nil, nil
 	}
 	connectDaemonBuildClient = func(ctx context.Context, conn net.Conn) (*sdkClient, error) {
 		t.Fatal("unexpected build client call")
@@ -174,9 +175,9 @@ func TestConnectDaemonWithAutostartRemovesStaleSocket(t *testing.T) {
 		}
 		return connA, nil
 	}
-	connectDaemonStart = func(ctx context.Context, statePath string) error {
+	connectDaemonStart = func(ctx context.Context, statePath string) (*exec.Cmd, error) {
 		startCalled = true
-		return nil
+		return nil, nil
 	}
 	connectDaemonBuildClient = func(ctx context.Context, conn net.Conn) (*sdkClient, error) {
 		return &sdkClient{conn: conn}, nil
@@ -217,9 +218,9 @@ func TestConnectDaemonSkipsAutostartWhenDialSucceeds(t *testing.T) {
 	connectDaemonDial = func(ctx context.Context, sockPath string) (net.Conn, error) {
 		return connA, nil
 	}
-	connectDaemonStart = func(ctx context.Context, statePath string) error {
+	connectDaemonStart = func(ctx context.Context, statePath string) (*exec.Cmd, error) {
 		startCalled = true
-		return nil
+		return nil, nil
 	}
 	connectDaemonBuildClient = func(ctx context.Context, conn net.Conn) (*sdkClient, error) {
 		return &sdkClient{conn: conn}, nil
@@ -246,8 +247,8 @@ func TestConnectDaemonWithAutostartReturnsAutostartFailure(t *testing.T) {
 	connectDaemonDial = func(ctx context.Context, sockPath string) (net.Conn, error) {
 		return nil, context.DeadlineExceeded
 	}
-	connectDaemonStart = func(ctx context.Context, statePath string) error {
-		return context.Canceled
+	connectDaemonStart = func(ctx context.Context, statePath string) (*exec.Cmd, error) {
+		return nil, context.Canceled
 	}
 	connectDaemonBuildClient = func(ctx context.Context, conn net.Conn) (*sdkClient, error) {
 		t.Fatal("unexpected build client call")

--- a/cmd/spacewave/cli/daemon-autostart-kill_test.go
+++ b/cmd/spacewave/cli/daemon-autostart-kill_test.go
@@ -1,0 +1,336 @@
+//go:build !js && (darwin || linux)
+
+package spacewave_cli
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/aperturerobotics/starpc/srpc"
+	resource_server "github.com/s4wave/spacewave/bldr/resource/server"
+)
+
+func startFakeDaemonTree(t *testing.T) (*exec.Cmd, int) {
+	t.Helper()
+	cmd := exec.Command("sh", "-c", `sleep 30 & child=$!; trap 'kill "$child" 2>/dev/null; wait "$child" 2>/dev/null; exit 0' INT; echo "$child"; wait "$child"`)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start fake daemon: %v", err)
+	}
+	line, err := bufio.NewReader(stdout).ReadString('\n')
+	if err != nil {
+		_ = killDaemonTree(cmd.Process.Pid)
+		_, _ = cmd.Process.Wait()
+		t.Fatalf("read fake daemon child PID: %v", err)
+	}
+	childPID, err := strconv.Atoi(strings.TrimSpace(line))
+	if err != nil {
+		_ = killDaemonTree(cmd.Process.Pid)
+		_, _ = cmd.Process.Wait()
+		t.Fatalf("parse fake daemon child PID: %v", err)
+	}
+	return cmd, childPID
+}
+
+func TestTerminateDaemonCmdAllowsGracefulShutdown(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "stopped")
+	cmd := exec.Command("sh", "-c", `trap 'printf stopped > "$1"; exit 0' INT; printf 'ready\n'; while :; do sleep 1; done`, "sh", marker)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start fake daemon: %v", err)
+	}
+	if line, err := bufio.NewReader(stdout).ReadString('\n'); err != nil || line != "ready\n" {
+		t.Fatalf("fake daemon readiness = %q, %v", line, err)
+	}
+
+	if err := terminateDaemonCmd(cmd, ""); err != nil {
+		t.Fatalf("terminate daemon: %v", err)
+	}
+	if got, err := os.ReadFile(marker); err != nil || string(got) != "stopped" {
+		t.Fatalf("graceful shutdown marker = %q, %v", got, err)
+	}
+}
+
+func TestTerminateDaemonCmdKillsDescendantAfterLeaderExit(t *testing.T) {
+	cmd := exec.Command("sh", "-c", `sleep 30 </dev/null >/dev/null 2>&1 & printf '%s\n' "$!"`)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start fake daemon: %v", err)
+	}
+	line, err := bufio.NewReader(stdout).ReadString('\n')
+	if err != nil {
+		t.Fatalf("read descendant PID: %v", err)
+	}
+	childPID, err := strconv.Atoi(strings.TrimSpace(line))
+	if err != nil {
+		t.Fatalf("parse descendant PID: %v", err)
+	}
+
+	if err := terminateDaemonCmd(cmd, ""); err != nil {
+		t.Fatalf("terminate daemon: %v", err)
+	}
+	if !waitProcessGone(t, childPID) {
+		t.Fatalf("daemon descendant PID %d survived leader exit", childPID)
+	}
+}
+
+func TestTerminateDaemonCmdForcesShutdownAfterGracePeriod(t *testing.T) {
+	oldGracePeriod := daemonShutdownGracePeriod
+	daemonShutdownGracePeriod = 25 * time.Millisecond
+	t.Cleanup(func() { daemonShutdownGracePeriod = oldGracePeriod })
+
+	cmd := exec.Command("sh", "-c", `trap '' INT; printf 'ready\n'; while :; do sleep 1; done`)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start fake daemon: %v", err)
+	}
+	if line, err := bufio.NewReader(stdout).ReadString('\n'); err != nil || line != "ready\n" {
+		t.Fatalf("fake daemon readiness = %q, %v", line, err)
+	}
+
+	if err := terminateDaemonCmd(cmd, ""); err != nil {
+		t.Fatalf("terminate daemon: %v", err)
+	}
+	if processAlive(t, cmd.Process.Pid) {
+		t.Fatalf("daemon PID %d survived forced shutdown", cmd.Process.Pid)
+	}
+}
+
+// TestAutostartedDaemonKilledOnClientBuildFailure proves that when the
+// daemon is autostarted and the initial Resource client handshake fails,
+// the child daemon process group is terminated so no orphan survives.
+func TestAutostartedDaemonKilledOnClientBuildFailure(t *testing.T) {
+	oldDial := connectDaemonDial
+	oldBuildClient := connectDaemonBuildClient
+	oldStart := connectDaemonStart
+	t.Cleanup(func() {
+		connectDaemonDial = oldDial
+		connectDaemonBuildClient = oldBuildClient
+		connectDaemonStart = oldStart
+	})
+
+	// Start a leader and descendant in one process group, matching the
+	// production daemon and plugin/helper process relationship.
+	daemonCmd, childPID := startFakeDaemonTree(t)
+	leaderPid := daemonCmd.Process.Pid
+	t.Cleanup(func() { _ = killDaemonTree(leaderPid) })
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() {
+		clientConn.Close()
+		serverConn.Close()
+	})
+	dialCount := 0
+	connectDaemonDial = func(ctx context.Context, sockPath string) (net.Conn, error) {
+		dialCount++
+		if dialCount == 1 {
+			return nil, &net.OpError{Op: "dial", Err: context.DeadlineExceeded}
+		}
+		return clientConn, nil
+	}
+	connectDaemonStart = func(ctx context.Context, statePath string) (*exec.Cmd, error) {
+		return daemonCmd, nil
+	}
+	connectDaemonBuildClient = func(ctx context.Context, conn net.Conn) (*sdkClient, error) {
+		return nil, &net.OpError{Op: "read", Err: context.DeadlineExceeded}
+	}
+
+	_, err := connectDaemonWithAutostart(context.Background(), "/tmp/test-state")
+	if err == nil {
+		t.Fatal("expected error from connectDaemonWithAutostart")
+	}
+
+	// Production cleanup is synchronous: it terminates the whole group and
+	// joins the leader before returning. The test must not call Wait itself.
+	if !waitProcessGone(t, leaderPid) {
+		t.Fatalf("daemon leader PID %d still has a process entry", leaderPid)
+	}
+	if !waitProcessGone(t, childPID) {
+		t.Fatalf("daemon descendant PID %d survived build failure", childPID)
+	}
+}
+
+// TestAutostartedDaemonSurvivesSuccessfulClientClose proves that when the
+// daemon is autostarted and the client handshake succeeds, closing the
+// client does not kill the daemon. The process handle is released so the
+// daemon persists for subsequent commands.
+func TestAutostartedDaemonSurvivesSuccessfulClientClose(t *testing.T) {
+	oldDial := connectDaemonDial
+	oldBuildClient := connectDaemonBuildClient
+	oldStart := connectDaemonStart
+	t.Cleanup(func() {
+		connectDaemonDial = oldDial
+		connectDaemonBuildClient = oldBuildClient
+		connectDaemonStart = oldStart
+	})
+
+	daemonCmd, childPID := startFakeDaemonTree(t)
+	daemonPid := daemonCmd.Process.Pid
+	t.Cleanup(func() { _ = killDaemonTree(daemonPid) })
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() {
+		clientConn.Close()
+		serverConn.Close()
+	})
+	dialCount := 0
+	connectDaemonDial = func(ctx context.Context, sockPath string) (net.Conn, error) {
+		dialCount++
+		if dialCount == 1 {
+			return nil, &net.OpError{Op: "dial", Err: context.DeadlineExceeded}
+		}
+		return clientConn, nil
+	}
+	connectDaemonStart = func(ctx context.Context, statePath string) (*exec.Cmd, error) {
+		return daemonCmd, nil
+	}
+	connectDaemonBuildClient = func(ctx context.Context, conn net.Conn) (*sdkClient, error) {
+		return &sdkClient{conn: conn}, nil
+	}
+
+	client, err := connectDaemonWithAutostart(context.Background(), "/tmp/test-state")
+	if err != nil {
+		t.Fatalf("connectDaemonWithAutostart: %v", err)
+	}
+
+	// Close the client. The daemon must survive.
+	client.close()
+
+	if !processAlive(t, daemonPid) {
+		t.Fatalf("daemon PID %d was killed on successful client close", daemonPid)
+	}
+	if !processAlive(t, childPID) {
+		t.Fatalf("daemon descendant PID %d was killed on successful client close", childPID)
+	}
+}
+
+// TestBuildSDKClientPreservesClientContext proves that the Resource
+// client's stream context is not canceled after the Init handshake
+// succeeds. buildSDKClient must use a cancel-only context (not a timeout
+// context) for NewClient so the stream stays alive after the handshake
+// bound expires. clientCancel is stored on the sdkClient and only invoked
+// in close().
+func TestBuildSDKClientPreservesClientContext(t *testing.T) {
+	// Use a Unix socket pair so srpc.NewClientWithConn can open a real
+	// muxed connection and resource_client.NewClient can complete Init.
+	tmpDir, err := os.MkdirTemp("/tmp", "sw-bld-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+	sockPath := filepath.Join(tmpDir, "s.sock")
+	lis, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { lis.Close() })
+
+	// Server side: a minimal Resource server that handles Init.
+	mux := srpc.NewMux()
+	if err := resource_server.NewResourceServer(srpc.NewMux()).Register(mux); err != nil {
+		t.Fatal(err)
+	}
+	srv := srpc.NewServer(mux)
+	go func() {
+		for {
+			conn, err := lis.Accept()
+			if err != nil {
+				return
+			}
+			mc, err := srpc.NewMuxedConn(conn, false, nil)
+			if err != nil {
+				conn.Close()
+				continue
+			}
+			go srv.AcceptMuxedConn(context.Background(), mc)
+		}
+	}()
+
+	// Client side: dial and build.
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := t.Context()
+
+	client, err := buildSDKClient(ctx, conn)
+	if err != nil {
+		conn.Close()
+		t.Fatalf("buildSDKClient: %v", err)
+	}
+
+	// clientCancel must be set so close can cancel the stream.
+	if client.clientCancel == nil {
+		t.Fatal("clientCancel is nil after successful build")
+	}
+
+	// The context must NOT be canceled yet — the handshake bound must
+	// not have killed the stream. Verify by performing a post-Init RPC.
+	rpcCtx, rpcCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer rpcCancel()
+	_, rpcErr := client.root.LookupProvider(rpcCtx, "local")
+	// The minimal test Resource server replies with a semantic unimplemented
+	// result. Receiving that exact reply proves a complete post-Init RPC
+	// traversed the retained client stream after buildSDKClient returned.
+	if rpcErr == nil || rpcErr.Error() != "unimplemented" {
+		t.Fatalf("post-Init RPC error = %v, want unimplemented", rpcErr)
+	}
+
+	// close must cancel the stream context.
+	client.close()
+}
+
+func waitProcessGone(t *testing.T, pid int) bool {
+	t.Helper()
+	deadline := time.NewTimer(2 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if !processAlive(t, pid) {
+			return true
+		}
+		select {
+		case <-deadline.C:
+			return false
+		case <-ticker.C:
+		}
+	}
+}
+
+// processAlive checks whether a process with the given PID is running.
+func processAlive(t *testing.T, pid int) bool {
+	t.Helper()
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = proc.Signal(syscall.Signal(0))
+	return err == nil
+}

--- a/cmd/spacewave/cli/daemon-process-kill-posix.go
+++ b/cmd/spacewave/cli/daemon-process-kill-posix.go
@@ -1,0 +1,33 @@
+//go:build !js && (darwin || linux)
+
+package spacewave_cli
+
+import (
+	"errors"
+	"os/exec"
+	"syscall"
+)
+
+func startDaemonCmd(cmd *exec.Cmd) error {
+	return cmd.Start()
+}
+
+func releaseDaemonTree(int) error {
+	return nil
+}
+
+// interruptDaemon sends SIGINT to the daemon. Its signal handler cancels the
+// root context, stops its descendants, and runs cleanup.
+func interruptDaemon(pid int) error {
+	return syscall.Kill(pid, syscall.SIGINT)
+}
+
+// killDaemonTree forces the daemon and its descendants to exit after the
+// graceful shutdown period expires.
+func killDaemonTree(pid int) error {
+	err := syscall.Kill(-pid, syscall.SIGKILL)
+	if errors.Is(err, syscall.ESRCH) {
+		return nil
+	}
+	return err
+}

--- a/cmd/spacewave/cli/daemon-process-kill-windows.go
+++ b/cmd/spacewave/cli/daemon-process-kill-windows.go
@@ -1,0 +1,52 @@
+//go:build !js && windows
+
+package spacewave_cli
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"strconv"
+	"sync"
+
+	winjob "github.com/aperturerobotics/go-winjob"
+)
+
+var daemonJobs sync.Map
+
+func startDaemonCmd(cmd *exec.Cmd) error {
+	job, err := winjob.Start(cmd)
+	if err != nil {
+		return err
+	}
+	daemonJobs.Store(cmd.Process.Pid, job)
+	return nil
+}
+
+func releaseDaemonTree(pid int) error {
+	value, ok := daemonJobs.LoadAndDelete(pid)
+	if !ok {
+		return nil
+	}
+	return value.(*winjob.JobObject).Close()
+}
+
+// interruptDaemon asks taskkill to stop the daemon process tree.
+func interruptDaemon(pid int) error {
+	ctx, cancel := context.WithTimeout(context.Background(), daemonShutdownGracePeriod)
+	defer cancel()
+	return exec.CommandContext(ctx, "taskkill", "/T", "/PID", strconv.Itoa(pid)).Run()
+}
+
+// killDaemonTree forces every process retained in the daemon's Job object to
+// exit. taskkill remains a fallback for commands started before the Job was
+// registered.
+func killDaemonTree(pid int) error {
+	if value, ok := daemonJobs.LoadAndDelete(pid); ok {
+		job := value.(*winjob.JobObject)
+		return errors.Join(job.Terminate(), job.Close())
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), daemonForcedShutdownTimeout)
+	defer cancel()
+	return exec.CommandContext(ctx, "taskkill", "/T", "/F", "/PID", strconv.Itoa(pid)).Run()
+}

--- a/cmd/spacewave/cli/daemon-startup.go
+++ b/cmd/spacewave/cli/daemon-startup.go
@@ -28,11 +28,12 @@ const daemonTracePathEnvVar = "SPACEWAVE_DAEMON_TRACE"
 var defaultDaemonStartupTimeout = time.Minute
 
 // startDaemonProcess starts the current CLI executable in background serve mode
-// and waits for a one-shot startup readiness signal.
-func startDaemonProcess(ctx context.Context, statePath string) error {
+// and waits for the startup pipe. It returns the command so the caller can stop
+// and wait for the child if Resource Init fails.
+func startDaemonProcess(ctx context.Context, statePath string) (*exec.Cmd, error) {
 	startupTimeout, err := getDaemonStartupTimeout()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	startCtx, cancel := context.WithTimeout(ctx, startupTimeout)
@@ -42,13 +43,13 @@ func startDaemonProcess(ctx context.Context, statePath string) error {
 	pipeLogger := newDaemonStartupPipeLogger()
 	pipeListener, err := pipesock.BuildPipeListener(pipeLogger, statePath, pipeID)
 	if err != nil {
-		return errors.Wrap(err, "listen for daemon startup")
+		return nil, errors.Wrap(err, "listen for daemon startup")
 	}
 	defer pipeListener.Close()
 
 	exePath, err := os.Executable()
 	if err != nil {
-		return errors.Wrap(err, "resolve executable")
+		return nil, errors.Wrap(err, "resolve executable")
 	}
 
 	cmd := exec.Command(
@@ -58,33 +59,31 @@ func startDaemonProcess(ctx context.Context, statePath string) error {
 	// cmd.Env is left nil so the daemon inherits the parent's environment;
 	// the variables in daemonChildEnvForwarded propagate via that default.
 	if err := prepareDaemonStart(cmd); err != nil {
-		return err
+		return nil, err
 	}
 
 	nullFile, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
 	if err != nil {
-		return errors.Wrap(err, "open devnull")
+		return nil, errors.Wrap(err, "open devnull")
 	}
 	defer nullFile.Close()
 	cmd.Stdin = nullFile
 	cmd.Stdout = nullFile
 	cmd.Stderr = nullFile
 
-	if err := cmd.Start(); err != nil {
-		return errors.Wrap(err, "start daemon process")
+	if err := startDaemonCmd(cmd); err != nil {
+		return nil, errors.Wrap(err, "start daemon process")
 	}
 
 	if err := waitForDaemonStartup(startCtx, pipeListener); err != nil {
-		if cmd.Process != nil {
-			_ = cmd.Process.Kill()
-			_ = cmd.Process.Release()
+		if stopErr := terminateDaemonCmd(cmd, statePath); stopErr != nil {
+			return nil, errors.Wrapf(err, "stop started daemon: %v", stopErr)
 		}
-		return err
+		return nil, err
 	}
-	if cmd.Process != nil {
-		_ = cmd.Process.Release()
-	}
-	return nil
+	// Keep the process handle until Resource Init succeeds. A later startup
+	// failure must stop and wait for this child before returning.
+	return cmd, nil
 }
 
 func daemonServeArgs(statePath string, pipeID string) []string {

--- a/cmd/spacewave/cli/daemon-stop_test.go
+++ b/cmd/spacewave/cli/daemon-stop_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
@@ -61,9 +62,9 @@ func TestRunStopRequestsDaemonShutdown(t *testing.T) {
 
 func TestRunStopWithoutDaemonDoesNotAutostart(t *testing.T) {
 	oldStart := connectDaemonStart
-	connectDaemonStart = func(ctx context.Context, statePath string) error {
+	connectDaemonStart = func(ctx context.Context, statePath string) (*exec.Cmd, error) {
 		t.Fatal("stop should not autostart daemon")
-		return nil
+		return nil, nil
 	}
 	t.Cleanup(func() {
 		connectDaemonStart = oldStart

--- a/cmd/spacewave/cli/debug_test.go
+++ b/cmd/spacewave/cli/debug_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"net"
+	"os/exec"
 	"path/filepath"
 	"runtime/trace"
 	"testing"
@@ -97,9 +98,9 @@ func TestConnectDebugTraceDaemonUsesSocketPathWithoutAutostart(t *testing.T) {
 	connectDaemonBuildClient = func(ctx context.Context, conn net.Conn) (*sdkClient, error) {
 		return &sdkClient{conn: conn}, nil
 	}
-	connectDaemonStart = func(ctx context.Context, statePath string) error {
+	connectDaemonStart = func(ctx context.Context, statePath string) (*exec.Cmd, error) {
 		t.Fatal("debug connection must not autostart daemon")
-		return nil
+		return nil, nil
 	}
 
 	client, err := connectDebugTraceDaemon(context.Background(), nil, t.TempDir(), sock)

--- a/cmd/spacewave/cli/device-policy_test.go
+++ b/cmd/spacewave/cli/device-policy_test.go
@@ -5,6 +5,7 @@ package spacewave_cli
 import (
 	"context"
 	"net"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
@@ -249,9 +250,9 @@ func TestDevicePolicyEnableShellCommandWritesPolicyAndReloadsDaemon(t *testing.T
 	withDeviceDaemonStub(t, func(sockPath string, call int) (net.Conn, error) {
 		dialed = sockPath
 		return newTestDaemonConn(t), nil
-	}, func(_ context.Context, path string) error {
+	}, func(_ context.Context, path string) (*exec.Cmd, error) {
 		t.Fatal("autostart must not run after successful dial")
-		return nil
+		return nil, nil
 	})
 	withDevicePolicyReloadStub(t, func(context.Context, *sdkClient) error {
 		reloads++
@@ -295,9 +296,9 @@ func TestDevicePolicyEnableShellDisableWritesPolicyAndReloadsDaemon(t *testing.T
 	var reloads int
 	withDeviceDaemonStub(t, func(sockPath string, call int) (net.Conn, error) {
 		return newTestDaemonConn(t), nil
-	}, func(_ context.Context, path string) error {
+	}, func(_ context.Context, path string) (*exec.Cmd, error) {
 		t.Fatal("autostart must not run after successful dial")
-		return nil
+		return nil, nil
 	})
 	withDevicePolicyReloadStub(t, func(context.Context, *sdkClient) error {
 		reloads++
@@ -336,9 +337,9 @@ func TestDevicePolicyCheckoutRootAddRemoveWritesPolicyAndReloadsDaemon(t *testin
 	var reloads int
 	withDeviceDaemonStub(t, func(sockPath string, call int) (net.Conn, error) {
 		return newTestDaemonConn(t), nil
-	}, func(_ context.Context, path string) error {
+	}, func(_ context.Context, path string) (*exec.Cmd, error) {
 		t.Fatal("autostart must not run after successful dial")
-		return nil
+		return nil, nil
 	})
 	withDevicePolicyReloadStub(t, func(context.Context, *sdkClient) error {
 		reloads++

--- a/cmd/spacewave/cli/device_test.go
+++ b/cmd/spacewave/cli/device_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -114,9 +115,9 @@ func TestDeviceSetupUsesResolvedStatePathAndAutostart(t *testing.T) {
 			return nil, os.ErrNotExist
 		}
 		return newTestDaemonConn(t), nil
-	}, func(_ context.Context, path string) error {
+	}, func(_ context.Context, path string) (*exec.Cmd, error) {
 		startedStatePath = path
-		return nil
+		return nil, nil
 	})
 
 	out, err := captureStdout(t, func() error {
@@ -154,9 +155,9 @@ func TestDeviceSetupUsesGlobalStatePathFlag(t *testing.T) {
 	withDeviceDaemonStub(t, func(sockPath string, call int) (net.Conn, error) {
 		dialed = sockPath
 		return newTestDaemonConn(t), nil
-	}, func(_ context.Context, path string) error {
+	}, func(_ context.Context, path string) (*exec.Cmd, error) {
 		t.Fatal("autostart must not run after successful dial")
-		return nil
+		return nil, nil
 	})
 
 	out, err := captureStdout(t, func() error {
@@ -193,9 +194,9 @@ func TestDeviceSetupUsesEnvStatePath(t *testing.T) {
 	})
 	withDeviceDaemonStub(t, func(sockPath string, call int) (net.Conn, error) {
 		return newTestDaemonConn(t), nil
-	}, func(_ context.Context, path string) error {
+	}, func(_ context.Context, path string) (*exec.Cmd, error) {
 		t.Fatal("autostart must not run after successful dial")
-		return nil
+		return nil, nil
 	})
 
 	out, err := captureStdout(t, func() error {
@@ -223,9 +224,9 @@ func TestDeviceSetupOutputsSignedDeviceTicketAndReusesIdentity(t *testing.T) {
 	statePath := filepath.Join(t.TempDir(), "state")
 	withDeviceDaemonStub(t, func(sockPath string, call int) (net.Conn, error) {
 		return newTestDaemonConn(t), nil
-	}, func(_ context.Context, path string) error {
+	}, func(_ context.Context, path string) (*exec.Cmd, error) {
 		t.Fatal("autostart must not run after successful dial")
-		return nil
+		return nil, nil
 	})
 
 	out, err := captureStdout(t, func() error {
@@ -305,9 +306,9 @@ func TestDeviceCompleteImportsApprovalCompletionIntoSetupState(t *testing.T) {
 	statePath := filepath.Join(t.TempDir(), "state")
 	withDeviceDaemonStub(t, func(sockPath string, call int) (net.Conn, error) {
 		return newTestDaemonConn(t), nil
-	}, func(_ context.Context, path string) error {
+	}, func(_ context.Context, path string) (*exec.Cmd, error) {
 		t.Fatal("autostart must not run after successful dial")
-		return nil
+		return nil, nil
 	})
 
 	setupOut, err := captureStdout(t, func() error {
@@ -453,9 +454,9 @@ func TestDeviceCompletePersistsCompletionWhenSessionMountFails(t *testing.T) {
 	statePath := filepath.Join(t.TempDir(), "state")
 	withDeviceDaemonStub(t, func(sockPath string, call int) (net.Conn, error) {
 		return newTestDaemonConn(t), nil
-	}, func(_ context.Context, path string) error {
+	}, func(_ context.Context, path string) (*exec.Cmd, error) {
 		t.Fatal("autostart must not run after successful dial")
-		return nil
+		return nil, nil
 	})
 
 	setupOut, err := captureStdout(t, func() error {
@@ -566,9 +567,9 @@ func TestDeviceCompletePreservesCompletionWhenDeviceObjectUpsertFails(t *testing
 	statePath := filepath.Join(t.TempDir(), "state")
 	withDeviceDaemonStub(t, func(sockPath string, call int) (net.Conn, error) {
 		return newTestDaemonConn(t), nil
-	}, func(_ context.Context, path string) error {
+	}, func(_ context.Context, path string) (*exec.Cmd, error) {
 		t.Fatal("autostart must not run after successful dial")
-		return nil
+		return nil, nil
 	})
 
 	setupOut, err := captureStdout(t, func() error {
@@ -631,9 +632,9 @@ func TestDeviceCompleteRecordsRetryableFailureAndSetupCanRegenerateTicket(t *tes
 	statePath := filepath.Join(t.TempDir(), "state")
 	withDeviceDaemonStub(t, func(sockPath string, call int) (net.Conn, error) {
 		return newTestDaemonConn(t), nil
-	}, func(_ context.Context, path string) error {
+	}, func(_ context.Context, path string) (*exec.Cmd, error) {
 		t.Fatal("autostart must not run after successful dial")
-		return nil
+		return nil, nil
 	})
 
 	setupOut, err := captureStdout(t, func() error {
@@ -701,9 +702,9 @@ func TestDeviceCompleteRejectsMismatchedNonceWithoutChangingState(t *testing.T) 
 	statePath := filepath.Join(t.TempDir(), "state")
 	withDeviceDaemonStub(t, func(sockPath string, call int) (net.Conn, error) {
 		return newTestDaemonConn(t), nil
-	}, func(_ context.Context, path string) error {
+	}, func(_ context.Context, path string) (*exec.Cmd, error) {
 		t.Fatal("autostart must not run after successful dial")
-		return nil
+		return nil, nil
 	})
 
 	setupOut, err := captureStdout(t, func() error {
@@ -772,9 +773,9 @@ func TestDeviceStatusUsesSocketOverrideWithoutAutostart(t *testing.T) {
 	withDeviceDaemonStub(t, func(sockPath string, call int) (net.Conn, error) {
 		dialed = sockPath
 		return newTestDaemonConn(t), nil
-	}, func(_ context.Context, path string) error {
+	}, func(_ context.Context, path string) (*exec.Cmd, error) {
 		t.Fatal("autostart must not run with --socket-path")
-		return nil
+		return nil, nil
 	})
 
 	out, err := captureStdout(t, func() error {
@@ -808,9 +809,9 @@ func TestDeviceStatusReportsNotConfiguredWhenSetupStateMissing(t *testing.T) {
 	statePath := filepath.Join(t.TempDir(), "state")
 	withDeviceDaemonStub(t, func(sockPath string, call int) (net.Conn, error) {
 		return newTestDaemonConn(t), nil
-	}, func(_ context.Context, path string) error {
+	}, func(_ context.Context, path string) (*exec.Cmd, error) {
 		t.Fatal("autostart must not run after successful dial")
-		return nil
+		return nil, nil
 	})
 
 	out, err := captureStdout(t, func() error {
@@ -1006,7 +1007,7 @@ func parseDeviceStatusOutputJSON(data []byte, out *deviceStatusOutput) error {
 func withDeviceDaemonStub(
 	t *testing.T,
 	dial func(sockPath string, call int) (net.Conn, error),
-	start func(context.Context, string) error,
+	start func(context.Context, string) (*exec.Cmd, error),
 ) {
 	t.Helper()
 

--- a/cmd/spacewave/cli/socket-path_test.go
+++ b/cmd/spacewave/cli/socket-path_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -81,9 +82,9 @@ func TestConnectDaemonAtSocketSkipsAutostart(t *testing.T) {
 	connectDaemonDial = func(ctx context.Context, sockPath string) (net.Conn, error) {
 		return nil, context.DeadlineExceeded
 	}
-	connectDaemonStart = func(ctx context.Context, statePath string) error {
+	connectDaemonStart = func(ctx context.Context, statePath string) (*exec.Cmd, error) {
 		t.Fatal("autostart must not run in connect-only mode")
-		return nil
+		return nil, nil
 	}
 	connectDaemonBuildClient = func(ctx context.Context, conn net.Conn) (*sdkClient, error) {
 		t.Fatal("build client must not run after dial failure")
@@ -131,9 +132,9 @@ func TestConnectDaemonFromContextUsesSocketPath(t *testing.T) {
 		dialedSocket = sockPath
 		return connA, nil
 	}
-	connectDaemonStart = func(ctx context.Context, statePath string) error {
+	connectDaemonStart = func(ctx context.Context, statePath string) (*exec.Cmd, error) {
 		t.Fatal("autostart must not run when --socket-path is set")
-		return nil
+		return nil, nil
 	}
 	connectDaemonBuildClient = func(ctx context.Context, conn net.Conn) (*sdkClient, error) {
 		return &sdkClient{conn: conn}, nil
@@ -192,9 +193,9 @@ func TestConnectDaemonFromContextFallsBackToStatePath(t *testing.T) {
 		dialedSocket = sockPath
 		return connA, nil
 	}
-	connectDaemonStart = func(ctx context.Context, statePath string) error {
+	connectDaemonStart = func(ctx context.Context, statePath string) (*exec.Cmd, error) {
 		t.Fatal("daemon start must not run when dial succeeds")
-		return nil
+		return nil, nil
 	}
 	connectDaemonBuildClient = func(ctx context.Context, conn net.Conn) (*sdkClient, error) {
 		return &sdkClient{conn: conn}, nil
@@ -260,9 +261,9 @@ func TestConnectDaemonFromContextStartsStatePathDaemon(t *testing.T) {
 		}
 		return connA, nil
 	}
-	connectDaemonStart = func(ctx context.Context, statePath string) error {
+	connectDaemonStart = func(ctx context.Context, statePath string) (*exec.Cmd, error) {
 		startStatePath = statePath
-		return nil
+		return nil, nil
 	}
 	connectDaemonBuildClient = func(ctx context.Context, conn net.Conn) (*sdkClient, error) {
 		return &sdkClient{conn: conn}, nil

--- a/cmd/spacewave/cli/web_test.go
+++ b/cmd/spacewave/cli/web_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -414,8 +415,8 @@ func startInProcessWebDaemon(t *testing.T, ctx context.Context) testWebDaemon {
 	}()
 
 	oldStart := connectDaemonStart
-	connectDaemonStart = func(ctx context.Context, statePath string) error {
-		return stderrors.New("unexpected daemon autostart")
+	connectDaemonStart = func(ctx context.Context, statePath string) (*exec.Cmd, error) {
+		return nil, stderrors.New("unexpected daemon autostart")
 	}
 	t.Cleanup(func() {
 		connectDaemonStart = oldStart


### PR DESCRIPTION
When a command started the Spacewave daemon, it released the child process handle as soon as the startup pipe reported socket readiness. If the first connection or Resource Init failed, the command returned while the daemon and its helper processes could continue running behind the socket.

Keep the process handle until the first Resource client is ready. A startup failure now asks the daemon to stop through its control socket and waits for normal cleanup. POSIX falls back to the interrupt the daemon already handles. After the grace period, cleanup kills anything left in the process tree and waits for the leader. Windows keeps the started process tree in a Job object so cleanup still works if the leader exits first.

A successful Resource Init releases the process handle so the daemon remains available for later commands. The Init deadline only bounds startup and does not cancel the returned client. Resource calls continue through the existing `spacewave-core` plugin client, including the host-to-plugin boundary used by release builds.
