### PR TITLE
fix(forge): register cluster job transitions

### DIFF
--- a/forge/cluster/cluster.go
+++ b/forge/cluster/cluster.go
@@ -59,6 +59,10 @@ func LookupClusterOp(ctx context.Context, opTypeID string) (world.Operation, err
 		return &ClusterAssignTaskOp{}, nil
 	case ClusterAssignPeerOpId:
 		return &ClusterAssignPeerOp{}, nil
+	case ClusterStartJobOpId:
+		return &ClusterStartJobOp{}, nil
+	case ClusterCompleteJobOpId:
+		return &ClusterCompleteJobOp{}, nil
 	}
 	return nil, nil
 }

--- a/forge/world/ops_test.go
+++ b/forge/world/ops_test.go
@@ -1,0 +1,27 @@
+package forge_world_test
+
+import (
+	"context"
+	"testing"
+
+	forge_cluster "github.com/s4wave/spacewave/forge/cluster"
+	forge_world "github.com/s4wave/spacewave/forge/world"
+)
+
+func TestLookupWorldOpReconstructsClusterJobTransitions(t *testing.T) {
+	start, err := forge_world.LookupWorldOp(context.Background(), forge_cluster.ClusterStartJobOpId)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := start.(*forge_cluster.ClusterStartJobOp); !ok {
+		t.Fatalf("lookup %q returned %T", forge_cluster.ClusterStartJobOpId, start)
+	}
+
+	complete, err := forge_world.LookupWorldOp(context.Background(), forge_cluster.ClusterCompleteJobOpId)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := complete.(*forge_cluster.ClusterCompleteJobOp); !ok {
+		t.Fatalf("lookup %q returned %T", forge_cluster.ClusterCompleteJobOpId, complete)
+	}
+}


### PR DESCRIPTION
Remote World transactions reconstruct Forge operations from their registered type IDs. Cluster job start and completion already had operation implementations and schemas, but the Forge registry omitted both constructors, so SDK-backed Worlds returned an unhandled-operation error while local Worlds accepted the concrete operations directly.

Register both existing cluster job transitions in `LookupClusterOp`. The focused registry test exercises the composed `forge_world.LookupWorldOp` boundary used to reconstruct remote operations.