### PR TITLE
fix(cli): restore local Resource readiness

### DIFF
--- a/cmd/spacewave/cli/plugin.go
+++ b/cmd/spacewave/cli/plugin.go
@@ -24,6 +24,8 @@ import (
 	s4wave_space "github.com/s4wave/spacewave/sdk/space"
 )
 
+const defaultPluginHostObjectKey = "plugin-host"
+
 // newPluginCommand builds the plugin command group.
 func newPluginCommand(getBus func() cli_entrypoint.CliBus) *cli.Command {
 	return &cli.Command{
@@ -64,7 +66,7 @@ func buildPluginImportManifestCommand(getBus func() cli_entrypoint.CliBus) *cli.
 			&cli.StringFlag{
 				Name:        "object-key",
 				Usage:       "plugin host object key to import into",
-				Value:       daemonPluginHostObjectKey,
+				Value:       defaultPluginHostObjectKey,
 				Destination: &objectKey,
 			},
 			&cli.StringFlag{

--- a/cmd/spacewave/cli/plugin_test.go
+++ b/cmd/spacewave/cli/plugin_test.go
@@ -52,8 +52,8 @@ func TestPluginImportManifestObjectKeyFlag(t *testing.T) {
 	if objectKey == nil {
 		t.Fatal("object-key flag missing")
 	}
-	if objectKey.DefValue != daemonPluginHostObjectKey {
-		t.Fatalf("object-key default = %q, want %q", objectKey.DefValue, daemonPluginHostObjectKey)
+	if objectKey.DefValue != defaultPluginHostObjectKey {
+		t.Fatalf("object-key default = %q, want %q", objectKey.DefValue, defaultPluginHostObjectKey)
 	}
 	if set.Lookup("target-db") == nil {
 		t.Fatal("target-db flag missing")

--- a/cmd/spacewave/cli/serve-resource_test.go
+++ b/cmd/spacewave/cli/serve-resource_test.go
@@ -1,0 +1,52 @@
+//go:build !js
+
+package spacewave_cli
+
+import (
+	"testing"
+
+	"github.com/aperturerobotics/controllerbus/controller"
+	controllerbus_core "github.com/aperturerobotics/controllerbus/core"
+	"github.com/aperturerobotics/starpc/srpc"
+	resource "github.com/s4wave/spacewave/bldr/resource"
+	resource_server "github.com/s4wave/spacewave/bldr/resource/server"
+	bifrost_rpc "github.com/s4wave/spacewave/net/rpc"
+	"github.com/sirupsen/logrus"
+)
+
+// TestLookupLocalResourceInvokerSelectsRegisteredService pins the CLI path to
+// the in-process Resource service and retains its directive reference.
+func TestLookupLocalResourceInvokerSelectsRegisteredService(t *testing.T) {
+	ctx := t.Context()
+	le := logrus.NewEntry(logrus.New())
+	b, _, err := controllerbus_core.NewCoreBus(ctx, le)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := srpc.NewMux()
+	if err := resource_server.NewResourceServer(nil).Register(mux); err != nil {
+		t.Fatal(err)
+	}
+	ctrl := bifrost_rpc.NewInvokerController(
+		le,
+		b,
+		controller.NewInfo("test/local-resource", controller.MustParseVersion("0.0.1"), ""),
+		mux,
+		[]string{resource.SRPCResourceServiceServiceID},
+	)
+	rel, err := b.AddController(ctx, ctrl, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rel()
+
+	invoker, invokerRef, err := lookupLocalResourceInvoker(ctx, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if invoker == nil || invokerRef == nil {
+		t.Fatal("local Resource lookup returned an incomplete result")
+	}
+	invokerRef.Release()
+}

--- a/cmd/spacewave/cli/serve.go
+++ b/cmd/spacewave/cli/serve.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"slices"
 	"sync"
 	"time"
 
@@ -17,20 +16,16 @@ import (
 	"github.com/aperturerobotics/starpc/srpc"
 	"github.com/pkg/errors"
 	cli_entrypoint "github.com/s4wave/spacewave/bldr/cli/entrypoint"
-	bldr_manifest_world "github.com/s4wave/spacewave/bldr/manifest/world"
 	bldr_plugin "github.com/s4wave/spacewave/bldr/plugin"
-	plugin_host_default "github.com/s4wave/spacewave/bldr/plugin/host/default"
 	resource "github.com/s4wave/spacewave/bldr/resource"
 	device_policy "github.com/s4wave/spacewave/core/device/policy"
 	resource_listener "github.com/s4wave/spacewave/core/resource/listener"
 	resource_root "github.com/s4wave/spacewave/core/resource/root"
 	terminal_remoteshell "github.com/s4wave/spacewave/core/terminal/remoteshell"
 	trace_service "github.com/s4wave/spacewave/core/trace/service"
-	db_world "github.com/s4wave/spacewave/db/world"
+	bifrost_rpc "github.com/s4wave/spacewave/net/rpc"
 	s4wave_trace "github.com/s4wave/spacewave/sdk/trace"
 )
-
-const daemonPluginHostObjectKey = "plugin-host"
 
 // newServeCommand builds the serve command that starts the daemon
 // with a resource service socket listener.
@@ -140,18 +135,19 @@ func runServeCommand(
 	leaseOwned = false
 	serveCtx, serveCancel := context.WithCancel(ctx)
 	defer serveCancel()
-	releasePluginRuntime := func() {}
+	var invoker srpc.Invoker
 	if cliBus.GetPluginHostObjectKey() == "" {
-		releasePluginRuntime, err = startDaemonPluginRuntime(serveCtx, resolved, cliBus)
+		var invokerRef directive.Reference
+		invoker, invokerRef, err = lookupLocalResourceInvoker(serveCtx, cliBus.GetBus())
 		if err != nil {
 			return err
 		}
+		defer invokerRef.Release()
+	} else {
+		// Each Dist Resource RPC waits for the current spacewave-core generation
+		// after its stream is opened.
+		invoker = newDaemonResourceInvoker(cliBus.GetBus())
 	}
-	defer releasePluginRuntime()
-
-	// The socket is the stable transport boundary. Each Resource RPC waits for
-	// the current spacewave-core generation after its stream is opened.
-	invoker := newDaemonResourceInvoker(cliBus.GetBus())
 	devicePolicy, err := device_policy.NewPolicyStore(resolved)
 	if err != nil {
 		return err
@@ -208,78 +204,27 @@ func runServeCommand(
 	return serveDaemonListener(serveCtx, serveCancel, lis, srv, controlHandler, shutdownCh, idleTracker)
 }
 
-func startDaemonPluginRuntime(
+// lookupLocalResourceInvoker waits for the Resource service already registered
+// on the CLI bus and returns the reference that keeps it alive.
+func lookupLocalResourceInvoker(
 	ctx context.Context,
-	stateRoot string,
-	cliBus cli_entrypoint.CliBus,
-) (func(), error) {
-	pluginRoot := filepath.Join(stateRoot, "plugin")
-	pluginStateRoot := filepath.Join(pluginRoot, "state")
-	pluginDistRoot := filepath.Join(pluginRoot, "dist")
-	for _, dir := range []string{pluginStateRoot, pluginDistRoot} {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			return nil, err
-		}
-	}
-
-	var rels []func()
-	rel := func() {
-		for _, v := range slices.Backward(rels) {
-			v()
-		}
-	}
-
-	lookupOpCtrl := db_world.NewLookupOpController(
-		"bldr-manifest-ops",
-		cliBus.GetWorldEngineID(),
-		bldr_manifest_world.LookupOp,
-	)
-	relLookupCtrl, err := cliBus.GetBus().AddController(ctx, lookupOpCtrl, nil)
-	if err != nil {
-		return nil, err
-	}
-	rels = append(rels, relLookupCtrl)
-
-	if _, err := bldr_manifest_world.CreateManifestStoreInEngine(
+	b bus.Bus,
+) (srpc.Invoker, directive.Reference, error) {
+	invokers, _, invokerRef, err := bifrost_rpc.ExLookupRpcService(
 		ctx,
-		cliBus.GetWorldEngine(),
-		daemonPluginHostObjectKey,
-	); err != nil {
-		rel()
-		return nil, err
-	}
-
-	_, relPluginSched, err := plugin_host_default.StartPluginScheduler(
-		ctx,
-		cliBus.GetBus(),
-		cliBus.GetWorldEngineID(),
-		daemonPluginHostObjectKey,
-		cliBus.GetVolume().GetID(),
-		cliBus.GetVolume().GetPeerID().String(),
-		true,
-		true,
-		true,
-	)
-	if err != nil {
-		rel()
-		return nil, err
-	}
-	rels = append(rels, relPluginSched)
-
-	_, relPluginHost, err := plugin_host_default.StartPluginHost(
-		ctx,
-		cliBus.GetBus(),
-		pluginStateRoot,
-		pluginDistRoot,
+		b,
+		resource.SRPCResourceServiceServiceID,
 		"",
+		true,
+		nil,
 	)
 	if err != nil {
-		rel()
-		return nil, err
+		return nil, nil, err
 	}
-	rels = append(rels, relPluginHost)
-
-	return rel, nil
+	if len(invokers) == 0 {
+		return nil, nil, errors.New("resource service not found")
+	}
+	return invokers[0], invokerRef, nil
 }
 
 // daemonPluginClientLoader waits for the current spacewave-core generation.

--- a/cmd/spacewave/e2e/testdata/script/auth-lock.txt
+++ b/cmd/spacewave/e2e/testdata/script/auth-lock.txt
@@ -11,3 +11,9 @@ stderr "no session found at index 1"
 
 ! spacewave auth lock status --state-path $WORK/state
 stderr "no session found at index 1"
+
+spacewave stop --state-path $WORK/state
+stdout "Stopped Spacewave daemon."
+
+spacewave stop --state-path $WORK/state
+stdout "No Spacewave daemon is running."


### PR DESCRIPTION
The CLI daemon now uses the Resource service already registered on its in-process bus when the plugin-host object key is empty. It waits for that service before reporting the Unix socket ready and retains the directive reference until serving ends. Packaged Dist runtimes keep per-stream lookup of the current spacewave-core generation.

The obsolete embedded plugin runtime startup has been removed. The auth-lock trajectory now stops the autostarted daemon and verifies a second stop reports that no daemon is running. Focused Resource selection and cancellation coverage accompanies the change.