### PR TITLE
style(proto): order scheduler config fields

### DIFF
--- a/.protoc-manifest.json
+++ b/.protoc-manifest.json
@@ -302,7 +302,7 @@
       ]
     },
     "github.com/s4wave/spacewave/bldr/plugin/host/scheduler": {
-      "hash": "4f860b3ff6952ec473200c44fda8ffe2da22995ff2a9e7ad196c97fb2157b838",
+      "hash": "d207969913611735e761c1540e00fbb8089cd8f93d4521b16753e8e47fbe2600",
       "generatedFiles": [
         "bldr/plugin/host/scheduler/config.pb.go",
         "bldr/plugin/host/scheduler/config.pb.ts"

--- a/bldr/plugin/host/scheduler/config.pb.go
+++ b/bldr/plugin/host/scheduler/config.pb.go
@@ -21,9 +21,6 @@ import (
 // Manages executing plugins via the plugin hosts.
 type Config struct {
 	unknownFields []byte
-	// InstanceKey identifies the isolated plugin instance set resolved by this scheduler.
-	// Empty retains the unscoped Dist behavior.
-	InstanceKey string `protobuf:"bytes,14,opt,name=instance_key,json=instanceKey,proto3" json:"instanceKey,omitempty"`
 	// EngineId is the world engine id to attach to.
 	EngineId string `protobuf:"bytes,1,opt,name=engine_id,json=engineId,proto3" json:"engineId,omitempty"`
 	// ObjectKey is the root object to attach to.
@@ -41,13 +38,6 @@ type Config struct {
 	// DisableStoreManifest disables storing manifests fetched with FetchManifest.
 	// This is used if we are watching the same world as the FetchManifest resolver.
 	DisableStoreManifest bool `protobuf:"varint,6,opt,name=disable_store_manifest,json=disableStoreManifest,proto3" json:"disableStoreManifest,omitempty"`
-	// DisableCopyManifest disables copying manifests to the plugin host world bucket.
-	// This is used if the manifest bucket is always accessible and locally cached.
-	// If unset, we will copy manifests to the same bucket as the plugin host world.
-	DisableCopyManifest bool `protobuf:"varint,10,opt,name=disable_copy_manifest,json=disableCopyManifest,proto3" json:"disableCopyManifest,omitempty"`
-	// NoCopyBucketIds lists source buckets that remain authoritative without a
-	// full-DAG copy.
-	NoCopyBucketIds []string `protobuf:"bytes,13,rep,name=no_copy_bucket_ids,json=noCopyBucketIds,proto3" json:"noCopyBucketIds,omitempty"`
 	// FetchConcurrency limits the number of blocks fetched concurrently per-manifest.
 	// If zero, uses no limit to the number of concurrent fetches.
 	//
@@ -61,12 +51,22 @@ type Config struct {
 	// ExecBackoff is the backoff config for executing plugin manifests.
 	// If unset, defaults to reasonable defaults.
 	ExecBackoff *backoff.Backoff `protobuf:"bytes,9,opt,name=exec_backoff,json=execBackoff,proto3" json:"execBackoff,omitempty"`
+	// DisableCopyManifest disables copying manifests to the plugin host world bucket.
+	// This is used if the manifest bucket is always accessible and locally cached.
+	// If unset, we will copy manifests to the same bucket as the plugin host world.
+	DisableCopyManifest bool `protobuf:"varint,10,opt,name=disable_copy_manifest,json=disableCopyManifest,proto3" json:"disableCopyManifest,omitempty"`
 	// Verbose enables verbose logging for world ops (slower).
 	Verbose bool `protobuf:"varint,11,opt,name=verbose,proto3" json:"verbose,omitempty"`
 	// PlatformSelectionPolicies restrict selected platform IDs to selected
 	// plugin IDs. If empty, every discovered plugin host platform is selectable
 	// for every plugin.
 	PlatformSelectionPolicies []*PlatformSelectionPolicy `protobuf:"bytes,12,rep,name=platform_selection_policies,json=platformSelectionPolicies,proto3" json:"platformSelectionPolicies,omitempty"`
+	// NoCopyBucketIds lists source buckets that remain authoritative without a
+	// full-DAG copy.
+	NoCopyBucketIds []string `protobuf:"bytes,13,rep,name=no_copy_bucket_ids,json=noCopyBucketIds,proto3" json:"noCopyBucketIds,omitempty"`
+	// InstanceKey identifies the isolated plugin instance set resolved by this scheduler.
+	// Empty retains the unscoped Dist behavior.
+	InstanceKey string `protobuf:"bytes,14,opt,name=instance_key,json=instanceKey,proto3" json:"instanceKey,omitempty"`
 }
 
 func (x *Config) Reset() {
@@ -74,13 +74,6 @@ func (x *Config) Reset() {
 }
 
 func (*Config) ProtoMessage() {}
-
-func (x *Config) GetInstanceKey() string {
-	if x != nil {
-		return x.InstanceKey
-	}
-	return ""
-}
 
 func (x *Config) GetEngineId() string {
 	if x != nil {
@@ -124,20 +117,6 @@ func (x *Config) GetDisableStoreManifest() bool {
 	return false
 }
 
-func (x *Config) GetDisableCopyManifest() bool {
-	if x != nil {
-		return x.DisableCopyManifest
-	}
-	return false
-}
-
-func (x *Config) GetNoCopyBucketIds() []string {
-	if x != nil {
-		return x.NoCopyBucketIds
-	}
-	return nil
-}
-
 func (x *Config) GetFetchConcurrency() uint32 {
 	if x != nil {
 		return x.FetchConcurrency
@@ -159,6 +138,13 @@ func (x *Config) GetExecBackoff() *backoff.Backoff {
 	return nil
 }
 
+func (x *Config) GetDisableCopyManifest() bool {
+	if x != nil {
+		return x.DisableCopyManifest
+	}
+	return false
+}
+
 func (x *Config) GetVerbose() bool {
 	if x != nil {
 		return x.Verbose
@@ -171,6 +157,20 @@ func (x *Config) GetPlatformSelectionPolicies() []*PlatformSelectionPolicy {
 		return x.PlatformSelectionPolicies
 	}
 	return nil
+}
+
+func (x *Config) GetNoCopyBucketIds() []string {
+	if x != nil {
+		return x.NoCopyBucketIds
+	}
+	return nil
+}
+
+func (x *Config) GetInstanceKey() string {
+	if x != nil {
+		return x.InstanceKey
+	}
+	return ""
 }
 
 // PlatformSelectionPolicy restricts a plugin host platform to a plugin ID list.
@@ -208,20 +208,20 @@ func (m *Config) CloneVT() *Config {
 		return (*Config)(nil)
 	}
 	r := new(Config)
-	r.InstanceKey = m.InstanceKey
 	r.EngineId = m.EngineId
 	r.ObjectKey = m.ObjectKey
 	r.PeerId = m.PeerId
 	r.VolumeId = m.VolumeId
 	r.WatchFetchManifest = m.WatchFetchManifest
 	r.DisableStoreManifest = m.DisableStoreManifest
-	r.DisableCopyManifest = m.DisableCopyManifest
 	r.FetchConcurrency = m.FetchConcurrency
+	r.DisableCopyManifest = m.DisableCopyManifest
 	r.Verbose = m.Verbose
-	r.NoCopyBucketIds = protobuf_go_lite.CloneSlice(m.NoCopyBucketIds)
+	r.InstanceKey = m.InstanceKey
 	r.FetchBackoff = protobuf_go_lite.CloneVTValue(m.FetchBackoff)
 	r.ExecBackoff = protobuf_go_lite.CloneVTValue(m.ExecBackoff)
 	r.PlatformSelectionPolicies = protobuf_go_lite.CloneVTSlice(m.PlatformSelectionPolicies)
+	r.NoCopyBucketIds = protobuf_go_lite.CloneSlice(m.NoCopyBucketIds)
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = slices.Clone(m.unknownFields)
 	}

--- a/bldr/plugin/host/scheduler/config.pb.ts
+++ b/bldr/plugin/host/scheduler/config.pb.ts
@@ -58,13 +58,6 @@ export const PlatformSelectionPolicy: MessageType<PlatformSelectionPolicy> =
  */
 export interface Config {
   /**
-   * InstanceKey identifies the isolated plugin instance set resolved by this scheduler.
-   * Empty retains the unscoped Dist behavior.
-   *
-   * @generated from field: string instance_key = 14;
-   */
-  instanceKey?: string
-  /**
    * EngineId is the world engine id to attach to.
    *
    * @generated from field: string engine_id = 1;
@@ -106,21 +99,6 @@ export interface Config {
    */
   disableStoreManifest?: boolean
   /**
-   * DisableCopyManifest disables copying manifests to the plugin host world bucket.
-   * This is used if the manifest bucket is always accessible and locally cached.
-   * If unset, we will copy manifests to the same bucket as the plugin host world.
-   *
-   * @generated from field: bool disable_copy_manifest = 10;
-   */
-  disableCopyManifest?: boolean
-  /**
-   * NoCopyBucketIds lists source buckets that remain authoritative without a
-   * full-DAG copy.
-   *
-   * @generated from field: repeated string no_copy_bucket_ids = 13;
-   */
-  noCopyBucketIds?: string[]
-  /**
    * FetchConcurrency limits the number of blocks fetched concurrently per-manifest.
    * If zero, uses no limit to the number of concurrent fetches.
    *
@@ -146,6 +124,14 @@ export interface Config {
    */
   execBackoff?: Backoff
   /**
+   * DisableCopyManifest disables copying manifests to the plugin host world bucket.
+   * This is used if the manifest bucket is always accessible and locally cached.
+   * If unset, we will copy manifests to the same bucket as the plugin host world.
+   *
+   * @generated from field: bool disable_copy_manifest = 10;
+   */
+  disableCopyManifest?: boolean
+  /**
    * Verbose enables verbose logging for world ops (slower).
    *
    * @generated from field: bool verbose = 11;
@@ -159,12 +145,25 @@ export interface Config {
    * @generated from field: repeated plugin.host.scheduler.PlatformSelectionPolicy platform_selection_policies = 12;
    */
   platformSelectionPolicies?: PlatformSelectionPolicy[]
+  /**
+   * NoCopyBucketIds lists source buckets that remain authoritative without a
+   * full-DAG copy.
+   *
+   * @generated from field: repeated string no_copy_bucket_ids = 13;
+   */
+  noCopyBucketIds?: string[]
+  /**
+   * InstanceKey identifies the isolated plugin instance set resolved by this scheduler.
+   * Empty retains the unscoped Dist behavior.
+   *
+   * @generated from field: string instance_key = 14;
+   */
+  instanceKey?: string
 }
 
 export const Config: MessageType<Config> = /* @__PURE__ */ createMessageType({
   typeName: 'plugin.host.scheduler.Config',
   fields: [
-    { no: 14, name: 'instance_key', kind: 'scalar', T: ScalarType.STRING },
     { no: 1, name: 'engine_id', kind: 'scalar', T: ScalarType.STRING },
     { no: 2, name: 'object_key', kind: 'scalar', T: ScalarType.STRING },
     { no: 3, name: 'peer_id', kind: 'scalar', T: ScalarType.STRING },
@@ -176,22 +175,15 @@ export const Config: MessageType<Config> = /* @__PURE__ */ createMessageType({
       kind: 'scalar',
       T: ScalarType.BOOL,
     },
+    { no: 7, name: 'fetch_concurrency', kind: 'scalar', T: ScalarType.UINT32 },
+    { no: 8, name: 'fetch_backoff', kind: 'message', T: () => Backoff },
+    { no: 9, name: 'exec_backoff', kind: 'message', T: () => Backoff },
     {
       no: 10,
       name: 'disable_copy_manifest',
       kind: 'scalar',
       T: ScalarType.BOOL,
     },
-    {
-      no: 13,
-      name: 'no_copy_bucket_ids',
-      kind: 'scalar',
-      T: ScalarType.STRING,
-      repeated: true,
-    },
-    { no: 7, name: 'fetch_concurrency', kind: 'scalar', T: ScalarType.UINT32 },
-    { no: 8, name: 'fetch_backoff', kind: 'message', T: () => Backoff },
-    { no: 9, name: 'exec_backoff', kind: 'message', T: () => Backoff },
     { no: 11, name: 'verbose', kind: 'scalar', T: ScalarType.BOOL },
     {
       no: 12,
@@ -200,6 +192,14 @@ export const Config: MessageType<Config> = /* @__PURE__ */ createMessageType({
       T: () => PlatformSelectionPolicy,
       repeated: true,
     },
+    {
+      no: 13,
+      name: 'no_copy_bucket_ids',
+      kind: 'scalar',
+      T: ScalarType.STRING,
+      repeated: true,
+    },
+    { no: 14, name: 'instance_key', kind: 'scalar', T: ScalarType.STRING },
   ] satisfies readonly PartialFieldInfo[],
   packedByDefault: true,
 })

--- a/bldr/plugin/host/scheduler/config.proto
+++ b/bldr/plugin/host/scheduler/config.proto
@@ -9,10 +9,6 @@ import "github.com/aperturerobotics/util/backoff/backoff.proto";
 // Manages downloading the most appropriate manifest for the available plugin hosts.
 // Manages executing plugins via the plugin hosts.
 message Config {
-  // InstanceKey identifies the isolated plugin instance set resolved by this scheduler.
-  // Empty retains the unscoped Dist behavior.
-  string instance_key = 14;
-
   // EngineId is the world engine id to attach to.
   string engine_id = 1;
   // ObjectKey is the root object to attach to.
@@ -30,13 +26,6 @@ message Config {
   // DisableStoreManifest disables storing manifests fetched with FetchManifest.
   // This is used if we are watching the same world as the FetchManifest resolver.
   bool disable_store_manifest = 6;
-  // DisableCopyManifest disables copying manifests to the plugin host world bucket.
-  // This is used if the manifest bucket is always accessible and locally cached.
-  // If unset, we will copy manifests to the same bucket as the plugin host world.
-  bool disable_copy_manifest = 10;
-  // NoCopyBucketIds lists source buckets that remain authoritative without a
-  // full-DAG copy.
-  repeated string no_copy_bucket_ids = 13;
   // FetchConcurrency limits the number of blocks fetched concurrently per-manifest.
   // If zero, uses no limit to the number of concurrent fetches.
   //
@@ -44,21 +33,28 @@ message Config {
   // so far. Fetches blocks, then the references those blocks reference. We only
   // know about the blocks on the frontier of the blocks fetched so far.
   uint32 fetch_concurrency = 7;
-
   // FetchBackoff is the backoff config for fetching plugin manifests.
   // If unset, defaults to reasonable defaults.
   .backoff.Backoff fetch_backoff = 8;
   // ExecBackoff is the backoff config for executing plugin manifests.
   // If unset, defaults to reasonable defaults.
   .backoff.Backoff exec_backoff = 9;
-
+  // DisableCopyManifest disables copying manifests to the plugin host world bucket.
+  // This is used if the manifest bucket is always accessible and locally cached.
+  // If unset, we will copy manifests to the same bucket as the plugin host world.
+  bool disable_copy_manifest = 10;
   // Verbose enables verbose logging for world ops (slower).
   bool verbose = 11;
-
   // PlatformSelectionPolicies restrict selected platform IDs to selected
   // plugin IDs. If empty, every discovered plugin host platform is selectable
   // for every plugin.
   repeated PlatformSelectionPolicy platform_selection_policies = 12;
+  // NoCopyBucketIds lists source buckets that remain authoritative without a
+  // full-DAG copy.
+  repeated string no_copy_bucket_ids = 13;
+  // InstanceKey identifies the isolated plugin instance set resolved by this scheduler.
+  // Empty retains the unscoped Dist behavior.
+  string instance_key = 14;
 }
 
 // PlatformSelectionPolicy restricts a plugin host platform to a plugin ID list.


### PR DESCRIPTION
Keep `Config` declarations in ascending wire-tag order so source and generated APIs match the protobuf numbering. Remove blank source lines between consecutive fields and regenerate the Go and TypeScript surfaces without changing any field number, type, name, or comment.