### PR TITLE
feat(space): bind caller-attached RPC services

### DIFF
--- a/.protoc-manifest.json
+++ b/.protoc-manifest.json
@@ -3691,7 +3691,7 @@
       ]
     },
     "github.com/s4wave/spacewave/sdk/space": {
-      "hash": "4ac69b6bb97247652ba69555f3d276e558a955093cf019f806a58ed4d58d2cee",
+      "hash": "199bfaf8a09f9dc899c5d55e36a0ee958d4596a0c30f36c1d4142617185896ce",
       "generatedFiles": [
         "sdk/space/space.pb.go",
         "sdk/space/space.pb.ts",

--- a/bldr/resource/routed-client.go
+++ b/bldr/resource/routed-client.go
@@ -15,15 +15,28 @@ import (
 type routedClient struct {
 	inner  srpc.Client
 	prefix string
+	// done closes when the routed resource is detached.
+	done <-chan struct{}
 }
 
 // NewRoutedClient wraps an SRPC client so all calls are prefixed with the
 // resource ID for routing to the correct attached resource mux.
 func NewRoutedClient(inner srpc.Client, resourceID uint32) srpc.Client {
+	return NewRoutedClientWithDone(inner, resourceID, nil)
+}
+
+// NewRoutedClientWithDone wraps a client with a resource route and its lifetime.
+func NewRoutedClientWithDone(inner srpc.Client, resourceID uint32, done <-chan struct{}) srpc.Client {
 	return &routedClient{
 		inner:  inner,
 		prefix: strconv.FormatUint(uint64(resourceID), 10) + "/",
+		done:   done,
 	}
+}
+
+// Done closes when the routed resource is detached.
+func (c *routedClient) Done() <-chan struct{} {
+	return c.done
 }
 
 // ExecCall executes a request/reply RPC with the resource ID prefix.

--- a/bldr/resource/server/server.go
+++ b/bldr/resource/server/server.go
@@ -351,12 +351,12 @@ func (s *ResourceServer) ResourceAttach(
 				resourceID = s.resourceIDCtr
 			})
 
-			// Create srpc.Client for this resource via routed SRPC over yamux.
-			resClient := resource.NewRoutedClient(srpcClient, resourceID)
-
 			// Derive a per-resource context so removing one resource does
 			// not tear down the entire yamux session.
-			_, resCancel := context.WithCancel(attachCtx)
+			resCtx, resCancel := context.WithCancel(attachCtx)
+
+			// Create srpc.Client for this resource via routed SRPC over yamux.
+			resClient := resource.NewRoutedClientWithDone(srpcClient, resourceID, resCtx.Done())
 
 			// Register on client.
 			addErr := client.AddAttachedResource(resourceID, label, resCancel, resClient, func() {

--- a/core/resource/space/attached-rpc-service_test.go
+++ b/core/resource/space/attached-rpc-service_test.go
@@ -1,0 +1,223 @@
+package resource_space
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aperturerobotics/starpc/echo"
+	"github.com/aperturerobotics/starpc/srpc"
+	resource_server "github.com/s4wave/spacewave/bldr/resource/server"
+	bifrost_rpc "github.com/s4wave/spacewave/net/rpc"
+	net_testbed "github.com/s4wave/spacewave/net/testbed"
+	s4wave_space "github.com/s4wave/spacewave/sdk/space"
+	"github.com/sirupsen/logrus"
+)
+
+// attachedRpcServiceStream supplies a caller context and records readiness.
+type attachedRpcServiceStream struct {
+	// Stream supplies default stream methods for the test double.
+	srpc.Stream
+	// ctx is returned to BindAttachedRpcService.
+	ctx context.Context
+	// ready records the first readiness response.
+	ready chan *s4wave_space.BindAttachedRpcServiceResponse
+}
+
+// newAttachedRpcServiceStream creates a bind stream with one readiness slot.
+func newAttachedRpcServiceStream(ctx context.Context) *attachedRpcServiceStream {
+	return &attachedRpcServiceStream{ctx: ctx, ready: make(chan *s4wave_space.BindAttachedRpcServiceResponse, 1)}
+}
+
+// Context returns the bind stream context.
+func (s *attachedRpcServiceStream) Context() context.Context {
+	return s.ctx
+}
+
+// Send records that the attached RPC service is callable.
+func (s *attachedRpcServiceStream) Send(resp *s4wave_space.BindAttachedRpcServiceResponse) error {
+	s.ready <- resp
+	return nil
+}
+
+// SendAndClose records readiness before closing the response direction.
+func (s *attachedRpcServiceStream) SendAndClose(resp *s4wave_space.BindAttachedRpcServiceResponse) error {
+	return s.Send(resp)
+}
+
+// MsgRecv implements srpc.Stream.
+func (*attachedRpcServiceStream) MsgRecv(srpc.Message) error {
+	return nil
+}
+
+// MsgSend implements srpc.Stream.
+func (*attachedRpcServiceStream) MsgSend(srpc.Message) error {
+	return nil
+}
+
+// CloseSend implements srpc.Stream.
+func (*attachedRpcServiceStream) CloseSend() error {
+	return nil
+}
+
+// Close implements srpc.Stream.
+func (*attachedRpcServiceStream) Close() error {
+	return nil
+}
+
+func TestBindAttachedRpcService(t *testing.T) {
+	ctx := t.Context()
+	le := logrus.NewEntry(logrus.New())
+	attachedBus, err := net_testbed.NewTestbed(ctx, le, net_testbed.TestbedOpts{NoEcho: true, NoPeer: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	siblingBus, err := net_testbed.NewTestbed(ctx, le, net_testbed.TestbedOpts{NoEcho: true, NoPeer: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resource := NewSpaceContentsResource(le, attachedBus.Bus, nil, "space-a", "engine-a")
+	runtime := &spaceRuntime{bus: attachedBus.Bus, done: make(chan struct{})}
+	resource.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		resource.runtime = runtime
+	})
+
+	attachedResources := newSpaceRecordingResourceClient(ctx)
+	attachedMux := srpc.NewMux()
+	if err := attachedMux.Register(echo.NewSRPCEchoerHandler(echo.NewEchoServer(nil), echo.SRPCEchoerServiceID)); err != nil {
+		t.Fatal(err)
+	}
+	attachedID, err := attachedResources.AddResource(attachedMux, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bindCtx := resource_server.WithResourceClientContext(ctx, attachedResources)
+	stream := newAttachedRpcServiceStream(bindCtx)
+	bindDone := make(chan error, 1)
+	go func() {
+		bindDone <- resource.BindAttachedRpcService(&s4wave_space.BindAttachedRpcServiceRequest{
+			AttachedResourceId: attachedID,
+			ServiceIdPrefix:    "attached/",
+		}, stream)
+	}()
+	<-stream.ready
+
+	invoker := bifrost_rpc.NewInvoker(attachedBus.Bus, "", false)
+	client := srpc.NewClient(srpc.NewServerPipe(srpc.NewServer(invoker)))
+	response, err := echo.NewSRPCEchoerClientWithServiceID(client, "attached/"+echo.SRPCEchoerServiceID).Echo(ctx, &echo.EchoMsg{Body: "attached"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.GetBody() != "attached" {
+		t.Fatalf("echo body = %q, want attached", response.GetBody())
+	}
+
+	values, _, valuesRef, err := bifrost_rpc.ExLookupRpcService(ctx, siblingBus.Bus, "attached/"+echo.SRPCEchoerServiceID, "", false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if valuesRef != nil {
+		valuesRef.Release()
+	}
+	if len(values) != 0 {
+		t.Fatal("sibling Space resolved attached service")
+	}
+
+	duplicate := newAttachedRpcServiceStream(bindCtx)
+	if err := resource.BindAttachedRpcService(&s4wave_space.BindAttachedRpcServiceRequest{
+		AttachedResourceId: attachedID,
+		ServiceIdPrefix:    "attached/",
+	}, duplicate); err == nil {
+		t.Fatal("duplicate prefix binding succeeded")
+	}
+	if err := resource.BindAttachedRpcService(&s4wave_space.BindAttachedRpcServiceRequest{
+		ServiceIdPrefix: "other/",
+	}, newAttachedRpcServiceStream(bindCtx)); err == nil {
+		t.Fatal("zero attachment ID binding succeeded")
+	}
+	if err := resource.BindAttachedRpcService(&s4wave_space.BindAttachedRpcServiceRequest{
+		AttachedResourceId: attachedID,
+		ServiceIdPrefix:    "attached",
+	}, newAttachedRpcServiceStream(bindCtx)); err == nil {
+		t.Fatal("unterminated prefix binding succeeded")
+	}
+	if err := resource.BindAttachedRpcService(&s4wave_space.BindAttachedRpcServiceRequest{
+		AttachedResourceId: attachedID,
+		ServiceIdPrefix:    "/attached/",
+	}, newAttachedRpcServiceStream(bindCtx)); err == nil {
+		t.Fatal("root prefix binding succeeded")
+	}
+	if err := resource.BindAttachedRpcService(&s4wave_space.BindAttachedRpcServiceRequest{
+		AttachedResourceId: attachedID,
+		ServiceIdPrefix:    strings.Repeat("a", 256) + "/",
+	}, newAttachedRpcServiceStream(bindCtx)); err == nil {
+		t.Fatal("oversized prefix binding succeeded")
+	}
+
+	if !attachedResources.ReleaseResource(attachedID) {
+		t.Fatal("attached resource release failed")
+	}
+	if err := <-bindDone; err != nil {
+		t.Fatalf("bind returned %v after attached resource release", err)
+	}
+	values, _, valuesRef, err = bifrost_rpc.ExLookupRpcService(ctx, attachedBus.Bus, "attached/"+echo.SRPCEchoerServiceID, "", false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if valuesRef != nil {
+		valuesRef.Release()
+	}
+	if len(values) != 0 {
+		t.Fatal("released attachment remained callable")
+	}
+}
+
+func TestBindAttachedRpcServicePreEndedOwner(t *testing.T) {
+	ctx := t.Context()
+	le := logrus.NewEntry(logrus.New())
+	testbed, err := net_testbed.NewTestbed(ctx, le, net_testbed.TestbedOpts{NoEcho: true, NoPeer: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resource := NewSpaceContentsResource(le, testbed.Bus, nil, "space-a", "engine-a")
+	runtime := &spaceRuntime{bus: testbed.Bus, done: make(chan struct{})}
+	resource.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		resource.runtime = runtime
+	})
+
+	ownerCtx, cancelOwner := context.WithCancel(ctx)
+	attachedResources := newSpaceRecordingResourceClient(ownerCtx)
+	attachedID, err := attachedResources.AddResource(srpc.NewMux(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cancelOwner()
+
+	stream := newAttachedRpcServiceStream(resource_server.WithResourceClientContext(ctx, attachedResources))
+	err = resource.BindAttachedRpcService(&s4wave_space.BindAttachedRpcServiceRequest{
+		AttachedResourceId: attachedID,
+		ServiceIdPrefix:    "ended/",
+	}, stream)
+	if err != context.Canceled {
+		t.Fatalf("BindAttachedRpcService error = %v, want %v", err, context.Canceled)
+	}
+	select {
+	case <-stream.ready:
+		t.Fatal("pre-ended owner received readiness")
+	default:
+	}
+
+	values, _, valuesRef, err := bifrost_rpc.ExLookupRpcService(ctx, testbed.Bus, "ended/service", "", false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if valuesRef != nil {
+		valuesRef.Release()
+	}
+	if len(values) != 0 {
+		t.Fatal("pre-ended owner retained attached service route")
+	}
+}

--- a/core/resource/space/contents.go
+++ b/core/resource/space/contents.go
@@ -11,9 +11,12 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/aperturerobotics/controllerbus/bus"
 	bus_bridge "github.com/aperturerobotics/controllerbus/bus/bridge"
+	"github.com/aperturerobotics/controllerbus/controller"
 	controllerbus_core "github.com/aperturerobotics/controllerbus/core"
 	"github.com/aperturerobotics/controllerbus/directive"
 	timestamppb "github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
@@ -27,6 +30,7 @@ import (
 	plugin_host_default "github.com/s4wave/spacewave/bldr/plugin/host/default"
 	plugin_host_root "github.com/s4wave/spacewave/bldr/plugin/host/root"
 	plugin_host_scheduler "github.com/s4wave/spacewave/bldr/plugin/host/scheduler"
+	resource_server "github.com/s4wave/spacewave/bldr/resource/server"
 	process_binding "github.com/s4wave/spacewave/core/plugin/process"
 	plugin_space "github.com/s4wave/spacewave/core/plugin/space"
 	space_world "github.com/s4wave/spacewave/core/space/world"
@@ -34,6 +38,7 @@ import (
 	"github.com/s4wave/spacewave/db/volume"
 	"github.com/s4wave/spacewave/db/world"
 	world_types "github.com/s4wave/spacewave/db/world/types"
+	bifrost_rpc "github.com/s4wave/spacewave/net/rpc"
 	s4wave_process "github.com/s4wave/spacewave/sdk/process"
 	s4wave_space "github.com/s4wave/spacewave/sdk/space"
 	"github.com/sirupsen/logrus"
@@ -84,6 +89,30 @@ func (r *spaceRuntime) Release() {
 	})
 }
 
+type attachedRpcServiceBinding struct {
+	// runtime retains the Space runtime that serves this binding.
+	runtime *spaceRuntime
+	// controller routes the attached resource through the Space runtime.
+	controller *attachedRpcServiceController
+}
+
+// attachedRpcServiceController signals when its RPC service can resolve calls.
+type attachedRpcServiceController struct {
+	// RpcServiceController provides the RPC route after it receives a context.
+	*bifrost_rpc.RpcServiceController
+	// ready closes after RpcServiceController.Execute sets its context.
+	ready chan struct{}
+	// readyOnce guards ready closure when ControllerBus executes this controller.
+	readyOnce sync.Once
+}
+
+// Execute initializes the RPC service controller and then signals readiness.
+func (c *attachedRpcServiceController) Execute(ctx context.Context) error {
+	err := c.RpcServiceController.Execute(ctx)
+	c.readyOnce.Do(func() { close(c.ready) })
+	return err
+}
+
 type spaceRuntimeStarter func(
 	ctx context.Context,
 	parent bus.Bus,
@@ -117,6 +146,8 @@ type SpaceContentsResource struct {
 	ctrlRef directive.Reference
 	// runtime retains the isolated scheduler and child bus for this Space.
 	runtime *spaceRuntime
+	// attachedRpcServices is guarded by bcast and retains one binding per private service prefix.
+	attachedRpcServices map[string]*attachedRpcServiceBinding
 	// startErr is the terminal error from the current runtime startup.
 	startErr error
 	// ctrl wakes the running plugin/space controller after content changes.
@@ -521,6 +552,178 @@ func startSpaceContentsController(
 ) (*plugin_space.Controller, directive.Reference, error) {
 	ctrl, _, ctrlRef, err := plugin_space.StartControllerWithConfig(ctx, b, conf, func() {})
 	return ctrl, ctrlRef, err
+}
+
+// BindAttachedRpcService publishes a caller-attached Resource under one private
+// service ID prefix until the caller disconnects or this Space runtime ends.
+func (r *SpaceContentsResource) BindAttachedRpcService(
+	req *s4wave_space.BindAttachedRpcServiceRequest,
+	strm s4wave_space.SRPCSpaceContentsResourceService_BindAttachedRpcServiceStream,
+) error {
+	if req.GetAttachedResourceId() == 0 {
+		return errors.New("attached resource ID must be nonzero")
+	}
+	prefix := req.GetServiceIdPrefix()
+	if !isSafeAttachedRpcServicePrefix(prefix) {
+		return errors.New("service ID prefix must be nonempty and safe")
+	}
+
+	resourceCtx, err := resource_server.MustGetResourceClientContext(strm.Context())
+	if err != nil {
+		return err
+	}
+	client, err := resourceCtx.GetAttachedResource(req.GetAttachedResourceId())
+	if err != nil {
+		return err
+	}
+	var clientDone <-chan struct{}
+	if doneClient, ok := client.(interface{ Done() <-chan struct{} }); ok {
+		clientDone = doneClient.Done()
+	}
+
+	// Refuse a route when the caller, attachment, or request has already ended.
+	if err := attachedRpcServiceLifetimeError(strm.Context(), resourceCtx.Context(), clientDone, nil); err != nil {
+		return err
+	}
+
+	ctrl := &attachedRpcServiceController{
+		RpcServiceController: bifrost_rpc.NewRpcServiceController(
+			controller.NewInfo(
+				"core/resource/space/attached-rpc-service/"+prefix,
+				controller.MustParseVersion("0.0.1"),
+				"attached RPC service route",
+			),
+			bifrost_rpc.NewRpcServiceBuilder(srpc.NewClientInvoker(client)),
+			[]string{prefix},
+			true,
+			nil,
+			nil,
+			nil,
+		),
+		ready: make(chan struct{}),
+	}
+	binding := &attachedRpcServiceBinding{controller: ctrl}
+
+	r.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		if r.runtime == nil {
+			err = errors.New("space runtime is not running")
+			return
+		}
+		if r.attachedRpcServices == nil {
+			r.attachedRpcServices = make(map[string]*attachedRpcServiceBinding)
+		}
+		if existing := r.attachedRpcServices[prefix]; existing != nil {
+			select {
+			case <-existing.runtime.done:
+				delete(r.attachedRpcServices, prefix)
+			default:
+				err = fmt.Errorf("service ID prefix %q is already bound", prefix)
+				return
+			}
+		}
+		binding.runtime = r.runtime
+		r.attachedRpcServices[prefix] = binding
+	})
+	if err != nil {
+		return err
+	}
+
+	// Check the installed binding lifetime before ControllerBus starts its route.
+	if err := attachedRpcServiceLifetimeError(strm.Context(), resourceCtx.Context(), clientDone, binding.runtime.done); err != nil {
+		r.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+			if r.attachedRpcServices[prefix] == binding {
+				delete(r.attachedRpcServices, prefix)
+			}
+		})
+		return err
+	}
+
+	release, err := binding.runtime.bus.AddController(strm.Context(), binding.controller, nil)
+	if err != nil {
+		r.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+			if r.attachedRpcServices[prefix] == binding {
+				delete(r.attachedRpcServices, prefix)
+			}
+		})
+		return err
+	}
+	defer func() {
+		release()
+		r.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+			if r.attachedRpcServices[prefix] == binding {
+				delete(r.attachedRpcServices, prefix)
+			}
+		})
+	}()
+
+	select {
+	case <-binding.controller.ready:
+	case <-strm.Context().Done():
+		return strm.Context().Err()
+	case <-resourceCtx.Context().Done():
+		return resourceCtx.Context().Err()
+	case <-clientDone:
+		return errors.New("attached resource ended before attached service was ready")
+	case <-binding.runtime.done:
+		return errors.New("space runtime ended before attached service was ready")
+	}
+
+	// Give an already-ended lifetime priority over the ready notification.
+	if err := attachedRpcServiceLifetimeError(strm.Context(), resourceCtx.Context(), clientDone, binding.runtime.done); err != nil {
+		return err
+	}
+	if err := strm.Send(&s4wave_space.BindAttachedRpcServiceResponse{}); err != nil {
+		return err
+	}
+	select {
+	case <-strm.Context().Done():
+		return strm.Context().Err()
+	case <-resourceCtx.Context().Done():
+		return resourceCtx.Context().Err()
+	case <-clientDone:
+		return nil
+	case <-binding.runtime.done:
+		return nil
+	}
+}
+
+// attachedRpcServiceLifetimeError reports an ended binding lifetime without waiting.
+func attachedRpcServiceLifetimeError(
+	streamCtx context.Context,
+	resourceCtx context.Context,
+	clientDone <-chan struct{},
+	runtimeDone <-chan struct{},
+) error {
+	if err := streamCtx.Err(); err != nil {
+		return err
+	}
+	if err := resourceCtx.Err(); err != nil {
+		return err
+	}
+	select {
+	case <-clientDone:
+		return errors.New("attached resource ended before attached service was ready")
+	default:
+	}
+	select {
+	case <-runtimeDone:
+		return errors.New("space runtime ended before attached service was ready")
+	default:
+	}
+	return nil
+}
+
+func isSafeAttachedRpcServicePrefix(prefix string) bool {
+	if prefix == "" || len(prefix) > 256 || !utf8.ValidString(prefix) ||
+		prefix[0] == '/' || prefix[len(prefix)-1] != '/' {
+		return false
+	}
+	for _, char := range prefix {
+		if unicode.IsSpace(char) || unicode.IsControl(char) {
+			return false
+		}
+	}
+	return true
 }
 
 // WatchState streams the current plugin and process state for the space.

--- a/core/resource/space/space_test.go
+++ b/core/resource/space/space_test.go
@@ -571,6 +571,17 @@ func assertSpaceChatSender(t *testing.T, ctx context.Context, engine world.Engin
 	}
 }
 
+type spaceAttachedResourceClient struct {
+	// Client forwards calls to the attached resource.
+	srpc.Client
+	// done closes when the attached resource is released.
+	done <-chan struct{}
+}
+
+func (c *spaceAttachedResourceClient) Done() <-chan struct{} {
+	return c.done
+}
+
 type spaceRecordingResourceClient struct {
 	ctx      context.Context
 	mu       sync.Mutex
@@ -578,6 +589,8 @@ type spaceRecordingResourceClient struct {
 	muxes    map[uint32]srpc.Invoker
 	values   map[uint32]any
 	releases map[uint32]func()
+	// dones is guarded by mu and closes when its resource is released.
+	dones map[uint32]chan struct{}
 }
 
 func newSpaceRecordingResourceClient(ctx context.Context) *spaceRecordingResourceClient {
@@ -586,6 +599,7 @@ func newSpaceRecordingResourceClient(ctx context.Context) *spaceRecordingResourc
 		muxes:    make(map[uint32]srpc.Invoker),
 		values:   make(map[uint32]any),
 		releases: make(map[uint32]func()),
+		dones:    make(map[uint32]chan struct{}),
 	}
 }
 
@@ -604,21 +618,25 @@ func (c *spaceRecordingResourceClient) AddResourceValue(mux srpc.Invoker, value 
 	c.muxes[c.nextID] = mux
 	c.values[c.nextID] = value
 	c.releases[c.nextID] = releaseFn
+	c.dones[c.nextID] = make(chan struct{})
 	return c.nextID, nil
 }
 
 func (c *spaceRecordingResourceClient) ReleaseResource(resourceID uint32) bool {
 	c.mu.Lock()
 	releaseFn, ok := c.releases[resourceID]
+	done := c.dones[resourceID]
 	if ok {
 		delete(c.muxes, resourceID)
 		delete(c.values, resourceID)
 		delete(c.releases, resourceID)
+		delete(c.dones, resourceID)
 	}
 	c.mu.Unlock()
 	if !ok {
 		return false
 	}
+	close(done)
 	if releaseFn != nil {
 		releaseFn()
 	}
@@ -638,11 +656,15 @@ func (c *spaceRecordingResourceClient) GetResourceValue(resourceID uint32) (any,
 func (c *spaceRecordingResourceClient) GetAttachedResource(resourceID uint32) (srpc.Client, error) {
 	c.mu.Lock()
 	mux := c.muxes[resourceID]
+	done := c.dones[resourceID]
 	c.mu.Unlock()
 	if mux == nil {
 		return nil, errors.New("resource mux not found")
 	}
-	return srpc.NewClient(srpc.NewServerPipe(srpc.NewServer(mux))), nil
+	return &spaceAttachedResourceClient{
+		Client: srpc.NewClient(srpc.NewServerPipe(srpc.NewServer(mux))),
+		done:   done,
+	}, nil
 }
 
 func (c *spaceRecordingResourceClient) client(t *testing.T, resourceID uint32) srpc.Client {

--- a/sdk/space/space.pb.go
+++ b/sdk/space/space.pb.go
@@ -526,6 +526,48 @@ func (x *WatchSpaceContentsStateRequest) Reset() {
 
 func (*WatchSpaceContentsStateRequest) ProtoMessage() {}
 
+// BindAttachedRpcServiceRequest identifies the caller-attached Resource and its
+// private service ID prefix in this Space runtime.
+type BindAttachedRpcServiceRequest struct {
+	unknownFields []byte
+	// AttachedResourceId identifies a Resource attached by this caller.
+	AttachedResourceId uint32 `protobuf:"varint,1,opt,name=attached_resource_id,json=attachedResourceId,proto3" json:"attachedResourceId,omitempty"`
+	// ServiceIdPrefix is a slash-terminated private prefix of at most 256 UTF-8
+	// bytes.
+	ServiceIdPrefix string `protobuf:"bytes,2,opt,name=service_id_prefix,json=serviceIdPrefix,proto3" json:"serviceIdPrefix,omitempty"`
+}
+
+func (x *BindAttachedRpcServiceRequest) Reset() {
+	*x = BindAttachedRpcServiceRequest{}
+}
+
+func (*BindAttachedRpcServiceRequest) ProtoMessage() {}
+
+func (x *BindAttachedRpcServiceRequest) GetAttachedResourceId() uint32 {
+	if x != nil {
+		return x.AttachedResourceId
+	}
+	return 0
+}
+
+func (x *BindAttachedRpcServiceRequest) GetServiceIdPrefix() string {
+	if x != nil {
+		return x.ServiceIdPrefix
+	}
+	return ""
+}
+
+// BindAttachedRpcServiceResponse confirms the attached service is callable.
+type BindAttachedRpcServiceResponse struct {
+	unknownFields []byte
+}
+
+func (x *BindAttachedRpcServiceResponse) Reset() {
+	*x = BindAttachedRpcServiceResponse{}
+}
+
+func (*BindAttachedRpcServiceResponse) ProtoMessage() {}
+
 // SpaceContentsState contains plugin status for the space.
 type SpaceContentsState struct {
 	unknownFields []byte
@@ -1102,6 +1144,38 @@ func (m *WatchSpaceContentsStateRequest) CloneMessageVT() protobuf_go_lite.Clone
 	return m.CloneVT()
 }
 
+func (m *BindAttachedRpcServiceRequest) CloneVT() *BindAttachedRpcServiceRequest {
+	if m == nil {
+		return (*BindAttachedRpcServiceRequest)(nil)
+	}
+	r := new(BindAttachedRpcServiceRequest)
+	r.AttachedResourceId = m.AttachedResourceId
+	r.ServiceIdPrefix = m.ServiceIdPrefix
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = slices.Clone(m.unknownFields)
+	}
+	return r
+}
+
+func (m *BindAttachedRpcServiceRequest) CloneMessageVT() protobuf_go_lite.CloneMessage {
+	return m.CloneVT()
+}
+
+func (m *BindAttachedRpcServiceResponse) CloneVT() *BindAttachedRpcServiceResponse {
+	if m == nil {
+		return (*BindAttachedRpcServiceResponse)(nil)
+	}
+	r := new(BindAttachedRpcServiceResponse)
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = slices.Clone(m.unknownFields)
+	}
+	return r
+}
+
+func (m *BindAttachedRpcServiceResponse) CloneMessageVT() protobuf_go_lite.CloneMessage {
+	return m.CloneVT()
+}
+
 func (m *SpaceContentsState) CloneVT() *SpaceContentsState {
 	if m == nil {
 		return (*SpaceContentsState)(nil)
@@ -1617,6 +1691,46 @@ func (this *WatchSpaceContentsStateRequest) EqualVT(that *WatchSpaceContentsStat
 
 func (this *WatchSpaceContentsStateRequest) EqualMessageVT(thatMsg any) bool {
 	that, ok := thatMsg.(*WatchSpaceContentsStateRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+
+func (this *BindAttachedRpcServiceRequest) EqualVT(that *BindAttachedRpcServiceRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.AttachedResourceId != that.AttachedResourceId {
+		return false
+	}
+	if this.ServiceIdPrefix != that.ServiceIdPrefix {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *BindAttachedRpcServiceRequest) EqualMessageVT(thatMsg any) bool {
+	that, ok := thatMsg.(*BindAttachedRpcServiceRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+
+func (this *BindAttachedRpcServiceResponse) EqualVT(that *BindAttachedRpcServiceResponse) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *BindAttachedRpcServiceResponse) EqualMessageVT(thatMsg any) bool {
+	that, ok := thatMsg.(*BindAttachedRpcServiceResponse)
 	if !ok {
 		return false
 	}
@@ -2770,6 +2884,86 @@ func (x *WatchSpaceContentsStateRequest) UnmarshalProtoJSON(s *json.UnmarshalSta
 
 // UnmarshalJSON unmarshals the WatchSpaceContentsStateRequest from JSON.
 func (x *WatchSpaceContentsStateRequest) UnmarshalJSON(b []byte) error {
+	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
+}
+
+// MarshalProtoJSON marshals the BindAttachedRpcServiceRequest message to JSON.
+func (x *BindAttachedRpcServiceRequest) MarshalProtoJSON(s *json.MarshalState) {
+	if x == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteObjectStart()
+	var wroteField bool
+	if x.AttachedResourceId != 0 || s.HasField("attachedResourceId") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("attachedResourceId")
+		s.WriteUint32(x.AttachedResourceId)
+	}
+	if x.ServiceIdPrefix != "" || s.HasField("serviceIdPrefix") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("serviceIdPrefix")
+		s.WriteString(x.ServiceIdPrefix)
+	}
+	s.WriteObjectEnd()
+}
+
+// MarshalJSON marshals the BindAttachedRpcServiceRequest to JSON.
+func (x *BindAttachedRpcServiceRequest) MarshalJSON() ([]byte, error) {
+	return json.DefaultMarshalerConfig.Marshal(x)
+}
+
+// UnmarshalProtoJSON unmarshals the BindAttachedRpcServiceRequest message from JSON.
+func (x *BindAttachedRpcServiceRequest) UnmarshalProtoJSON(s *json.UnmarshalState) {
+	if s.ReadNil() {
+		return
+	}
+	s.ReadObject(func(key string) {
+		switch key {
+		default:
+			s.Skip() // ignore unknown field
+		case "attached_resource_id", "attachedResourceId":
+			s.AddField("attached_resource_id")
+			x.AttachedResourceId = s.ReadUint32()
+		case "service_id_prefix", "serviceIdPrefix":
+			s.AddField("service_id_prefix")
+			x.ServiceIdPrefix = s.ReadString()
+		}
+	})
+}
+
+// UnmarshalJSON unmarshals the BindAttachedRpcServiceRequest from JSON.
+func (x *BindAttachedRpcServiceRequest) UnmarshalJSON(b []byte) error {
+	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
+}
+
+// MarshalProtoJSON marshals the BindAttachedRpcServiceResponse message to JSON.
+func (x *BindAttachedRpcServiceResponse) MarshalProtoJSON(s *json.MarshalState) {
+	if x == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteObjectStart()
+	s.WriteObjectEnd()
+}
+
+// MarshalJSON marshals the BindAttachedRpcServiceResponse to JSON.
+func (x *BindAttachedRpcServiceResponse) MarshalJSON() ([]byte, error) {
+	return json.DefaultMarshalerConfig.Marshal(x)
+}
+
+// UnmarshalProtoJSON unmarshals the BindAttachedRpcServiceResponse message from JSON.
+func (x *BindAttachedRpcServiceResponse) UnmarshalProtoJSON(s *json.UnmarshalState) {
+	if s.ReadNil() {
+		return
+	}
+	s.ReadObject(func(key string) {
+		// no fields
+	})
+}
+
+// UnmarshalJSON unmarshals the BindAttachedRpcServiceResponse from JSON.
+func (x *BindAttachedRpcServiceResponse) UnmarshalJSON(b []byte) error {
 	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
 }
 
@@ -4054,6 +4248,80 @@ func (m *WatchSpaceContentsStateRequest) MarshalToSizedBufferVT(dAtA []byte) (in
 	return len(dAtA) - i, nil
 }
 
+func (m *BindAttachedRpcServiceRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *BindAttachedRpcServiceRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *BindAttachedRpcServiceRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	if len(m.ServiceIdPrefix) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.ServiceIdPrefix)
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.AttachedResourceId != 0 {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(m.AttachedResourceId))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *BindAttachedRpcServiceResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *BindAttachedRpcServiceResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *BindAttachedRpcServiceResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *SpaceContentsState) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -4729,6 +4997,28 @@ func (m *WatchSpaceContentsStateRequest) SizeVT() (n int) {
 	return n
 }
 
+func (m *BindAttachedRpcServiceRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	n += protobuf_go_lite.SizeVarintNonZero(1, m.AttachedResourceId)
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.ServiceIdPrefix)
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *BindAttachedRpcServiceResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *SpaceContentsState) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -5183,6 +5473,34 @@ func (x *WatchSpaceContentsStateRequest) MarshalProtoText() string {
 }
 
 func (x *WatchSpaceContentsStateRequest) String() string {
+	return x.MarshalProtoText()
+}
+
+func (x *BindAttachedRpcServiceRequest) MarshalProtoText() string {
+	var sb protobuf_go_lite.TextBuilder
+	initialLen := protobuf_go_lite.TextStartMessage(&sb, "BindAttachedRpcServiceRequest")
+	if x.AttachedResourceId != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "attached_resource_id")
+		protobuf_go_lite.TextWriteUint(&sb, x.AttachedResourceId)
+	}
+	if x.ServiceIdPrefix != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "service_id_prefix")
+		protobuf_go_lite.TextWriteString(&sb, x.ServiceIdPrefix)
+	}
+	return protobuf_go_lite.TextFinishMessage(&sb)
+}
+
+func (x *BindAttachedRpcServiceRequest) String() string {
+	return x.MarshalProtoText()
+}
+
+func (x *BindAttachedRpcServiceResponse) MarshalProtoText() string {
+	var sb protobuf_go_lite.TextBuilder
+	protobuf_go_lite.TextStartMessage(&sb, "BindAttachedRpcServiceResponse")
+	return protobuf_go_lite.TextFinishMessage(&sb)
+}
+
+func (x *BindAttachedRpcServiceResponse) String() string {
 	return x.MarshalProtoText()
 }
 
@@ -6371,6 +6689,111 @@ func (m *WatchSpaceContentsStateRequest) UnmarshalVT(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: WatchSpaceContentsStateRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protobuf_go_lite.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+
+func (m *BindAttachedRpcServiceRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	var err error
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		wire, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+		if err != nil {
+			return err
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: BindAttachedRpcServiceRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: BindAttachedRpcServiceRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AttachedResourceId", wireType)
+			}
+			m.AttachedResourceId = 0
+			m.AttachedResourceId, iNdEx, err = protobuf_go_lite.DecodeVarintUint32(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ServiceIdPrefix", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.ServiceIdPrefix = v
+		default:
+			iNdEx = preIndex
+			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protobuf_go_lite.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+
+func (m *BindAttachedRpcServiceResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	var err error
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		wire, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+		if err != nil {
+			return err
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: BindAttachedRpcServiceResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: BindAttachedRpcServiceResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:

--- a/sdk/space/space.pb.ts
+++ b/sdk/space/space.pb.ts
@@ -599,6 +599,61 @@ export const WatchSpaceContentsStateRequest: MessageType<WatchSpaceContentsState
   )
 
 /**
+ * BindAttachedRpcServiceRequest identifies the caller-attached Resource and its
+ * private service ID prefix in this Space runtime.
+ *
+ * @generated from message s4wave.space.BindAttachedRpcServiceRequest
+ */
+export interface BindAttachedRpcServiceRequest {
+  /**
+   * AttachedResourceId identifies a Resource attached by this caller.
+   *
+   * @generated from field: uint32 attached_resource_id = 1;
+   */
+  attachedResourceId?: number
+  /**
+   * ServiceIdPrefix is a slash-terminated private prefix of at most 256 UTF-8
+   * bytes.
+   *
+   * @generated from field: string service_id_prefix = 2;
+   */
+  serviceIdPrefix?: string
+}
+
+export const BindAttachedRpcServiceRequest: MessageType<BindAttachedRpcServiceRequest> =
+  /* @__PURE__ */ createMessageType({
+    typeName: 's4wave.space.BindAttachedRpcServiceRequest',
+    fields: [
+      {
+        no: 1,
+        name: 'attached_resource_id',
+        kind: 'scalar',
+        T: ScalarType.UINT32,
+      },
+      {
+        no: 2,
+        name: 'service_id_prefix',
+        kind: 'scalar',
+        T: ScalarType.STRING,
+      },
+    ] satisfies readonly PartialFieldInfo[],
+    packedByDefault: true,
+  })
+
+/**
+ * BindAttachedRpcServiceResponse confirms the attached service is callable.
+ *
+ * @generated from message s4wave.space.BindAttachedRpcServiceResponse
+ */
+export interface BindAttachedRpcServiceResponse {}
+
+export const BindAttachedRpcServiceResponse: MessageType<BindAttachedRpcServiceResponse> =
+  /* @__PURE__ */ createEmptyMessageType<BindAttachedRpcServiceResponse>(
+    's4wave.space.BindAttachedRpcServiceResponse',
+    true,
+  )
+
+/**
  * SpacePluginStatus contains runtime state for a single plugin.
  *
  * @generated from message s4wave.space.SpacePluginStatus

--- a/sdk/space/space.proto
+++ b/sdk/space/space.proto
@@ -34,6 +34,11 @@ service SpaceContentsResourceService {
   rpc WatchState(WatchSpaceContentsStateRequest) returns (stream SpaceContentsState) {}
 
   rpc SetProcessBinding(SetProcessBindingRequest) returns (SetProcessBindingResponse) {}
+
+  // BindAttachedRpcService publishes a caller-attached Resource under one
+  // private service ID prefix for this Space runtime.
+  rpc BindAttachedRpcService(BindAttachedRpcServiceRequest)
+    returns (stream BindAttachedRpcServiceResponse) {}
 }
 
 // WatchSpaceStateRequest is a request to watch the Workspace state.
@@ -153,6 +158,20 @@ message ReadSecretPayloadResponse {
 
 // WatchSpaceContentsStateRequest is a request to watch the space contents state.
 message WatchSpaceContentsStateRequest {}
+
+// BindAttachedRpcServiceRequest identifies the caller-attached Resource and its
+// private service ID prefix in this Space runtime.
+message BindAttachedRpcServiceRequest {
+  // AttachedResourceId identifies a Resource attached by this caller.
+  uint32 attached_resource_id = 1;
+  // ServiceIdPrefix is a slash-terminated private prefix of at most 256 UTF-8
+  // bytes.
+  string service_id_prefix = 2;
+}
+
+// BindAttachedRpcServiceResponse confirms the attached service is callable.
+message BindAttachedRpcServiceResponse {
+}
 
 // SpaceContentsState contains plugin status for the space.
 message SpaceContentsState {

--- a/sdk/space/space_srpc.pb.go
+++ b/sdk/space/space_srpc.pb.go
@@ -536,6 +536,9 @@ type SRPCSpaceContentsResourceServiceClient interface {
 	WatchState(ctx context.Context, in *WatchSpaceContentsStateRequest) (SRPCSpaceContentsResourceService_WatchStateClient, error)
 
 	SetProcessBinding(ctx context.Context, in *SetProcessBindingRequest) (*SetProcessBindingResponse, error)
+	// BindAttachedRpcService publishes a caller-attached Resource under one
+	// private service ID prefix for this Space runtime.
+	BindAttachedRpcService(ctx context.Context, in *BindAttachedRpcServiceRequest) (SRPCSpaceContentsResourceService_BindAttachedRpcServiceClient, error)
 }
 
 type srpcSpaceContentsResourceServiceClient struct {
@@ -599,10 +602,47 @@ func (c *srpcSpaceContentsResourceServiceClient) SetProcessBinding(ctx context.C
 	return out, nil
 }
 
+func (c *srpcSpaceContentsResourceServiceClient) BindAttachedRpcService(ctx context.Context, in *BindAttachedRpcServiceRequest) (SRPCSpaceContentsResourceService_BindAttachedRpcServiceClient, error) {
+	stream, err := c.cc.NewStream(ctx, c.serviceID, "BindAttachedRpcService", in)
+	if err != nil {
+		return nil, err
+	}
+	strm := &srpcSpaceContentsResourceService_BindAttachedRpcServiceClient{stream}
+	if err := strm.CloseSend(); err != nil {
+		return nil, err
+	}
+	return strm, nil
+}
+
+type SRPCSpaceContentsResourceService_BindAttachedRpcServiceClient interface {
+	srpc.Stream
+	Recv() (*BindAttachedRpcServiceResponse, error)
+	RecvTo(*BindAttachedRpcServiceResponse) error
+}
+
+type srpcSpaceContentsResourceService_BindAttachedRpcServiceClient struct {
+	srpc.Stream
+}
+
+func (x *srpcSpaceContentsResourceService_BindAttachedRpcServiceClient) Recv() (*BindAttachedRpcServiceResponse, error) {
+	m := new(BindAttachedRpcServiceResponse)
+	if err := x.MsgRecv(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func (x *srpcSpaceContentsResourceService_BindAttachedRpcServiceClient) RecvTo(m *BindAttachedRpcServiceResponse) error {
+	return x.MsgRecv(m)
+}
+
 type SRPCSpaceContentsResourceServiceServer interface {
 	WatchState(*WatchSpaceContentsStateRequest, SRPCSpaceContentsResourceService_WatchStateStream) error
 
 	SetProcessBinding(context.Context, *SetProcessBindingRequest) (*SetProcessBindingResponse, error)
+	// BindAttachedRpcService publishes a caller-attached Resource under one
+	// private service ID prefix for this Space runtime.
+	BindAttachedRpcService(*BindAttachedRpcServiceRequest, SRPCSpaceContentsResourceService_BindAttachedRpcServiceStream) error
 }
 
 const SRPCSpaceContentsResourceServiceServiceID = "s4wave.space.SpaceContentsResourceService"
@@ -633,6 +673,7 @@ func (SRPCSpaceContentsResourceServiceHandler) GetMethodIDs() []string {
 	return []string{
 		"WatchState",
 		"SetProcessBinding",
+		"BindAttachedRpcService",
 	}
 }
 
@@ -649,6 +690,8 @@ func (d *SRPCSpaceContentsResourceServiceHandler) InvokeMethod(
 		return true, d.InvokeMethod_WatchState(d.impl, strm)
 	case "SetProcessBinding":
 		return true, d.InvokeMethod_SetProcessBinding(d.impl, strm)
+	case "BindAttachedRpcService":
+		return true, d.InvokeMethod_BindAttachedRpcService(d.impl, strm)
 	default:
 		return false, nil
 	}
@@ -673,6 +716,15 @@ func (SRPCSpaceContentsResourceServiceHandler) InvokeMethod_SetProcessBinding(im
 		return err
 	}
 	return strm.MsgSend(out)
+}
+
+func (SRPCSpaceContentsResourceServiceHandler) InvokeMethod_BindAttachedRpcService(impl SRPCSpaceContentsResourceServiceServer, strm srpc.Stream) error {
+	req := new(BindAttachedRpcServiceRequest)
+	if err := strm.MsgRecv(req); err != nil {
+		return err
+	}
+	serverStrm := &srpcSpaceContentsResourceService_BindAttachedRpcServiceStream{strm}
+	return impl.BindAttachedRpcService(req, serverStrm)
 }
 
 type SRPCSpaceContentsResourceService_WatchStateStream interface {
@@ -704,4 +756,27 @@ type SRPCSpaceContentsResourceService_SetProcessBindingStream interface {
 
 type srpcSpaceContentsResourceService_SetProcessBindingStream struct {
 	srpc.Stream
+}
+
+type SRPCSpaceContentsResourceService_BindAttachedRpcServiceStream interface {
+	srpc.Stream
+	Send(*BindAttachedRpcServiceResponse) error
+	SendAndClose(*BindAttachedRpcServiceResponse) error
+}
+
+type srpcSpaceContentsResourceService_BindAttachedRpcServiceStream struct {
+	srpc.Stream
+}
+
+func (x *srpcSpaceContentsResourceService_BindAttachedRpcServiceStream) Send(m *BindAttachedRpcServiceResponse) error {
+	return x.MsgSend(m)
+}
+
+func (x *srpcSpaceContentsResourceService_BindAttachedRpcServiceStream) SendAndClose(m *BindAttachedRpcServiceResponse) error {
+	if m != nil {
+		if err := x.MsgSend(m); err != nil {
+			return err
+		}
+	}
+	return x.CloseSend()
 }

--- a/sdk/space/space_srpc.pb.ts
+++ b/sdk/space/space_srpc.pb.ts
@@ -7,6 +7,8 @@ import {
   AccessWorldResponse,
   AddSpacePluginRequest,
   AddSpacePluginResponse,
+  BindAttachedRpcServiceRequest,
+  BindAttachedRpcServiceResponse,
   CreateSecretRequest,
   CreateSecretResponse,
   MountSpaceContentsRequest,
@@ -482,6 +484,18 @@ export const SpaceContentsResourceServiceDefinition = {
       O: SetProcessBindingResponse,
       kind: MethodKind.Unary,
     },
+    /**
+     * BindAttachedRpcService publishes a caller-attached Resource under one
+     * private service ID prefix for this Space runtime.
+     *
+     * @generated from rpc s4wave.space.SpaceContentsResourceService.BindAttachedRpcService
+     */
+    BindAttachedRpcService: {
+      name: 'BindAttachedRpcService',
+      I: BindAttachedRpcServiceRequest,
+      O: BindAttachedRpcServiceResponse,
+      kind: MethodKind.ServerStreaming,
+    },
   },
 } as const
 
@@ -504,6 +518,17 @@ export interface SpaceContentsResourceService {
     request: SetProcessBindingRequest,
     abortSignal?: AbortSignal,
   ): Promise<SetProcessBindingResponse>
+
+  /**
+   * BindAttachedRpcService publishes a caller-attached Resource under one
+   * private service ID prefix for this Space runtime.
+   *
+   * @generated from rpc s4wave.space.SpaceContentsResourceService.BindAttachedRpcService
+   */
+  BindAttachedRpcService(
+    request: BindAttachedRpcServiceRequest,
+    abortSignal?: AbortSignal,
+  ): MessageStream<BindAttachedRpcServiceResponse>
 }
 
 /**
@@ -527,6 +552,18 @@ export interface SpaceContentsResourceServiceHandler {
     abortSignal: AbortSignal,
     context: ServerContext,
   ): Promise<SetProcessBindingResponse>
+
+  /**
+   * BindAttachedRpcService publishes a caller-attached Resource under one
+   * private service ID prefix for this Space runtime.
+   *
+   * @generated from rpc s4wave.space.SpaceContentsResourceService.BindAttachedRpcService
+   */
+  BindAttachedRpcService(
+    request: BindAttachedRpcServiceRequest,
+    abortSignal: AbortSignal,
+    context: ServerContext,
+  ): MessageStream<BindAttachedRpcServiceResponse>
 }
 
 export const SpaceContentsResourceServiceServiceName =
@@ -540,6 +577,7 @@ export class SpaceContentsResourceServiceClient implements SpaceContentsResource
     this.rpc = rpc
     this.WatchState = this.WatchState.bind(this)
     this.SetProcessBinding = this.SetProcessBinding.bind(this)
+    this.BindAttachedRpcService = this.BindAttachedRpcService.bind(this)
   }
   /**
    * @generated from rpc s4wave.space.SpaceContentsResourceService.WatchState
@@ -573,5 +611,26 @@ export class SpaceContentsResourceServiceClient implements SpaceContentsResource
       abortSignal || undefined,
     )
     return SetProcessBindingResponse.fromBinary(result)
+  }
+
+  /**
+   * BindAttachedRpcService publishes a caller-attached Resource under one
+   * private service ID prefix for this Space runtime.
+   *
+   * @generated from rpc s4wave.space.SpaceContentsResourceService.BindAttachedRpcService
+   */
+  BindAttachedRpcService(
+    request: BindAttachedRpcServiceRequest,
+    abortSignal?: AbortSignal,
+  ): MessageStream<BindAttachedRpcServiceResponse> {
+    const requestMsg = BindAttachedRpcServiceRequest.create(request)
+    const result = this.rpc.serverStreamingRequest(
+      this.service,
+      SpaceContentsResourceServiceDefinition.methods.BindAttachedRpcService
+        .name,
+      BindAttachedRpcServiceRequest.toBinary(requestMsg),
+      abortSignal || undefined,
+    )
+    return buildDecodeMessageTransform(BindAttachedRpcServiceResponse)(result)
   }
 }


### PR DESCRIPTION
A process mounted into one Space sometimes needs to publish an RPC tree without opening another transport. Resource attachments already carry those trees, but the isolated Space runtime could not route a private service prefix to one.

This adds `BindAttachedRpcService` to `SpaceContentsResourceService`. The server validates that the resource belongs to the caller, installs a prefix-stripping controller only on that Space runtime, and acknowledges readiness only after the controller starts. The route ends with the bind stream, attachment generation, or Space runtime. Resource IDs remain ephemeral and are never persisted.

Routed attachment clients now expose their individual resource lifetime so detaching one resource removes only its route while the parent connection remains active. Prefix validation keeps bindings private and unambiguous.
