### PR TITLE
fix(space): initialize Space plugin manifest store

### DIFF
--- a/bldr/plugin/host/scheduler/controller.go
+++ b/bldr/plugin/host/scheduler/controller.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aperturerobotics/util/ccontainer"
 	"github.com/aperturerobotics/util/keyed"
 	bldr_manifest "github.com/s4wave/spacewave/bldr/manifest"
+	bldr_manifest_world "github.com/s4wave/spacewave/bldr/manifest/world"
 	bldr_plugin "github.com/s4wave/spacewave/bldr/plugin"
 	bldr_plugin_host "github.com/s4wave/spacewave/bldr/plugin/host"
 	plugin_host_resource "github.com/s4wave/spacewave/bldr/plugin/host/resource"
@@ -70,6 +71,12 @@ type Controller struct {
 	pluginHostsCtr *ccontainer.CContainer[*pluginHostSet]
 	// manifestCopyGate delays startup copies until runtime readiness.
 	manifestCopyGateCtr *ccontainer.CContainer[ManifestCopyGate]
+	// manifestStoreMtx guards manifest store initialization state.
+	manifestStoreMtx sync.Mutex
+	// manifestStoreReady caches successful manifest store initialization.
+	manifestStoreReady bool
+	// manifestStoreInit closes when the current initialization attempt completes.
+	manifestStoreInit chan struct{}
 	// manifestCommitOnce initializes manifestCommitSlots.
 	manifestCommitOnce sync.Once
 	// manifestCommitSlots serializes world manifest publication and sync.
@@ -205,6 +212,40 @@ func (c *Controller) acquireManifestCommit(ctx context.Context) (func(), error) 
 		}, nil
 	case <-ctx.Done():
 		return nil, context.Canceled
+	}
+}
+
+// ensureManifestStore creates the scheduler manifest store before a plugin reads it.
+func (c *Controller) ensureManifestStore(ctx context.Context) error {
+	for {
+		c.manifestStoreMtx.Lock()
+		if c.manifestStoreReady {
+			c.manifestStoreMtx.Unlock()
+			return nil
+		}
+		if wait := c.manifestStoreInit; wait != nil {
+			c.manifestStoreMtx.Unlock()
+			select {
+			case <-wait:
+				continue
+			case <-ctx.Done():
+				return context.Canceled
+			}
+		}
+		c.manifestStoreInit = make(chan struct{})
+		c.manifestStoreMtx.Unlock()
+
+		engine := world.NewBusEngine(ctx, c.bus, c.conf.GetEngineId())
+		_, err := bldr_manifest_world.CreateManifestStoreInEngine(ctx, engine, c.objKey)
+
+		c.manifestStoreMtx.Lock()
+		if err == nil {
+			c.manifestStoreReady = true
+		}
+		close(c.manifestStoreInit)
+		c.manifestStoreInit = nil
+		c.manifestStoreMtx.Unlock()
+		return err
 	}
 }
 

--- a/bldr/plugin/host/scheduler/manifest-store_test.go
+++ b/bldr/plugin/host/scheduler/manifest-store_test.go
@@ -1,0 +1,71 @@
+package plugin_host_scheduler
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	bldr_manifest_world "github.com/s4wave/spacewave/bldr/manifest/world"
+	"github.com/s4wave/spacewave/db/world"
+	world_testbed "github.com/s4wave/spacewave/db/world/testbed"
+	"github.com/sirupsen/logrus"
+)
+
+func TestControllerEnsuresManifestStoreOnPluginDemand(t *testing.T) {
+	ctx := t.Context()
+	tb, err := world_testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tb.Release()
+
+	const objectKey = "plugin-host"
+	controller := NewController(logrus.NewEntry(logrus.New()), tb.Bus, NewConfig(
+		"",
+		tb.EngineID,
+		objectKey,
+		tb.EngineVolumeID,
+		tb.Volume.GetPeerID().String(),
+		true,
+		false,
+		false,
+	))
+	state := world.NewEngineWorldState(tb.BusEngine, false)
+	_, exists, err := state.GetObject(ctx, objectKey)
+	if err != nil {
+		t.Fatalf("read manifest store before plugin demand: %v", err)
+	}
+	if exists {
+		t.Fatal("manifest store exists before the first plugin demand")
+	}
+
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	if err := controller.ensureManifestStore(canceledCtx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled manifest store initialization = %v, want context.Canceled", err)
+	}
+
+	const demandCount = 8
+	start := make(chan struct{})
+	errs := make(chan error, demandCount)
+	var wg sync.WaitGroup
+	for range demandCount {
+		wg.Go(func() {
+			<-start
+			errs <- controller.ensureManifestStore(ctx)
+		})
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("ensure manifest store: %v", err)
+		}
+	}
+
+	if err := bldr_manifest_world.CheckManifestStoreType(ctx, state, objectKey); err != nil {
+		t.Fatalf("manifest store after first plugin demand: %v", err)
+	}
+}

--- a/bldr/plugin/host/scheduler/plugin-instance.go
+++ b/bldr/plugin/host/scheduler/plugin-instance.go
@@ -131,6 +131,9 @@ func (c *Controller) newPluginInstance(key string) (keyed.Routine, *pluginInstan
 
 // execute executes the routine.
 func (t *pluginInstance) execute(ctx context.Context) error {
+	if err := t.c.ensureManifestStore(ctx); err != nil {
+		return err
+	}
 	t.ensureAccessProviders()
 
 	t.c.setPluginStatus(


### PR DESCRIPTION
Space runtime startup now creates the plugin-host manifest store in the Space engine before the scheduler starts. This makes a newly mounted Space ready for scheduler manifest lookup without changing existing stores.

The regression test starts with no plugin-host store, makes the plugin-host watch fail, and verifies that startup still created a correctly typed store before scheduler setup can proceed.