### PR TITLE
fix(webrtc): defer signals during ICE disconnect

### DIFF
--- a/net/transport/webrtc/session.go
+++ b/net/transport/webrtc/session.go
@@ -470,7 +470,11 @@ func (s *session) onNegotiationNeeded() {
 // acceptIncomingSignalLocked accepts sig only while this session is live.
 // The caller must hold s.bcast.
 func (s *session) acceptIncomingSignalLocked(sig *incomingSignal) {
-	if sig == nil || s.fatalErr != nil || s.connState == webrtc.PeerConnectionStateFailed {
+	if sig == nil || s.fatalErr != nil {
+		return
+	}
+	switch s.connState {
+	case webrtc.PeerConnectionStateDisconnected, webrtc.PeerConnectionStateFailed:
 		return
 	}
 	sig.accept()

--- a/net/transport/webrtc/session_test.go
+++ b/net/transport/webrtc/session_test.go
@@ -44,6 +44,31 @@ func TestCompleteExecutionWaitsForChildCompletion(t *testing.T) {
 	})
 }
 
+func TestDisconnectedSessionDefersSignalAcceptance(t *testing.T) {
+	incoming := &incomingSignal{accepted: make(chan struct{})}
+	sess := &session{connState: pion_webrtc.PeerConnectionStateDisconnected}
+
+	sess.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		sess.acceptIncomingSignalLocked(incoming)
+	})
+
+	select {
+	case <-incoming.accepted:
+		t.Fatal("disconnected session accepted a signal before reconnect or replacement")
+	default:
+	}
+
+	sess.connState = pion_webrtc.PeerConnectionStateConnected
+	sess.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		sess.acceptIncomingSignalLocked(incoming)
+	})
+	select {
+	case <-incoming.accepted:
+	default:
+		t.Fatal("reconnected session did not accept the pending signal")
+	}
+}
+
 func TestCreateDataChannelRegistersNegotiationCallbackFirst(t *testing.T) {
 	tpt := &WebRTC{
 		conf: &Config{},


### PR DESCRIPTION
A WebRTC session could accept a signaling message while its ICE connection was disconnected. If Pion changed the connection to failed immediately afterward, the tracker exited after accepting the message and before processing it. The sender then considered the message delivered, so reconnect negotiation stopped.

Defer signal acceptance while the peer connection is disconnected. The existing ingress delivery loop retains the same message until the connection recovers or the failed tracker retires and a replacement execution can accept it.

Add a regression that pins both sides of the rule: a disconnected session does not accept the pending signal, and the same session accepts it after reconnecting.