### PR TITLE
fix(space): resolve approved cold plugin manifests

### DIFF
--- a/core/plugin/space/controller.go
+++ b/core/plugin/space/controller.go
@@ -83,6 +83,8 @@ type Controller struct {
 	bcast broadcast.Broadcast
 	// resolverBcast fires when the resolver set changes.
 	resolverBcast broadcast.Broadcast
+	// manifestSource resolves approved manifests from the parent bus.
+	manifestSource bus.Bus
 	// resolvers is the set of active FetchManifest resolvers.
 	resolvers map[*resolverEntry]struct{}
 	// pluginIDs is the current set of plugin IDs from SpaceSettings.
@@ -114,8 +116,24 @@ func (c *Controller) GetLoadedPluginIDsAndWaitCh() ([]string, <-chan struct{}) {
 	return c.loadedPlugins.GetAndWaitCh()
 }
 
+// FactoryOption configures a Space plugin controller factory.
+type FactoryOption func(*factoryConfig)
+
+type factoryConfig struct {
+	manifestSource bus.Bus
+}
+
+// WithManifestSource permits approved Space plugins to fetch manifests from source.
+func WithManifestSource(source bus.Bus) FactoryOption {
+	return func(conf *factoryConfig) { conf.manifestSource = source }
+}
+
 // NewFactory constructs the component factory.
-func NewFactory(b bus.Bus) controller.Factory {
+func NewFactory(b bus.Bus, opts ...FactoryOption) controller.Factory {
+	factoryConf := factoryConfig{}
+	for _, opt := range opts {
+		opt(&factoryConf)
+	}
 	return bus.NewBusControllerFactory(
 		b,
 		ConfigID,
@@ -128,6 +146,7 @@ func NewFactory(b bus.Bus) controller.Factory {
 		func(base *bus.BusController[*Config]) (*Controller, error) {
 			c := &Controller{
 				BusController:  base,
+				manifestSource: factoryConf.manifestSource,
 				resolvers:      make(map[*resolverEntry]struct{}),
 				processConfigs: make(map[string]processConfig),
 			}
@@ -243,6 +262,9 @@ func (c *Controller) resolveFetchManifest(
 	}
 
 	return directive.R(directive.NewFuncResolver(func(ctx context.Context, handler directive.ResolverHandler) error {
+		if source, _, _ := c.getManifestSourceApproval(mid); source != nil {
+			return c.resolveSourceFetchManifest(ctx, handler, dir)
+		}
 		entry := &resolverEntry{ctx: ctx, dir: dir, handler: handler}
 		c.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
 			c.resolvers[entry] = struct{}{}

--- a/core/plugin/space/res-fetch-manifest-source.go
+++ b/core/plugin/space/res-fetch-manifest-source.go
@@ -1,0 +1,80 @@
+package plugin_space
+
+import (
+	"context"
+	"slices"
+
+	"github.com/aperturerobotics/controllerbus/bus"
+	"github.com/aperturerobotics/controllerbus/directive"
+	manifest "github.com/s4wave/spacewave/bldr/manifest"
+)
+
+// resolveSourceFetchManifest relays an approved manifest request to the parent
+// bus. The parent directive exists only while the Space approval remains.
+func (c *Controller) resolveSourceFetchManifest(
+	ctx context.Context,
+	handler directive.ResolverHandler,
+	dir manifest.FetchManifest,
+) error {
+	for {
+		source, approved, waitCh := c.getManifestSourceApproval(dir.GetManifestId())
+		if source == nil || !approved {
+			_ = handler.ClearValues()
+			handler.MarkIdle(true)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-waitCh:
+			}
+			continue
+		}
+
+		demandCtx, cancel := context.WithCancel(ctx)
+		_, release, err := bus.ExecCollectValuesWatch[*manifest.FetchManifestValue](
+			demandCtx,
+			source,
+			dir,
+			true,
+			func(_ []error, vals []*manifest.FetchManifestValue) error {
+				if demandCtx.Err() != nil {
+					return nil
+				}
+				refs := make([]*manifest.ManifestRef, 0)
+				for _, val := range vals {
+					refs = append(refs, val.GetManifestRefs()...)
+				}
+				_ = handler.ClearValues()
+				_, _ = handler.AddValue(&manifest.FetchManifestValue{ManifestRefs: refs})
+				handler.MarkIdle(true)
+				return nil
+			},
+			nil,
+		)
+		if err != nil {
+			cancel()
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			cancel()
+			release()
+			return ctx.Err()
+		case <-waitCh:
+			cancel()
+			release()
+		}
+	}
+}
+
+// getManifestSourceApproval snapshots the parent source and SpaceSettings gate.
+func (c *Controller) getManifestSourceApproval(manifestID string) (bus.Bus, bool, <-chan struct{}) {
+	var source bus.Bus
+	var approved bool
+	var waitCh <-chan struct{}
+	c.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
+		source = c.manifestSource
+		approved = slices.Contains(c.pluginIDs, manifestID)
+		waitCh = getWaitCh()
+	})
+	return source, approved, waitCh
+}

--- a/core/plugin/space/res-fetch-manifest-source_test.go
+++ b/core/plugin/space/res-fetch-manifest-source_test.go
@@ -1,0 +1,140 @@
+package plugin_space
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aperturerobotics/controllerbus/bus"
+	"github.com/aperturerobotics/controllerbus/controller"
+	controllerbus_core "github.com/aperturerobotics/controllerbus/core"
+	"github.com/aperturerobotics/controllerbus/directive"
+	bldr_manifest "github.com/s4wave/spacewave/bldr/manifest"
+	"github.com/sirupsen/logrus"
+)
+
+const sourceManifestID = "cold-plugin"
+
+type sourceManifestController struct {
+	started  chan struct{}
+	released chan struct{}
+}
+
+func (c *sourceManifestController) GetControllerInfo() *controller.Info {
+	return controller.NewInfo("test/manifest-source", controller.MustParseVersion("0.0.1"), "serves a cold manifest")
+}
+
+func (c *sourceManifestController) Execute(ctx context.Context) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (c *sourceManifestController) Close() error { return nil }
+
+func (c *sourceManifestController) HandleDirective(
+	_ context.Context,
+	inst directive.Instance,
+) ([]directive.Resolver, error) {
+	dir, ok := inst.GetDirective().(bldr_manifest.FetchManifest)
+	if !ok || dir.GetManifestId() != sourceManifestID {
+		return nil, nil
+	}
+	return directive.R(directive.NewFuncResolver(func(ctx context.Context, handler directive.ResolverHandler) error {
+		close(c.started)
+		defer close(c.released)
+		_, _ = handler.AddValue(&bldr_manifest.FetchManifestValue{ManifestRefs: []*bldr_manifest.ManifestRef{{}}})
+		handler.MarkIdle(true)
+		<-ctx.Done()
+		return ctx.Err()
+	}), nil)
+}
+
+func TestFetchManifestSourceRequiresSpaceApproval(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	parent, _, err := controllerbus_core.NewCoreBus(ctx, logrus.NewEntry(logrus.New()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := &sourceManifestController{started: make(chan struct{}), released: make(chan struct{})}
+	parentRef, err := parent.AddController(ctx, source, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer parentRef()
+
+	child, resolver, err := controllerbus_core.NewCoreBus(ctx, logrus.NewEntry(logrus.New()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver.AddFactory(NewFactory(child, WithManifestSource(parent)))
+	ctrl, _, ctrlRef, err := StartControllerWithConfig(ctx, child, &Config{EngineId: "test-engine"}, func() {})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ctrlRef.Release()
+
+	watchCtx, watchCancel := context.WithCancel(ctx)
+	defer watchCancel()
+	values := make(chan []*bldr_manifest.ManifestRef, 2)
+	_, release, err := bus.ExecCollectValuesWatch[*bldr_manifest.FetchManifestValue](
+		watchCtx,
+		child,
+		bldr_manifest.NewFetchManifest(sourceManifestID, nil, nil, 0),
+		true,
+		func(_ []error, vals []*bldr_manifest.FetchManifestValue) error {
+			refs := make([]*bldr_manifest.ManifestRef, 0)
+			for _, val := range vals {
+				refs = append(refs, val.GetManifestRefs()...)
+			}
+			select {
+			case values <- refs:
+			default:
+			}
+			return nil
+		},
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	select {
+	case <-source.started:
+		t.Fatal("unapproved manifest fetched from parent")
+	default:
+	}
+	setSourcePluginIDs(ctrl, []string{sourceManifestID})
+	for {
+		select {
+		case refs := <-values:
+			if len(refs) == 1 {
+				goto resolved
+			}
+		case <-ctx.Done():
+			t.Fatal("approved manifest did not resolve from parent")
+		}
+	}
+
+resolved:
+	select {
+	case <-source.started:
+	case <-ctx.Done():
+		t.Fatal("approved manifest did not demand the parent source")
+	}
+
+	setSourcePluginIDs(ctrl, nil)
+	select {
+	case <-source.released:
+	case <-ctx.Done():
+		t.Fatal("removing approval did not release parent manifest demand")
+	}
+}
+
+func setSourcePluginIDs(c *Controller, ids []string) {
+	c.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		c.pluginIDs = ids
+		broadcast()
+	})
+}

--- a/core/resource/space/contents.go
+++ b/core/resource/space/contents.go
@@ -424,7 +424,7 @@ func startSpaceRuntime(
 		return nil, err
 	}
 	resolver.AddFactory(plugin_host_scheduler.NewFactory(child))
-	resolver.AddFactory(plugin_space.NewFactory(child))
+	resolver.AddFactory(plugin_space.NewFactory(child, plugin_space.WithManifestSource(parent)))
 	bridgeCtrl := bus_bridge.NewBusBridge(parent, spaceRuntimeBridgeFilter)
 	bridgeRef, err := child.AddController(childCtx, bridgeCtrl, nil)
 	if err != nil {


### PR DESCRIPTION
Allow a per-Space plugin scheduler to fetch a cold manifest from its parent source only after that plugin ID is approved in the Space settings. The generic runtime bridge continues to reject manifest fetches, so child controllers cannot read arbitrary parent manifests.

The forwarded demand remains active only while the plugin is approved. Removal or cancellation releases the parent directive. This lets newly approved plugins start in a fresh Space without pre-seeding their manifests.