### PR TITLE
fix(space): restart runtime after plugin host changes

### DIFF
--- a/core/resource/space/contents.go
+++ b/core/resource/space/contents.go
@@ -124,7 +124,10 @@ type spaceRuntimeTerminalWaiter func(
 	seq uint64,
 	runtime *spaceRuntime,
 	ctrlRef directive.Reference,
+	conf *plugin_space.Config,
 )
+
+var errSpaceRuntimePluginHostSetChanged = errors.New("daemon plugin host set changed")
 
 // SpaceContentsResource provides streaming plugin status for a mounted space.
 type SpaceContentsResource struct {
@@ -270,25 +273,28 @@ func (r *SpaceContentsResource) GetMux() srpc.Invoker {
 
 // StartController starts the plugin/space controller behind this resource.
 func (r *SpaceContentsResource) StartController(conf *plugin_space.Config) {
-	var seq uint64
-	var start *routine.RoutineContainer
+	conf = conf.CloneVT()
 	r.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
-		if r.released {
-			return
-		}
-		r.ensureStartOwnerLocked()
-		r.startSeq++
-		seq = r.startSeq
-		r.startErr = nil
-		start = r.start
-		broadcast()
+		r.startControllerLocked(conf, broadcast)
 	})
-	if start == nil {
+}
+
+// startControllerLocked reserves the next controller start while bcast is held.
+func (r *SpaceContentsResource) startControllerLocked(
+	conf *plugin_space.Config,
+	broadcast func(),
+) {
+	if r.released {
 		return
 	}
-	start.SetRoutine(func(ctx context.Context) error {
+	r.ensureStartOwnerLocked()
+	r.startSeq++
+	seq := r.startSeq
+	r.startErr = nil
+	r.start.SetRoutine(func(ctx context.Context) error {
 		return r.startControllerRoutine(ctx, seq, conf)
 	})
+	broadcast()
 }
 
 func (r *SpaceContentsResource) ensureStartOwnerLocked() {
@@ -364,7 +370,7 @@ func (r *SpaceContentsResource) startControllerRoutine(ctx context.Context, seq 
 		releaseRuntime.Release()
 	}
 	if runtime != nil && installed {
-		go r.waitRuntimeTerminal(seq, runtime, ctrlRef)
+		go r.waitRuntimeTerminal(seq, runtime, ctrlRef, conf)
 	}
 	return nil
 }
@@ -373,6 +379,7 @@ func (r *SpaceContentsResource) runRuntimeTerminalWaiter(
 	seq uint64,
 	runtime *spaceRuntime,
 	ctrlRef directive.Reference,
+	conf *plugin_space.Config,
 ) {
 	var err error
 	var ok bool
@@ -386,14 +393,19 @@ func (r *SpaceContentsResource) runRuntimeTerminalWaiter(
 	}
 	var release bool
 	r.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
-		if !r.released && r.startSeq == seq && r.runtime == runtime {
-			r.startErr = err
-			r.ctrl = nil
-			r.ctrlRef = nil
-			r.runtime = nil
-			release = true
-			broadcast()
+		if r.released || r.startSeq != seq || r.runtime != runtime {
+			return
 		}
+		r.ctrl = nil
+		r.ctrlRef = nil
+		r.runtime = nil
+		release = true
+		if errors.Is(err, errSpaceRuntimePluginHostSetChanged) {
+			r.startControllerLocked(conf.CloneVT(), broadcast)
+			return
+		}
+		r.startErr = err
+		broadcast()
 	})
 	if release {
 		ctrlRef.Release()
@@ -463,7 +475,7 @@ func startSpaceRuntime(
 				return nil
 			}
 			if !initialSnapshot.CompareAndSwap(false, true) {
-				reportTerminal(errors.New("daemon plugin host set changed"))
+				reportTerminal(errSpaceRuntimePluginHostSetChanged)
 				return nil
 			}
 			mirror.SetHosts(hosts)

--- a/core/resource/space/contents_start_test.go
+++ b/core/resource/space/contents_start_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -41,9 +42,9 @@ func TestSpaceContentsResourceReleaseStopsRuntimeWaiter(t *testing.T) {
 
 	waiterStarted := make(chan struct{})
 	waiterExited := make(chan struct{})
-	r.waitRuntimeTerminal = func(seq uint64, runtime *spaceRuntime, ctrlRef directive.Reference) {
+	r.waitRuntimeTerminal = func(seq uint64, runtime *spaceRuntime, ctrlRef directive.Reference, conf *plugin_space.Config) {
 		close(waiterStarted)
-		r.runRuntimeTerminalWaiter(seq, runtime, ctrlRef)
+		r.runRuntimeTerminalWaiter(seq, runtime, ctrlRef, conf)
 		close(waiterExited)
 	}
 
@@ -67,6 +68,130 @@ func TestSpaceContentsResourceReleaseStopsRuntimeWaiter(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("runtime terminal waiter did not stop")
 	}
+}
+
+func TestSpaceContentsResourceReleasePreventsHostRuntimeRestart(t *testing.T) {
+	r := NewSpaceContentsResource(nil, nil, nil, "space-test", "engine-test")
+	terminal := make(chan error, 1)
+	runtime := &spaceRuntime{terminal: terminal}
+	startCalls := make(chan *plugin_space.Config, 2)
+	ref := newTestSpaceContentsRef()
+	r.startRuntime = func(
+		_ context.Context,
+		parent bus.Bus,
+		_ *logrus.Entry,
+		conf *plugin_space.Config,
+	) (*spaceRuntime, error) {
+		startCalls <- conf
+		runtime.bus = parent
+		return runtime, nil
+	}
+	r.startController = func(
+		context.Context,
+		bus.Bus,
+		*plugin_space.Config,
+	) (*plugin_space.Controller, directive.Reference, error) {
+		return nil, ref, nil
+	}
+	waitTerminal := make(chan struct{})
+	waiterDone := make(chan struct{})
+	r.waitRuntimeTerminal = func(
+		seq uint64,
+		runtime *spaceRuntime,
+		ctrlRef directive.Reference,
+		conf *plugin_space.Config,
+	) {
+		<-waitTerminal
+		r.runRuntimeTerminalWaiter(seq, runtime, ctrlRef, conf)
+		close(waiterDone)
+	}
+
+	conf := &plugin_space.Config{SpaceId: "space-test"}
+	r.StartController(conf)
+	if got := <-startCalls; got == conf || got.GetSpaceId() != "space-test" {
+		t.Fatalf("startup config = %#v, want owned clone of %#v", got, conf)
+	}
+	waitSpaceContentsCtrlRef(t, r, ref)
+
+	terminal <- errSpaceRuntimePluginHostSetChanged
+	r.Release()
+	close(waitTerminal)
+	select {
+	case <-waiterDone:
+	case <-t.Context().Done():
+		t.Fatal("host-change terminal waiter did not exit after release")
+	}
+	waitSpaceContentsRefReleased(t, ref, "resource release")
+	assertSpaceContentsCtrlRef(t, r, nil)
+	select {
+	case extra := <-startCalls:
+		t.Fatalf("Release allowed replacement startup: %#v", extra)
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func TestSpaceContentsResourceHostRestartCannotSupersedeNewerStart(t *testing.T) {
+	r := NewSpaceContentsResource(nil, nil, nil, "space-test", "engine-test")
+	defer r.Release()
+
+	terminal := make(chan error, 1)
+	initialRuntime := &spaceRuntime{terminal: terminal}
+	startCalls := make(chan *plugin_space.Config, 3)
+	var startCount atomic.Int32
+	r.startRuntime = func(
+		_ context.Context,
+		parent bus.Bus,
+		_ *logrus.Entry,
+		conf *plugin_space.Config,
+	) (*spaceRuntime, error) {
+		startCalls <- conf
+		if startCount.Add(1) == 1 {
+			initialRuntime.bus = parent
+			return initialRuntime, nil
+		}
+		return &spaceRuntime{bus: parent, done: make(chan struct{}), terminal: make(chan error)}, nil
+	}
+
+	initialRef := newBlockingSpaceContentsRef()
+	hostRestartRef := newTestSpaceContentsRef()
+	newRef := newTestSpaceContentsRef()
+	var controllerCount atomic.Int32
+	r.startController = func(
+		_ context.Context,
+		_ bus.Bus,
+		conf *plugin_space.Config,
+	) (*plugin_space.Controller, directive.Reference, error) {
+		if controllerCount.Add(1) == 1 {
+			return nil, initialRef, nil
+		}
+		if conf.GetSpaceId() == "new-space" {
+			return nil, newRef, nil
+		}
+		return nil, hostRestartRef, nil
+	}
+
+	r.StartController(&plugin_space.Config{SpaceId: "old-space"})
+	if got := recvSpaceContentsStartConfig(t, startCalls, "initial start"); got.GetSpaceId() != "old-space" {
+		t.Fatalf("initial config = %q, want old-space", got.GetSpaceId())
+	}
+	waitSpaceContentsCtrlRef(t, r, initialRef)
+
+	terminal <- errSpaceRuntimePluginHostSetChanged
+	waitBlockingSpaceContentsRefReleaseStarted(t, initialRef)
+	if got := recvSpaceContentsStartConfig(t, startCalls, "host restart"); got.GetSpaceId() != "old-space" {
+		t.Fatalf("host restart config = %q, want old-space", got.GetSpaceId())
+	}
+
+	r.StartController(&plugin_space.Config{SpaceId: "new-space"})
+	if got := recvSpaceContentsStartConfig(t, startCalls, "newer start"); got.GetSpaceId() != "new-space" {
+		t.Fatalf("newer start config = %q, want new-space", got.GetSpaceId())
+	}
+	waitSpaceContentsCtrlRef(t, r, newRef)
+	waitSpaceContentsRefReleased(t, hostRestartRef, "host restart replacement")
+
+	close(initialRef.unblock)
+	waitSpaceContentsRefReleased(t, initialRef.testSpaceContentsRef, "initial controller release")
+	assertSpaceContentsCtrlRef(t, r, newRef)
 }
 
 func TestSpaceContentsResourceStartControllerReleasesReplacedController(t *testing.T) {
@@ -215,6 +340,28 @@ type testSpaceContentsRef struct {
 	released chan struct{}
 }
 
+type blockingSpaceContentsRef struct {
+	*testSpaceContentsRef
+	releaseStarted chan struct{}
+	unblock        chan struct{}
+}
+
+func newBlockingSpaceContentsRef() *blockingSpaceContentsRef {
+	return &blockingSpaceContentsRef{
+		testSpaceContentsRef: newTestSpaceContentsRef(),
+		releaseStarted:       make(chan struct{}),
+		unblock:              make(chan struct{}),
+	}
+}
+
+func (r *blockingSpaceContentsRef) Release() {
+	r.once.Do(func() {
+		close(r.releaseStarted)
+		<-r.unblock
+		close(r.released)
+	})
+}
+
 func newTestSpaceContentsRef() *testSpaceContentsRef {
 	return &testSpaceContentsRef{released: make(chan struct{})}
 }
@@ -297,6 +444,30 @@ func waitSpaceContentsRefReleased(t *testing.T, ref *testSpaceContentsRef, name 
 	case <-ref.released:
 	case <-time.After(time.Second):
 		t.Fatalf("timed out waiting for %s release", name)
+	}
+}
+
+func recvSpaceContentsStartConfig(
+	t *testing.T,
+	calls <-chan *plugin_space.Config,
+	name string,
+) *plugin_space.Config {
+	t.Helper()
+	select {
+	case conf := <-calls:
+		return conf
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %s", name)
+		return nil
+	}
+}
+
+func waitBlockingSpaceContentsRefReleaseStarted(t *testing.T, ref *blockingSpaceContentsRef) {
+	t.Helper()
+	select {
+	case <-ref.releaseStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for initial controller release")
 	}
 }
 

--- a/core/resource/space/runtime-proof_test.go
+++ b/core/resource/space/runtime-proof_test.go
@@ -3,6 +3,7 @@ package resource_space
 import (
 	"context"
 	"errors"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -13,6 +14,7 @@ import (
 	controllerbus_core "github.com/aperturerobotics/controllerbus/core"
 	"github.com/aperturerobotics/controllerbus/directive"
 	"github.com/aperturerobotics/starpc/srpc"
+	"github.com/aperturerobotics/util/broadcast"
 	bldr_manifest "github.com/s4wave/spacewave/bldr/manifest"
 	bldr_plugin "github.com/s4wave/spacewave/bldr/plugin"
 	plugin_host "github.com/s4wave/spacewave/bldr/plugin/host"
@@ -29,6 +31,8 @@ import (
 	"github.com/s4wave/spacewave/testbed"
 	"github.com/sirupsen/logrus"
 )
+
+const spaceRuntimeManifestID = "cold-plugin"
 
 func TestSpaceRuntimeBusBridgesOnlyInfrastructure(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
@@ -85,6 +89,139 @@ func TestSpaceRuntimeBusBridgesOnlyInfrastructure(t *testing.T) {
 	recorded.assertNoMore(t)
 }
 
+func TestSpaceRuntimeSchedulesApprovedPluginFromParentManifestSource(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	tb, err := testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tb.Release()
+
+	volumeRef, err := tb.Bus.AddController(ctx, &spaceRuntimeVolumeAliasController{volume: tb.Volume}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer volumeRef()
+	hostRef := addSpaceRuntimePluginHost(t, ctx, tb.Bus, "test/platform")
+	defer hostRef()
+	manifestSource := newSpaceRuntimeManifestSourceController()
+	sourceRef, err := tb.Bus.AddController(ctx, manifestSource, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sourceRef()
+
+	resource := NewSpaceContentsResource(tb.Logger, tb.Bus, tb.Engine, "space-test", tb.EngineID)
+	resource.StartController(&plugin_space.Config{
+		SpaceId:       "space-test",
+		VolumeId:      tb.EngineVolumeID,
+		ObjectStoreId: tb.EngineObjectStoreID,
+		EngineId:      tb.EngineID,
+		SessionPeerId: tb.Volume.GetPeerID().String(),
+	})
+	defer resource.Release()
+	waitSpaceRuntimeStarted(t, resource)
+
+	select {
+	case <-manifestSource.started:
+		t.Fatal("unapproved Space plugin fetched its parent manifest")
+	default:
+	}
+
+	if _, _, err := space_world_ops.SetSpaceSettings(
+		ctx,
+		tb.WorldState,
+		peer.ID(""),
+		"",
+		&space_world.SpaceSettings{PluginIds: []string{spaceRuntimeManifestID}},
+		true,
+		time.Now(),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-manifestSource.started:
+	case <-ctx.Done():
+		t.Fatal("approved Space plugin did not fetch its parent manifest")
+	}
+
+	scheduler := resource.runtime.scheduler
+	for _, status := range scheduler.GetPluginStatusCtr().GetValue().Plugins {
+		if status.GetPluginId() == spaceRuntimeManifestID &&
+			status.GetInstanceKey() == "space-test" &&
+			status.GetState() == bldr_plugin.PluginState_PluginState_REQUESTED {
+			return
+		}
+	}
+	t.Fatalf("plugin lifecycle did not reach requested: %#v", scheduler.GetPluginStatusCtr().GetValue())
+}
+
+func TestSpaceRuntimeRestartsAfterParentHostPublication(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	tb, err := testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tb.Release()
+
+	volumeRef, err := tb.Bus.AddController(ctx, &spaceRuntimeVolumeAliasController{volume: tb.Volume}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer volumeRef()
+	hosts := newSpaceRuntimeMutablePluginHostController()
+	hostsRef, err := tb.Bus.AddController(ctx, hosts, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer hostsRef()
+	manifestSource := newSpaceRuntimeManifestSourceController()
+	sourceRef, err := tb.Bus.AddController(ctx, manifestSource, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sourceRef()
+
+	resource := NewSpaceContentsResource(tb.Logger, tb.Bus, tb.Engine, "space-test", tb.EngineID)
+	resource.StartController(&plugin_space.Config{
+		SpaceId:       "space-test",
+		VolumeId:      tb.EngineVolumeID,
+		ObjectStoreId: tb.EngineObjectStoreID,
+		EngineId:      tb.EngineID,
+		SessionPeerId: tb.Volume.GetPeerID().String(),
+	})
+	defer resource.Release()
+	waitSpaceRuntimeStarted(t, resource)
+	firstRuntime := resource.runtime
+
+	host := &spaceRuntimePluginHost{platformID: "test/platform"}
+	hosts.SetHosts([]plugin_host.PluginHost{host})
+	if err := resource.bcast.Wait(ctx, func(_ func(), _ func() <-chan struct{}) (bool, error) {
+		return resource.runtime != nil && resource.runtime != firstRuntime && resource.startErr == nil, nil
+	}); err != nil {
+		t.Fatalf("Space runtime did not restart after parent host publication: %v", err)
+	}
+	if _, _, err := space_world_ops.SetSpaceSettings(
+		ctx,
+		tb.WorldState,
+		peer.ID(""),
+		"",
+		&space_world.SpaceSettings{PluginIds: []string{spaceRuntimeManifestID}},
+		true,
+		time.Now(),
+	); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-manifestSource.started:
+	case <-ctx.Done():
+		t.Fatal("restarted Space runtime did not fetch the approved parent manifest")
+	}
+}
+
 func TestSpaceContentsResourceProjectsPluginHostWatchChange(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
@@ -109,6 +246,7 @@ func TestSpaceContentsResourceProjectsPluginHostWatchChange(t *testing.T) {
 	})
 	defer resource.Release()
 	waitSpaceRuntimeStarted(t, resource)
+	firstRuntime := resource.runtime
 
 	watchCtx, watchCancel := context.WithCancel(ctx)
 	defer watchCancel()
@@ -121,15 +259,18 @@ func TestSpaceContentsResourceProjectsPluginHostWatchChange(t *testing.T) {
 
 	secondRef := addSpaceRuntimePluginHost(t, ctx, tb.Bus, "desktop/test-b")
 	defer secondRef()
+	if err := resource.bcast.Wait(ctx, func(_ func(), _ func() <-chan struct{}) (bool, error) {
+		return resource.runtime != nil && resource.runtime != firstRuntime && resource.startErr == nil, nil
+	}); err != nil {
+		t.Fatalf("Space runtime did not restart after daemon plugin host change: %v", err)
+	}
 	state := recvSpaceRuntimeWatchState(t, stream)
 	if len(state.GetPlugins()) != 1 {
 		t.Fatalf("plugins = %d, want 1", len(state.GetPlugins()))
 	}
-	plugin := state.GetPlugins()[0]
-	if plugin.GetState() != s4wave_space.SpacePluginLifecycleState_SpacePluginLifecycleState_FAILED || plugin.GetDetail() != "daemon plugin host set changed" {
-		t.Fatalf("plugin state = %#v", plugin)
+	if state.GetPlugins()[0].GetState() == s4wave_space.SpacePluginLifecycleState_SpacePluginLifecycleState_FAILED {
+		t.Fatalf("plugin state = %#v", state.GetPlugins()[0])
 	}
-	waitSpaceRuntimeReleased(t, resource)
 	watchCancel()
 	if err := <-watchErr; err != nil && err != context.Canceled {
 		t.Fatalf("WatchState: %v", err)
@@ -287,6 +428,100 @@ func recvSpaceRuntimeWatchState(t *testing.T, stream *testWatchSpaceContentsStat
 		t.Fatal("timed out waiting for terminal Space state")
 		return nil
 	}
+}
+
+type spaceRuntimeManifestSourceController struct {
+	started chan struct{}
+	once    sync.Once
+}
+
+func newSpaceRuntimeManifestSourceController() *spaceRuntimeManifestSourceController {
+	return &spaceRuntimeManifestSourceController{started: make(chan struct{})}
+}
+
+func (c *spaceRuntimeManifestSourceController) GetControllerInfo() *controller.Info {
+	return controller.NewInfo("test/space-runtime-manifest-source", controller.MustParseVersion("0.0.1"), "test manifest source")
+}
+
+func (c *spaceRuntimeManifestSourceController) Execute(ctx context.Context) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+func (c *spaceRuntimeManifestSourceController) Close() error { return nil }
+func (c *spaceRuntimeManifestSourceController) HandleDirective(_ context.Context, inst directive.Instance) ([]directive.Resolver, error) {
+	dir, ok := inst.GetDirective().(bldr_manifest.FetchManifest)
+	if !ok || dir.GetManifestId() != spaceRuntimeManifestID {
+		return nil, nil
+	}
+	return directive.R(directive.NewFuncResolver(func(ctx context.Context, handler directive.ResolverHandler) error {
+		c.once.Do(func() { close(c.started) })
+		_, _ = handler.AddValue(&bldr_manifest.FetchManifestValue{})
+		handler.MarkIdle(true)
+		<-ctx.Done()
+		return ctx.Err()
+	}), nil)
+}
+
+type spaceRuntimeVolumeAliasController struct{ volume volume.Volume }
+
+func (c *spaceRuntimeVolumeAliasController) GetControllerInfo() *controller.Info {
+	return controller.NewInfo("test/space-runtime-volume-alias", controller.MustParseVersion("0.0.1"), "test plugin host volume alias")
+}
+func (c *spaceRuntimeVolumeAliasController) Execute(context.Context) error { return nil }
+func (c *spaceRuntimeVolumeAliasController) Close() error                  { return nil }
+func (c *spaceRuntimeVolumeAliasController) HandleDirective(_ context.Context, inst directive.Instance) ([]directive.Resolver, error) {
+	dir, ok := inst.GetDirective().(volume.LookupVolume)
+	if !ok || dir.LookupVolumeID() != bldr_plugin.PluginVolumeID {
+		return nil, nil
+	}
+	return directive.R(directive.NewValueResolver([]volume.Volume{c.volume}), nil)
+}
+
+type spaceRuntimeMutablePluginHostController struct {
+	bcast broadcast.Broadcast
+	hosts []plugin_host.PluginHost
+}
+
+func newSpaceRuntimeMutablePluginHostController() *spaceRuntimeMutablePluginHostController {
+	return &spaceRuntimeMutablePluginHostController{}
+}
+
+func (c *spaceRuntimeMutablePluginHostController) GetControllerInfo() *controller.Info {
+	return controller.NewInfo("test/space-runtime-mutable-plugin-host", controller.MustParseVersion("0.0.1"), "test mutable plugin host")
+}
+func (c *spaceRuntimeMutablePluginHostController) Execute(context.Context) error { return nil }
+func (c *spaceRuntimeMutablePluginHostController) Close() error                  { return nil }
+func (c *spaceRuntimeMutablePluginHostController) HandleDirective(_ context.Context, inst directive.Instance) ([]directive.Resolver, error) {
+	if _, ok := inst.GetDirective().(plugin_host.LookupPluginHost); !ok {
+		return nil, nil
+	}
+	return directive.R(directive.NewFuncResolver(func(ctx context.Context, handler directive.ResolverHandler) error {
+		for {
+			var hosts []plugin_host.PluginHost
+			var waitCh <-chan struct{}
+			c.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
+				hosts = slices.Clone(c.hosts)
+				waitCh = getWaitCh()
+			})
+			_ = handler.ClearValues()
+			for _, host := range hosts {
+				_, _ = handler.AddValue(host)
+			}
+			handler.MarkIdle(true)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-waitCh:
+			}
+		}
+	}), nil)
+}
+
+func (c *spaceRuntimeMutablePluginHostController) SetHosts(hosts []plugin_host.PluginHost) {
+	c.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		c.hosts = slices.Clone(hosts)
+		broadcast()
+	})
 }
 
 type spaceRuntimePluginHostController struct{ host plugin_host.PluginHost }


### PR DESCRIPTION
A Space runtime can start from an empty parent plugin-host snapshot during daemon startup. When the host is published later, the runtime treats that topology change as terminal. The old waiter removed the runtime but did not replace it, so subsequently approved plugins never requested their manifests and quickstart remained at 88%.

Reserve a replacement through the existing `StartController` lifecycle only for this host-set transition. Clone configuration at the asynchronous boundary and fence the replacement with the current sequence, so shutdown and newer explicit starts cannot be superseded by a stale waiter. Other terminal failures remain visible.

The joined regression starts with no parent host, publishes one, requires a distinct replacement runtime, approves a cold plugin, and observes its parent manifest request. Additional lifecycle tests cover dynamic approval, shutdown, retained references, and a newer explicit start while old cleanup is blocked.
