### PR TITLE
test(cdn): observe replacement RPC service path

### DIFF
--- a/core/cdn/world/controller/cache_test.go
+++ b/core/cdn/world/controller/cache_test.go
@@ -557,7 +557,7 @@ func TestReleaseWorldSharesTransportAndDurableCacheAcrossRpcBridge(t *testing.T)
 	serviceAdded := make(chan srpc.Invoker, 4)
 	serviceRemoved := make(chan srpc.Invoker, 4)
 	_, serviceRef, err := host.Bus.AddDirective(
-		bifrost_rpc.NewLookupRpcService(serviceID, "test-held-demand"),
+		bifrost_rpc.NewLookupRpcService(serviceID, ""),
 		directive.NewCallbackHandler(
 			func(v directive.AttachedValue) { serviceAdded <- v.GetValue().(srpc.Invoker) },
 			func(v directive.AttachedValue) { serviceRemoved <- v.GetValue().(srpc.Invoker) },


### PR DESCRIPTION
The replacement test observed a qualified RPC service demand while the retained plugin client resolves the unqualified service path on every call. Those are different controllerbus directive instances, so seeing the replacement on the observer did not prove it was visible to the client. The client could still reach the withdrawn store and report `packfile store: closed` or `unimplemented`.

Observe the exact unqualified service path used by the running bridge. The existing add/remove events then fence replacement publication on the same directive instance as the retained client.
