### PR TITLE
fix(space): preserve attached routes across runtime restart

### DIFF
--- a/core/resource/space/attached-rpc-service_test.go
+++ b/core/resource/space/attached-rpc-service_test.go
@@ -22,6 +22,8 @@ type attachedRpcServiceStream struct {
 	ctx context.Context
 	// ready records the first readiness response.
 	ready chan *s4wave_space.BindAttachedRpcServiceResponse
+	// checkReady verifies the route before recording readiness.
+	checkReady func() error
 }
 
 // newAttachedRpcServiceStream creates a bind stream with one readiness slot.
@@ -36,6 +38,11 @@ func (s *attachedRpcServiceStream) Context() context.Context {
 
 // Send records that the attached RPC service is callable.
 func (s *attachedRpcServiceStream) Send(resp *s4wave_space.BindAttachedRpcServiceResponse) error {
+	if s.checkReady != nil {
+		if err := s.checkReady(); err != nil {
+			return err
+		}
+	}
 	s.ready <- resp
 	return nil
 }

--- a/core/resource/space/contents.go
+++ b/core/resource/space/contents.go
@@ -90,10 +90,13 @@ func (r *spaceRuntime) Release() {
 }
 
 type attachedRpcServiceBinding struct {
-	// runtime retains the Space runtime that serves this binding.
+	// client supplies calls to the caller-attached Resource.
+	client *srpc.ClientInvoker
+	// prefix is the private Space service ID prefix.
+	prefix string
+	// runtime is the Space runtime where the current controller is installed.
+	// Guarded by SpaceContentsResource.bcast.
 	runtime *spaceRuntime
-	// controller routes the attached resource through the Space runtime.
-	controller *attachedRpcServiceController
 }
 
 // attachedRpcServiceController signals when its RPC service can resolve calls.
@@ -178,6 +181,8 @@ type SpaceContentsResource struct {
 	startRuntime    spaceRuntimeStarter
 	// waitRuntimeTerminal runs the current runtime's terminal lifecycle waiter.
 	waitRuntimeTerminal spaceRuntimeTerminalWaiter
+	// afterAttachedRpcServiceReady blocks the bind continuation in focused lifecycle tests.
+	afterAttachedRpcServiceReady func()
 }
 
 // NewSpaceContentsResource creates a new SpaceContentsResource.
@@ -571,7 +576,8 @@ func startSpaceContentsController(
 }
 
 // BindAttachedRpcService publishes a caller-attached Resource under one private
-// service ID prefix until the caller disconnects or this Space runtime ends.
+// service ID prefix for the caller attachment lifetime. It reinstalls the route
+// when the isolated Space runtime is replaced.
 func (r *SpaceContentsResource) BindAttachedRpcService(
 	req *s4wave_space.BindAttachedRpcServiceRequest,
 	strm s4wave_space.SRPCSpaceContentsResourceService_BindAttachedRpcServiceStream,
@@ -602,69 +608,25 @@ func (r *SpaceContentsResource) BindAttachedRpcService(
 		return err
 	}
 
-	ctrl := &attachedRpcServiceController{
-		RpcServiceController: bifrost_rpc.NewRpcServiceController(
-			controller.NewInfo(
-				"core/resource/space/attached-rpc-service/"+prefix,
-				controller.MustParseVersion("0.0.1"),
-				"attached RPC service route",
-			),
-			bifrost_rpc.NewRpcServiceBuilder(srpc.NewClientInvoker(client)),
-			[]string{prefix},
-			true,
-			nil,
-			nil,
-			nil,
-		),
-		ready: make(chan struct{}),
-	}
-	binding := &attachedRpcServiceBinding{controller: ctrl}
-
+	binding := &attachedRpcServiceBinding{client: srpc.NewClientInvoker(client), prefix: prefix}
 	r.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
-		if r.runtime == nil {
-			err = errors.New("space runtime is not running")
+		if r.released {
+			err = errors.New("space contents resource is released")
 			return
 		}
 		if r.attachedRpcServices == nil {
 			r.attachedRpcServices = make(map[string]*attachedRpcServiceBinding)
 		}
-		if existing := r.attachedRpcServices[prefix]; existing != nil {
-			select {
-			case <-existing.runtime.done:
-				delete(r.attachedRpcServices, prefix)
-			default:
-				err = fmt.Errorf("service ID prefix %q is already bound", prefix)
-				return
-			}
+		if r.attachedRpcServices[prefix] != nil {
+			err = fmt.Errorf("service ID prefix %q is already bound", prefix)
+			return
 		}
-		binding.runtime = r.runtime
 		r.attachedRpcServices[prefix] = binding
 	})
 	if err != nil {
 		return err
 	}
-
-	// Check the installed binding lifetime before ControllerBus starts its route.
-	if err := attachedRpcServiceLifetimeError(strm.Context(), resourceCtx.Context(), clientDone, binding.runtime.done); err != nil {
-		r.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
-			if r.attachedRpcServices[prefix] == binding {
-				delete(r.attachedRpcServices, prefix)
-			}
-		})
-		return err
-	}
-
-	release, err := binding.runtime.bus.AddController(strm.Context(), binding.controller, nil)
-	if err != nil {
-		r.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
-			if r.attachedRpcServices[prefix] == binding {
-				delete(r.attachedRpcServices, prefix)
-			}
-		})
-		return err
-	}
 	defer func() {
-		release()
 		r.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
 			if r.attachedRpcServices[prefix] == binding {
 				delete(r.attachedRpcServices, prefix)
@@ -672,34 +634,148 @@ func (r *SpaceContentsResource) BindAttachedRpcService(
 		})
 	}()
 
-	select {
-	case <-binding.controller.ready:
-	case <-strm.Context().Done():
-		return strm.Context().Err()
-	case <-resourceCtx.Context().Done():
-		return resourceCtx.Context().Err()
-	case <-clientDone:
-		return errors.New("attached resource ended before attached service was ready")
-	case <-binding.runtime.done:
-		return errors.New("space runtime ended before attached service was ready")
-	}
+	var installed *spaceRuntime
+	var release func()
+	defer func() {
+		if release != nil {
+			release()
+		}
+	}()
+	ready := false
+	for {
+		var runtime *spaceRuntime
+		var startErr error
+		var released bool
+		var waitCh <-chan struct{}
+		r.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
+			runtime = r.runtime
+			startErr = r.startErr
+			released = r.released
+			waitCh = getWaitCh()
+		})
+		if released {
+			return errors.New("space contents resource is released")
+		}
+		if startErr != nil {
+			return startErr
+		}
+		if runtime == nil {
+			select {
+			case <-strm.Context().Done():
+				return strm.Context().Err()
+			case <-resourceCtx.Context().Done():
+				return resourceCtx.Context().Err()
+			case <-clientDone:
+				return nil
+			case <-waitCh:
+				continue
+			}
+		}
+		if runtime == installed {
+			select {
+			case <-strm.Context().Done():
+				return strm.Context().Err()
+			case <-resourceCtx.Context().Done():
+				return resourceCtx.Context().Err()
+			case <-clientDone:
+				return nil
+			case <-runtime.done:
+				installed = nil
+				if release != nil {
+					release()
+					release = nil
+				}
+				continue
+			}
+		}
 
-	// Give an already-ended lifetime priority over the ready notification.
-	if err := attachedRpcServiceLifetimeError(strm.Context(), resourceCtx.Context(), clientDone, binding.runtime.done); err != nil {
-		return err
+		// Stop the previous generation before installing the route on its replacement.
+		if release != nil {
+			release()
+			release = nil
+		}
+		ctrl := newAttachedRpcServiceController(binding)
+		if err := attachedRpcServiceLifetimeError(strm.Context(), resourceCtx.Context(), clientDone, runtime.done); err != nil {
+			return err
+		}
+		release, err = runtime.bus.AddController(strm.Context(), ctrl, nil)
+		if err != nil {
+			select {
+			case <-runtime.done:
+				continue
+			default:
+			}
+			return err
+		}
+		installed = runtime
+
+		// Wait until the route can answer before the first readiness response.
+		select {
+		case <-ctrl.ready:
+		case <-strm.Context().Done():
+			return strm.Context().Err()
+		case <-resourceCtx.Context().Done():
+			return resourceCtx.Context().Err()
+		case <-clientDone:
+			return errors.New("attached resource ended before attached service was ready")
+		case <-runtime.done:
+			installed = nil
+			release()
+			release = nil
+			continue
+		}
+		// Let focused lifecycle tests replace the Space runtime after its route is ready.
+		if r.afterAttachedRpcServiceReady != nil {
+			r.afterAttachedRpcServiceReady()
+		}
+
+		// Publish this route only while its runtime remains the current generation.
+		current := false
+		r.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+			current = r.attachedRpcServices[prefix] == binding &&
+				!r.released &&
+				r.startErr == nil &&
+				r.runtime == runtime
+			if current {
+				binding.runtime = runtime
+			}
+		})
+		if !current {
+			installed = nil
+			release()
+			release = nil
+			continue
+		}
+		if !ready {
+			// Check the caller lifetimes again before reporting the first route.
+			if err := attachedRpcServiceLifetimeError(strm.Context(), resourceCtx.Context(), clientDone, nil); err != nil {
+				return err
+			}
+			if err := strm.Send(&s4wave_space.BindAttachedRpcServiceResponse{}); err != nil {
+				return err
+			}
+			ready = true
+		}
 	}
-	if err := strm.Send(&s4wave_space.BindAttachedRpcServiceResponse{}); err != nil {
-		return err
-	}
-	select {
-	case <-strm.Context().Done():
-		return strm.Context().Err()
-	case <-resourceCtx.Context().Done():
-		return resourceCtx.Context().Err()
-	case <-clientDone:
-		return nil
-	case <-binding.runtime.done:
-		return nil
+}
+
+// newAttachedRpcServiceController builds one route for one Space runtime generation.
+func newAttachedRpcServiceController(binding *attachedRpcServiceBinding) *attachedRpcServiceController {
+	return &attachedRpcServiceController{
+		RpcServiceController: bifrost_rpc.NewRpcServiceController(
+			controller.NewInfo(
+				"core/resource/space/attached-rpc-service/"+binding.prefix,
+				controller.MustParseVersion("0.0.1"),
+				"attached RPC service route",
+			),
+			bifrost_rpc.NewRpcServiceBuilder(binding.client),
+			[]string{binding.prefix},
+			true,
+			nil,
+			nil,
+			nil,
+		),
+		ready: make(chan struct{}),
 	}
 }
 

--- a/core/resource/space/runtime-proof_test.go
+++ b/core/resource/space/runtime-proof_test.go
@@ -14,6 +14,7 @@ import (
 	controller_exec "github.com/aperturerobotics/controllerbus/controller/exec"
 	controllerbus_core "github.com/aperturerobotics/controllerbus/core"
 	"github.com/aperturerobotics/controllerbus/directive"
+	"github.com/aperturerobotics/starpc/echo"
 	"github.com/aperturerobotics/starpc/srpc"
 	"github.com/aperturerobotics/util/broadcast"
 	bldr_manifest "github.com/s4wave/spacewave/bldr/manifest"
@@ -21,6 +22,7 @@ import (
 	plugin_entrypoint_controller "github.com/s4wave/spacewave/bldr/plugin/entrypoint/controller"
 	plugin_host "github.com/s4wave/spacewave/bldr/plugin/host"
 	plugin_host_root "github.com/s4wave/spacewave/bldr/plugin/host/root"
+	resource_server "github.com/s4wave/spacewave/bldr/resource/server"
 	plugin_space "github.com/s4wave/spacewave/core/plugin/space"
 	space_world "github.com/s4wave/spacewave/core/space/world"
 	space_world_ops "github.com/s4wave/spacewave/core/space/world/ops"
@@ -324,6 +326,180 @@ func TestSpaceRuntimeRestartsAfterParentHostPublication(t *testing.T) {
 	case <-ctx.Done():
 		t.Fatal("restarted Space runtime did not fetch the approved parent manifest")
 	}
+}
+
+func TestBindAttachedRpcServiceRebindsAfterSpaceRuntimeReplacement(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	tb, err := testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tb.Release()
+
+	volumeRef, err := tb.Bus.AddController(ctx, &spaceRuntimeVolumeAliasController{volume: tb.Volume}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer volumeRef()
+	hosts := newSpaceRuntimeMutablePluginHostController()
+	hostsRef, err := tb.Bus.AddController(ctx, hosts, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer hostsRef()
+	manifestSource := newSpaceRuntimeManifestSourceController()
+	sourceRef, err := tb.Bus.AddController(ctx, manifestSource, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sourceRef()
+
+	resource := NewSpaceContentsResource(tb.Logger, tb.Bus, tb.Engine, "space-test", tb.EngineID)
+	resource.StartController(&plugin_space.Config{
+		SpaceId:       "space-test",
+		VolumeId:      tb.EngineVolumeID,
+		ObjectStoreId: tb.EngineObjectStoreID,
+		EngineId:      tb.EngineID,
+		SessionPeerId: tb.Volume.GetPeerID().String(),
+	})
+	defer resource.Release()
+	waitSpaceRuntimeStarted(t, resource)
+	firstRuntime := resource.runtime
+
+	// Pause after the old route becomes callable, before it can publish readiness.
+	readyEntered := make(chan struct{})
+	continueBind := make(chan struct{})
+	var readyOnce sync.Once
+	resource.afterAttachedRpcServiceReady = func() {
+		readyOnce.Do(func() {
+			close(readyEntered)
+			<-continueBind
+		})
+	}
+
+	attachedResources := newSpaceRecordingResourceClient(ctx)
+	attachedMux := srpc.NewMux()
+	if err := attachedMux.Register(echo.NewSRPCEchoerHandler(echo.NewEchoServer(nil), echo.SRPCEchoerServiceID)); err != nil {
+		t.Fatal(err)
+	}
+	attachedID, err := attachedResources.AddResource(attachedMux, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bindCtx := resource_server.WithResourceClientContext(ctx, attachedResources)
+	stream := newAttachedRpcServiceStream(bindCtx)
+	stream.checkReady = func() error {
+		return invokeAttachedEcho(ctx, resource, "first response")
+	}
+	bindDone := make(chan error, 1)
+	go func() {
+		bindDone <- resource.BindAttachedRpcService(&s4wave_space.BindAttachedRpcServiceRequest{
+			AttachedResourceId: attachedID,
+			ServiceIdPrefix:    "attached/",
+		}, stream)
+	}()
+	select {
+	case <-readyEntered:
+	case <-ctx.Done():
+		t.Fatal("attached route did not become callable")
+	}
+	if err := invokeAttachedEcho(ctx, resource, "before replacement"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Replace the isolated runtime while the old bind continuation is paused.
+	hosts.SetHosts([]plugin_host.PluginHost{&spaceRuntimePluginHost{platformID: "test/platform"}})
+	if err := resource.bcast.Wait(ctx, func(_ func(), _ func() <-chan struct{}) (bool, error) {
+		return resource.runtime != nil && resource.runtime != firstRuntime && resource.startErr == nil, nil
+	}); err != nil {
+		t.Fatalf("Space runtime did not restart: %v", err)
+	}
+	select {
+	case <-stream.ready:
+		t.Fatal("old runtime reported readiness after replacement")
+	default:
+	}
+
+	close(continueBind)
+	select {
+	case <-stream.ready:
+	case <-ctx.Done():
+		t.Fatal("replacement attached route did not become ready")
+	}
+	if err := invokeAttachedEcho(ctx, resource, "after replacement"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-bindDone:
+		t.Fatalf("bind stream ended after runtime replacement: %v", err)
+	default:
+	}
+
+	if !attachedResources.ReleaseResource(attachedID) {
+		t.Fatal("attached resource release failed")
+	}
+	if err := <-bindDone; err != nil {
+		t.Fatalf("bind returned %v after attached resource release", err)
+	}
+	if err := assertAttachedEchoAbsent(ctx, resource); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// invokeAttachedEcho calls the current Space runtime through its attached route.
+func invokeAttachedEcho(ctx context.Context, resource *SpaceContentsResource, body string) error {
+	runtime, err := currentSpaceRuntime(resource)
+	if err != nil {
+		return err
+	}
+	serviceID := "attached/" + echo.SRPCEchoerServiceID
+	invoker := bifrost_rpc.NewInvoker(runtime.bus, "", false)
+	client := srpc.NewClient(srpc.NewServerPipe(srpc.NewServer(invoker)))
+	response, err := echo.NewSRPCEchoerClientWithServiceID(client, serviceID).Echo(ctx, &echo.EchoMsg{Body: body})
+	if err != nil {
+		return err
+	}
+	if response.GetBody() != body {
+		return errors.New("attached echo response body differs")
+	}
+	return nil
+}
+
+func assertAttachedEchoAbsent(ctx context.Context, resource *SpaceContentsResource) error {
+	runtime, err := currentSpaceRuntime(resource)
+	if err != nil {
+		return err
+	}
+	values, _, valuesRef, err := bifrost_rpc.ExLookupRpcService(
+		ctx,
+		runtime.bus,
+		"attached/"+echo.SRPCEchoerServiceID,
+		"",
+		false,
+		nil,
+	)
+	if valuesRef != nil {
+		valuesRef.Release()
+	}
+	if err != nil {
+		return err
+	}
+	if len(values) != 0 {
+		return errors.New("released attachment remained callable")
+	}
+	return nil
+}
+
+func currentSpaceRuntime(resource *SpaceContentsResource) (*spaceRuntime, error) {
+	var runtime *spaceRuntime
+	resource.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		runtime = resource.runtime
+	})
+	if runtime == nil {
+		return nil, errors.New("Space runtime is not running")
+	}
+	return runtime, nil
 }
 
 func TestSpaceContentsResourceProjectsPluginHostWatchChange(t *testing.T) {


### PR DESCRIPTION
Caller-attached RPC services were scoped to one internal Space runtime generation. Replacing that runtime for a PluginHost topology change ended the bind stream, removed the route, and left callers that had already observed readiness without a service.

Retain each binding for its caller attachment and SpaceContents lifetime. Install a fresh prefix controller on every runtime generation, reserve the prefix across migration, and keep the original stream open. Initial readiness is sent only when the callable controller still belongs to the current runtime. Stream, attachment, resource, and fatal startup cancellation remove the current controller and binding exactly once.

The joined regression binds a real attached echo resource, forces a real host-triggered Space runtime replacement in the stale-readiness window, and proves the same binding becomes callable on the replacement without ending its stream. Attachment release then removes the route.