### PR TITLE
fix(app): describe pending session connection

### DIFF
--- a/app/AppSession.test.tsx
+++ b/app/AppSession.test.tsx
@@ -62,6 +62,22 @@ describe('AppSession', () => {
     vi.clearAllMocks()
   })
 
+  it('describes a pending session attachment as connecting', () => {
+    mockUseParams.mockReturnValue({ sessionIndex: '1' })
+    mockUseRootResource.mockReturnValue({ value: null })
+    mockUseSessionMetadata.mockReturnValue(null)
+    mockUseResource.mockReturnValue({
+      value: null,
+      loading: true,
+      error: null,
+      retry: vi.fn(),
+    })
+
+    render(<AppSession />)
+
+    expect(screen.getByText('Connecting to the session.')).toBeTruthy()
+  })
+
   it('renders the pre-mount PIN unlock overlay for locked sessions', () => {
     mockUseParams.mockReturnValue({ sessionIndex: '1' })
     mockUseRootResource.mockReturnValue({ value: null })

--- a/app/AppSession.tsx
+++ b/app/AppSession.tsx
@@ -175,7 +175,7 @@ export function AppSession() {
             view={{
               state: 'loading',
               title: 'Loading session',
-              detail: 'Mounting the session and its resources.',
+              detail: 'Connecting to the session.',
             }}
           />
         </div>


### PR DESCRIPTION
Describe the pending mount state in user terms. The page now says “Connecting to the session.” while the session resource is still loading, with component coverage for that state.