### PR TITLE
fix(webrtc): retire data channels before send

### DIFF
--- a/bldr/web/runtime/wasm/webrtc-bridge.browser.test.ts
+++ b/bldr/web/runtime/wasm/webrtc-bridge.browser.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { DataChannelWrapper } from './webrtc-bridge.js'
+
+function waitForIceGatheringComplete(peer: RTCPeerConnection): Promise<void> {
+  if (peer.iceGatheringState === 'complete') return Promise.resolve()
+  return new Promise((resolve) => {
+    peer.onicegatheringstatechange = () => {
+      if (peer.iceGatheringState === 'complete') resolve()
+    }
+  })
+}
+
+describe('DataChannelWrapper browser lifecycle', () => {
+  it('does not send after a remote data channel closes', async () => {
+    const local = new RTCPeerConnection()
+    const remote = new RTCPeerConnection()
+    let localChannel: RTCDataChannel | undefined
+    let remoteChannel: RTCDataChannel | undefined
+
+    try {
+      const remoteChannelReady = new Promise<RTCDataChannel>((resolve) => {
+        remote.ondatachannel = (event) => {
+          resolve(event.channel)
+        }
+      })
+      localChannel = local.createDataChannel('teardown')
+      const localOpen = new Promise<void>((resolve) => {
+        localChannel!.onopen = () => resolve()
+      })
+
+      const localCandidates: RTCIceCandidateInit[] = []
+      const remoteCandidates: RTCIceCandidateInit[] = []
+      local.onicecandidate = ({ candidate }) => {
+        if (candidate) localCandidates.push(candidate.toJSON())
+      }
+      remote.onicecandidate = ({ candidate }) => {
+        if (candidate) remoteCandidates.push(candidate.toJSON())
+      }
+
+      const offer = await local.createOffer()
+      await local.setLocalDescription(offer)
+      await waitForIceGatheringComplete(local)
+      await remote.setRemoteDescription(offer)
+      await Promise.all(
+        localCandidates.map((candidate) => remote.addIceCandidate(candidate)),
+      )
+      const answer = await remote.createAnswer()
+      await remote.setLocalDescription(answer)
+      await waitForIceGatheringComplete(remote)
+      await local.setRemoteDescription(answer)
+      await Promise.all(
+        remoteCandidates.map((candidate) => local.addIceCandidate(candidate)),
+      )
+
+      remoteChannel = await remoteChannelReady
+      await localOpen
+
+      const wrapper = new DataChannelWrapper(localChannel.label)
+      wrapper.attach(localChannel)
+      const nativeSend = vi.spyOn(localChannel, 'send')
+      const closed = new Promise<void>((resolve) => {
+        wrapper.onclose = () => resolve()
+      })
+
+      remoteChannel.close()
+      await closed
+
+      expect(() => wrapper.send('after-close')).toThrow(
+        expect.objectContaining({ name: 'InvalidStateError' }),
+      )
+      expect(nativeSend).not.toHaveBeenCalled()
+    } finally {
+      localChannel?.close()
+      remoteChannel?.close()
+      local.close()
+      remote.close()
+    }
+  }, 10_000)
+})

--- a/bldr/web/runtime/wasm/webrtc-bridge.test.ts
+++ b/bldr/web/runtime/wasm/webrtc-bridge.test.ts
@@ -140,7 +140,7 @@ describe('DataChannelWrapper transferred channel bridge', () => {
     expect(realChannel.bufferedAmountLowThreshold).toBe(11)
     expect(realChannel.onopen).toBe(onopen)
     expect(realChannel.onmessage).toBe(onmessage)
-    expect(realChannel.onclose).toBe(onclose)
+    expect(realChannel.onclose).toBeTypeOf('function')
     expect(realChannel.onbufferedamountlow).toBe(onbufferedamountlow)
     expect(realChannel.onerror).toBeTypeOf('function')
 
@@ -161,7 +161,80 @@ describe('DataChannelWrapper transferred channel bridge', () => {
     const message = new MessageEvent('message', { data: new Uint8Array([1]) })
     realChannel.onmessage?.call(asRTCDataChannel(realChannel), message)
     expect(nextMessageHandler).toHaveBeenCalledWith(message)
+
+    const close = new Event('close')
+    realChannel.onclose?.call(asRTCDataChannel(realChannel), close)
+    expect(onclose).toHaveBeenCalledWith(close)
+    expect(wrapper.readyState).toBe('closed')
   })
+
+  it('does not send through a transferred channel after close starts', () => {
+    const wrapper = new DataChannelWrapper('quic')
+    const realChannel = new FakeRTCDataChannel('open')
+    wrapper.attach(asRTCDataChannel(realChannel))
+
+    wrapper.close()
+
+    expect(realChannel.closed).toBe(true)
+    expect(() => wrapper.send('after-close')).toThrow(
+      expect.objectContaining({ name: 'InvalidStateError' }),
+    )
+    expect(realChannel.sent).toEqual([])
+  })
+
+  it('does not send when the transferred channel starts closing', () => {
+    const wrapper = new DataChannelWrapper('quic')
+    const realChannel = new FakeRTCDataChannel('closing')
+    wrapper.attach(asRTCDataChannel(realChannel))
+
+    expect(() => wrapper.send('after-closing')).toThrow(
+      expect.objectContaining({ name: 'InvalidStateError' }),
+    )
+    expect(realChannel.sent).toEqual([])
+    expect(wrapper.readyState).toBe('closing')
+  })
+
+  it('waits for native close after local close and bridge death', () => {
+    const wrapper = new DataChannelWrapper('quic')
+    const realChannel = new FakeRTCDataChannel('open')
+    const events: string[] = []
+    wrapper.onerror = (event) => events.push(event.type)
+    wrapper.onclose = (event) => events.push(event.type)
+    wrapper.attach(asRTCDataChannel(realChannel))
+
+    wrapper.close()
+    wrapper.bridgeDied()
+
+    expect(events).toEqual([])
+    realChannel.onclose?.call(
+      asRTCDataChannel(realChannel),
+      new Event('close'),
+    )
+    realChannel.onclose?.call(
+      asRTCDataChannel(realChannel),
+      new Event('close'),
+    )
+    wrapper.bridgeDied()
+    expect(events).toEqual(['close'])
+  })
+
+  it.each(['closing', 'closed'] as const)(
+    'does not replay queued data into an already %s transferred channel',
+    (readyState) => {
+      const wrapper = new DataChannelWrapper('quic')
+      const realChannel = new FakeRTCDataChannel(readyState)
+      wrapper.send('queued')
+
+      wrapper.attach(asRTCDataChannel(realChannel))
+
+      expect(realChannel.sent).toEqual([])
+      expect(wrapper.bufferedAmount).toBe(0)
+      expect(wrapper.readyState).toBe(readyState)
+      expect(() => wrapper.send('after-attach')).toThrow(
+        expect.objectContaining({ name: 'InvalidStateError' }),
+      )
+    },
+  )
 
   it('closes a pending wrapper on bridge death, clears queued bytes, and fires error before close', () => {
     const wrapper = new DataChannelWrapper('quic')
@@ -178,7 +251,9 @@ describe('DataChannelWrapper transferred channel bridge', () => {
     expect(wrapper.bufferedAmount).toBe(0)
     expect(events).toEqual(['error', 'close'])
 
-    wrapper.send('after-death')
+    expect(() => wrapper.send('after-death')).toThrow(
+      expect.objectContaining({ name: 'InvalidStateError' }),
+    )
     expect(wrapper.bufferedAmount).toBe(0)
 
     const lateChannel = new FakeRTCDataChannel()
@@ -253,7 +328,9 @@ describe('ProxyRTCPeerConnection supporting WebRTC objects', () => {
     expect(channel.bufferedAmount).toBe(0)
     expect(events).toEqual(['error', 'close'])
 
-    channel.send('after-death')
+    expect(() => channel.send('after-death')).toThrow(
+      expect.objectContaining({ name: 'InvalidStateError' }),
+    )
     expect(channel.bufferedAmount).toBe(0)
   })
 })

--- a/bldr/web/runtime/wasm/webrtc-bridge.ts
+++ b/bldr/web/runtime/wasm/webrtc-bridge.ts
@@ -92,6 +92,7 @@ export class DataChannelWrapper {
   private _bufferedAmount = 0
   private _bufferedAmountLowThreshold = 0
   private _closed = false
+  private _closeEmitted = false
   private _realDC: RTCDataChannel | null = null
 
   // Queued sends before the real DC arrives
@@ -121,11 +122,11 @@ export class DataChannelWrapper {
     if (this._realDC) this._realDC.onmessage = v
   }
   get onclose() {
-    return this._realDC ? this._realDC.onclose : this._onclose
+    return this._onclose
   }
   set onclose(v: ((ev: Event) => void) | null) {
     this._onclose = v
-    if (this._realDC) this._realDC.onclose = v
+    if (this._realDC) this.forwardClose(this._realDC)
   }
   get onerror(): ((ev: Event) => void) | null {
     return this._onerror
@@ -190,11 +191,17 @@ export class DataChannelWrapper {
   }
 
   send(data: string | ArrayBuffer | ArrayBufferView): void {
-    if (this._realDC) {
-      sendRtcDataChannelPayload(this._realDC, data)
-      return
+    const dc = this._realDC
+    if (dc) {
+      if (dc.readyState !== 'closing' && dc.readyState !== 'closed') {
+        sendRtcDataChannelPayload(dc, data)
+        return
+      }
+      this.retire()
     }
-    if (this._closed) return
+    if (this._closed) {
+      throw new DOMException('RTCDataChannel is closed', 'InvalidStateError')
+    }
     this.sendQueue.push(data)
     // Track buffered amount for pre-attach reads
     if (typeof data === 'string') {
@@ -207,14 +214,29 @@ export class DataChannelWrapper {
   }
 
   close(): void {
-    if (this._realDC) {
-      this._realDC.close()
-      return
-    }
+    const dc = this._realDC
+    this.retire()
+    dc?.close()
+  }
+
+  private retire() {
     this._closed = true
     this._readyState = 'closed'
     this.sendQueue.length = 0
     this._bufferedAmount = 0
+  }
+
+  private finishClose(dc: RTCDataChannel, event: Event) {
+    if (this._realDC !== dc) return
+    this.retire()
+    this._realDC = null
+    if (this._closeEmitted) return
+    this._closeEmitted = true
+    this._onclose?.(event)
+  }
+
+  private forwardClose(dc: RTCDataChannel) {
+    dc.onclose = (event) => this.finishClose(dc, event)
   }
 
   // attach swaps in the real transferred DC. Called by ProxyRTCPeerConnection
@@ -233,10 +255,16 @@ export class DataChannelWrapper {
     // Re-attach stored event handlers to the real DC
     if (this._onopen) dc.onopen = this._onopen
     if (this._onmessage) dc.onmessage = this._onmessage
-    if (this._onclose) dc.onclose = this._onclose
+    this.forwardClose(dc)
     if (this._onerror) dc.onerror = (event) => this._onerror?.(event)
     if (this._onbufferedamountlow)
       dc.onbufferedamountlow = this._onbufferedamountlow
+
+    if (dc.readyState === 'closing' || dc.readyState === 'closed') {
+      this.retire()
+      if (dc.readyState === 'closed') this.finishClose(dc, new Event('close'))
+      return
+    }
 
     // Replay queued sends
     for (const data of this.sendQueue) {
@@ -253,19 +281,17 @@ export class DataChannelWrapper {
 
   // bridgeDied is called when the bridge port closes before the DC arrives.
   bridgeDied(reason = 'WebRTC bridge closed') {
-    if (this._realDC) return
-    this._closed = true
-    this._readyState = 'closed'
-    this.sendQueue.length = 0
-    this._bufferedAmount = 0
+    if (this._realDC || this._closed) return
+    this.retire()
     if (this._onerror) {
       this._onerror({
         type: 'error',
         error: new Error(reason),
       } as unknown as Event)
     }
-    if (this._onclose) {
-      this._onclose(new Event('close'))
+    if (!this._closeEmitted) {
+      this._closeEmitted = true
+      this._onclose?.(new Event('close'))
     }
   }
 }


### PR DESCRIPTION
Retire browser data-channel sends as soon as closing starts while retaining the native channel until its one terminal close event. Closing or already closed transferred channels no longer replay queued payloads. Unit coverage pins local and remote close ordering, and a real Chromium peer test exercises remote teardown.