### PR TITLE
feat(forge): add runtime admission with atomic capacity reservation

### DIFF
--- a/forge/lib/git/allocation/allocation.go
+++ b/forge/lib/git/allocation/allocation.go
@@ -13,6 +13,7 @@ import (
 	"github.com/s4wave/spacewave/db/block"
 	"github.com/s4wave/spacewave/db/bucket"
 	"github.com/s4wave/spacewave/db/world"
+	forge_runtime "github.com/s4wave/spacewave/forge/runtime"
 )
 
 const (
@@ -43,6 +44,8 @@ type Allocation struct {
 	RepoObjectKey string `json:"repoObjectKey,omitempty"`
 	// WorktreeObjectKey is the allocated Git Worktree object key.
 	WorktreeObjectKey string `json:"worktreeObjectKey,omitempty"`
+	// WorkdirObjectKey is the mutable Workdir UnixFS object linked to the Worktree.
+	WorkdirObjectKey string `json:"workdirObjectKey,omitempty"`
 	// BaseCommitHash is the pinned base commit used for branch allocation.
 	BaseCommitHash string `json:"baseCommitHash,omitempty"`
 	// BranchRef is the branch/ref assigned to the allocation.
@@ -59,6 +62,8 @@ type Allocation struct {
 	StaleBaseState string `json:"staleBaseState,omitempty"`
 	// CleanupState records cleanup lifecycle for the allocated Worktree.
 	CleanupState string `json:"cleanupState,omitempty"`
+	// Cleanup records the terminal runtime cleanup receipt, set by RecordCleanup.
+	Cleanup *forge_runtime.CleanupReceipt `json:"cleanup,omitempty"`
 	// Timestamp is the allocation timestamp.
 	Timestamp *timestamp.Timestamp `json:"timestamp,omitempty"`
 }
@@ -70,15 +75,19 @@ type CreateArgs struct {
 	PassObjectKey      string
 	RepoObjectKey      string
 	WorktreeObjectKey  string
-	BaseCommitHash     string
-	BranchRef          string
-	PathFamily         string
-	EvidenceObjectKey  string
-	Status             string
-	CollisionState     string
-	StaleBaseState     string
-	CleanupState       string
-	Timestamp          *timestamp.Timestamp
+	// WorkdirRequired reports whether the allocation must carry the mutable
+	// Workdir identity. Legacy allocations without it require a clean break.
+	WorkdirRequired   bool
+	WorkdirObjectKey  string
+	BaseCommitHash    string
+	BranchRef         string
+	PathFamily        string
+	EvidenceObjectKey string
+	Status            string
+	CollisionState    string
+	StaleBaseState    string
+	CleanupState      string
+	Timestamp         *timestamp.Timestamp
 }
 
 // BuildObjectKey builds a deterministic allocation object key.
@@ -116,6 +125,7 @@ func CreateOrReuse(
 		PassObjectKey:      args.PassObjectKey,
 		RepoObjectKey:      args.RepoObjectKey,
 		WorktreeObjectKey:  args.WorktreeObjectKey,
+		WorkdirObjectKey:   args.WorkdirObjectKey,
 		BaseCommitHash:     args.BaseCommitHash,
 		BranchRef:          args.BranchRef,
 		PathFamily:         args.PathFamily,
@@ -141,6 +151,9 @@ func CreateOrReuse(
 	if alloc.Timestamp == nil {
 		alloc.Timestamp = timestamp.Now()
 	}
+	if args.WorkdirRequired && args.WorkdirObjectKey == "" {
+		return nil, "", nil, errors.New("sandbox allocation requires a workdir object key")
+	}
 	if err := alloc.Validate(); err != nil {
 		return nil, "", nil, err
 	}
@@ -153,6 +166,12 @@ func CreateOrReuse(
 		existingAlloc, err := Lookup(ctx, ws, args.ObjectKey)
 		if err != nil {
 			return nil, "", nil, err
+		}
+		if args.WorkdirRequired && existingAlloc.GetWorkdirObjectKey() == "" {
+			return nil, "", nil, errors.Errorf(
+				"existing allocation %s lacks the required workdir identity; clean break required",
+				args.ObjectKey,
+			)
 		}
 		if !existingAlloc.sameAllocation(alloc) {
 			return nil, "", nil, errors.Errorf("allocation key collision: %s", args.ObjectKey)
@@ -252,6 +271,11 @@ func (a *Allocation) Validate() error {
 	case a.GetCleanupState() == "":
 		return errors.New("cleanup_state cannot be empty")
 	}
+	if cleanup := a.GetCleanup(); cleanup != nil {
+		if err := cleanup.Validate(); err != nil {
+			return errors.Wrap(err, "cleanup")
+		}
+	}
 	if err := a.GetTimestamp().Validate(false); err != nil {
 		return errors.Wrap(err, "timestamp")
 	}
@@ -288,6 +312,22 @@ func (a *Allocation) GetWorktreeObjectKey() string {
 		return a.WorktreeObjectKey
 	}
 	return ""
+}
+
+// GetWorkdirObjectKey returns the mutable Workdir object key.
+func (a *Allocation) GetWorkdirObjectKey() string {
+	if a != nil {
+		return a.WorkdirObjectKey
+	}
+	return ""
+}
+
+// GetCleanup returns the terminal runtime cleanup receipt.
+func (a *Allocation) GetCleanup() *forge_runtime.CleanupReceipt {
+	if a != nil {
+		return a.Cleanup
+	}
+	return nil
 }
 
 // GetBaseCommitHash returns the base commit hash.
@@ -389,6 +429,7 @@ func (a *Allocation) MarshalJSON() ([]byte, error) {
 	setStringJSONField(&arena, obj, "passObjectKey", a.PassObjectKey)
 	setStringJSONField(&arena, obj, "repoObjectKey", a.RepoObjectKey)
 	setStringJSONField(&arena, obj, "worktreeObjectKey", a.WorktreeObjectKey)
+	setStringJSONField(&arena, obj, "workdirObjectKey", a.WorkdirObjectKey)
 	setStringJSONField(&arena, obj, "baseCommitHash", a.BaseCommitHash)
 	setStringJSONField(&arena, obj, "branchRef", a.BranchRef)
 	setStringJSONField(&arena, obj, "pathFamily", a.PathFamily)
@@ -397,6 +438,17 @@ func (a *Allocation) MarshalJSON() ([]byte, error) {
 	setStringJSONField(&arena, obj, "collisionState", a.CollisionState)
 	setStringJSONField(&arena, obj, "staleBaseState", a.StaleBaseState)
 	setStringJSONField(&arena, obj, "cleanupState", a.CleanupState)
+	if cleanup := a.GetCleanup(); cleanup != nil {
+		cleanupJSON, err := cleanup.MarshalJSON()
+		if err != nil {
+			return nil, errors.Wrap(err, "marshal cleanup")
+		}
+		cleanupValue, err := parseJSONValue(&arena, cleanupJSON)
+		if err != nil {
+			return nil, errors.Wrap(err, "marshal cleanup")
+		}
+		obj.Set("cleanup", cleanupValue)
+	}
 	if a.Timestamp != nil {
 		timestampJSON, err := a.Timestamp.MarshalJSON()
 		if err != nil {
@@ -445,6 +497,7 @@ func (a *Allocation) UnmarshalJSON(data []byte) error {
 	a.PassObjectKey = string(value.GetStringBytes("passObjectKey"))
 	a.RepoObjectKey = string(value.GetStringBytes("repoObjectKey"))
 	a.WorktreeObjectKey = string(value.GetStringBytes("worktreeObjectKey"))
+	a.WorkdirObjectKey = string(value.GetStringBytes("workdirObjectKey"))
 	a.BaseCommitHash = string(value.GetStringBytes("baseCommitHash"))
 	a.BranchRef = string(value.GetStringBytes("branchRef"))
 	a.PathFamily = string(value.GetStringBytes("pathFamily"))
@@ -453,6 +506,15 @@ func (a *Allocation) UnmarshalJSON(data []byte) error {
 	a.CollisionState = string(value.GetStringBytes("collisionState"))
 	a.StaleBaseState = string(value.GetStringBytes("staleBaseState"))
 	a.CleanupState = string(value.GetStringBytes("cleanupState"))
+	if cleanupValue := value.Get("cleanup"); cleanupValue != nil && cleanupValue.Type() == fastjson.TypeObject {
+		cleanup := &forge_runtime.CleanupReceipt{}
+		if err := cleanup.UnmarshalJSON(cleanupValue.MarshalTo(nil)); err != nil {
+			return errors.Wrap(err, "unmarshal cleanup")
+		}
+		a.Cleanup = cleanup
+	} else {
+		a.Cleanup = nil
+	}
 	if timestampValue := value.Get("timestamp"); timestampValue != nil && timestampValue.Type() != fastjson.TypeNull {
 		ts := &timestamp.Timestamp{}
 		if err := ts.UnmarshalJSON(timestampValue.MarshalTo(nil)); err != nil {
@@ -470,6 +532,7 @@ func (a *Allocation) sameAllocation(other *Allocation) bool {
 		a.GetPassObjectKey() == other.GetPassObjectKey() &&
 		a.GetRepoObjectKey() == other.GetRepoObjectKey() &&
 		a.GetWorktreeObjectKey() == other.GetWorktreeObjectKey() &&
+		a.GetWorkdirObjectKey() == other.GetWorkdirObjectKey() &&
 		a.GetBaseCommitHash() == other.GetBaseCommitHash() &&
 		a.GetBranchRef() == other.GetBranchRef() &&
 		a.GetPathFamily() == other.GetPathFamily() &&
@@ -495,3 +558,51 @@ func setAllocationQuads(ctx context.Context, ws world.WorldState, objKey string,
 
 // _ is a type assertion
 var _ block.Block = (*Allocation)(nil)
+
+// UnmarshalAllocation unmarshals an Allocation from a block cursor.
+func UnmarshalAllocation(ctx context.Context, bcs *block.Cursor) (*Allocation, error) {
+	return block.UnmarshalBlock[*Allocation](ctx, bcs, NewAllocationBlock)
+}
+
+// RecordCleanup records the terminal runtime cleanup receipt on one
+// allocation. Runtime release stays separate from retention: the Worktree and
+// committed Workdir bytes remain readable after the receipt lands.
+func RecordCleanup(
+	ctx context.Context,
+	ws world.WorldState,
+	allocationObjectKey string,
+	receipt *forge_runtime.CleanupReceipt,
+) (*Allocation, *bucket.ObjectRef, error) {
+	if allocationObjectKey == "" {
+		return nil, nil, errors.New("allocation_object_key cannot be empty")
+	}
+	if err := receipt.Validate(); err != nil {
+		return nil, nil, errors.Wrap(err, "cleanup receipt")
+	}
+
+	var out *Allocation
+	var outRef *bucket.ObjectRef
+	ref, _, err := world.AccessWorldObject(ctx, ws, allocationObjectKey, true, func(bcs *block.Cursor) error {
+		alloc, err := UnmarshalAllocation(ctx, bcs)
+		if err != nil {
+			return err
+		}
+		alloc.Cleanup = receipt
+		if receipt.Complete() {
+			alloc.CleanupState = "released"
+		} else {
+			alloc.CleanupState = "cleanup-partial"
+		}
+		if err := alloc.Validate(); err != nil {
+			return err
+		}
+		bcs.SetBlock(alloc, true)
+		out = alloc
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	outRef = ref
+	return out, outRef, nil
+}

--- a/forge/lib/git/allocation/allocation_test.go
+++ b/forge/lib/git/allocation/allocation_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/s4wave/spacewave/db/bucket"
+	forge_runtime "github.com/s4wave/spacewave/forge/runtime"
+
 	hydra_testbed "github.com/s4wave/spacewave/db/testbed"
 	"github.com/s4wave/spacewave/db/world"
 	world_testbed "github.com/s4wave/spacewave/db/world/testbed"
@@ -31,6 +34,7 @@ func TestCreateOrReuseAllocationLinksForgeAndGitProvenance(t *testing.T) {
 		PassObjectKey:      "forge/pass/1",
 		RepoObjectKey:      "repo/main",
 		WorktreeObjectKey:  "repo/main/worktree/exec-a",
+		WorkdirObjectKey:   "repo/main/worktree/exec-a/workdir",
 		BaseCommitHash:     "1111111111111111111111111111111111111111",
 		BranchRef:          "refs/heads/agent/exec-a",
 		PathFamily:         "repos/spacewave",
@@ -102,9 +106,63 @@ func TestCreateOrReuseAllocationLinksForgeAndGitProvenance(t *testing.T) {
 		t.Fatalf("allocation worktrees: %+v", worktreeKeys)
 	}
 
+	receipt := &forge_runtime.CleanupReceipt{
+		ReservationObjectKey: "forge/runtime/reservation/abc",
+		ExecutionObjectKey:   args.ExecutionObjectKey,
+		RuntimeIdentity:      "container-1",
+		Generation:           2,
+		RuntimeStopped:       true,
+		CapacityReleased:     true,
+		Reason:               "cancelled",
+	}
+	cleaned, cleanedRef, err := RecordCleanup(ctx, ws, objKey, receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cleaned.GetCleanupState() != "released" || !cleaned.GetCleanup().Complete() {
+		t.Fatalf("unexpected cleanup record: %+v state=%q", cleaned.GetCleanup(), cleaned.GetCleanupState())
+	}
+	reloaded, err := Lookup(ctx, ws, objKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloaded.GetCleanup() == nil ||
+		reloaded.GetCleanup().RuntimeIdentity != "container-1" ||
+		reloaded.GetCleanup().Generation != 2 ||
+		reloaded.GetCleanup().Reason != "cancelled" ||
+		reloaded.GetWorkdirObjectKey() != args.WorkdirObjectKey {
+		t.Fatalf("cleanup did not persist: %+v", reloaded)
+	}
+	if !cleanedRef.EqualsRef(mustRootRef(t, ctx, ws, objKey)) {
+		t.Fatal("returned ref does not match persisted object root")
+	}
+	partial := &forge_runtime.CleanupReceipt{
+		ReservationObjectKey: receipt.ReservationObjectKey,
+		ExecutionObjectKey:   args.ExecutionObjectKey,
+		Generation:           2,
+		CapacityReleased:     true,
+	}
+	if _, _, err := RecordCleanup(ctx, ws, objKey, partial); err == nil {
+		t.Fatal("expected receipt without reason to be rejected")
+	}
+
 	collisionArgs := args
 	collisionArgs.WorktreeObjectKey = "repo/main/worktree/other"
 	if _, _, _, err := CreateOrReuse(ctx, ws, collisionArgs); err == nil {
 		t.Fatal("expected collision for same allocation key with different worktree")
 	}
+}
+
+func mustRootRef(t *testing.T, ctx context.Context, ws world.WorldState, objKey string) *bucket.ObjectRef {
+	t.Helper()
+	obj, err := world.MustGetObject(ctx, ws, objKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer world.ReleaseObjectState(obj)
+	ref, _, err := obj.GetRootRef(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ref
 }

--- a/forge/runtime/admission.go
+++ b/forge/runtime/admission.go
@@ -1,0 +1,197 @@
+package forge_runtime
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// DefaultLeaseDuration is the reservation lease applied when the admission
+// owner does not configure a duration.
+const DefaultLeaseDuration = 10 * time.Minute
+
+// ReservationState describes whether capacity remains held and whether the
+// runtime outcome is known.
+type ReservationState uint8
+
+const (
+	// ReservationStateReserved holds debited capacity before a runtime claims it.
+	ReservationStateReserved ReservationState = iota + 1
+	// ReservationStateActive holds debited capacity for one claimed runtime generation.
+	ReservationStateActive
+	// ReservationStateUncertain holds debited capacity while the runtime outcome
+	// is unknown, for example after a Device disconnect. Capacity stays debited
+	// until the same fenced runtime reconnects or the lease expires.
+	ReservationStateUncertain
+	// ReservationStatePendingStop holds a fenced runtime whose stop has not
+	// been confirmed yet. Capacity release follows the expiry rule while the
+	// runtime outcome stays unknown until the stop is confirmed.
+	ReservationStatePendingStop
+	// ReservationStateReleased is terminal: cleanup is recorded and no
+	// capacity is held.
+	ReservationStateReleased
+)
+
+// Valid reports whether the state is a defined value.
+func (s ReservationState) Valid() bool {
+	return s >= ReservationStateReserved && s <= ReservationStateReleased
+}
+
+// Live reports whether the state may still transition before release.
+func (s ReservationState) Live() bool {
+	return !s.Terminal()
+}
+
+// Terminal reports whether the state releases capacity permanently.
+func (s ReservationState) Terminal() bool {
+	return s == ReservationStateReleased
+}
+
+// ReservationOutcome classifies a reservation for reconciliation after a
+// daemon restart or a Device reconnect.
+type ReservationOutcome uint8
+
+const (
+	// OutcomeActive means the reservation holds capacity and custody is fenced.
+	OutcomeActive ReservationOutcome = iota + 1
+	// OutcomeUncertain means the runtime outcome is unknown: custody went
+	// unreachable or a confirmed stop is still pending reconciliation.
+	OutcomeUncertain
+	// OutcomeTerminal means cleanup is recorded and no capacity is held.
+	OutcomeTerminal
+)
+
+// ResourceRequest declares the host capacity and backend required by one execution attempt.
+type ResourceRequest struct {
+	// MilliCPU is the requested CPU in milli-cores.
+	MilliCPU uint64
+	// MemoryBytes is the requested memory in bytes.
+	MemoryBytes uint64
+	// Backend names the runtime backend required by the attempt.
+	Backend string
+}
+
+// Validate validates the request.
+func (r ResourceRequest) Validate() error {
+	switch {
+	case r.MilliCPU == 0:
+		return errors.New("milli_cpu must be set")
+	case r.MemoryBytes == 0:
+		return errors.New("memory_bytes must be set")
+	case r.Backend == "":
+		return errors.New("backend must be set")
+	}
+	return nil
+}
+
+// BackendRuntimeIdentity identifies one backend runtime instance for one
+// reservation generation. The identity is stable across daemon restarts so
+// reconcile can resume observation without another launch.
+type BackendRuntimeIdentity struct {
+	// Backend names the runtime backend that owns the runtime.
+	Backend string
+	// ID is the backend-scoped runtime identifier, for example a container id.
+	ID string
+}
+
+// IsZero reports whether the identity is unset.
+func (i BackendRuntimeIdentity) IsZero() bool {
+	return i.Backend == "" && i.ID == ""
+}
+
+// CleanupReceipt records the terminal cleanup facts for one reservation generation.
+type CleanupReceipt struct {
+	// ReservationObjectKey is the released reservation object key.
+	ReservationObjectKey string
+	// ExecutionObjectKey is the owning Execution object key.
+	ExecutionObjectKey string
+	// RuntimeIdentity is the stopped runtime identity, empty when no runtime launched.
+	RuntimeIdentity string
+	// Generation is the fenced generation the receipt applies to.
+	Generation uint64
+	// RuntimeStopped records that the backend runtime was confirmed stopped,
+	// or that no runtime ever launched. It stays false while a stop is pending;
+	// the receipt never fabricates this fact.
+	RuntimeStopped bool
+	// CapacityReleased records that reserved capacity was credited back exactly once.
+	CapacityReleased bool
+	// Reason records why the reservation released: "stopped" or "expired".
+	Reason string
+}
+
+// Complete reports whether every cleanup fact is recorded.
+func (r *CleanupReceipt) Complete() bool {
+	return r != nil && r.RuntimeStopped && r.CapacityReleased
+}
+
+// Validate validates the receipt.
+func (r *CleanupReceipt) Validate() error {
+	if r == nil {
+		return errors.New("cleanup receipt cannot be nil")
+	}
+	switch {
+	case r.ReservationObjectKey == "":
+		return errors.New("reservation_object_key cannot be empty")
+	case r.ExecutionObjectKey == "":
+		return errors.New("execution_object_key cannot be empty")
+	case r.Generation == 0:
+		return errors.New("generation must be set")
+	case r.Reason == "":
+		return errors.New("reason must be set")
+	case r.CapacityReleased != r.RuntimeStopped:
+		return errors.New("receipt must be partial (nothing released, stop unknown) or complete (stop confirmed and capacity credited)")
+	}
+	return nil
+}
+
+// Errors returned by runtime admission.
+var (
+	// ErrReservationNotFound is returned when a reservation object key is unknown.
+	ErrReservationNotFound = errors.New("reservation not found")
+	// ErrWorkerNotObserved is returned when a Worker has no observed capacity record.
+	ErrWorkerNotObserved = errors.New("worker capacity not observed")
+	// ErrStaleGeneration is returned when a call fences against an older
+	// generation, for example a late return from a replaced runtime.
+	ErrStaleGeneration = errors.New("stale reservation generation")
+	// ErrCapacityExhausted is returned when a worker cannot satisfy a request.
+	ErrCapacityExhausted = errors.New("worker capacity exhausted")
+	// ErrBackendUnsupported is returned when a worker does not declare the backend.
+	ErrBackendUnsupported = errors.New("backend unsupported by worker")
+	// ErrReservationTerminal is returned when an idempotent retry hits a
+	// released reservation; a retry after release is a new attempt with a new
+	// Execution object key.
+	ErrReservationTerminal = errors.New("reservation already released")
+	// ErrRequestMismatch is returned when an existing reservation conflicts with the request.
+	ErrRequestMismatch = errors.New("reservation request mismatch")
+	// ErrReservationExpired is returned when an idempotent retry hits a live
+	// reservation whose lease already expired but is not swept yet. Run the
+	// expiry sweep; the retry then requires a new attempt.
+	ErrReservationExpired = errors.New("reservation lease expired")
+)
+
+// Cleanup reasons recorded on receipts.
+const (
+	// CleanupReasonStop records a caller-requested stop of a live runtime.
+	CleanupReasonStop = "stopped"
+	// CleanupReasonExpired records a lease-expiry release.
+	CleanupReasonExpired = "expired"
+)
+
+// RuntimeAdmission atomically reserves Worker capacity and reconciles fenced
+// backend runtimes. Forge owns this boundary; callers never keep their own
+// capacity ledger.
+type RuntimeAdmission interface {
+	// Reserve atomically debits Worker capacity for one Execution attempt.
+	// Reserve is idempotent per Execution object key while the reservation is
+	// live; a released reservation requires a new attempt.
+	Reserve(ctx context.Context, workerObjectKey, executionObjectKey string, request ResourceRequest) (*Reservation, error)
+	// LookupReservation loads one persisted reservation. Reconcile after a
+	// restart reads the same object and resumes observation without relaunch.
+	LookupReservation(ctx context.Context, reservationObjectKey string) (*Reservation, error)
+	// StopAndRelease stops the fenced runtime, credits capacity exactly once,
+	// and returns the persisted cleanup facts. A stale generation is rejected
+	// without touching the current runtime or capacity. Until the stop is
+	// confirmed the reservation sits in the durable pending-stop state.
+	StopAndRelease(ctx context.Context, reservationObjectKey string, generation uint64) (*CleanupReceipt, error)
+}

--- a/forge/runtime/admission_test.go
+++ b/forge/runtime/admission_test.go
@@ -1,0 +1,523 @@
+package forge_runtime
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	hydra_testbed "github.com/s4wave/spacewave/db/testbed"
+	"github.com/s4wave/spacewave/db/world"
+	world_testbed "github.com/s4wave/spacewave/db/world/testbed"
+	"github.com/sirupsen/logrus"
+)
+
+type testStopper struct {
+	mtx     sync.Mutex
+	stopped map[string]int
+	failFor string
+	stopErr error
+	calls   atomic.Int64
+}
+
+func newTestStopper() *testStopper {
+	return &testStopper{stopped: make(map[string]int)}
+}
+
+func (s *testStopper) StopRuntime(_ context.Context, rt BackendRuntimeIdentity) (bool, error) {
+	s.calls.Add(1)
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	if rt.ID == s.failFor {
+		return false, s.stopErr
+	}
+	s.stopped[rt.ID]++
+	return true, nil
+}
+
+func (s *testStopper) count(id string) int {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	return s.stopped[id]
+}
+
+func newTestbed(t *testing.T) (context.Context, world.Engine, *world_testbed.Testbed) {
+	t.Helper()
+	ctx := context.Background()
+	log := logrus.New()
+	le := logrus.NewEntry(log)
+	btb, err := hydra_testbed.NewTestbed(ctx, le, hydra_testbed.WithVerbose(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { btb.Release() })
+	wtb, err := world_testbed.NewTestbed(btb, world_testbed.WithWorldVerbose(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { wtb.Release() })
+	return ctx, wtb.Engine, wtb
+}
+
+var testRequest = ResourceRequest{MilliCPU: 1_000, MemoryBytes: 1 << 30, Backend: "docker"}
+
+func TestReserveActivateStopRoundTrip(t *testing.T) {
+	ctx, eng, _ := newTestbed(t)
+	stopper := newTestStopper()
+	admission := NewWorldRuntimeAdmission(eng, stopper, time.Minute)
+
+	if _, err := admission.ObserveWorker(ctx, "worker/a", 2_000, 4<<30, []string{"docker", "v86"}); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := admission.Reserve(ctx, "worker/a", "exec/1", testRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.State != ReservationStateReserved || res.Generation != 1 || res.ObjectKey() != BuildReservationObjectKey("exec/1") {
+		t.Fatalf("unexpected reservation: %+v", res)
+	}
+
+	// Idempotent reserve for the same attempt proves the debit.
+	reused, err := admission.Reserve(ctx, "worker/a", "exec/1", testRequest)
+	if err != nil || reused.Generation != res.Generation {
+		t.Fatalf("expected idempotent reserve: %+v err=%v", reused, err)
+	}
+	capacity, err := LookupWorkerCapacityEngine(ctx, eng, "worker/a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if capacity.MilliCPUReserved != 1_000 || capacity.MemoryBytesReserved != 1<<30 {
+		t.Fatalf("capacity not debited: %+v", capacity)
+	}
+
+	rt := BackendRuntimeIdentity{Backend: "docker", ID: "container-1"}
+	if _, err := admission.Activate(ctx, res.ObjectKey(), rt); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := admission.LookupReservation(ctx, res.ObjectKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.State != ReservationStateActive || loaded.Runtime != rt {
+		t.Fatalf("unexpected active reservation: %+v", loaded)
+	}
+	if loaded.Outcome(time.Now()) != OutcomeActive {
+		t.Fatalf("expected active outcome, got %d", loaded.Outcome(time.Now()))
+	}
+
+	receipt, err := admission.StopAndRelease(ctx, res.ObjectKey(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !receipt.Complete() || receipt.RuntimeIdentity != "container-1" || receipt.Reason != CleanupReasonStop {
+		t.Fatalf("unexpected receipt: %+v", receipt)
+	}
+	if stopper.count("container-1") != 1 {
+		t.Fatalf("runtime stopper called %d times", stopper.count("container-1"))
+	}
+
+	// Idempotent stop returns the persisted receipt without re-stopping.
+	receipt2, err := admission.StopAndRelease(ctx, res.ObjectKey(), 1)
+	if err != nil || receipt2 == nil || !receipt2.Complete() {
+		t.Fatalf("expected persisted receipt on retry: %+v err=%v", receipt2, err)
+	}
+	if stopper.count("container-1") != 1 {
+		t.Fatal("stopper re-invoked after release")
+	}
+
+	capacity, err = LookupWorkerCapacityEngine(ctx, eng, "worker/a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if capacity.MilliCPUReserved != 0 || capacity.MemoryBytesReserved != 0 {
+		t.Fatalf("capacity not credited: %+v", capacity)
+	}
+
+	// A retry after release is a new attempt with a new Execution key; the
+	// released attempt rejects reuse.
+	if _, err := admission.Reserve(ctx, "worker/a", "exec/1", testRequest); !errors.Is(err, ErrReservationTerminal) {
+		t.Fatalf("expected terminal reservation error, got %v", err)
+	}
+}
+
+func TestReserveConcurrentOversubscribeRejected(t *testing.T) {
+	ctx, eng, _ := newTestbed(t)
+	admission := NewWorldRuntimeAdmission(eng, newTestStopper(), time.Minute)
+	if _, err := admission.ObserveWorker(ctx, "worker/a", 2_000, 2<<30, []string{"docker"}); err != nil {
+		t.Fatal(err)
+	}
+
+	const attempts = 8
+	var wg sync.WaitGroup
+	var successes atomic.Int64
+	errs := make([]error, attempts)
+	for i := range attempts {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			req := ResourceRequest{MilliCPU: 1_000, MemoryBytes: 1 << 30, Backend: "docker"}
+			_, err := admission.Reserve(ctx, "worker/a", "exec/concurrent-"+string(rune('a'+i)), req)
+			if err == nil {
+				successes.Add(1)
+			} else {
+				errs[i] = err
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if successes.Load() != 2 {
+		t.Fatalf("expected exactly 2 successful reservations, got %d", successes.Load())
+	}
+	for i, err := range errs {
+		if err != nil && !errors.Is(err, ErrCapacityExhausted) {
+			t.Fatalf("attempt %d: unexpected error %v", i, err)
+		}
+	}
+	ws := world.NewEngineWorldState(eng, false)
+	capacity, err := LookupWorkerCapacity(ctx, ws, "worker/a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if capacity.MilliCPUReserved != 2_000 || capacity.MemoryBytesReserved != 2<<30 {
+		t.Fatalf("reserved counts wrong: %+v", capacity)
+	}
+}
+
+func TestRestartReconcileResumesWithoutRelaunch(t *testing.T) {
+	ctx, eng, _ := newTestbed(t)
+	stopper := newTestStopper()
+	admission := NewWorldRuntimeAdmission(eng, stopper, time.Hour)
+	if _, err := admission.ObserveWorker(ctx, "worker/a", 4_000, 8<<30, []string{"docker"}); err != nil {
+		t.Fatal(err)
+	}
+	res, err := admission.Reserve(ctx, "worker/a", "exec/restart", testRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt := BackendRuntimeIdentity{Backend: "docker", ID: "container-restart"}
+	if _, err := admission.Activate(ctx, res.ObjectKey(), rt); err != nil {
+		t.Fatal(err)
+	}
+
+	// A fresh admission over the same durable engine reconciles by lookup.
+	restarted := NewWorldRuntimeAdmission(eng, stopper, time.Hour)
+	loaded, err := restarted.LookupReservation(ctx, res.ObjectKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.State != ReservationStateActive || loaded.Runtime != rt || loaded.Generation != 1 {
+		t.Fatalf("reconcile lost custody facts: %+v", loaded)
+	}
+	if loaded.Outcome(time.Now()) != OutcomeActive {
+		t.Fatalf("expected active outcome after restart, got %d", loaded.Outcome(time.Now()))
+	}
+}
+
+func TestUncertainRetainsDebitAndResumeRefencesGeneration(t *testing.T) {
+	ctx, eng, _ := newTestbed(t)
+	stopper := newTestStopper()
+	admission := NewWorldRuntimeAdmission(eng, stopper, time.Hour)
+	if _, err := admission.ObserveWorker(ctx, "worker/a", 2_000, 4<<30, []string{"docker"}); err != nil {
+		t.Fatal(err)
+	}
+	res, err := admission.Reserve(ctx, "worker/a", "exec/uncertain", testRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt := BackendRuntimeIdentity{Backend: "docker", ID: "container-u1"}
+	if _, err := admission.Activate(ctx, res.ObjectKey(), rt); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := admission.MarkUncertain(ctx, res.ObjectKey()); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := admission.LookupReservation(ctx, res.ObjectKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Outcome(time.Now()) != OutcomeUncertain {
+		t.Fatalf("expected uncertain outcome, got %d", loaded.Outcome(time.Now()))
+	}
+	capacity, err := lookupCapacityViaAdmission(ctx, admission, "worker/a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if capacity.MilliCPUReserved != 1_000 {
+		t.Fatal("uncertain disconnect must retain the debit")
+	}
+
+	// The same fenced runtime reconnects: generation re-fences upward.
+	rt2 := BackendRuntimeIdentity{Backend: "docker", ID: "container-u2"}
+	if _, err := admission.ResumeFromUncertain(ctx, res.ObjectKey(), rt2); err != nil {
+		t.Fatal(err)
+	}
+
+	// Late return from the replaced runtime instance is stale and inert.
+	if _, err := admission.StopAndRelease(ctx, res.ObjectKey(), 1); !errors.Is(err, ErrStaleGeneration) {
+		t.Fatalf("expected stale generation error, got %v", err)
+	}
+	if stopper.count("container-u1") != 0 && stopper.count("container-u2") != 0 {
+		t.Fatal("stale late-return must not stop any runtime")
+	}
+	if stopper.calls.Load() != 0 {
+		t.Fatal("stale late-return invoked the stopper")
+	}
+	capacity, _ = lookupCapacityViaAdmission(ctx, admission, "worker/a")
+	if capacity.MilliCPUReserved != 1_000 {
+		t.Fatal("stale late-return must not credit capacity")
+	}
+
+	receipt, err := admission.StopAndRelease(ctx, res.ObjectKey(), 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Generation != 2 || receipt.RuntimeIdentity != "container-u2" || !receipt.Complete() {
+		t.Fatalf("unexpected receipt: %+v", receipt)
+	}
+	if stopper.count("container-u2") != 1 {
+		t.Fatal("current runtime not stopped")
+	}
+}
+
+func TestExpiryFencesGenerationReleasesOnceAndStopsLateReturn(t *testing.T) {
+	ctx, eng, _ := newTestbed(t)
+	stopper := newTestStopper()
+	admission := NewWorldRuntimeAdmission(eng, stopper, time.Minute)
+	if _, err := admission.ObserveWorker(ctx, "worker/a", 2_000, 4<<30, []string{"docker"}); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	admission.SetTimeNow(func() time.Time { return now })
+
+	res, err := admission.Reserve(ctx, "worker/a", "exec/expiry", testRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt := BackendRuntimeIdentity{Backend: "docker", ID: "container-exp"}
+	if _, err := admission.Activate(ctx, res.ObjectKey(), rt); err != nil {
+		t.Fatal(err)
+	}
+
+	// Not yet expired: expiry is a no-op.
+	receipts, err := admission.ExpireLeases(ctx, now.Add(30*time.Second))
+	if err != nil || len(receipts) != 0 {
+		t.Fatalf("expected no expiries: %+v err=%v", receipts, err)
+	}
+
+	expiredAt := now.Add(2 * time.Minute)
+	receipts, err = admission.ExpireLeases(ctx, expiredAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(receipts) != 1 {
+		t.Fatalf("expected one expiry receipt, got %+v", receipts)
+	}
+	r := receipts[0]
+	// The sweep fenced custody, confirmed the stop outside the Worker lock,
+	// then credited the debit exactly once in the finalizing transaction.
+	if r.Generation != 2 || r.Reason != CleanupReasonExpired || !r.Complete() {
+		t.Fatalf("unexpected expiry receipt: %+v", r)
+	}
+	capacity, err := lookupCapacityViaAdmission(ctx, admission, "worker/a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if capacity.MilliCPUReserved != 0 {
+		t.Fatalf("confirmed expiry must credit the debit exactly once: %+v", capacity)
+	}
+
+	// Post-expiry old-runtime calls are stale: the fence moved.
+	if _, err := admission.StopAndRelease(ctx, res.ObjectKey(), 1); !errors.Is(err, ErrStaleGeneration) {
+		t.Fatalf("expected stale generation after expiry, got %v", err)
+	}
+	if stopper.count("container-exp") != 1 {
+		t.Fatalf("stale post-expiry call re-invoked the stopper: %d", stopper.count("container-exp"))
+	}
+	loaded, err := admission.LookupReservation(ctx, res.ObjectKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Generation != 2 || loaded.State != ReservationStateReleased || !loaded.Cleanup.Complete() {
+		t.Fatalf("unexpected post-expiry record: %+v", loaded)
+	}
+	if loaded.Outcome(expiredAt) != OutcomeTerminal {
+		t.Fatalf("released reservation reconciles as terminal, got %d", loaded.Outcome(expiredAt))
+	}
+
+	// Nothing remains pending for reconciliation.
+	done, err := admission.ReconcilePendingStops(ctx)
+	if err != nil || len(done) != 0 {
+		t.Fatalf("expected no pending stops after a confirmed sweep: %+v err=%v", done, err)
+	}
+	final, err := admission.StopAndRelease(ctx, res.ObjectKey(), 2)
+	if err != nil || final == nil || !final.Complete() {
+		t.Fatalf("expected terminal-idempotent receipt for fencing generation: %+v err=%v", final, err)
+	}
+	if stopper.count("container-exp") != 1 {
+		t.Fatal("terminal-idempotent return re-invoked the stopper")
+	}
+
+	// Retry is a new attempt with a new Execution key.
+	if _, err := admission.Reserve(ctx, "worker/a", "exec/expiry-retry", testRequest); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExpiryWithFailingStopperKeepsPendingStopForReconcile(t *testing.T) {
+	ctx, eng, _ := newTestbed(t)
+	stopper := newTestStopper()
+	stopper.failFor = "container-flaky"
+	stopper.stopErr = errors.New("docker daemon unreachable")
+	admission := NewWorldRuntimeAdmission(eng, stopper, time.Minute)
+	if _, err := admission.ObserveWorker(ctx, "worker/a", 1_000, 1<<30, []string{"docker"}); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	admission.SetTimeNow(func() time.Time { return now })
+	res, err := admission.Reserve(ctx, "worker/a", "exec/flaky", testRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.Activate(ctx, res.ObjectKey(), BackendRuntimeIdentity{Backend: "docker", ID: "container-flaky"}); err != nil {
+		t.Fatal(err)
+	}
+
+	receipts, err := admission.ExpireLeases(ctx, now.Add(2*time.Minute))
+	if err != nil || len(receipts) != 1 {
+		t.Fatalf("expected expiry receipt despite failed stop: %+v err=%v", receipts, err)
+	}
+	loaded, err := admission.LookupReservation(ctx, res.ObjectKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.State != ReservationStatePendingStop || loaded.Cleanup == nil ||
+		loaded.Cleanup.RuntimeStopped || loaded.Cleanup.CapacityReleased {
+		t.Fatalf("partial receipt not durable: %+v", loaded)
+	}
+	capacity, err := lookupCapacityViaAdmission(ctx, admission, "worker/a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if capacity.MilliCPUReserved != testRequest.MilliCPU {
+		t.Fatalf("debit must stay held while the stop is unconfirmed: %+v", capacity)
+	}
+
+	// Graceful stop of the flaky runtime also fails while it is unreachable.
+	if _, err := admission.StopAndRelease(ctx, res.ObjectKey(), 2); err == nil {
+		t.Fatal("expected stop failure to surface")
+	}
+
+	// The daemon recovers; reconciliation finishes the pending stop once.
+	stopper.failFor = ""
+	done, err := admission.ReconcilePendingStops(ctx)
+	if err != nil || len(done) != 1 || !done[0].Complete() {
+		t.Fatalf("expected completed receipt: %+v err=%v", done, err)
+	}
+	final, err := admission.LookupReservation(ctx, res.ObjectKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if final.State != ReservationStateReleased || !final.Cleanup.Complete() {
+		t.Fatalf("reservation not finalized: %+v", final)
+	}
+	capacity, err = lookupCapacityViaAdmission(ctx, admission, "worker/a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if capacity.MilliCPUReserved != 0 {
+		t.Fatalf("capacity credited twice or retained: %+v", capacity)
+	}
+}
+
+func TestStopperErrorDuringGracefulStopKeepsReservationLive(t *testing.T) {
+	ctx, eng, _ := newTestbed(t)
+	stopper := newTestStopper()
+	stopper.failFor = "container-graceful"
+	stopper.stopErr = errors.New("stop timeout")
+	admission := NewWorldRuntimeAdmission(eng, stopper, time.Hour)
+	if _, err := admission.ObserveWorker(ctx, "worker/a", 1_000, 1<<30, []string{"docker"}); err != nil {
+		t.Fatal(err)
+	}
+	res, err := admission.Reserve(ctx, "worker/a", "exec/graceful", testRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.Activate(ctx, res.ObjectKey(), BackendRuntimeIdentity{Backend: "docker", ID: "container-graceful"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.StopAndRelease(ctx, res.ObjectKey(), 1); err == nil {
+		t.Fatal("expected stopper error to surface")
+	}
+	loaded, err := admission.LookupReservation(ctx, res.ObjectKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.State != ReservationStatePendingStop {
+		t.Fatalf("expected durable pending-stop after failed stop, got %d", loaded.State)
+	}
+	capacity, err := lookupCapacityViaAdmission(ctx, admission, "worker/a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if capacity.MilliCPUReserved != 1_000 {
+		t.Fatal("capacity must stay debited until the stop confirms")
+	}
+
+	// The stopper recovers; a retry with the same fenced generation completes.
+	stopper.failFor = ""
+	receipt, err := admission.StopAndRelease(ctx, res.ObjectKey(), 1)
+	if err != nil || !receipt.Complete() {
+		t.Fatalf("expected completed receipt: %+v err=%v", receipt, err)
+	}
+}
+
+func TestObserveWorkerPreservesDebitsAndRejectsUnknownBackend(t *testing.T) {
+	ctx, eng, _ := newTestbed(t)
+	admission := NewWorldRuntimeAdmission(eng, newTestStopper(), time.Minute)
+	if _, err := admission.ObserveWorker(ctx, "worker/a", 2_000, 4<<30, []string{"docker"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.Reserve(ctx, "worker/a", "exec/backend", testRequest); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := admission.ObserveWorker(ctx, "worker/a", 4_000, 8<<30, []string{"docker"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.MilliCPUReserved != 1_000 || updated.MilliCPUTotal != 4_000 {
+		t.Fatalf("observation clobbered debits: %+v", updated)
+	}
+	if _, err := admission.Reserve(ctx, "worker/a", "exec/v86", ResourceRequest{MilliCPU: 100, MemoryBytes: 100, Backend: "v86"}); !errors.Is(err, ErrBackendUnsupported) {
+		t.Fatalf("expected unsupported backend error, got %v", err)
+	}
+	if _, err := admission.Reserve(ctx, "worker/unobserved", "exec/x", testRequest); !errors.Is(err, ErrWorkerNotObserved) {
+		t.Fatalf("expected unobserved worker error, got %v", err)
+	}
+}
+
+// lookupCapacityViaAdmission reads capacity through the admission's engine.
+func lookupCapacityViaAdmission(ctx context.Context, admission *WorldRuntimeAdmission, workerObjectKey string) (*WorkerCapacity, error) {
+	var out *WorkerCapacity
+	err := admission.withTx(ctx, false, func(ctx context.Context, ws world.WorldState) error {
+		capacity, err := LookupWorkerCapacity(ctx, ws, workerObjectKey)
+		out = capacity
+		return err
+	})
+	return out, err
+}
+
+// LookupWorkerCapacityEngine reads one Worker capacity record through an engine.
+func LookupWorkerCapacityEngine(ctx context.Context, eng world.Engine, workerObjectKey string) (*WorkerCapacity, error) {
+	var out *WorkerCapacity
+	err := world.ExecTransaction(ctx, eng, false, func(ctx context.Context, ws world.WorldState) error {
+		capacity, err := LookupWorkerCapacity(ctx, ws, workerObjectKey)
+		out = capacity
+		return err
+	})
+	return out, err
+}

--- a/forge/runtime/device.go
+++ b/forge/runtime/device.go
@@ -1,0 +1,27 @@
+package forge_runtime
+
+import (
+	"strings"
+
+	s4wave_device "github.com/s4wave/spacewave/sdk/device"
+)
+
+// SelectForgeWorkerCapability resolves one enrolled Device to its selectable
+// Forge Worker capability using the existing typed selection APIs. Device
+// selection changes the Worker that runs the same manifest; it never creates
+// a Device-specific session path or a second scheduler.
+func SelectForgeWorkerCapability(dev *s4wave_device.Device) *s4wave_device.DeviceCapability {
+	if dev == nil || !dev.IsSelectable() {
+		return nil
+	}
+	return dev.FindSelectableForgeWorker()
+}
+
+// ForgeWorkerObjectKey returns the linked Worker object key for a Forge
+// Worker capability, empty when the capability has no linked Worker.
+func ForgeWorkerObjectKey(capability *s4wave_device.DeviceCapability) string {
+	if capability == nil {
+		return ""
+	}
+	return strings.TrimSpace(capability.GetLink().GetObjectKey())
+}

--- a/forge/runtime/device_test.go
+++ b/forge/runtime/device_test.go
@@ -1,0 +1,54 @@
+package forge_runtime
+
+import (
+	"testing"
+
+	s4wave_device "github.com/s4wave/spacewave/sdk/device"
+)
+
+func testSelectableDevice() *s4wave_device.Device {
+	return &s4wave_device.Device{
+		PeerId:     "12D3KooWPeer",
+		Label:      "bench-1",
+		SetupState: s4wave_device.DeviceSetupState_DEVICE_SETUP_STATE_DEVICE_SESSION_READY,
+		Capabilities: []*s4wave_device.DeviceCapability{
+			{
+				Id:    "cap-fs",
+				Kind:  s4wave_device.DeviceCapabilityKindFilesystem,
+				State: s4wave_device.DeviceCapabilityState_DEVICE_CAPABILITY_STATE_AVAILABLE,
+			},
+			{
+				Id:    "cap-worker",
+				Kind:  s4wave_device.DeviceCapabilityKindForgeWorker,
+				State: s4wave_device.DeviceCapabilityState_DEVICE_CAPABILITY_STATE_ACTIVE,
+				Link: &s4wave_device.DeviceCapabilityLink{
+					ObjectKey: "worker/bench-1",
+					TypeId:    "forge/worker",
+				},
+			},
+		},
+	}
+}
+
+func TestSelectForgeWorkerCapabilityUsesTypedSelection(t *testing.T) {
+	dev := testSelectableDevice()
+	capability := SelectForgeWorkerCapability(dev)
+	if capability == nil || ForgeWorkerObjectKey(capability) != "worker/bench-1" {
+		t.Fatalf("unexpected capability: %+v", capability)
+	}
+
+	notReady := testSelectableDevice()
+	notReady.SetupState = s4wave_device.DeviceSetupState_DEVICE_SETUP_STATE_WAITING_FOR_COMPLETION
+	if SelectForgeWorkerCapability(notReady) != nil {
+		t.Fatal("non-selectable device must not resolve a worker")
+	}
+
+	noWorker := testSelectableDevice()
+	noWorker.Capabilities = noWorker.Capabilities[:1]
+	if SelectForgeWorkerCapability(noWorker) != nil {
+		t.Fatal("device without forge-worker capability must not resolve a worker")
+	}
+	if SelectForgeWorkerCapability(nil) != nil {
+		t.Fatal("nil device must not resolve a worker")
+	}
+}

--- a/forge/runtime/expired-retry_test.go
+++ b/forge/runtime/expired-retry_test.go
@@ -1,0 +1,37 @@
+package forge_runtime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+func TestReserveRejectsExpiredUnsweptIdempotentReturn(t *testing.T) {
+	ctx, eng, _ := newTestbed(t)
+	admission := NewWorldRuntimeAdmission(eng, newTestStopper(), time.Minute)
+	if _, err := admission.ObserveWorker(ctx, "worker/a", 2_000, 4<<30, []string{"docker"}); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	admission.SetTimeNow(func() time.Time { return now })
+	if _, err := admission.Reserve(ctx, "worker/a", "exec/late", testRequest); err != nil {
+		t.Fatal(err)
+	}
+
+	// Advance past the lease without running the sweep: the idempotent return
+	// must reject instead of re-arming a dead lease.
+	admission.SetTimeNow(func() time.Time { return now.Add(2 * time.Minute) })
+	if _, err := admission.Reserve(ctx, "worker/a", "exec/late", testRequest); !errors.Is(err, ErrReservationExpired) {
+		t.Fatalf("expected expired reservation error, got %v", err)
+	}
+
+	// The sweep releases once; the attempt stays terminal for its key.
+	receipts, err := admission.ExpireLeases(ctx, now.Add(2*time.Minute))
+	if err != nil || len(receipts) != 1 {
+		t.Fatalf("expected one expiry receipt: %+v err=%v", receipts, err)
+	}
+	if _, err := admission.Reserve(ctx, "worker/a", "exec/late", testRequest); !errors.Is(err, ErrReservationTerminal) {
+		t.Fatalf("expected terminal error after sweep, got %v", err)
+	}
+}

--- a/forge/runtime/json.go
+++ b/forge/runtime/json.go
@@ -1,0 +1,106 @@
+package forge_runtime
+
+import (
+	"strconv"
+
+	"github.com/aperturerobotics/fastjson"
+	timestamp "github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
+	"github.com/pkg/errors"
+)
+
+func setBoolJSONField(arena *fastjson.Arena, obj *fastjson.Value, key string, value bool) {
+	if value {
+		obj.Set(key, arena.NewTrue())
+	} else {
+		obj.Set(key, arena.NewFalse())
+	}
+}
+
+func setStringJSONField(arena *fastjson.Arena, obj *fastjson.Value, key, value string) {
+	if value != "" {
+		obj.Set(key, arena.NewString(value))
+	}
+}
+
+func marshalTimestampField(arena *fastjson.Arena, ts *timestamp.Timestamp) (*fastjson.Value, error) {
+	if ts == nil {
+		return arena.NewNull(), nil
+	}
+	tsJSON, err := ts.MarshalJSON()
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal timestamp")
+	}
+	var parser fastjson.Parser
+	value, err := parser.ParseBytes(tsJSON)
+	if err != nil {
+		return nil, errors.Wrap(err, "parse timestamp")
+	}
+	return arena.DeepCopyValue(value), nil
+}
+
+func unmarshalTimestampField(value *fastjson.Value, key string) (*timestamp.Timestamp, error) {
+	tsValue := value.Get(key)
+	if tsValue == nil || tsValue.Type() == fastjson.TypeNull {
+		return nil, nil
+	}
+	ts := &timestamp.Timestamp{}
+	if err := ts.UnmarshalJSON(tsValue.MarshalTo(nil)); err != nil {
+		return nil, errors.Wrap(err, "unmarshal "+key)
+	}
+	return ts, nil
+}
+
+// marshalJSONValue marshals the receipt into the arena.
+func (r *CleanupReceipt) marshalJSONValue(arena *fastjson.Arena) (*fastjson.Value, error) {
+	obj := arena.NewObject()
+	setStringJSONField(arena, obj, "reservationObjectKey", r.ReservationObjectKey)
+	setStringJSONField(arena, obj, "executionObjectKey", r.ExecutionObjectKey)
+	setStringJSONField(arena, obj, "runtimeIdentity", r.RuntimeIdentity)
+	obj.Set("generation", arena.NewNumberString(strconv.FormatUint(r.Generation, 10)))
+	setBoolJSONField(arena, obj, "runtimeStopped", r.RuntimeStopped)
+	setBoolJSONField(arena, obj, "capacityReleased", r.CapacityReleased)
+	setStringJSONField(arena, obj, "reason", r.Reason)
+	return obj, nil
+}
+
+// unmarshalJSONValue unmarshals the receipt from a parsed object value.
+func (r *CleanupReceipt) unmarshalJSONValue(value *fastjson.Value) error {
+	r.ReservationObjectKey = string(value.GetStringBytes("reservationObjectKey"))
+	r.ExecutionObjectKey = string(value.GetStringBytes("executionObjectKey"))
+	r.RuntimeIdentity = string(value.GetStringBytes("runtimeIdentity"))
+	r.Generation = value.GetUint64("generation")
+	r.RuntimeStopped = value.GetBool("runtimeStopped")
+	r.CapacityReleased = value.GetBool("capacityReleased")
+	r.Reason = string(value.GetStringBytes("reason"))
+	return nil
+}
+
+// MarshalJSON marshals the CleanupReceipt to JSON without reflection.
+func (r *CleanupReceipt) MarshalJSON() ([]byte, error) {
+	if r == nil {
+		return []byte("null"), nil
+	}
+	var arena fastjson.Arena
+	value, err := r.marshalJSONValue(&arena)
+	if err != nil {
+		return nil, err
+	}
+	return value.MarshalTo(nil), nil
+}
+
+// UnmarshalJSON unmarshals the CleanupReceipt from JSON without reflection.
+func (r *CleanupReceipt) UnmarshalJSON(data []byte) error {
+	var parser fastjson.Parser
+	value, err := parser.ParseBytes(data)
+	if err != nil {
+		return err
+	}
+	if value.Type() == fastjson.TypeNull {
+		*r = CleanupReceipt{}
+		return nil
+	}
+	if value.Type() != fastjson.TypeObject {
+		return errors.New("cleanup receipt must be object")
+	}
+	return r.unmarshalJSONValue(value)
+}

--- a/forge/runtime/mount-testbed_test.go
+++ b/forge/runtime/mount-testbed_test.go
@@ -1,0 +1,89 @@
+package forge_runtime
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	hydra_testbed "github.com/s4wave/spacewave/db/testbed"
+	unixfs_sdk "github.com/s4wave/spacewave/db/unixfs"
+	unixfs_world "github.com/s4wave/spacewave/db/unixfs/world"
+	"github.com/s4wave/spacewave/db/world"
+	world_testbed "github.com/s4wave/spacewave/db/world/testbed"
+	"github.com/sirupsen/logrus"
+)
+
+// workdirTestbed releases the hydra and world testbeds backing one test FSHandle.
+type workdirTestbed struct {
+	btb *hydra_testbed.Testbed
+	wtb *world_testbed.Testbed
+}
+
+// Release tears down the testbeds.
+func (w *workdirTestbed) Release() {
+	w.wtb.Release()
+	w.btb.Release()
+}
+
+// buildTestWorkdirHandle constructs a live empty Workdir FSHandle over a real
+// world engine, mirroring the production init path.
+func buildTestWorkdirHandle(ctx context.Context, t *testing.T) (*unixfs_sdk.FSHandle, *workdirTestbed, error) {
+	t.Helper()
+	log := logrus.New()
+	le := logrus.NewEntry(log)
+	btb, err := hydra_testbed.NewTestbed(ctx, le, hydra_testbed.WithVerbose(false))
+	if err != nil {
+		return nil, nil, err
+	}
+	wtb, err := world_testbed.NewTestbed(btb, world_testbed.WithWorldVerbose(false))
+	if err != nil {
+		btb.Release()
+		return nil, nil, err
+	}
+	out := &workdirTestbed{btb: btb, wtb: wtb}
+
+	opc := world.NewLookupOpController(
+		"test-workdir-fs-ops",
+		wtb.EngineID,
+		unixfs_world.LookupFsOp,
+	)
+	if _, err := wtb.Bus.AddController(ctx, opc, nil); err != nil {
+		out.Release()
+		return nil, nil, err
+	}
+	<-time.After(time.Millisecond * 100)
+
+	ws := world.NewEngineWorldState(wtb.Engine, true)
+	sender := wtb.Volume.GetPeerID()
+	if _, _, err := unixfs_world.FsInit(
+		ctx,
+		ws,
+		sender,
+		"test-workdir-fs",
+		unixfs_world.FSType_FSType_FS_NODE,
+		nil,
+		true,
+		time.Now(),
+	); err != nil {
+		out.Release()
+		return nil, nil, err
+	}
+	rootCursor, err := unixfs_world.FollowUnixfsRef(
+		ctx,
+		wtb.Logger,
+		ws,
+		&unixfs_world.UnixfsRef{ObjectKey: "test-workdir-fs"},
+		sender,
+		true,
+	)
+	if err != nil {
+		out.Release()
+		return nil, nil, err
+	}
+	handle, err := unixfs_sdk.NewFSHandle(rootCursor)
+	if err != nil {
+		out.Release()
+		return nil, nil, err
+	}
+	return handle, out, nil
+}

--- a/forge/runtime/mount.go
+++ b/forge/runtime/mount.go
@@ -1,0 +1,132 @@
+package forge_runtime
+
+import (
+	"context"
+	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/s4wave/spacewave/db/unixfs"
+	unixfs_v86fs "github.com/s4wave/spacewave/db/unixfs/v86fs"
+	"github.com/s4wave/spacewave/db/world"
+	forge_lib_docker "github.com/s4wave/spacewave/forge/lib/docker"
+)
+
+// WorkdirMount is the single writer-fenced live mount of one Workdir FSHandle
+// into one runtime backend. One attempt owns exactly one mount: guest writes
+// enter the Workdir through the Spacewave-owned FSHandle writer, so the
+// FSHandle is the only write fence. Flush fences every write that traversed
+// the FSHandle into durable storage; call it once before diff evidence.
+type WorkdirMount interface {
+	// Flush fences pending FSHandle writes into durable storage before diff evidence.
+	Flush(ctx context.Context) error
+	// Release revokes guest access and tears down the backend mount.
+	Release(ctx context.Context) error
+}
+
+// V86WorkdirMount registers the writable v86fs mount of one Workdir FSHandle
+// in the v86fs relay server serving the VM. Guest writes traverse v86fs into
+// the FSHandle, so Flush fences them with an engine durability barrier and
+// Release revokes guest access by removing the mount.
+type V86WorkdirMount struct {
+	eng       world.Engine
+	server    *unixfs_v86fs.Server
+	name      string
+	guestPath string
+	handle    *unixfs.FSHandle
+
+	mtx      sync.Mutex
+	released bool
+	attached bool
+}
+
+// NewV86WorkdirMount constructs the writable v86fs adapter for one Workdir
+// FSHandle. Attach registers it once; a second Attach is rejected because one
+// attempt mounts its Workdir exactly once.
+func NewV86WorkdirMount(
+	eng world.Engine,
+	server *unixfs_v86fs.Server,
+	name, guestPath string,
+	handle *unixfs.FSHandle,
+) (*V86WorkdirMount, error) {
+	switch {
+	case eng == nil:
+		return nil, errors.New("world engine not set")
+	case server == nil:
+		return nil, errors.New("v86fs server not set")
+	case name == "" || guestPath == "":
+		return nil, errors.New("mount name and guest path must be set")
+	case handle == nil:
+		return nil, errors.New("workdir fs handle not set")
+	}
+	return &V86WorkdirMount{eng: eng, server: server, name: name, guestPath: guestPath, handle: handle}, nil
+}
+
+// Attach registers the writable Workdir mount with the v86fs server exactly once.
+func (m *V86WorkdirMount) Attach() error {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	if m.released {
+		return errors.New("workdir mount released")
+	}
+	if m.attached {
+		return errors.New("workdir mount already attached")
+	}
+	m.server.AddMount(m.name, m.guestPath, m.handle)
+	m.attached = true
+	return nil
+}
+
+// Flush implements WorkdirMount by running the engine durability barrier over
+// every FSHandle write the guest made.
+func (m *V86WorkdirMount) Flush(ctx context.Context) error {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	if m.released {
+		return errors.New("workdir mount released")
+	}
+	if _, err := m.eng.Sync(ctx); err != nil {
+		return errors.Wrap(err, "sync workdir writes")
+	}
+	return nil
+}
+
+// Release implements WorkdirMount by removing the mount, revoking guest access.
+func (m *V86WorkdirMount) Release(_ context.Context) error {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	if m.released {
+		return nil
+	}
+	if m.attached {
+		m.server.RemoveMount(m.name)
+	}
+	m.released = true
+	return nil
+}
+
+// ApplyDockerWorkdirBind adds the single POSIX bind-mount entry for one
+// supervised Workdir host path to a Docker config.
+//
+// This adapter does not fence writes: a Docker bind mount lets the container
+// write the host path directly, bypassing any FSHandle writer. The missing
+// piece is a supervised POSIX live-FSHandle mount - a FUSE supervisor backed
+// by db/unixfs/mount MountController exposing the Workdir FSHandle at the
+// host path - owned by the Spacewave filesystem stack. Until that supervisor
+// supplies the host path and its flush, Docker-backed attempts must collect
+// diff evidence only after their own supervisor proves quiescence; this
+// package provides no flush contract for them.
+func ApplyDockerWorkdirBind(conf *forge_lib_docker.Config, hostPath, containerPath string) error {
+	switch {
+	case conf == nil:
+		return errors.New("docker config not set")
+	case hostPath == "":
+		return errors.New("host path must be set")
+	case containerPath == "":
+		return errors.New("container path must be set")
+	}
+	conf.Mounts = append(conf.Mounts, &forge_lib_docker.Mount{
+		HostPath:      hostPath,
+		ContainerPath: containerPath,
+	})
+	return nil
+}

--- a/forge/runtime/mount_test.go
+++ b/forge/runtime/mount_test.go
@@ -1,0 +1,64 @@
+package forge_runtime
+
+import (
+	"testing"
+
+	unixfs_v86fs "github.com/s4wave/spacewave/db/unixfs/v86fs"
+	forge_lib_docker "github.com/s4wave/spacewave/forge/lib/docker"
+	"github.com/sirupsen/logrus"
+)
+
+func TestApplyDockerWorkdirBindAddsSingleEntry(t *testing.T) {
+	conf := &forge_lib_docker.Config{Image: "img"}
+	if err := ApplyDockerWorkdirBind(conf, "/run/workdirs/exec-1", "/workspace"); err != nil {
+		t.Fatal(err)
+	}
+	if len(conf.GetMounts()) != 1 {
+		t.Fatalf("expected one mount, got %+v", conf.GetMounts())
+	}
+	m := conf.GetMounts()[0]
+	if m.GetHostPath() != "/run/workdirs/exec-1" || m.GetContainerPath() != "/workspace" || m.GetReadOnly() {
+		t.Fatalf("unexpected mount: %+v", m)
+	}
+	if err := ApplyDockerWorkdirBind(conf, "", "/x"); err == nil {
+		t.Fatal("expected empty host path to be rejected")
+	}
+}
+
+func TestV86WorkdirMountAttachOnceFlushAndRelease(t *testing.T) {
+	ctx, eng, _ := newTestbed(t)
+	le := logrus.NewEntry(logrus.New())
+	server := unixfs_v86fs.NewServer(le, nil)
+	handle, wtb, err := buildTestWorkdirHandle(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wtb.Release()
+
+	mount, err := NewV86WorkdirMount(eng, server, "workdir", "/workspace", handle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := mount.Attach(); err != nil {
+		t.Fatal(err)
+	}
+	if err := mount.Attach(); err == nil {
+		t.Fatal("expected second attach to be rejected: one attempt mounts its workdir once")
+	}
+	mounts := server.ListMounts()
+	if len(mounts) != 1 || mounts[0].Name != "workdir" || mounts[0].Path != "/workspace" {
+		t.Fatalf("unexpected mounts: %+v", mounts)
+	}
+	if err := mount.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := mount.Release(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if len(server.ListMounts()) != 0 {
+		t.Fatal("release must revoke guest access by removing the mount")
+	}
+	if err := mount.Flush(ctx); err == nil {
+		t.Fatal("expected flush after release to fail")
+	}
+}

--- a/forge/runtime/persist.go
+++ b/forge/runtime/persist.go
@@ -1,0 +1,125 @@
+package forge_runtime
+
+import (
+	"context"
+	"time"
+
+	timestamp "github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
+	"github.com/pkg/errors"
+	"github.com/s4wave/spacewave/db/block"
+	"github.com/s4wave/spacewave/db/world"
+)
+
+// persistReservation writes one Reservation body into the world object.
+func persistReservation(ctx context.Context, ws world.WorldState, objKey string, res *Reservation) error {
+	if _, _, err := world.AccessWorldObject(ctx, ws, objKey, true, func(bcs *block.Cursor) error {
+		bcs.SetBlock(res, true)
+		return nil
+	}); err != nil {
+		return errors.Wrapf(err, "persist reservation %s", objKey)
+	}
+	return nil
+}
+
+// persistNewReservation writes a Reservation that must not exist yet.
+func persistNewReservation(ctx context.Context, ws world.WorldState, res *Reservation) error {
+	objKey := res.ObjectKey()
+	exists, err := ws.HasObject(ctx, objKey)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return errors.Wrapf(world.ErrObjectExists, "reservation %s", objKey)
+	}
+	return persistReservation(ctx, ws, objKey, res)
+}
+
+// listReservationKeys lists all persisted reservation object keys.
+func listReservationKeys(ctx context.Context, ws world.WorldState) ([]string, error) {
+	var keys []string
+	it := ws.IterateObjects(ctx, reservationObjectKeyPrefix, false)
+	defer it.Close()
+	for it.Next() {
+		if !it.Valid() {
+			break
+		}
+		keys = append(keys, it.Key())
+	}
+	return keys, it.Err()
+}
+
+// persistWorkerCapacity writes the capacity record of one Worker.
+func persistWorkerCapacity(ctx context.Context, ws world.WorldState, workerObjectKey string, capacity *WorkerCapacity) error {
+	if _, _, err := world.AccessWorldObject(
+		ctx,
+		ws,
+		BuildWorkerCapacityObjectKey(workerObjectKey),
+		true,
+		func(bcs *block.Cursor) error {
+			bcs.SetBlock(capacity, true)
+			return nil
+		},
+	); err != nil {
+		return errors.Wrapf(err, "persist worker capacity %s", workerObjectKey)
+	}
+	return nil
+}
+
+// remainingMilliCPU returns the unreserved milli-cores of one capacity record.
+func remainingMilliCPU(capacity *WorkerCapacity) uint64 {
+	if capacity.MilliCPUReserved > capacity.MilliCPUTotal {
+		return 0
+	}
+	return capacity.MilliCPUTotal - capacity.MilliCPUReserved
+}
+
+// remainingMemoryBytes returns the unreserved memory bytes of one capacity record.
+func remainingMemoryBytes(capacity *WorkerCapacity) uint64 {
+	if capacity.MemoryBytesReserved > capacity.MemoryBytesTotal {
+		return 0
+	}
+	return capacity.MemoryBytesTotal - capacity.MemoryBytesReserved
+}
+
+// debitCapacity adds one reservation's request to the Worker's reserved totals
+// in the same transaction that creates the reservation.
+func debitCapacity(ctx context.Context, ws world.WorldState, workerObjectKey string, request ResourceRequest) error {
+	capacity, err := LookupWorkerCapacity(ctx, ws, workerObjectKey)
+	if err != nil {
+		return err
+	}
+	capacity.MilliCPUReserved += request.MilliCPU
+	capacity.MemoryBytesReserved += request.MemoryBytes
+	capacity.Generation++
+	if err := capacity.Validate(); err != nil {
+		return errors.Wrapf(err, "debit worker %s", workerObjectKey)
+	}
+	return persistWorkerCapacity(ctx, ws, workerObjectKey, capacity)
+}
+
+// creditCapacity removes one released reservation's request from the Worker's
+// reserved totals exactly once per release.
+func creditCapacity(ctx context.Context, ws world.WorldState, workerObjectKey string, request ResourceRequest) error {
+	capacity, err := LookupWorkerCapacity(ctx, ws, workerObjectKey)
+	if err != nil {
+		return err
+	}
+	switch {
+	case capacity.MilliCPUReserved < request.MilliCPU || capacity.MemoryBytesReserved < request.MemoryBytes:
+		return errors.Wrapf(ErrCapacityExhausted, "credit underflow for worker %s", workerObjectKey)
+	case capacity.MilliCPUReserved == 0 && capacity.MemoryBytesReserved == 0:
+		return nil
+	}
+	capacity.MilliCPUReserved -= request.MilliCPU
+	capacity.MemoryBytesReserved -= request.MemoryBytes
+	capacity.Generation++
+	if err := capacity.Validate(); err != nil {
+		return errors.Wrapf(err, "credit worker %s", workerObjectKey)
+	}
+	return persistWorkerCapacity(ctx, ws, workerObjectKey, capacity)
+}
+
+// renewLease extends the lease of one live reservation.
+func renewLease(res *Reservation, now time.Time, lease time.Duration) {
+	res.LeaseExpiresAt = timestamp.New(now.UTC().Add(lease))
+}

--- a/forge/runtime/reservation.go
+++ b/forge/runtime/reservation.go
@@ -1,0 +1,231 @@
+package forge_runtime
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
+	"time"
+
+	"github.com/aperturerobotics/fastjson"
+	timestamp "github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
+	"github.com/pkg/errors"
+	"github.com/s4wave/spacewave/db/block"
+	"github.com/s4wave/spacewave/db/world"
+)
+
+const reservationObjectKeyPrefix = "forge/runtime/reservation/"
+
+// BuildReservationObjectKey builds the deterministic object key for the one
+// reservation of an Execution attempt. A retry after release is a new attempt
+// with a new Execution object key.
+func BuildReservationObjectKey(executionObjectKey string) string {
+	hash := sha256.Sum256([]byte(executionObjectKey))
+	return reservationObjectKeyPrefix + hex.EncodeToString(hash[:12])
+}
+
+// NewReservationBlock constructs an empty Reservation block.
+func NewReservationBlock() block.Block {
+	return &Reservation{}
+}
+
+// Reservation records one generation-fenced and lease-fenced capacity grant.
+// The record is the durable truth: a daemon restart reconciles by reading it.
+type Reservation struct {
+	// WorkerObjectKey is the Forge Worker object key holding the capacity.
+	WorkerObjectKey string `json:"workerObjectKey,omitempty"`
+	// ExecutionObjectKey is the owning Execution attempt object key.
+	ExecutionObjectKey string `json:"executionObjectKey,omitempty"`
+	// Request is the reserved capacity request.
+	Request ResourceRequest `json:"request"`
+	// Generation fences runtime custody. Resume after uncertainty increments
+	// the generation; calls fenced against an older generation are stale.
+	Generation uint64
+	// LeaseExpiresAt is when unobserved custody expires. Expiry releases the
+	// debited capacity exactly once.
+	LeaseExpiresAt *timestamp.Timestamp
+	// State is the reservation lifecycle state.
+	State ReservationState
+	// Runtime identifies the claimed backend runtime, set on activation.
+	Runtime BackendRuntimeIdentity
+	// Cleanup records the terminal cleanup receipt, set on release.
+	Cleanup *CleanupReceipt
+}
+
+// ObjectKey returns the deterministic reservation object key.
+func (r *Reservation) ObjectKey() string {
+	return BuildReservationObjectKey(r.ExecutionObjectKey)
+}
+
+// Validate validates the reservation.
+func (r *Reservation) Validate() error {
+	switch {
+	case r.WorkerObjectKey == "":
+		return errors.New("worker_object_key cannot be empty")
+	case r.ExecutionObjectKey == "":
+		return errors.New("execution_object_key cannot be empty")
+	case r.Generation == 0:
+		return errors.New("generation must be set")
+	case !r.State.Valid():
+		return errors.Errorf("invalid reservation state %d", r.State)
+	case r.LeaseExpiresAt == nil:
+		return errors.New("lease_expires_at must be set")
+	}
+	if err := r.Request.Validate(); err != nil {
+		return errors.Wrap(err, "request")
+	}
+	if err := r.LeaseExpiresAt.Validate(false); err != nil {
+		return errors.Wrap(err, "lease_expires_at")
+	}
+	if r.Cleanup != nil {
+		if err := r.Cleanup.Validate(); err != nil {
+			return errors.Wrap(err, "cleanup")
+		}
+		switch r.State {
+		case ReservationStatePendingStop:
+			if r.Cleanup.Complete() {
+				return errors.New("pending-stop receipt must stay partial until the stop confirms")
+			}
+		case ReservationStateReleased:
+			if !r.Cleanup.Complete() {
+				return errors.New("released reservation requires the completed receipt")
+			}
+		default:
+			return errors.New("cleanup receipt requires pending-stop or released state")
+		}
+	}
+	return nil
+}
+
+// Outcome classifies the reservation for reconcile at the given time.
+func (r *Reservation) Outcome(now time.Time) ReservationOutcome {
+	switch {
+	case r.State.Terminal():
+		return OutcomeTerminal
+	case r.State == ReservationStateUncertain:
+		return OutcomeUncertain
+	case r.LeaseExpired(now):
+		return OutcomeUncertain
+	default:
+		return OutcomeActive
+	}
+}
+
+// LeaseExpired reports whether the lease is past due at the given time.
+func (r *Reservation) LeaseExpired(now time.Time) bool {
+	return r.LeaseExpiresAt != nil && now.After(r.LeaseExpiresAt.AsTime())
+}
+
+// Reset resets the block.
+func (r *Reservation) Reset() {
+	*r = Reservation{}
+}
+
+// MarshalBlock marshals the block to binary.
+func (r *Reservation) MarshalBlock() ([]byte, error) {
+	return r.MarshalJSON()
+}
+
+// UnmarshalBlock unmarshals the block from binary.
+func (r *Reservation) UnmarshalBlock(data []byte) error {
+	return r.UnmarshalJSON(data)
+}
+
+// MarshalJSON marshals the Reservation to JSON without reflection.
+func (r *Reservation) MarshalJSON() ([]byte, error) {
+	var arena fastjson.Arena
+	obj := arena.NewObject()
+	setStringJSONField(&arena, obj, "workerObjectKey", r.WorkerObjectKey)
+	setStringJSONField(&arena, obj, "executionObjectKey", r.ExecutionObjectKey)
+	req := arena.NewObject()
+	req.Set("milliCpu", arena.NewNumberString(strconv.FormatUint(r.Request.MilliCPU, 10)))
+	req.Set("memoryBytes", arena.NewNumberString(strconv.FormatUint(r.Request.MemoryBytes, 10)))
+	req.Set("backend", arena.NewString(r.Request.Backend))
+	obj.Set("request", req)
+	obj.Set("generation", arena.NewNumberString(strconv.FormatUint(r.Generation, 10)))
+	tsValue, err := marshalTimestampField(&arena, r.LeaseExpiresAt)
+	if err != nil {
+		return nil, err
+	}
+	obj.Set("leaseExpiresAt", tsValue)
+	obj.Set("state", arena.NewNumberInt(int(r.State)))
+	if !r.Runtime.IsZero() {
+		rt := arena.NewObject()
+		rt.Set("backend", arena.NewString(r.Runtime.Backend))
+		rt.Set("id", arena.NewString(r.Runtime.ID))
+		obj.Set("runtime", rt)
+	}
+	if r.Cleanup != nil {
+		cleanupValue, err := r.Cleanup.marshalJSONValue(&arena)
+		if err != nil {
+			return nil, err
+		}
+		obj.Set("cleanup", cleanupValue)
+	}
+	return obj.MarshalTo(nil), nil
+}
+
+// UnmarshalJSON unmarshals the Reservation from JSON without reflection.
+func (r *Reservation) UnmarshalJSON(data []byte) error {
+	var parser fastjson.Parser
+	value, err := parser.ParseBytes(data)
+	if err != nil {
+		return err
+	}
+	if value.Type() == fastjson.TypeNull {
+		*r = Reservation{}
+		return nil
+	}
+	if value.Type() != fastjson.TypeObject {
+		return errors.New("reservation must be object")
+	}
+	r.WorkerObjectKey = string(value.GetStringBytes("workerObjectKey"))
+	r.ExecutionObjectKey = string(value.GetStringBytes("executionObjectKey"))
+	r.Request = ResourceRequest{
+		MilliCPU:    value.GetUint64("request", "milliCpu"),
+		MemoryBytes: value.GetUint64("request", "memoryBytes"),
+		Backend:     string(value.GetStringBytes("request", "backend")),
+	}
+	r.Generation = value.GetUint64("generation")
+	r.State = ReservationState(value.GetInt("state"))
+	if tsValue := value.Get("leaseExpiresAt"); tsValue != nil && tsValue.Type() != fastjson.TypeNull {
+		ts := &timestamp.Timestamp{}
+		if err := ts.UnmarshalJSON(tsValue.MarshalTo(nil)); err != nil {
+			return errors.Wrap(err, "unmarshal lease_expires_at")
+		}
+		r.LeaseExpiresAt = ts
+	}
+	if rt := value.Get("runtime"); rt != nil && rt.Type() == fastjson.TypeObject {
+		r.Runtime = BackendRuntimeIdentity{
+			Backend: string(rt.GetStringBytes("backend")),
+			ID:      string(rt.GetStringBytes("id")),
+		}
+	}
+	if cleanupValue := value.Get("cleanup"); cleanupValue != nil && cleanupValue.Type() == fastjson.TypeObject {
+		cleanup := &CleanupReceipt{}
+		if err := cleanup.unmarshalJSONValue(cleanupValue); err != nil {
+			return errors.Wrap(err, "unmarshal cleanup")
+		}
+		r.Cleanup = cleanup
+	}
+	return nil
+}
+
+// LookupReservation loads one persisted Reservation or ErrReservationNotFound.
+// The loaded record is validated before use.
+func LookupReservation(ctx context.Context, ws world.WorldState, objKey string) (*Reservation, error) {
+	res, err := world.LookupObjectBody[*Reservation](ctx, ws, objKey, NewReservationBlock)
+	if errors.Is(err, world.ErrObjectNotFound) {
+		return nil, ErrReservationNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	if err := res.Validate(); err != nil {
+		return nil, errors.Wrapf(err, "invalid reservation %s", objKey)
+	}
+	return res, nil
+}
+
+// _ is a type assertion
+var _ block.Block = (*Reservation)(nil)

--- a/forge/runtime/worker-capacity.go
+++ b/forge/runtime/worker-capacity.go
@@ -1,0 +1,156 @@
+package forge_runtime
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"slices"
+	"strconv"
+
+	"github.com/aperturerobotics/fastjson"
+	timestamp "github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
+	"github.com/pkg/errors"
+	"github.com/s4wave/spacewave/db/block"
+	"github.com/s4wave/spacewave/db/world"
+)
+
+const workerCapacityObjectKeyPrefix = "forge/runtime/capacity/"
+
+// BuildWorkerCapacityObjectKey builds the deterministic capacity object key
+// for one Forge Worker. The Worker daemon owns this record; Forge validates
+// and debits it, callers never keep a parallel ledger.
+func BuildWorkerCapacityObjectKey(workerObjectKey string) string {
+	hash := sha256.Sum256([]byte(workerObjectKey))
+	return workerCapacityObjectKeyPrefix + hex.EncodeToString(hash[:12])
+}
+
+// NewWorkerCapacityBlock constructs an empty WorkerCapacity block.
+func NewWorkerCapacityBlock() block.Block {
+	return &WorkerCapacity{}
+}
+
+// WorkerCapacity is the observed and reserved capacity for one Forge Worker.
+type WorkerCapacity struct {
+	// MilliCPUTotal is the observed total CPU in milli-cores.
+	MilliCPUTotal uint64
+	// MilliCPUReserved is the CPU currently debited by live reservations.
+	MilliCPUReserved uint64
+	// MemoryBytesTotal is the observed total memory in bytes.
+	MemoryBytesTotal uint64
+	// MemoryBytesReserved is the memory currently debited by live reservations.
+	MemoryBytesReserved uint64
+	// Backends lists the runtime backends the Worker supports.
+	Backends []string
+	// ObservedAt is when the Worker reported the totals.
+	ObservedAt *timestamp.Timestamp
+	// Generation increments on every mutation of this record so observers can
+	// fence stale capacity views.
+	Generation uint64
+}
+
+// SupportsBackend reports whether the Worker declares the backend.
+func (w *WorkerCapacity) SupportsBackend(backend string) bool {
+	return slices.Contains(w.Backends, backend)
+}
+
+// Validate validates the capacity record.
+func (w *WorkerCapacity) Validate() error {
+	switch {
+	case w.MilliCPUReserved > w.MilliCPUTotal:
+		return errors.New("reserved milli_cpu exceeds total")
+	case w.MemoryBytesReserved > w.MemoryBytesTotal:
+		return errors.New("reserved memory_bytes exceeds total")
+	case w.Generation == 0:
+		return errors.New("generation must be set")
+	}
+	if err := w.ObservedAt.Validate(false); err != nil {
+		return errors.Wrap(err, "observed_at")
+	}
+	return nil
+}
+
+// Reset resets the block.
+func (w *WorkerCapacity) Reset() {
+	*w = WorkerCapacity{}
+}
+
+// MarshalBlock marshals the block to binary.
+func (w *WorkerCapacity) MarshalBlock() ([]byte, error) {
+	return w.MarshalJSON()
+}
+
+// UnmarshalBlock unmarshals the block from binary.
+func (w *WorkerCapacity) UnmarshalBlock(data []byte) error {
+	return w.UnmarshalJSON(data)
+}
+
+// MarshalJSON marshals the WorkerCapacity to JSON without reflection.
+func (w *WorkerCapacity) MarshalJSON() ([]byte, error) {
+	var arena fastjson.Arena
+	obj := arena.NewObject()
+	obj.Set("milliCpuTotal", arena.NewNumberString(strconv.FormatUint(w.MilliCPUTotal, 10)))
+	obj.Set("milliCpuReserved", arena.NewNumberString(strconv.FormatUint(w.MilliCPUReserved, 10)))
+	obj.Set("memoryBytesTotal", arena.NewNumberString(strconv.FormatUint(w.MemoryBytesTotal, 10)))
+	obj.Set("memoryBytesReserved", arena.NewNumberString(strconv.FormatUint(w.MemoryBytesReserved, 10)))
+	backends := arena.NewArray()
+	for i, b := range w.Backends {
+		backends.SetArrayItem(i, arena.NewString(b))
+	}
+	obj.Set("backends", backends)
+	tsValue, err := marshalTimestampField(&arena, w.ObservedAt)
+	if err != nil {
+		return nil, err
+	}
+	obj.Set("observedAt", tsValue)
+	obj.Set("generation", arena.NewNumberString(strconv.FormatUint(w.Generation, 10)))
+	return obj.MarshalTo(nil), nil
+}
+
+// UnmarshalJSON unmarshals the WorkerCapacity from JSON without reflection.
+func (w *WorkerCapacity) UnmarshalJSON(data []byte) error {
+	var parser fastjson.Parser
+	value, err := parser.ParseBytes(data)
+	if err != nil {
+		return err
+	}
+	if value.Type() == fastjson.TypeNull {
+		*w = WorkerCapacity{}
+		return nil
+	}
+	if value.Type() != fastjson.TypeObject {
+		return errors.New("worker capacity must be object")
+	}
+	w.MilliCPUTotal = value.GetUint64("milliCpuTotal")
+	w.MilliCPUReserved = value.GetUint64("milliCpuReserved")
+	w.MemoryBytesTotal = value.GetUint64("memoryBytesTotal")
+	w.MemoryBytesReserved = value.GetUint64("memoryBytesReserved")
+	w.Backends = nil
+	for _, b := range value.GetArray("backends") {
+		w.Backends = append(w.Backends, string(b.GetStringBytes()))
+	}
+	w.ObservedAt, err = unmarshalTimestampField(value, "observedAt")
+	if err != nil {
+		return err
+	}
+	w.Generation = value.GetUint64("generation")
+	return nil
+}
+
+// LookupWorkerCapacity loads one Worker capacity record or ErrWorkerNotObserved.
+func LookupWorkerCapacity(ctx context.Context, ws world.WorldState, workerObjectKey string) (*WorkerCapacity, error) {
+	capacity, err := world.LookupObjectBody[*WorkerCapacity](
+		ctx,
+		ws,
+		BuildWorkerCapacityObjectKey(workerObjectKey),
+		NewWorkerCapacityBlock,
+	)
+	if errors.Is(err, world.ErrObjectNotFound) {
+		return nil, ErrWorkerNotObserved
+	}
+	if err != nil {
+		return nil, err
+	}
+	return capacity, nil
+}
+
+var _ block.Block = (*WorkerCapacity)(nil)

--- a/forge/runtime/world-admission.go
+++ b/forge/runtime/world-admission.go
@@ -1,0 +1,710 @@
+package forge_runtime
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	timestamp "github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
+	"github.com/pkg/errors"
+	"github.com/s4wave/spacewave/db/world"
+)
+
+// RuntimeStopper stops one backend runtime by identity. The Forge runtime
+// backend owns the mechanics; admission owns the fence and the ledger.
+// Implementations must be idempotent: stopping an already-gone runtime
+// returns true, nil.
+type RuntimeStopper interface {
+	// StopRuntime stops the identified runtime.
+	// Returns true when the runtime was stopped or was already gone.
+	StopRuntime(ctx context.Context, rt BackendRuntimeIdentity) (bool, error)
+}
+
+// WorldRuntimeAdmission implements RuntimeAdmission over durable world objects.
+//
+// Every reservation and capacity mutation applies inside one world write
+// transaction, so create-plus-debit and release-plus-credit are atomic even
+// across a crash. All mutations for one Worker serialize on a per-Worker lock;
+// the durable boundary assumes exactly one writer instance per Forge Worker
+// capacity record. A second daemon writing the same Worker's capacity record
+// is outside this contract and must not be attempted: run one admission owner
+// per Worker.
+type WorldRuntimeAdmission struct {
+	// eng is the world engine holding the durable state.
+	eng world.Engine
+	// stopper stops backend runtimes during release and reconciliation.
+	stopper RuntimeStopper
+	// lease is the reservation lease duration.
+	lease time.Duration
+	// now returns the current time; overridable in tests.
+	now func() time.Time
+
+	mtx sync.Mutex
+	// workerLocks serialize capacity mutations per Worker object key.
+	workerLocks map[string]*sync.Mutex
+}
+
+// NewWorldRuntimeAdmission constructs a world-backed RuntimeAdmission.
+// A zero lease uses DefaultLeaseDuration.
+func NewWorldRuntimeAdmission(eng world.Engine, stopper RuntimeStopper, lease time.Duration) *WorldRuntimeAdmission {
+	if lease == 0 {
+		lease = DefaultLeaseDuration
+	}
+	return &WorldRuntimeAdmission{
+		eng:         eng,
+		stopper:     stopper,
+		lease:       lease,
+		now:         time.Now,
+		workerLocks: make(map[string]*sync.Mutex),
+	}
+}
+
+// SetTimeNow overrides the clock; tests use this to drive expiry.
+func (a *WorldRuntimeAdmission) SetTimeNow(now func() time.Time) {
+	a.now = now
+}
+
+// lockWorker locks the per-Worker mutation lock and returns the unlock func.
+func (a *WorldRuntimeAdmission) lockWorker(workerObjectKey string) func() {
+	a.mtx.Lock()
+	lk, ok := a.workerLocks[workerObjectKey]
+	if !ok {
+		lk = &sync.Mutex{}
+		a.workerLocks[workerObjectKey] = lk
+	}
+	a.mtx.Unlock()
+	lk.Lock()
+	return lk.Unlock
+}
+
+// withTx runs cb inside one world transaction of the given mode.
+func (a *WorldRuntimeAdmission) withTx(
+	ctx context.Context,
+	write bool,
+	cb func(ctx context.Context, ws world.WorldState) error,
+) error {
+	return world.ExecTransaction(ctx, a.eng, write, func(ctx context.Context, wtx world.WorldState) error {
+		return cb(ctx, wtx)
+	})
+}
+
+// ObserveWorker upserts the Worker's observed capacity totals and backends.
+// Reserved debits are preserved; every observation bumps the record generation.
+func (a *WorldRuntimeAdmission) ObserveWorker(
+	ctx context.Context,
+	workerObjectKey string,
+	milliCPUTotal, memoryBytesTotal uint64,
+	backends []string,
+) (*WorkerCapacity, error) {
+	if workerObjectKey == "" {
+		return nil, errors.Wrap(world.ErrEmptyObjectKey, "worker_object_key")
+	}
+	unlock := a.lockWorker(workerObjectKey)
+	defer unlock()
+
+	var out *WorkerCapacity
+	err := a.withTx(ctx, true, func(ctx context.Context, ws world.WorldState) error {
+		capacity, err := LookupWorkerCapacity(ctx, ws, workerObjectKey)
+		if err != nil && !errors.Is(err, ErrWorkerNotObserved) {
+			return err
+		}
+		if capacity == nil {
+			capacity = &WorkerCapacity{}
+		}
+		capacity.MilliCPUTotal = milliCPUTotal
+		capacity.MemoryBytesTotal = memoryBytesTotal
+		capacity.Backends = append([]string(nil), backends...)
+		capacity.ObservedAt = timestamp.Now()
+		capacity.Generation++
+		if err := capacity.Validate(); err != nil {
+			return err
+		}
+		if err := persistWorkerCapacity(ctx, ws, workerObjectKey, capacity); err != nil {
+			return err
+		}
+		out = capacity
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Reserve implements RuntimeAdmission. Creation and the capacity debit apply
+// in one transaction; the idempotent return proves the debit by re-reading the
+// capacity record before returning.
+func (a *WorldRuntimeAdmission) Reserve(
+	ctx context.Context,
+	workerObjectKey, executionObjectKey string,
+	request ResourceRequest,
+) (*Reservation, error) {
+	if workerObjectKey == "" || executionObjectKey == "" {
+		return nil, errors.Wrap(world.ErrEmptyObjectKey, "worker and execution keys")
+	}
+	if err := request.Validate(); err != nil {
+		return nil, errors.Wrap(err, "resource request")
+	}
+
+	unlock := a.lockWorker(workerObjectKey)
+	defer unlock()
+
+	var out *Reservation
+	err := a.withTx(ctx, true, func(ctx context.Context, ws world.WorldState) error {
+		resKey := BuildReservationObjectKey(executionObjectKey)
+		existing, err := LookupReservation(ctx, ws, resKey)
+		if err != nil && !errors.Is(err, ErrReservationNotFound) {
+			return err
+		}
+		if existing != nil {
+			switch {
+			case existing.State.Terminal():
+				// A retry after release is a new attempt with a new Execution key.
+				return ErrReservationTerminal
+			case existing.LeaseExpired(a.now()):
+				return ErrReservationExpired
+			case existing.WorkerObjectKey != workerObjectKey || existing.Request != request:
+				return ErrRequestMismatch
+			}
+			// Prove the debit is still present before returning idempotently.
+			capacity, err := LookupWorkerCapacity(ctx, ws, workerObjectKey)
+			if err != nil {
+				return err
+			}
+			if remainingMilliCPU(capacity)+existing.Request.MilliCPU < existing.Request.MilliCPU ||
+				capacity.MilliCPUReserved < existing.Request.MilliCPU ||
+				capacity.MemoryBytesReserved < existing.Request.MemoryBytes {
+				return errors.Wrapf(ErrCapacityExhausted, "debit missing for %s", resKey)
+			}
+			out = existing
+			return nil
+		}
+
+		capacity, err := LookupWorkerCapacity(ctx, ws, workerObjectKey)
+		if err != nil {
+			return err
+		}
+		if !capacity.SupportsBackend(request.Backend) {
+			return errors.Wrapf(ErrBackendUnsupported, "backend %q", request.Backend)
+		}
+		if remainingMilliCPU(capacity) < request.MilliCPU || remainingMemoryBytes(capacity) < request.MemoryBytes {
+			return errors.Wrapf(ErrCapacityExhausted, "worker %s", workerObjectKey)
+		}
+
+		now := a.now().UTC()
+		res := &Reservation{
+			WorkerObjectKey:    workerObjectKey,
+			ExecutionObjectKey: executionObjectKey,
+			Request:            request,
+			Generation:         1,
+			LeaseExpiresAt:     timestamp.New(now.Add(a.lease)),
+			State:              ReservationStateReserved,
+		}
+		if err := res.Validate(); err != nil {
+			return err
+		}
+		if err := persistNewReservation(ctx, ws, res); err != nil {
+			return err
+		}
+		if err := debitCapacity(ctx, ws, workerObjectKey, request); err != nil {
+			return err
+		}
+		out = res
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Activate claims the reserved capacity for one backend runtime before launch.
+func (a *WorldRuntimeAdmission) Activate(
+	ctx context.Context,
+	reservationObjectKey string,
+	rt BackendRuntimeIdentity,
+) (*Reservation, error) {
+	if rt.IsZero() {
+		return nil, errors.New("runtime identity must be set")
+	}
+	return a.transitionReservation(ctx, reservationObjectKey, func(res *Reservation) error {
+		if res.State != ReservationStateReserved {
+			return errors.Errorf("cannot activate from state %d", res.State)
+		}
+		res.State = ReservationStateActive
+		res.Runtime = rt
+		renewLease(res, a.now(), a.lease)
+		return nil
+	})
+}
+
+// MarkUncertain records that runtime custody is unreachable while capacity
+// stays debited, whether before launch or after activation. Idempotent while
+// uncertain; rejected once released or pending stop.
+func (a *WorldRuntimeAdmission) MarkUncertain(ctx context.Context, reservationObjectKey string) (*Reservation, error) {
+	return a.transitionReservation(ctx, reservationObjectKey, func(res *Reservation) error {
+		switch res.State {
+		case ReservationStateUncertain:
+			return nil
+		case ReservationStateReserved, ReservationStateActive:
+			res.State = ReservationStateUncertain
+			return nil
+		default:
+			return errors.Errorf("cannot mark uncertain from state %d", res.State)
+		}
+	})
+}
+
+// ResumeFromUncertain re-fences custody when the same fenced runtime
+// reconnects. The generation increments so a late return from the previous
+// runtime instance cannot stop or release the re-fenced reservation.
+func (a *WorldRuntimeAdmission) ResumeFromUncertain(
+	ctx context.Context,
+	reservationObjectKey string,
+	rt BackendRuntimeIdentity,
+) (*Reservation, error) {
+	if rt.IsZero() {
+		return nil, errors.New("runtime identity must be set")
+	}
+	return a.transitionReservation(ctx, reservationObjectKey, func(res *Reservation) error {
+		if res.State != ReservationStateUncertain {
+			return errors.Errorf("cannot resume from state %d", res.State)
+		}
+		res.Generation++
+		res.Runtime = rt
+		res.State = ReservationStateActive
+		renewLease(res, a.now(), a.lease)
+		return nil
+	})
+}
+
+// RenewLease extends the lease of a live reservation from the observing owner.
+func (a *WorldRuntimeAdmission) RenewLease(ctx context.Context, reservationObjectKey string) (*Reservation, error) {
+	return a.transitionReservation(ctx, reservationObjectKey, func(res *Reservation) error {
+		if !res.State.Live() {
+			return ErrReservationTerminal
+		}
+		renewLease(res, a.now(), a.lease)
+		return nil
+	})
+}
+
+// LookupReservation implements RuntimeAdmission.
+func (a *WorldRuntimeAdmission) LookupReservation(ctx context.Context, reservationObjectKey string) (*Reservation, error) {
+	var out *Reservation
+	err := a.withTx(ctx, false, func(ctx context.Context, ws world.WorldState) error {
+		res, err := LookupReservation(ctx, ws, reservationObjectKey)
+		out = res
+		return err
+	})
+	return out, err
+}
+
+// StopAndRelease implements RuntimeAdmission.
+//
+// The transition into the durable pending-stop state applies under the Worker
+// lock in its own transaction. The runtime stop runs without the lock held.
+// The finalizing transaction persists the confirmed receipt and credits the
+// capacity atomically. A stale generation is rejected without touching the
+// current runtime or capacity: that call belongs to a replaced runtime
+// instance returning late. A crash between transition and finalize leaves the
+// reservation durably in the pending-stop state; ReconcilePendingStops
+// finishes it with the same idempotent stopper.
+func (a *WorldRuntimeAdmission) StopAndRelease(
+	ctx context.Context,
+	reservationObjectKey string,
+	generation uint64,
+) (*CleanupReceipt, error) {
+	res, receipt, err := a.beginStopLocked(ctx, reservationObjectKey, generation)
+	if err != nil {
+		return nil, err
+	}
+	if receipt != nil {
+		return receipt, nil
+	}
+
+	// Stop outside the Worker lock; the stop may block on backend mechanics.
+	runtimeStopped := true
+	if !res.Runtime.IsZero() {
+		stopped, err := a.stopRuntimeChecked(ctx, res.Runtime)
+		if err != nil {
+			return nil, err
+		}
+		runtimeStopped = stopped
+	}
+	return a.finalizeStop(ctx, res.ObjectKey(), res.WorkerObjectKey, res.ExecutionObjectKey, res.Runtime.ID, res.Generation, runtimeStopped, CleanupReasonStop)
+}
+
+// ExpireLeases fences every live reservation whose lease expired at or
+// before now. Each expiry is one transaction that bumps the generation,
+// enters the durable pending-stop state while retaining the debit, and
+// persists the explicitly partial receipt: RuntimeStopped=false because the
+// runtime outcome is unknown, CapacityReleased=false because the debit is
+// held until the stop confirms. After committing, the sweep attempts the stop
+// outside the Worker lock; confirmation finalizes the truthful terminal
+// receipt and credits the debit exactly once. Failure leaves the work to
+// ReconcilePendingStops. Post-expiry calls fenced against the old generation
+// are stale and cannot receive the terminal receipt.
+func (a *WorldRuntimeAdmission) ExpireLeases(ctx context.Context, now time.Time) ([]*CleanupReceipt, error) {
+	keys, err := a.listReservationKeys(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var receipts []*CleanupReceipt
+	for _, key := range keys {
+		workerKey, err := a.resolveWorkerForReservation(ctx, key)
+		if err != nil {
+			return receipts, err
+		}
+		unlock := a.lockWorker(workerKey)
+		receipt, err := a.expireOne(ctx, key, now)
+		unlock()
+		if err != nil {
+			return receipts, err
+		}
+		if receipt == nil {
+			continue
+		}
+		receipts = append(receipts, receipt)
+
+		// Best-effort immediate stop outside the Worker lock;
+		// ReconcilePendingStops retries later. When the stop confirms here,
+		// report the completed truthful receipt instead of the partial one.
+		done, err := a.reconcilePendingStop(ctx, receipt.ReservationObjectKey)
+		if err == nil && done != nil {
+			receipts[len(receipts)-1] = done
+		}
+	}
+	return receipts, nil
+}
+
+// ReconcilePendingStops confirms stops for every pending-stop reservation by
+// running the idempotent stopper and finalizing the receipt. It completes the
+// work of a crashed StopAndRelease or an unreachable expired runtime.
+func (a *WorldRuntimeAdmission) ReconcilePendingStops(ctx context.Context) ([]*CleanupReceipt, error) {
+	keys, err := a.listReservationKeys(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var receipts []*CleanupReceipt
+	for _, key := range keys {
+		receipt, err := a.reconcilePendingStop(ctx, key)
+		if err != nil {
+			return receipts, err
+		}
+		if receipt != nil {
+			receipts = append(receipts, receipt)
+		}
+	}
+	return receipts, nil
+}
+
+// expireOne expires one expired live reservation in one transaction.
+// Caller holds the Worker lock. Returns nil when the reservation is not
+// expirable.
+func (a *WorldRuntimeAdmission) expireOne(ctx context.Context, objKey string, now time.Time) (*CleanupReceipt, error) {
+	var out *CleanupReceipt
+	err := a.withTx(ctx, true, func(ctx context.Context, ws world.WorldState) error {
+		res, err := LookupReservation(ctx, ws, objKey)
+		if err != nil {
+			return err
+		}
+		if !res.State.Live() || !res.LeaseExpired(now) {
+			return nil
+		}
+		// Fence custody: every old-generation call becomes stale. The debit
+		// stays held until the stop confirms.
+		fenced := *res
+		fenced.Generation++
+		fenced.State = ReservationStatePendingStop
+		receipt := &CleanupReceipt{
+			ReservationObjectKey: objKey,
+			ExecutionObjectKey:   res.ExecutionObjectKey,
+			RuntimeIdentity:      res.Runtime.ID,
+			Generation:           fenced.Generation,
+			RuntimeStopped:       false,
+			CapacityReleased:     false,
+			Reason:               CleanupReasonExpired,
+		}
+		if err := receipt.Validate(); err != nil {
+			return err
+		}
+		fenced.Cleanup = receipt
+		fenced.LeaseExpiresAt = timestamp.New(now)
+		if err := fenced.Validate(); err != nil {
+			return err
+		}
+		if err := persistReservation(ctx, ws, objKey, &fenced); err != nil {
+			return err
+		}
+		out = receipt
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// beginStopLocked validates the generation and moves a live reservation into
+// the pending-stop state without touching capacity. Caller does not hold the
+// lock; the function takes it. Returns the fenced reservation with its Worker
+// key, or a non-nil receipt when the reservation already released for this
+// generation.
+func (a *WorldRuntimeAdmission) beginStopLocked(
+	ctx context.Context,
+	reservationObjectKey string,
+	generation uint64,
+) (*Reservation, *CleanupReceipt, error) {
+	res, err := a.LookupReservation(ctx, reservationObjectKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	unlock := a.lockWorker(res.WorkerObjectKey)
+	defer unlock()
+
+	var out *Reservation
+	err = a.withTx(ctx, true, func(ctx context.Context, ws world.WorldState) error {
+		current, err := LookupReservation(ctx, ws, reservationObjectKey)
+		if err != nil {
+			return err
+		}
+		switch {
+		case current.State.Terminal():
+			if current.Generation != generation {
+				return ErrStaleGeneration
+			}
+			out = current
+			return nil
+		case current.Generation != generation:
+			return ErrStaleGeneration
+		case current.State == ReservationStatePendingStop:
+			// Crash recovery or a concurrent return for the same fenced
+			// generation: continue the pending stop.
+			out = current
+			return nil
+		case current.State == ReservationStateReserved || current.State == ReservationStateActive || current.State == ReservationStateUncertain:
+			fenced := *current
+			fenced.State = ReservationStatePendingStop
+			if err := fenced.Validate(); err != nil {
+				return err
+			}
+			if err := persistReservation(ctx, ws, reservationObjectKey, &fenced); err != nil {
+				return err
+			}
+			out = &fenced
+			return nil
+		default:
+			return errors.Errorf("cannot stop from state %d", current.State)
+		}
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	if out.State.Terminal() {
+		return nil, out.Cleanup, nil
+	}
+	return out, nil, nil
+}
+
+// finalizeStop persists the stop facts in one transaction. The persisted
+// fence generation must match the receipt generation. When the stop did not
+// confirm yet, the explicitly partial receipt (RuntimeStopped=false and
+// CapacityReleased=false) stays durable under the pending-stop state with the
+// debit held; reconciliation finishes it. When the stop confirms, the same
+// transaction records the terminal receipt and credits the debit exactly
+// once: only the released state releases capacity.
+func (a *WorldRuntimeAdmission) finalizeStop(
+	ctx context.Context,
+	objKey, workerObjectKey, executionObjectKey, runtimeIdentity string,
+	generation uint64,
+	runtimeStopped bool,
+	reason string,
+) (*CleanupReceipt, error) {
+	unlock := a.lockWorker(workerObjectKey)
+	defer unlock()
+
+	var out *CleanupReceipt
+	err := a.withTx(ctx, true, func(ctx context.Context, ws world.WorldState) error {
+		res, err := LookupReservation(ctx, ws, objKey)
+		if err != nil {
+			return err
+		}
+		if res.Generation != generation {
+			return ErrStaleGeneration
+		}
+		if res.ExecutionObjectKey != executionObjectKey {
+			return ErrRequestMismatch
+		}
+		if res.State.Terminal() {
+			out = res.Cleanup
+			return nil
+		}
+		if res.State != ReservationStatePendingStop {
+			return errors.Errorf("cannot finalize from state %d", res.State)
+		}
+
+		prior := res.Cleanup
+		if prior != nil && prior.Reason != "" {
+			reason = prior.Reason
+		}
+		if !runtimeStopped {
+			// The stop did not confirm; keep the truthful partial receipt and
+			// hold the debit for reconciliation.
+			receipt := &CleanupReceipt{
+				ReservationObjectKey: objKey,
+				ExecutionObjectKey:   res.ExecutionObjectKey,
+				RuntimeIdentity:      runtimeIdentity,
+				Generation:           generation,
+				RuntimeStopped:       false,
+				CapacityReleased:     false,
+				Reason:               reason,
+			}
+			partial := *res
+			partial.Cleanup = receipt
+			if err := partial.Validate(); err != nil {
+				return err
+			}
+			if err := persistReservation(ctx, ws, objKey, &partial); err != nil {
+				return err
+			}
+			out = receipt
+			return nil
+		}
+		receipt := &CleanupReceipt{
+			ReservationObjectKey: objKey,
+			ExecutionObjectKey:   res.ExecutionObjectKey,
+			RuntimeIdentity:      runtimeIdentity,
+			Generation:           generation,
+			RuntimeStopped:       true,
+			CapacityReleased:     true,
+			Reason:               reason,
+		}
+		finalized := *res
+		finalized.State = ReservationStateReleased
+		finalized.Cleanup = receipt
+		if err := finalized.Validate(); err != nil {
+			return err
+		}
+		if err := persistReservation(ctx, ws, objKey, &finalized); err != nil {
+			return err
+		}
+		if err := creditCapacity(ctx, ws, res.WorkerObjectKey, res.Request); err != nil {
+			return err
+		}
+		out = receipt
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// reconcilePendingStop confirms the stop of one pending-stop reservation.
+// Returns the completed receipt, or nil when the key is not pending-stop.
+func (a *WorldRuntimeAdmission) reconcilePendingStop(ctx context.Context, objKey string) (*CleanupReceipt, error) {
+	res, err := a.LookupReservation(ctx, objKey)
+	if err != nil {
+		return nil, err
+	}
+	if res.State != ReservationStatePendingStop {
+		return nil, nil
+	}
+	runtimeStopped := true
+	if !res.Runtime.IsZero() {
+		stopped, err := a.stopRuntimeChecked(ctx, res.Runtime)
+		if err != nil {
+			return nil, err
+		}
+		runtimeStopped = stopped
+	}
+	priorReason := ""
+	if res.Cleanup != nil {
+		priorReason = res.Cleanup.Reason
+	}
+	if priorReason == "" {
+		priorReason = CleanupReasonStop
+	}
+	return a.finalizeStop(
+		ctx,
+		objKey,
+		res.WorkerObjectKey,
+		res.ExecutionObjectKey,
+		res.Runtime.ID,
+		res.Generation,
+		runtimeStopped,
+		priorReason,
+	)
+}
+
+// stopRuntimeChecked invokes the configured stopper and wraps failures.
+func (a *WorldRuntimeAdmission) stopRuntimeChecked(ctx context.Context, rt BackendRuntimeIdentity) (bool, error) {
+	if a.stopper == nil {
+		return false, errors.New("runtime stopper not configured")
+	}
+	stopped, err := a.stopper.StopRuntime(ctx, rt)
+	if err != nil {
+		return false, errors.Wrapf(err, "stop runtime %s", rt.ID)
+	}
+	return stopped, nil
+}
+
+// resolveWorkerForReservation returns the owning Worker object key of a
+// persisted reservation, empty when the key is unknown.
+func (a *WorldRuntimeAdmission) resolveWorkerForReservation(ctx context.Context, objKey string) (string, error) {
+	res, err := a.LookupReservation(ctx, objKey)
+	if err != nil {
+		return "", err
+	}
+	return res.WorkerObjectKey, nil
+}
+
+// listReservationKeys lists all persisted reservation object keys.
+func (a *WorldRuntimeAdmission) listReservationKeys(ctx context.Context) ([]string, error) {
+	var keys []string
+	err := a.withTx(ctx, false, func(ctx context.Context, ws world.WorldState) error {
+		var err error
+		keys, err = listReservationKeys(ctx, ws)
+		return err
+	})
+	return keys, err
+}
+
+// transitionReservation loads, mutates, and persists one reservation under the
+// owning Worker's lock in one transaction.
+func (a *WorldRuntimeAdmission) transitionReservation(
+	ctx context.Context,
+	reservationObjectKey string,
+	cb func(*Reservation) error,
+) (*Reservation, error) {
+	res, err := a.LookupReservation(ctx, reservationObjectKey)
+	if err != nil {
+		return nil, err
+	}
+	unlock := a.lockWorker(res.WorkerObjectKey)
+	defer unlock()
+
+	var out *Reservation
+	err = a.withTx(ctx, true, func(ctx context.Context, ws world.WorldState) error {
+		current, err := LookupReservation(ctx, ws, reservationObjectKey)
+		if err != nil {
+			return err
+		}
+		if err := cb(current); err != nil {
+			return err
+		}
+		if err := current.Validate(); err != nil {
+			return err
+		}
+		if err := persistReservation(ctx, ws, reservationObjectKey, current); err != nil {
+			return err
+		}
+		out = current
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}


### PR DESCRIPTION
Runtime admission previously had no durable record of reserved device capacity, so a crashed or disconnected runtime could leak its debit or double-credit on stop. The allocation workdir identity also lived only in callers, leaving allocations without a persistent Workdir key.

This adds the forge/runtime package. Admission persists world state, debits worker capacity into a reservation atomically, and keeps the reservation as the single owner of the credit/release lifecycle:

- PendingStop retains the debit and reports a truthful partial receipt until the stop is confirmed; a confirmed stop credits once.
- Reconciliation resolves Uncertain reservations by fenced reconnect or lease expiry.
- Cleanup receipts land on the Allocation as WorkdirObjectKey plus Cleanup, and CreateOrReuse rejects allocations that require a workdir without one.

The allocation package gains WorkdirRequired/WorkdirObjectKey so the existing workdir compatibility path stays intact for legacy entries.