### PR TITLE
fix(bldr): resolve sdk imports from dist source root

### DIFF
--- a/bldr/web/bundler/vite/vite-base.config.test.ts
+++ b/bldr/web/bundler/vite/vite-base.config.test.ts
@@ -1,25 +1,28 @@
 import { describe, it, expect, afterAll, vi } from 'vitest'
-import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
-import { realpathSync } from 'node:fs'
+import {
+  mkdtemp,
+  mkdir,
+  writeFile,
+  readdir,
+  readFile,
+  rm,
+} from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { createServer, type ViteDevServer } from 'vite'
+import { build } from 'vite'
 
 // The isolated Bldr harness ships the SDK inside its own dist root. The app
 // project roots here have no node_modules install of @aptre/bldr-sdk, no
 // tsconfig paths, and no vendored Spacewave sources, so only the base-config
-// alias can resolve these imports.
+// alias can resolve these imports. The regression runs a real Vite/Rolldown
+// bundle against a flat dist root containing both a .ts and a .tsx packaged
+// SDK module.
 type HarnessLayout = 'flat' | 'nested' | 'none'
-
-interface ResolveResult {
-  id?: string
-  meta?: Record<string, Record<string, unknown>>
-}
 
 async function startIsolatedHarness(layout: HarnessLayout): Promise<{
   baseDir: string
   distRoot: string
-  server: ViteDevServer
+  appRoot: string
 }> {
   const baseDir = await mkdtemp(join(tmpdir(), 'bldr-sdk-alias-'))
   const appRoot = join(baseDir, 'app')
@@ -34,9 +37,15 @@ async function startIsolatedHarness(layout: HarnessLayout): Promise<{
       join(sdkRoot, 'plugin.ts'),
       'export const bldrSdkPlugin = true\n',
     )
+    // Packaged SDK modules ship as either .ts or .tsx; the alias must not
+    // assume one extension.
     await writeFile(
       join(sdkRoot, 'hooks', 'useStreamingResource.ts'),
-      'export function useStreamingResource() {}\n',
+      "export function useStreamingResource() { return 'stream' }\n",
+    )
+    await writeFile(
+      join(sdkRoot, 'hooks', 'ResourcesContext.tsx'),
+      "export function ResourcesContext() { return 'resources' }\n",
     )
   }
   await mkdir(appRoot, { recursive: true })
@@ -45,94 +54,132 @@ async function startIsolatedHarness(layout: HarnessLayout): Promise<{
   process.env['BLDR_PROJECT_ROOT'] = appRoot
   process.env['BLDR_DIST_ROOT'] = distRoot
   vi.resetModules()
+  return { baseDir, distRoot, appRoot }
+}
+
+async function loadBaseConfig(appRoot: string) {
+  vi.resetModules()
   const { default: baseConfig } = await import('./vite-base.config.js')
-  const server = await createServer({
+  return {
     ...baseConfig,
     root: appRoot,
     configFile: false,
-    logLevel: 'error',
-    server: { middlewareMode: true },
-  })
-  return { baseDir, distRoot, server }
+    logLevel: 'error' as const,
+  }
 }
 
 describe('vite-base.config bldr-sdk aliases in an isolated harness', () => {
-  const harnesses: Awaited<ReturnType<typeof startIsolatedHarness>>[] = []
+  const baseDirs: string[] = []
   afterAll(async () => {
     delete process.env['BLDR_PROJECT_ROOT']
     delete process.env['BLDR_DIST_ROOT']
-    for (const harness of harnesses) {
-      await harness.server.close()
-      await rm(harness.baseDir, { recursive: true, force: true })
+    for (const baseDir of baseDirs) {
+      await rm(baseDir, { recursive: true, force: true })
     }
   })
 
-  // resolveId returns { id, meta }; the Vite alias plugin reports an unmatched
-  // replacement through the vite:alias noResolved marker instead of null.
-  type Harness = Awaited<ReturnType<typeof startIsolatedHarness>>
-  async function resolveImport(
-    harness: Harness,
-    source: string,
-  ): Promise<string | null> {
-    const result = (await harness.server.pluginContainer.resolveId(
-      source,
-    )) as ResolveResult | string | null
-    if (typeof result === 'string') {
-      return result
-    }
-    if (result?.meta?.['vite:alias']?.['noResolved']) {
-      return null
-    }
-    return result?.id ?? null
-  }
-
-  function existingPath(path: string): string {
-    // macOS reports temp dirs through /var symlinks; compare real paths.
-    return realpathSync(path)
-  }
-
-  it.each([
-    ['flat', (distRoot: string) => join(distRoot, 'sdk')],
-    ['nested', (distRoot: string) => join(distRoot, 'bldr', 'sdk')],
-  ] as const)(
-    'resolves bldr-sdk imports against the %s dist layout',
-    async (layout, sdkRootOf) => {
+  it.each(['flat', 'nested'] as const)(
+    'bundles .ts and .tsx bldr-sdk hooks from the %s dist layout',
+    async (layout) => {
       const harness = await startIsolatedHarness(layout)
-      harnesses.push(harness)
-      const sdkRoot = sdkRootOf(harness.distRoot)
-      expect(
-        existingPath(
-          (await resolveImport(harness, '@aptre/bldr-sdk')) as string,
-        ),
-      ).toBe(existingPath(join(sdkRoot, 'plugin.ts')))
-      expect(
-        existingPath(
-          (await resolveImport(
-            harness,
-            '@aptre/bldr-sdk/hooks/useStreamingResource.js',
-          )) as string,
-        ),
-      ).toBe(existingPath(join(sdkRoot, 'hooks', 'useStreamingResource.ts')))
+      baseDirs.push(harness.baseDir)
+      const appEntry = join(harness.appRoot, 'index.ts')
+      await writeFile(
+        appEntry,
+        [
+          "import { bldrSdkPlugin } from '@aptre/bldr-sdk'",
+          "import { useStreamingResource } from '@aptre/bldr-sdk/hooks/useStreamingResource.js'",
+          "import { ResourcesContext } from '@aptre/bldr-sdk/hooks/ResourcesContext.js'",
+          'console.log(bldrSdkPlugin, useStreamingResource(), ResourcesContext())',
+          '',
+        ].join('\n'),
+      )
+
+      const outDir = join(harness.appRoot, 'vite-dist')
+      await build({
+        ...(await loadBaseConfig(harness.appRoot)),
+        build: {
+          outDir,
+          emptyOutDir: true,
+          write: true,
+          minify: false,
+          rolldownOptions: { input: appEntry },
+        },
+      })
+
+      // Vite writes the bundle under outDir/assets/.
+      const chunkPaths: string[] = []
+      async function walk(dir: string) {
+        for (const entry of await readdir(dir, { withFileTypes: true })) {
+          const path = join(dir, entry.name)
+          if (entry.isDirectory()) {
+            await walk(path)
+          } else if (path.endsWith('.js')) {
+            chunkPaths.push(path)
+          }
+        }
+      }
+      await walk(outDir)
+      expect(chunkPaths.length).toBeGreaterThan(0)
+      const bundled = await Promise.all(
+        chunkPaths.map((chunk) => readFile(chunk, 'utf-8')),
+      ).then((parts) => parts.join('\n'))
+      expect(bundled).toContain('stream')
+      expect(bundled).toContain('resources')
     },
   )
 
-  it('does not resolve a .js hook import with no packaged .ts file', async () => {
+  it('fails the bundle when a .js hook import has no packaged target', async () => {
     const harness = await startIsolatedHarness('flat')
-    harnesses.push(harness)
-    expect(
-      await resolveImport(harness, '@aptre/bldr-sdk/hooks/doesNotExist.js'),
-    ).toBeNull()
+    baseDirs.push(harness.baseDir)
+    const appEntry = join(harness.appRoot, 'index.ts')
+    await writeFile(
+      appEntry,
+      [
+        "import { useResource } from '@aptre/bldr-sdk/hooks/useResource.js'",
+        'console.log(useResource())',
+        '',
+      ].join('\n'),
+    )
+
+    await expect(
+      build({
+        ...(await loadBaseConfig(harness.appRoot)),
+        build: {
+          outDir: join(harness.appRoot, 'vite-dist'),
+          emptyOutDir: true,
+          write: false,
+          minify: false,
+          rolldownOptions: { input: appEntry },
+        },
+      }),
+    ).rejects.toThrow(/useResource|UNLOADABLE_DEPENDENCY|Could not load/i)
   })
 
   it('leaves bldr-sdk imports unresolved when the dist root has no SDK', async () => {
     const harness = await startIsolatedHarness('none')
-    harnesses.push(harness)
-    expect(await resolveImport(harness, '@aptre/bldr-sdk')).toBeNull()
-    expect(
-      await resolveImport(
-        harness,
-        '@aptre/bldr-sdk/hooks/useStreamingResource.js',
-      ),
-    ).toBeNull()
+    baseDirs.push(harness.baseDir)
+    const appEntry = join(harness.appRoot, 'index.ts')
+    await writeFile(
+      appEntry,
+      [
+        "import { bldrSdkPlugin } from '@aptre/bldr-sdk'",
+        'console.log(bldrSdkPlugin)',
+        '',
+      ].join('\n'),
+    )
+
+    await expect(
+      build({
+        ...(await loadBaseConfig(harness.appRoot)),
+        build: {
+          outDir: join(harness.appRoot, 'vite-dist'),
+          emptyOutDir: true,
+          write: false,
+          minify: false,
+          rolldownOptions: { input: appEntry },
+        },
+      }),
+    ).rejects.toThrow()
   })
 })

--- a/bldr/web/bundler/vite/vite-base.config.test.ts
+++ b/bldr/web/bundler/vite/vite-base.config.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, afterAll, vi } from 'vitest'
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
+import { realpathSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { createServer, type ViteDevServer } from 'vite'
+
+// The isolated Bldr harness ships the SDK inside its own dist root. The app
+// project roots here have no node_modules install of @aptre/bldr-sdk, no
+// tsconfig paths, and no vendored Spacewave sources, so only the base-config
+// alias can resolve these imports.
+type HarnessLayout = 'flat' | 'nested' | 'none'
+
+interface ResolveResult {
+  id?: string
+  meta?: Record<string, Record<string, unknown>>
+}
+
+async function startIsolatedHarness(layout: HarnessLayout): Promise<{
+  baseDir: string
+  distRoot: string
+  server: ViteDevServer
+}> {
+  const baseDir = await mkdtemp(join(tmpdir(), 'bldr-sdk-alias-'))
+  const appRoot = join(baseDir, 'app')
+  const distRoot = join(baseDir, 'dist')
+  if (layout !== 'none') {
+    // Flat harness dist layout is <dist>/sdk; the monorepo dist tree nests it
+    // under <dist>/bldr/sdk. Both must resolve.
+    const sdkRoot =
+      layout === 'flat' ? join(distRoot, 'sdk') : join(distRoot, 'bldr', 'sdk')
+    await mkdir(join(sdkRoot, 'hooks'), { recursive: true })
+    await writeFile(
+      join(sdkRoot, 'plugin.ts'),
+      'export const bldrSdkPlugin = true\n',
+    )
+    await writeFile(
+      join(sdkRoot, 'hooks', 'useStreamingResource.ts'),
+      'export function useStreamingResource() {}\n',
+    )
+  }
+  await mkdir(appRoot, { recursive: true })
+  // vite-base.config reads these at import time; reset the module registry so
+  // each harness picks up its own roots.
+  process.env['BLDR_PROJECT_ROOT'] = appRoot
+  process.env['BLDR_DIST_ROOT'] = distRoot
+  vi.resetModules()
+  const { default: baseConfig } = await import('./vite-base.config.js')
+  const server = await createServer({
+    ...baseConfig,
+    root: appRoot,
+    configFile: false,
+    logLevel: 'error',
+    server: { middlewareMode: true },
+  })
+  return { baseDir, distRoot, server }
+}
+
+describe('vite-base.config bldr-sdk aliases in an isolated harness', () => {
+  const harnesses: Awaited<ReturnType<typeof startIsolatedHarness>>[] = []
+  afterAll(async () => {
+    delete process.env['BLDR_PROJECT_ROOT']
+    delete process.env['BLDR_DIST_ROOT']
+    for (const harness of harnesses) {
+      await harness.server.close()
+      await rm(harness.baseDir, { recursive: true, force: true })
+    }
+  })
+
+  // resolveId returns { id, meta }; the Vite alias plugin reports an unmatched
+  // replacement through the vite:alias noResolved marker instead of null.
+  type Harness = Awaited<ReturnType<typeof startIsolatedHarness>>
+  async function resolveImport(
+    harness: Harness,
+    source: string,
+  ): Promise<string | null> {
+    const result = (await harness.server.pluginContainer.resolveId(
+      source,
+    )) as ResolveResult | string | null
+    if (typeof result === 'string') {
+      return result
+    }
+    if (result?.meta?.['vite:alias']?.['noResolved']) {
+      return null
+    }
+    return result?.id ?? null
+  }
+
+  function existingPath(path: string): string {
+    // macOS reports temp dirs through /var symlinks; compare real paths.
+    return realpathSync(path)
+  }
+
+  it.each([
+    ['flat', (distRoot: string) => join(distRoot, 'sdk')],
+    ['nested', (distRoot: string) => join(distRoot, 'bldr', 'sdk')],
+  ] as const)(
+    'resolves bldr-sdk imports against the %s dist layout',
+    async (layout, sdkRootOf) => {
+      const harness = await startIsolatedHarness(layout)
+      harnesses.push(harness)
+      const sdkRoot = sdkRootOf(harness.distRoot)
+      expect(
+        existingPath(
+          (await resolveImport(harness, '@aptre/bldr-sdk')) as string,
+        ),
+      ).toBe(existingPath(join(sdkRoot, 'plugin.ts')))
+      expect(
+        existingPath(
+          (await resolveImport(
+            harness,
+            '@aptre/bldr-sdk/hooks/useStreamingResource.js',
+          )) as string,
+        ),
+      ).toBe(existingPath(join(sdkRoot, 'hooks', 'useStreamingResource.ts')))
+    },
+  )
+
+  it('does not resolve a .js hook import with no packaged .ts file', async () => {
+    const harness = await startIsolatedHarness('flat')
+    harnesses.push(harness)
+    expect(
+      await resolveImport(harness, '@aptre/bldr-sdk/hooks/doesNotExist.js'),
+    ).toBeNull()
+  })
+
+  it('leaves bldr-sdk imports unresolved when the dist root has no SDK', async () => {
+    const harness = await startIsolatedHarness('none')
+    harnesses.push(harness)
+    expect(await resolveImport(harness, '@aptre/bldr-sdk')).toBeNull()
+    expect(
+      await resolveImport(
+        harness,
+        '@aptre/bldr-sdk/hooks/useStreamingResource.js',
+      ),
+    ).toBeNull()
+  })
+})

--- a/bldr/web/bundler/vite/vite-base.config.test.ts
+++ b/bldr/web/bundler/vite/vite-base.config.test.ts
@@ -9,7 +9,7 @@ import {
 } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { build } from 'vite'
+import { build, type InlineConfig } from 'vite'
 
 // The isolated Bldr harness ships the SDK inside its own dist root. The app
 // project roots here have no node_modules install of @aptre/bldr-sdk, no
@@ -57,7 +57,7 @@ async function startIsolatedHarness(layout: HarnessLayout): Promise<{
   return { baseDir, distRoot, appRoot }
 }
 
-async function loadBaseConfig(appRoot: string) {
+async function loadBaseConfig(appRoot: string): Promise<InlineConfig> {
   vi.resetModules()
   const { default: baseConfig } = await import('./vite-base.config.js')
   return {

--- a/bldr/web/bundler/vite/vite-base.config.ts
+++ b/bldr/web/bundler/vite/vite-base.config.ts
@@ -50,6 +50,17 @@ export default defineConfig({
         find: /^@aptre\/bldr$/,
         replacement: resolveBldrDistPath('web/bldr/index.js'),
       },
+      // The Bldr harness ships the SDK inside the dist root; map both the
+      // plugin entry and exact .js imports onto the packaged .ts sources so
+      // apps need no local SDK install or tsconfig paths.
+      {
+        find: /^@aptre\/bldr-sdk$/,
+        replacement: resolveBldrDistPath('sdk/plugin.ts'),
+      },
+      {
+        find: /^@aptre\/bldr-sdk\/(.*)\.js$/,
+        replacement: resolveBldrDistPath('sdk/$1.ts'),
+      },
       {
         find: /^@aptre\/bldr-react$/,
         replacement: resolveBldrDistPath('web/bldr-react/index.js'),

--- a/bldr/web/bundler/vite/vite-base.config.ts
+++ b/bldr/web/bundler/vite/vite-base.config.ts
@@ -51,15 +51,17 @@ export default defineConfig({
         replacement: resolveBldrDistPath('web/bldr/index.js'),
       },
       // The Bldr harness ships the SDK inside the dist root; map both the
-      // plugin entry and exact .js imports onto the packaged .ts sources so
-      // apps need no local SDK install or tsconfig paths.
+      // plugin entry and explicit .js imports onto the packaged sources so
+      // apps need no local SDK install or tsconfig paths. The .js imports
+      // resolve to an extensionless path so Vite picks the packaged .ts or
+      // .tsx module.
       {
         find: /^@aptre\/bldr-sdk$/,
         replacement: resolveBldrDistPath('sdk/plugin.ts'),
       },
       {
         find: /^@aptre\/bldr-sdk\/(.*)\.js$/,
-        replacement: resolveBldrDistPath('sdk/$1.ts'),
+        replacement: resolveBldrDistPath('sdk/$1'),
       },
       {
         find: /^@aptre\/bldr-react$/,


### PR DESCRIPTION
Resolve Bldr SDK imports from the packaged dist source root rather than application-local aliases. The base Vite configuration now maps the bare SDK entry and explicit JavaScript imports onto the SDK shipped with the harness.

Deep imports use an extensionless replacement so Vite can load either TypeScript or TSX modules. Real Vite bundle regressions cover flat and monorepo dist layouts, both source extensions, missing targets, and missing SDK content.

The Mercury hosted harness now builds both browser manifests and reaches the running application with this range; its later WebRTC connectivity failure is outside this resolver boundary.
