### PR TITLE
test(cli): accept stale socket cleanup message

### DIFF
--- a/cmd/spacewave/e2e/testdata/script/auth-lock.txt
+++ b/cmd/spacewave/e2e/testdata/script/auth-lock.txt
@@ -16,4 +16,4 @@ spacewave stop --state-path $WORK/state
 stdout "Stopped Spacewave daemon."
 
 spacewave stop --state-path $WORK/state
-stdout "No Spacewave daemon is running."
+stdout "No Spacewave daemon is running"


### PR DESCRIPTION
The second stop in the auth-lock trajectory races normal daemon cleanup. Depending on whether the Unix socket has been unlinked, the command correctly reports either that no daemon is running or that it also removed the stale socket. Match the stable message prefix so both valid outcomes pass.