### PR TITLE
fix(devtool): publish start web running after listen

### DIFF
--- a/bldr/devtool/bldr-devtool-tui-runner_test.go
+++ b/bldr/devtool/bldr-devtool-tui-runner_test.go
@@ -1,0 +1,58 @@
+//go:build !js
+
+package devtool
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	devtool_status "github.com/s4wave/spacewave/bldr/devtool/status"
+)
+
+// TestDevtoolTUIRawCtrlCCancelsCommandContext drives the Ctrl-C key byte 0x03
+// through the TUI key path. The TUI maps it to the active command cancel
+// function, so the command context must cancel and stopTUI must join the TUI
+// goroutine without hanging.
+func TestDevtoolTUIRawCtrlCCancelsCommandContext(t *testing.T) {
+	deadlineCtx, stopDeadline := context.WithTimeout(context.Background(), 10*time.Second)
+	defer stopDeadline()
+	producer := devtool_status.NewBldrDevtoolStatusProducer(nil)
+	inputReader, inputWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = inputReader.Close() }()
+	defer func() { _ = inputWriter.Close() }()
+	outputReader, outputWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = outputReader.Close() }()
+	defer func() { _ = outputWriter.Close() }()
+
+	runner := &devtoolTUIRunner{input: inputReader, output: outputWriter}
+	commandCtx, stopTUI := runner.start(deadlineCtx, producer)
+
+	if _, err := inputWriter.Write([]byte{3}); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-commandCtx.Done():
+	case <-deadlineCtx.Done():
+		t.Fatalf("raw Ctrl-C did not cancel the active command context: %v", deadlineCtx.Err())
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		stopTUI()
+		close(stopped)
+	}()
+	select {
+	case <-stopped:
+	case <-deadlineCtx.Done():
+		t.Fatal("stopTUI did not join the TUI goroutine")
+	}
+}

--- a/bldr/devtool/start-web-wasm.go
+++ b/bldr/devtool/start-web-wasm.go
@@ -113,12 +113,8 @@ func (a *DevtoolArgs) ExecuteWebWasmProject(ctx context.Context) (err error) {
 	webStartupSrcPath, _ := startConf.ParseWebStartupPath()
 
 	buildType := bldr_manifest.BuildType(a.BuildType)
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	d.setCommandRunningWithLogFile("start web", "wasm web runtime active on "+a.WebListenAddr, commandLogFile)
 	a.writeBannerTo(os.Stderr)
-	return d.ExecuteWebWasm(
+	return d.executeWebWasm(
 		ctx,
 		repoRoot,
 		a.MinifyEntrypoint,
@@ -129,6 +125,10 @@ func (a *DevtoolArgs) ExecuteWebWasmProject(ctx context.Context) (err error) {
 		startupManifestPreflights,
 		webStartupSrcPath,
 		false,
+		func(string) error {
+			d.setCommandRunningWithLogFile("start web", "wasm web runtime active on "+a.WebListenAddr, commandLogFile)
+			return nil
+		},
 	)
 }
 
@@ -144,6 +144,22 @@ func (d *DevtoolBus) ExecuteWebWasm(
 	startupManifestPreflights []StartupManifestPreflight,
 	webStartupSrcPath string,
 	forceDedicatedWorkers bool,
+) error {
+	return d.executeWebWasm(ctx, repoRoot, minifyEntrypoint, devMode, listenAddr, appID, startPlugins, startupManifestPreflights, webStartupSrcPath, forceDedicatedWorkers, nil)
+}
+
+func (d *DevtoolBus) executeWebWasm(
+	ctx context.Context,
+	repoRoot string,
+	minifyEntrypoint,
+	devMode bool,
+	listenAddr string,
+	appID string,
+	startPlugins []string,
+	startupManifestPreflights []StartupManifestPreflight,
+	webStartupSrcPath string,
+	forceDedicatedWorkers bool,
+	onListening func(string) error,
 ) error {
 	le := d.GetLogger()
 	stateDir := d.GetStateRoot()
@@ -390,7 +406,12 @@ func (d *DevtoolBus) ExecuteWebWasm(
 			ref.Release()
 		}
 	}()
-	return listenAndServeDevtoolHTTP(ctx, server, func(_ string) error {
+	return listenAndServeDevtoolHTTP(ctx, server, func(addr string) error {
+		if onListening != nil {
+			if err := onListening(addr); err != nil {
+				return err
+			}
+		}
 		if !devMode {
 			return nil
 		}

--- a/bldr/devtool/start-web-ws.go
+++ b/bldr/devtool/start-web-ws.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/aperturerobotics/controllerbus/bus"
@@ -31,6 +32,67 @@ import (
 	bifrost_rpc "github.com/s4wave/spacewave/net/rpc"
 	"github.com/sirupsen/logrus"
 )
+
+// errWebSocketConnectionsClosed is returned when a connection arrives after
+// the server stopped accepting upgraded connections.
+var errWebSocketConnectionsClosed = errors.New("devtool websocket connections closed")
+
+// webSocketControllerConnections binds upgraded connections and their controllers to the server lifetime.
+type webSocketControllerConnections struct {
+	ctx context.Context
+
+	mtx         sync.Mutex
+	connections map[*websocket.Conn]struct{}
+	closed      bool
+	wait        sync.WaitGroup
+}
+
+func newWebSocketControllerConnections(ctx context.Context) *webSocketControllerConnections {
+	return &webSocketControllerConnections{ctx: ctx, connections: make(map[*websocket.Conn]struct{})}
+}
+
+func (c *webSocketControllerConnections) Execute(connection *websocket.Conn, execute func(context.Context) error) error {
+	c.mtx.Lock()
+	if c.closed {
+		c.mtx.Unlock()
+		_ = connection.CloseNow()
+		return errWebSocketConnectionsClosed
+	}
+	if ctxErr := c.ctx.Err(); ctxErr != nil {
+		c.mtx.Unlock()
+		_ = connection.CloseNow()
+		return ctxErr
+	}
+	c.connections[connection] = struct{}{}
+	c.wait.Add(1)
+	c.mtx.Unlock()
+	defer func() {
+		c.mtx.Lock()
+		delete(c.connections, connection)
+		c.mtx.Unlock()
+		c.wait.Done()
+	}()
+	return execute(c.ctx)
+}
+
+func (c *webSocketControllerConnections) Close() {
+	c.mtx.Lock()
+	if c.closed {
+		c.mtx.Unlock()
+		return
+	}
+	c.closed = true
+	connections := make([]*websocket.Conn, 0, len(c.connections))
+	for connection := range c.connections {
+		connections = append(connections, connection)
+	}
+	c.mtx.Unlock()
+	for _, connection := range connections {
+		_ = connection.CloseNow()
+	}
+}
+
+func (c *webSocketControllerConnections) Wait() { c.wait.Wait() }
 
 // DevtoolWsVersion is the version to report for the ws-backed devtool runtime.
 var DevtoolWsVersion = controller.MustParseVersion("0.0.1")
@@ -186,20 +248,19 @@ func (a *DevtoolArgs) ExecuteWebWsProject(ctx context.Context) (err error) {
 	}
 	defer relStatusCtrl()
 
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	d.setCommandRunningWithLogFile("start web", "web runtime active on "+a.WebListenAddr, commandLogFile)
-	return d.ExecuteWebWs(ctx, repoRoot, a.MinifyEntrypoint, buildType.IsDev(), a.WebListenAddr, webStartupSrcPath)
+	return d.executeWebWs(ctx, repoRoot, a.MinifyEntrypoint, buildType.IsDev(), a.WebListenAddr, webStartupSrcPath, func(string) error {
+		d.setCommandRunningWithLogFile("start web", "web runtime active on "+a.WebListenAddr, commandLogFile)
+		return nil
+	})
 }
 
-// ExecuteWebWs starts the application in the browser with a websocket.
-func (d *DevtoolBus) ExecuteWebWs(
+func (d *DevtoolBus) executeWebWs(
 	ctx context.Context,
 	repoRoot string,
 	minifyEntrypoint, devMode bool,
 	listenAddr string,
 	webStartupSrcPath string,
+	onListening func(string) error,
 ) error {
 	le := d.GetLogger()
 	stateDir := d.GetStateRoot()
@@ -256,6 +317,7 @@ func (d *DevtoolBus) ExecuteWebWs(
 
 	// serve the websocket if the path matches
 	webRuntimeWsPath := "/bldr-dev/web-runtime.ws"
+	connections := newWebSocketControllerConnections(ctx)
 	serveFn := func(rw http.ResponseWriter, req *http.Request) {
 		// Add Cross-Origin Isolation headers required for SharedArrayBuffer
 		// These enable SAB-based communication between SharedWorkers
@@ -271,8 +333,13 @@ func (d *DevtoolBus) ExecuteWebWs(
 				return
 			}
 			ctrl := buildWsWebRuntime(le, d.GetBus(), runtimeID, wc)
-			err = d.GetBus().ExecuteController(req.Context(), ctrl)
-			if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, io.EOF) {
+			err = connections.Execute(wc, func(connectionCtx context.Context) error {
+				return d.GetBus().ExecuteController(connectionCtx, ctrl)
+			})
+			if err != nil &&
+				!errors.Is(err, context.Canceled) &&
+				!errors.Is(err, io.EOF) &&
+				!errors.Is(err, errWebSocketConnectionsClosed) {
 				le.WithError(err).Warn("websocket disconnected with error")
 			} else {
 				le.Debug("websocket disconnected normally")
@@ -285,7 +352,22 @@ func (d *DevtoolBus) ExecuteWebWs(
 
 	le.Infof("listening on: %s", listenAddr)
 	server := &http.Server{Addr: listenAddr, Handler: http.HandlerFunc(serveFn), ReadHeaderTimeout: time.Second * 30}
-	return listenAndServeDevtoolHTTP(ctx, server, nil)
+	return listenAndServeDevtoolWebWs(ctx, server, connections, onListening)
+}
+
+// listenAndServeDevtoolWebWs serves the devtool websocket HTTP server until it
+// returns, then closes every upgraded connection and waits for its controller
+// to exit before returning.
+func listenAndServeDevtoolWebWs(
+	ctx context.Context,
+	server *http.Server,
+	connections *webSocketControllerConnections,
+	onListening func(string) error,
+) error {
+	err := listenAndServeDevtoolHTTP(ctx, server, onListening)
+	connections.Close()
+	connections.Wait()
+	return err
 }
 
 func writeWebWsBuildManifest(entrypointDir string, bundleResult *entrypoint_browser_bundle.BrowserBundleResult) error {
@@ -349,36 +431,33 @@ func listenAndServeDevtoolHTTP(ctx context.Context, server *http.Server, onListe
 	}
 
 	serveErrCh := make(chan error, 1)
-	go func() {
-		serveErrCh <- server.Serve(listener)
-	}()
+	go func() { serveErrCh <- server.Serve(listener) }()
 	stopShutdownCh := make(chan struct{})
-	shutdownDoneCh := make(chan struct{})
-	defer func() {
-		close(stopShutdownCh)
-		<-shutdownDoneCh
-	}()
+	shutdownErrCh := make(chan error, 1)
 	go func() {
-		defer close(shutdownDoneCh)
 		select {
 		case <-ctx.Done():
-			shutdownCtx, shutdownCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
-			defer shutdownCancel()
-			_ = server.Shutdown(shutdownCtx)
+			// Drain plain HTTP requests without a deadline. Upgraded
+			// (hijacked) connections are not tracked by Shutdown; their
+			// lifecycle owner closes and joins them separately.
+			shutdownErrCh <- server.Shutdown(context.WithoutCancel(ctx))
 		case <-stopShutdownCh:
+			shutdownErrCh <- nil
 		}
 	}()
 
+	var callbackErr error
 	if onListening != nil {
-		if err := onListening(listener.Addr().String()); err != nil {
+		callbackErr = onListening(listener.Addr().String())
+		if callbackErr != nil {
 			_ = server.Close()
-			<-serveErrCh
-			return err
 		}
 	}
-	err = <-serveErrCh
-	if err == http.ErrServerClosed {
-		return nil
+	serveErr := <-serveErrCh
+	close(stopShutdownCh)
+	shutdownErr := <-shutdownErrCh
+	if errors.Is(serveErr, http.ErrServerClosed) {
+		serveErr = nil
 	}
-	return err
+	return errors.Join(callbackErr, serveErr, shutdownErr)
 }

--- a/bldr/devtool/start-web-ws_test.go
+++ b/bldr/devtool/start-web-ws_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/aperturerobotics/fastjson"
+	"github.com/aperturerobotics/go-websocket"
 	entrypoint_browser_bundle "github.com/s4wave/spacewave/bldr/web/entrypoint/browser/bundle"
 )
 
@@ -174,5 +175,224 @@ func TestListenAndServeDevtoolHTTPServesWhileOnListeningBlocked(t *testing.T) {
 				t.Fatal("HTTP listener remained open after listenAndServeDevtoolHTTP returned")
 			}
 		})
+	}
+}
+
+// TestListenAndServeDevtoolWebWsClosesUpgradedControllers drives the production
+// websocket serve path: an upgraded connection whose controller only exits when
+// the socket closes. The server must close every upgraded connection and wait
+// for its controller before listenAndServeDevtoolWebWs returns.
+func TestListenAndServeDevtoolWebWsClosesUpgradedControllers(t *testing.T) {
+	deadlineCtx, stopDeadline := context.WithTimeout(context.Background(), 10*time.Second)
+	defer stopDeadline()
+	ctx, cancel := context.WithCancel(deadlineCtx)
+	connections := newWebSocketControllerConnections(ctx)
+	handlerStarted := make(chan struct{})
+	handlerExited := make(chan struct{})
+	server := &http.Server{
+		Addr:              "127.0.0.1:0",
+		ReadHeaderTimeout: time.Second,
+		Handler: http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			connection, err := websocket.Accept(rw, req, nil)
+			if err != nil {
+				return
+			}
+			_ = connections.Execute(connection, func(context.Context) error {
+				close(handlerStarted)
+				// Read until the socket closes; do not return on cancellation.
+				readCtx := context.WithoutCancel(deadlineCtx)
+				_, _, readErr := connection.Read(readCtx)
+				close(handlerExited)
+				return readErr
+			})
+		}),
+	}
+	listeningAddr := make(chan string, 1)
+	serverDone := make(chan error, 1)
+	go func() {
+		serverDone <- listenAndServeDevtoolWebWs(ctx, server, connections, func(addr string) error {
+			listeningAddr <- addr
+			return nil
+		})
+	}()
+
+	addr := <-listeningAddr
+	client, _, err := websocket.Dial(deadlineCtx, "ws://"+addr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.CloseNow()
+	<-handlerStarted
+	cancel()
+
+	select {
+	case err := <-serverDone:
+		select {
+		case <-handlerExited:
+		default:
+			t.Fatal("server returned before the upgraded WebSocket controller exited")
+		}
+		if err != nil {
+			t.Fatalf("server shutdown: %v", err)
+		}
+	case <-deadlineCtx.Done():
+		t.Fatalf("server did not close and join upgraded controllers: %v", deadlineCtx.Err())
+	}
+
+	readCtx, stopRead := context.WithTimeout(context.Background(), time.Second)
+	defer stopRead()
+	if _, _, err := client.Read(readCtx); err == nil {
+		t.Fatal("WebSocket remained open after server shutdown")
+	}
+}
+
+// TestListenAndServeDevtoolHTTPDrainsPlainRequestsOnCancel pins the graceful
+// plain HTTP path: an in-flight request finishes and the caller sees a normal
+// response even though cancellation started while the request was active.
+func TestListenAndServeDevtoolHTTPDrainsPlainRequestsOnCancel(t *testing.T) {
+	deadlineCtx, stopDeadline := context.WithTimeout(context.Background(), 10*time.Second)
+	defer stopDeadline()
+	ctx, cancel := context.WithCancel(deadlineCtx)
+	requestStarted := make(chan struct{})
+	server := &http.Server{
+		Addr:              "127.0.0.1:0",
+		ReadHeaderTimeout: time.Second,
+		Handler: http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			close(requestStarted)
+			select {
+			case <-req.Context().Done():
+				return
+			case <-time.After(300 * time.Millisecond):
+			}
+			_, _ = io.WriteString(rw, "drained")
+		}),
+	}
+	listeningAddr := make(chan string, 1)
+	serverDone := make(chan error, 1)
+	go func() {
+		serverDone <- listenAndServeDevtoolHTTP(ctx, server, func(addr string) error {
+			listeningAddr <- addr
+			return nil
+		})
+	}()
+
+	addr := <-listeningAddr
+	type httpResult struct {
+		body string
+		err  error
+	}
+	resultCh := make(chan httpResult, 1)
+	go func() {
+		resp, err := http.Get("http://" + addr)
+		if err != nil {
+			resultCh <- httpResult{err: err}
+			return
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		resultCh <- httpResult{body: string(body), err: err}
+	}()
+	<-requestStarted
+	cancel()
+
+	select {
+	case result := <-resultCh:
+		if result.err != nil {
+			t.Fatalf("in-flight request was not drained: %v", result.err)
+		}
+		if result.body != "drained" {
+			t.Fatalf("drained request body: got %q, want %q", result.body, "drained")
+		}
+	case <-deadlineCtx.Done():
+		t.Fatalf("in-flight request did not complete during shutdown: %v", deadlineCtx.Err())
+	}
+
+	select {
+	case err := <-serverDone:
+		if err != nil {
+			t.Fatalf("server shutdown: %v", err)
+		}
+	case <-deadlineCtx.Done():
+		t.Fatalf("server did not finish draining: %v", deadlineCtx.Err())
+	}
+}
+
+// TestWebSocketControllerConnectionsRejectExecuteAfterClose pins post-close
+// rejection: Execute after Close force-closes the connection, reports an
+// error, and never runs the controller.
+func TestWebSocketControllerConnectionsRejectExecuteAfterClose(t *testing.T) {
+	deadlineCtx, stopDeadline := context.WithTimeout(context.Background(), 10*time.Second)
+	defer stopDeadline()
+	ctx, cancel := context.WithCancel(deadlineCtx)
+	defer cancel()
+	connections := newWebSocketControllerConnections(ctx)
+	accepted := make(chan struct{})
+	closeGate := make(chan struct{})
+	executeErr := make(chan error, 1)
+	executed := make(chan struct{})
+	server := &http.Server{
+		Addr:              "127.0.0.1:0",
+		ReadHeaderTimeout: time.Second,
+		Handler: http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			connection, err := websocket.Accept(rw, req, nil)
+			if err != nil {
+				return
+			}
+			close(accepted)
+			<-closeGate
+			executeErr <- connections.Execute(connection, func(context.Context) error {
+				close(executed)
+				return nil
+			})
+		}),
+	}
+	listeningAddr := make(chan string, 1)
+	serverDone := make(chan error, 1)
+	go func() {
+		serverDone <- listenAndServeDevtoolWebWs(ctx, server, connections, func(addr string) error {
+			listeningAddr <- addr
+			return nil
+		})
+	}()
+
+	addr := <-listeningAddr
+	client, _, err := websocket.Dial(deadlineCtx, "ws://"+addr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.CloseNow()
+	<-accepted
+
+	connections.Close()
+	close(closeGate)
+
+	select {
+	case err := <-executeErr:
+		if !errors.Is(err, errWebSocketConnectionsClosed) {
+			t.Fatalf("Execute after Close: got %v, want %v", err, errWebSocketConnectionsClosed)
+		}
+	case <-deadlineCtx.Done():
+		t.Fatal("Execute after Close did not return")
+	}
+	select {
+	case <-executed:
+		t.Fatal("controller ran after Close rejected it")
+	default:
+	}
+
+	readCtx, stopRead := context.WithTimeout(context.Background(), time.Second)
+	defer stopRead()
+	if _, _, err := client.Read(readCtx); err == nil {
+		t.Fatal("WebSocket remained open after Close rejected it")
+	}
+
+	cancel()
+	select {
+	case err := <-serverDone:
+		if err != nil {
+			t.Fatalf("server shutdown: %v", err)
+		}
+	case <-deadlineCtx.Done():
+		t.Fatalf("server did not shut down: %v", deadlineCtx.Err())
 	}
 }


### PR DESCRIPTION
The start-web command published RUNNING before the HTTP listener bound, so callers could observe readiness while the port was still unavailable. Publish the running state from the listener callback instead.

HTTP shutdown now drains ordinary requests while upgraded WebSocket connections are tracked, closed, and joined explicitly. Raw Ctrl-C cancellation closes the served runtime and returns control to the terminal without leaving controllers behind.