### PR TITLE
fix(logfile): preserve records across process startup

### DIFF
--- a/bldr/util/logfile/attach.go
+++ b/bldr/util/logfile/attach.go
@@ -43,7 +43,12 @@ func AttachLogFiles(logger *logrus.Logger, specs []LogFileSpec) (func(), error) 
 			return nil, err
 		}
 
-		f, err := os.Create(spec.Path)
+		// Open with append semantics: multiple processes can resolve the
+		// same log-file path within the same second (same-second {ts}
+		// template or an explicit shared spec), and a truncate-on-open
+		// here would destroy the records a still-running first writer
+		// already emitted.
+		f, err := os.OpenFile(spec.Path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o666)
 		if err != nil {
 			for _, h := range hooks {
 				h.Close()

--- a/bldr/util/logfile/attach_test.go
+++ b/bldr/util/logfile/attach_test.go
@@ -1,9 +1,12 @@
 package logfile
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -119,6 +122,123 @@ func TestAttachLogFilesJSON(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "{") {
 		t.Errorf("expected JSON format, got: %q", string(data))
+	}
+}
+
+// TestAttachLogFilesAppendPreservesExistingRecords pins append semantics for
+// the shared log-file path. Two processes starting within the same second
+// resolve the same {ts}.log path; the second attach must not destroy records
+// the first process already wrote.
+func TestAttachLogFilesAppendPreservesExistingRecords(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shared.log")
+
+	logA := logrus.New()
+	logA.SetLevel(logrus.DebugLevel)
+	cleanupA, err := AttachLogFiles(logA, []LogFileSpec{
+		{Level: logrus.DebugLevel, Format: "text", Path: path},
+	})
+	if err != nil {
+		t.Fatalf("first AttachLogFiles error: %v", err)
+	}
+	for i := range 10 {
+		logA.Infof("a record %d", i)
+	}
+	cleanupA()
+
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after first writer: %v", err)
+	}
+	if !strings.Contains(string(before), "a record 0") {
+		t.Fatalf("first writer records missing before second attach: %q", before)
+	}
+
+	logB := logrus.New()
+	logB.SetLevel(logrus.DebugLevel)
+	cleanupB, err := AttachLogFiles(logB, []LogFileSpec{
+		{Level: logrus.DebugLevel, Format: "text", Path: path},
+	})
+	if err != nil {
+		t.Fatalf("second AttachLogFiles error: %v", err)
+	}
+	logB.Info("b record 0")
+	cleanupB()
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after second writer: %v", err)
+	}
+	if bytes.IndexByte(after, 0) >= 0 {
+		t.Error("log file contains NUL padding after second attach")
+	}
+	for i := range 10 {
+		if want := fmt.Sprintf("a record %d", i); !strings.Contains(string(after), want) {
+			t.Errorf("second attach destroyed existing record %q", want)
+		}
+	}
+	if !strings.Contains(string(after), "b record 0") {
+		t.Errorf("second writer record missing: %q", after)
+	}
+}
+
+// TestAttachLogFilesConcurrentWritersKeepsCompleteRecords verifies that two
+// hooks attached to one log file path both keep every record. This models
+// overlapping service-startup processes sharing one {ts}.log sink.
+func TestAttachLogFilesConcurrentWritersKeepsCompleteRecords(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shared.log")
+
+	specs := []LogFileSpec{{Level: logrus.DebugLevel, Format: "text", Path: path}}
+	logA := logrus.New()
+	logA.SetLevel(logrus.DebugLevel)
+	cleanupA, err := AttachLogFiles(logA, specs)
+	if err != nil {
+		t.Fatalf("first AttachLogFiles error: %v", err)
+	}
+	logB := logrus.New()
+	logB.SetLevel(logrus.DebugLevel)
+	cleanupB, err := AttachLogFiles(logB, specs)
+	if err != nil {
+		cleanupA()
+		t.Fatalf("second AttachLogFiles error: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := range 50 {
+			logA.Infof("a record %d", i)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := range 50 {
+			logB.Infof("b record %d", i)
+		}
+	}()
+	wg.Wait()
+	cleanupA()
+	cleanupB()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+	if bytes.IndexByte(data, 0) >= 0 {
+		t.Error("log file contains NUL padding from truncating writes")
+	}
+	records := strings.Count(string(data), "time=")
+	if records != 100 {
+		t.Errorf("record count = %d, want 100 (records were destroyed by a truncating attach)", records)
+	}
+	for i := range 50 {
+		for _, prefix := range []string{"a", "b"} {
+			if want := fmt.Sprintf("%s record %d", prefix, i); !strings.Contains(string(data), want) {
+				t.Errorf("missing record %q", want)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
AttachLogFiles opened each log file with os.Create, which truncates on open. When two processes start within the same second they resolve the same {ts} template path, or share an explicit spec path; the second attach then destroyed every record the still-running first writer had already emitted, leaving torn and truncated lines in the shared log.

Open with O_CREATE|O_WRONLY|O_APPEND instead. POSIX makes the implicit seek-and-write atomic per syscall for regular files, so concurrent writers append without overwriting each other's records, and each hook still issues one write per formatted record. File mode stays 0o666 with the same umask behavior as before.

Regression tests pin the invariant: a second attach preserves all prior records, and two concurrent writers keep exactly 100 intact records.