### PR TITLE
fix(world): release looked-up object states on body-only paths

### DIFF
--- a/core/forge/job/ops.go
+++ b/core/forge/job/ops.go
@@ -52,7 +52,7 @@ func (o *ForgeJobCreateOp) ApplyWorldOp(
 	jobKey := o.GetJobKey()
 
 	// Check the cluster exists and can be decoded as a Cluster object.
-	cluster, _, err := forge_cluster.LookupCluster(ctx, ws, clusterKey)
+	cluster, err := forge_cluster.LookupClusterBody(ctx, ws, clusterKey)
 	if err != nil {
 		return false, errors.Wrap(err, "cluster")
 	}

--- a/core/forge/task/ops.go
+++ b/core/forge/task/ops.go
@@ -44,7 +44,7 @@ func (o *ForgeTaskCreateOp) ApplyWorldOp(
 
 	// If a job key is provided, verify it exists and can be decoded as a Job.
 	if jobKey != "" {
-		job, _, err := forge_job.LookupJob(ctx, ws, jobKey)
+		job, err := forge_job.LookupJobBody(ctx, ws, jobKey)
 		if err != nil {
 			return false, errors.Wrap(err, "job")
 		}

--- a/core/plugin/space/controller.go
+++ b/core/plugin/space/controller.go
@@ -362,7 +362,7 @@ func (c *Controller) reconcilePlugins(ctx context.Context, ws world.WorldState, 
 	le := c.GetLogger()
 	conf := c.GetConfig()
 
-	settings, _, err := space_world.LookupSpaceSettings(ctx, ws)
+	settings, err := space_world.LookupSpaceSettingsBody(ctx, ws)
 	if err != nil {
 		warnOnErrorUnlessCanceled(ctx, le, err, "failed to lookup SpaceSettings")
 		return

--- a/core/resource/space/contents.go
+++ b/core/resource/space/contents.go
@@ -844,7 +844,7 @@ func (r *SpaceContentsResource) WatchState(
 				return err
 			}
 
-			settings, _, err := space_world.LookupSpaceSettings(ctx, wtx)
+			settings, err := space_world.LookupSpaceSettingsBody(ctx, wtx)
 			if err != nil {
 				return err
 			}

--- a/core/resource/space/secret.go
+++ b/core/resource/space/secret.go
@@ -117,7 +117,7 @@ func (r *SpaceResource) ReadSecretPayload(
 	if err := world_types.CheckObjectType(ctx, wtx, req.GetObjectKey(), s4wave_secret.SecretTypeID); err != nil {
 		return nil, err
 	}
-	secret, _, err := world.LookupObject[*s4wave_secret.Secret](ctx, wtx, req.GetObjectKey(), s4wave_secret.NewSecretBlock)
+	secret, err := world.LookupObjectBody[*s4wave_secret.Secret](ctx, wtx, req.GetObjectKey(), s4wave_secret.NewSecretBlock)
 	if err != nil {
 		return nil, err
 	}

--- a/core/resource/space/settings.go
+++ b/core/resource/space/settings.go
@@ -29,7 +29,7 @@ func (r *SpaceResource) AddSpacePlugin(
 	defer tx.Discard()
 
 	// Read current settings (may be nil if not yet created).
-	settings, _, err := space_world.LookupSpaceSettings(ctx, tx)
+	settings, err := space_world.LookupSpaceSettingsBody(ctx, tx)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func (r *SpaceResource) RemoveSpacePlugin(
 	}
 	defer tx.Discard()
 
-	settings, _, err := space_world.LookupSpaceSettings(ctx, tx)
+	settings, err := space_world.LookupSpaceSettingsBody(ctx, tx)
 	if err != nil {
 		return nil, err
 	}

--- a/core/resource/space/space.go
+++ b/core/resource/space/space.go
@@ -142,7 +142,7 @@ func (r *SpaceResource) WatchSpaceState(
 			}
 
 			// Load SpaceSettings when present.
-			state.Settings, _, err = space_world.LookupSpaceSettings(ctx, wtx)
+			state.Settings, err = space_world.LookupSpaceSettingsBody(ctx, wtx)
 			if err != nil {
 				return err
 			}

--- a/core/space/world/ops/set-space-settings.go
+++ b/core/space/world/ops/set-space-settings.go
@@ -115,7 +115,7 @@ func (o *SetSpaceSettingsOp) ApplyWorldOp(
 	}
 
 	if o.GetExpectedKeybindingOverrides() != nil {
-		current, _, err := space_world.LookupSpaceSettings(ctx, worldHandle)
+		current, err := space_world.LookupSpaceSettingsBody(ctx, worldHandle)
 		if err != nil {
 			return false, err
 		}

--- a/core/space/world/release_regression_test.go
+++ b/core/space/world/release_regression_test.go
@@ -1,0 +1,86 @@
+package space_world_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	space_world "github.com/s4wave/spacewave/core/space/world"
+	space_world_ops "github.com/s4wave/spacewave/core/space/world/ops"
+	"github.com/s4wave/spacewave/db/world"
+	world_testbed "github.com/s4wave/spacewave/db/world/testbed"
+)
+
+// countingWorldState counts ObjectState releases issued through GetObject.
+type countingWorldState struct {
+	world.WorldState
+	released *int
+}
+
+func (c *countingWorldState) GetObject(ctx context.Context, key string) (world.ObjectState, bool, error) {
+	obj, found, err := c.WorldState.GetObject(ctx, key)
+	if err != nil || !found || obj == nil {
+		return obj, found, err
+	}
+	return &countingObjectState{ObjectState: obj, released: c.released}, true, nil
+}
+
+// countingObjectState delegates to the wrapped state and counts Release calls.
+type countingObjectState struct {
+	world.ObjectState
+	released *int
+}
+
+func (o *countingObjectState) Release() {
+	*o.released++
+	world.ReleaseObjectState(o.ObjectState)
+}
+
+// TestLookupSpaceSettingsBodyReleasesStates fails if a body-only SpaceSettings
+// lookup leaves its remote-releasable ObjectState alive, or if the missing
+// settings case stops returning nil without error.
+func TestLookupSpaceSettingsBodyReleasesStates(t *testing.T) {
+	ctx := context.Background()
+
+	tb, err := world_testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tb.Release()
+
+	var released int
+	ws := &countingWorldState{WorldState: tb.WorldState, released: &released}
+
+	// Missing settings still return nil without error.
+	settings, err := space_world.LookupSpaceSettingsBody(ctx, ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if settings != nil {
+		t.Fatalf("expected nil settings, got %#v", settings)
+	}
+	if released != 0 {
+		t.Fatalf("missing settings: released %d states, want 0", released)
+	}
+
+	op := space_world_ops.NewSetSpaceSettingsOp(
+		"",
+		&space_world.SpaceSettings{IndexPath: "/files"},
+		true,
+		time.Unix(10, 0),
+	)
+	if _, _, err := tb.WorldState.ApplyWorldOp(ctx, op, ""); err != nil {
+		t.Fatalf("ApplyWorldOp settings failed: %v", err)
+	}
+
+	settings, err = space_world.LookupSpaceSettingsBody(ctx, ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if settings == nil || settings.GetIndexPath() != "/files" {
+		t.Fatalf("expected stored settings, got %#v", settings)
+	}
+	if released != 1 {
+		t.Fatalf("present settings: released %d states, want 1", released)
+	}
+}

--- a/core/space/world/space-settings.go
+++ b/core/space/world/space-settings.go
@@ -34,12 +34,26 @@ func LookupSpaceSettings(ctx context.Context, ws world.WorldState) (*SpaceSettin
 	return settings, state, err
 }
 
+// LookupSpaceSettingsBody looks up the SpaceSettings body in the world.
+// Returns nil, nil if the settings object does not exist.
+func LookupSpaceSettingsBody(ctx context.Context, ws world.WorldState) (*SpaceSettings, error) {
+	settings, err := world.LookupObjectBody[*SpaceSettings](
+		ctx,
+		ws,
+		SpaceSettingsObjectKey,
+		NewSpaceSettingsBlock,
+	)
+	if errors.Is(err, world.ErrObjectNotFound) {
+		return nil, nil
+	}
+	return settings, err
+}
+
 // LookupSpaceIndexObjectType returns the durable ObjectType selected by
 // SpaceSettings.index_path. Missing settings, an empty index, and stale index
 // paths have no semantic type and return an empty string.
 func LookupSpaceIndexObjectType(ctx context.Context, ws world.WorldState) (string, error) {
-	settings, state, err := LookupSpaceSettings(ctx, ws)
-	defer world.ReleaseObjectState(state)
+	settings, err := LookupSpaceSettingsBody(ctx, ws)
 	if err != nil {
 		return "", err
 	}

--- a/db/world/types/types.go
+++ b/db/world/types/types.go
@@ -233,15 +233,17 @@ func ListObjectsWithType(ctx context.Context, ws world.WorldState, typeID string
 // Unmarshals the bodies of the matched objects.
 //
 // ctor must return an object of type T
-// returns two slices of length objKeys
-// if any objects are not found, returns nil for that object state / value and objs, objsStates, ErrNotFound
-// returns nil, nil, err for any other error
+// Returns two slices of length len(objKeys). If any objects are not found,
+// their entries are nil and ErrNotFound is returned after all states release.
 func ListCollectObjectsWithType[T block.Block](ctx context.Context, ws world.WorldState, typeID string, ctor func() block.Block) ([]T, []string, error) {
 	objKeys, err := ListObjectsWithType(ctx, ws, typeID)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	objs, _, err := world.CollectObjectBodies[T](ctx, ws, objKeys, ctor)
+	objs, states, err := world.CollectObjectBodies[T](ctx, ws, objKeys, ctor)
+	for _, state := range states {
+		world.ReleaseObjectState(state)
+	}
 	return objs, objKeys, err
 }

--- a/db/world/types/types_release_test.go
+++ b/db/world/types/types_release_test.go
@@ -1,0 +1,117 @@
+package world_types_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/s4wave/spacewave/db/block"
+	"github.com/s4wave/spacewave/db/world"
+	world_testbed "github.com/s4wave/spacewave/db/world/testbed"
+	world_types "github.com/s4wave/spacewave/db/world/types"
+)
+
+// releaseTestBlock is a minimal block for lifecycle tests.
+type releaseTestBlock struct {
+	Value string
+}
+
+func (b *releaseTestBlock) MarshalBlock() ([]byte, error) {
+	return []byte(b.Value), nil
+}
+
+func (b *releaseTestBlock) UnmarshalBlock(data []byte) error {
+	b.Value = string(data)
+	return nil
+}
+
+// countingWorldState counts ObjectState releases issued through GetObject.
+type countingWorldState struct {
+	world.WorldState
+	released *int
+}
+
+func (c *countingWorldState) GetObject(ctx context.Context, key string) (world.ObjectState, bool, error) {
+	obj, found, err := c.WorldState.GetObject(ctx, key)
+	if err != nil || !found || obj == nil {
+		return obj, found, err
+	}
+	return &countingObjectState{ObjectState: obj, released: c.released}, true, nil
+}
+
+// countingObjectState delegates to the wrapped state and counts Release calls.
+type countingObjectState struct {
+	world.ObjectState
+	released *int
+}
+
+func (o *countingObjectState) Release() {
+	*o.released++
+	world.ReleaseObjectState(o.ObjectState)
+}
+
+// TestListCollectObjectsWithTypeReleasesStates fails if the typed batch
+// collection leaves its remote-releasable ObjectState handles alive.
+func TestListCollectObjectsWithTypeReleasesStates(t *testing.T) {
+	ctx := context.Background()
+
+	tb, err := world_testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tb.Release()
+
+	const typeID = "test/release-check-block"
+	store := func(ws world.WorldState, key, value string) {
+		t.Helper()
+		if _, _, err := world.CreateWorldObject(ctx, ws, key, func(bcs *block.Cursor) error {
+			bcs.SetBlock(&releaseTestBlock{Value: value}, true)
+			return nil
+		}); err != nil {
+			t.Fatalf("CreateWorldObject %s: %v", key, err)
+		}
+		if err := world_types.SetObjectType(ctx, ws, key, typeID); err != nil {
+			t.Fatalf("SetObjectType %s: %v", key, err)
+		}
+	}
+	store(tb.WorldState, "test/one", "one")
+	store(tb.WorldState, "test/two", "two")
+
+	var released int
+	cws := &countingWorldState{WorldState: tb.WorldState, released: &released}
+	ctor := func() block.Block { return &releaseTestBlock{} }
+
+	objs, objKeys, err := world_types.ListCollectObjectsWithType[*releaseTestBlock](ctx, cws, typeID, ctor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(objs) != 2 || objs[0].Value != "one" || objs[1].Value != "two" {
+		t.Fatalf("unexpected bodies: %#v", objs)
+	}
+	if len(objKeys) != 2 {
+		t.Fatalf("unexpected keys: %#v", objKeys)
+	}
+	if released != 2 {
+		t.Fatalf("success path: released %d states, want 2", released)
+	}
+
+	// CollectObjectBodies returns ErrNotFound for a missing key and hands the
+	// found states to the caller, which releases them.
+	objs2, states, err := world.CollectObjectBodies[*releaseTestBlock](
+		ctx,
+		cws,
+		[]string{"test/one", "test/gone"},
+		ctor,
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if len(objs2) != 2 || objs2[0].Value != "one" || objs2[1] != nil {
+		t.Fatalf("unexpected bodies on not-found: %#v", objs2)
+	}
+	for _, state := range states {
+		world.ReleaseObjectState(state)
+	}
+	if released != 3 {
+		t.Fatalf("not-found path: released %d states total, want 3", released)
+	}
+}

--- a/forge/cluster/assign-job.go
+++ b/forge/cluster/assign-job.go
@@ -61,14 +61,14 @@ func (o *ClusterAssignJobOp) ApplyWorldOp(
 
 	// Check the job and cluster objects by decoding their bodies rather than
 	// relying on the type index being immediately visible.
-	cluster, _, err := LookupCluster(ctx, worldHandle, clusterKey)
+	cluster, err := LookupClusterBody(ctx, worldHandle, clusterKey)
 	if err != nil {
 		return false, err
 	}
 	if err := cluster.Validate(); err != nil {
 		return false, err
 	}
-	job, _, err := forge_job.LookupJob(ctx, worldHandle, jobKey)
+	job, err := forge_job.LookupJobBody(ctx, worldHandle, jobKey)
 	if err != nil {
 		return false, err
 	}

--- a/forge/cluster/assign-task.go
+++ b/forge/cluster/assign-task.go
@@ -83,7 +83,7 @@ func (o *ClusterAssignTaskOp) ApplyWorldOp(
 	}
 
 	// Load the cluster record and its controlling peer.
-	cluster, _, err := LookupCluster(ctx, worldHandle, clusterKey)
+	cluster, err := LookupClusterBody(ctx, worldHandle, clusterKey)
 	if err != nil {
 		return false, err
 	}
@@ -109,7 +109,7 @@ func (o *ClusterAssignTaskOp) ApplyWorldOp(
 	}
 
 	// Load the job record.
-	job, _, err := forge_job.LookupJob(ctx, worldHandle, jobKey)
+	job, err := forge_job.LookupJobBody(ctx, worldHandle, jobKey)
 	if err != nil {
 		return false, err
 	}

--- a/forge/cluster/world-util.go
+++ b/forge/cluster/world-util.go
@@ -17,6 +17,11 @@ func LookupCluster(ctx context.Context, ws world.WorldState, objKey string) (*Cl
 	return world.LookupObject[*Cluster](ctx, ws, objKey, NewClusterBlock)
 }
 
+// LookupClusterBody looks up a Cluster body in the world.
+func LookupClusterBody(ctx context.Context, ws world.WorldState, objKey string) (*Cluster, error) {
+	return world.LookupObjectBody[*Cluster](ctx, ws, objKey, NewClusterBlock)
+}
+
 // CheckClusterType checks the type graph quad for a cluster.
 func CheckClusterType(ctx context.Context, ws world.WorldState, objKey string) error {
 	return world_types.CheckObjectType(ctx, ws, objKey, ClusterTypeID)
@@ -48,7 +53,7 @@ func CollectClusterJobs(
 
 	states := make([]*forge_job.Job, len(kpObjectKeys))
 	for i, objKey := range kpObjectKeys {
-		states[i], _, err = forge_job.LookupJob(ctx, ws, objKey)
+		states[i], err = forge_job.LookupJobBody(ctx, ws, objKey)
 		if err == nil {
 			err = states[i].Validate()
 		}
@@ -109,7 +114,7 @@ func CollectClusterWorkers(
 
 	states := make([]*forge_worker.Worker, len(kpObjectKeys))
 	for i, objKey := range kpObjectKeys {
-		states[i], _, err = forge_worker.LookupWorker(ctx, ws, objKey)
+		states[i], err = world.LookupObjectBody[*forge_worker.Worker](ctx, ws, objKey, forge_worker.NewWorkerBlock)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/forge/job/world-util.go
+++ b/forge/job/world-util.go
@@ -190,7 +190,7 @@ func CollectJobTasks(
 
 	tasks := make([]*forge_task.Task, len(kpObjectKeys))
 	for i, objKey := range kpObjectKeys {
-		tasks[i], _, err = forge_task.LookupTask(ctx, ws, objKey)
+		tasks[i], err = forge_task.LookupTaskBody(ctx, ws, objKey)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/forge/pass/world-util.go
+++ b/forge/pass/world-util.go
@@ -112,7 +112,7 @@ func CollectPassExecutions(
 
 	states := make([]*forge_execution.Execution, len(kpObjectKeys))
 	for i, objKey := range kpObjectKeys {
-		states[i], _, err = forge_execution.LookupExecution(ctx, ws, objKey)
+		states[i], err = world.LookupObjectBody[*forge_execution.Execution](ctx, ws, objKey, forge_execution.NewExecutionBlock)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/forge/task/controller/controller.go
+++ b/forge/task/controller/controller.go
@@ -135,7 +135,7 @@ func (c *Controller) updateWithPassState(ctx context.Context) error {
 	// lookup the task and make sure it is still in RUNNING state
 	// ... and peer id matches
 	taskObjKey := c.objKey
-	taskObj, _, err := forge_task.LookupTask(ctx, wtx, taskObjKey)
+	taskObj, err := forge_task.LookupTaskBody(ctx, wtx, taskObjKey)
 	if err != nil {
 		return errors.Wrap(err, "lookup task")
 	}

--- a/forge/task/world-util.go
+++ b/forge/task/world-util.go
@@ -23,6 +23,11 @@ func LookupTask(ctx context.Context, ws world.WorldState, objKey string) (*Task,
 	return world.LookupObject[*Task](ctx, ws, objKey, NewTaskBlock)
 }
 
+// LookupTaskBody looks up a Task body in the world.
+func LookupTaskBody(ctx context.Context, ws world.WorldState, objKey string) (*Task, error) {
+	return world.LookupObjectBody[*Task](ctx, ws, objKey, NewTaskBlock)
+}
+
 // ListTaskPasses lists all Pass object keys that are linked to by the Task.
 func ListTaskPasses(ctx context.Context, w world.WorldState, taskKeys ...string) ([]string, error) {
 	return world.CollectGraphPathStepWithKeys(
@@ -214,7 +219,7 @@ func CollectTaskSubtasks(
 
 	tasks := make([]*Task, len(objKeys))
 	for i, objKey := range objKeys {
-		tasks[i], _, err = LookupTask(ctx, ws, objKey)
+		tasks[i], err = LookupTaskBody(ctx, ws, objKey)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "subtasks[%s]", objKey)
 		}

--- a/forge/worker/world-util.go
+++ b/forge/worker/world-util.go
@@ -53,7 +53,8 @@ func CollectWorkerKeypairs(ctx context.Context, w world.WorldState, workerKeys .
 
 	kps := make([]*identity.Keypair, len(kpObjectKeys))
 	for i, objKey := range kpObjectKeys {
-		kps[i], _, err = identity_world.LookupKeypair(ctx, w, objKey)
+		var err error
+		kps[i], err = identity_world.LookupKeypairBody(ctx, w, objKey)
 		if err != nil {
 			return nil, kpObjectKeys, err
 		}

--- a/identity/world/domain-info.go
+++ b/identity/world/domain-info.go
@@ -83,6 +83,7 @@ func LookupDomainInfo(ctx context.Context, w world.WorldState, objKey string) (*
 		return err
 	})
 	if err != nil {
+		world.ReleaseObjectState(obj)
 		return nil, nil, err
 	}
 	return entity, obj, nil
@@ -93,7 +94,9 @@ func LookupDomainInfos(ctx context.Context, w world.WorldState, objKeys []string
 	kps := make([]*identity_domain.DomainInfo, len(objKeys))
 	for i, objKey := range objKeys {
 		var err error
-		kps[i], _, err = LookupDomainInfo(ctx, w, objKey)
+		var state world.ObjectState
+		kps[i], state, err = LookupDomainInfo(ctx, w, objKey)
+		world.ReleaseObjectState(state)
 		if err != nil {
 			return nil, err
 		}

--- a/identity/world/entities.go
+++ b/identity/world/entities.go
@@ -98,6 +98,7 @@ func LookupEntity(ctx context.Context, w world.WorldState, objKey string) (*iden
 		return err
 	})
 	if err != nil {
+		world.ReleaseObjectState(obj)
 		return nil, nil, err
 	}
 	return entity, obj, nil
@@ -108,7 +109,9 @@ func LookupEntities(ctx context.Context, w world.WorldState, objKeys []string) (
 	ents := make([]*identity.Entity, len(objKeys))
 	var err error
 	for i, objKey := range objKeys {
-		ents[i], _, err = LookupEntity(ctx, w, objKey)
+		var state world.ObjectState
+		ents[i], state, err = LookupEntity(ctx, w, objKey)
+		world.ReleaseObjectState(state)
 		if err != nil {
 			return nil, err
 		}

--- a/identity/world/keypair-update.go
+++ b/identity/world/keypair-update.go
@@ -93,7 +93,7 @@ func LookupOrStoreKeypair(
 	}
 
 	kpKey := NewKeypairKey(keypairPeerStr)
-	kp, _, err := LookupKeypair(ctx, w, kpKey)
+	kp, err := LookupKeypairBody(ctx, w, kpKey)
 	if err != nil {
 		return nil, "", err
 	}

--- a/identity/world/keypairs.go
+++ b/identity/world/keypairs.go
@@ -99,9 +99,17 @@ func LookupKeypair(ctx context.Context, w world.WorldState, objKey string) (*ide
 		return err
 	})
 	if err != nil {
+		world.ReleaseObjectState(obj)
 		return nil, nil, err
 	}
 	return entity, obj, nil
+}
+
+// LookupKeypairBody looks up a keypair without returning its object-state handle.
+func LookupKeypairBody(ctx context.Context, w world.WorldState, objKey string) (*identity.Keypair, error) {
+	kp, state, err := LookupKeypair(ctx, w, objKey)
+	world.ReleaseObjectState(state)
+	return kp, err
 }
 
 // LookupKeypairs looks up a set of keypairs.
@@ -109,7 +117,7 @@ func LookupKeypairs(ctx context.Context, w world.WorldState, objKeys []string) (
 	kps := make([]*identity.Keypair, len(objKeys))
 	for i, objKey := range objKeys {
 		var err error
-		kps[i], _, err = LookupKeypair(ctx, w, objKey)
+		kps[i], err = LookupKeypairBody(ctx, w, objKey)
 		if err != nil {
 			return nil, err
 		}
@@ -205,7 +213,8 @@ func CollectObjectKeypairs(ctx context.Context, w world.WorldState, objectKeys .
 
 	kps := make([]*identity.Keypair, len(kpObjectKeys))
 	for i, objKey := range kpObjectKeys {
-		kps[i], _, err = LookupKeypair(ctx, w, objKey)
+		var err error
+		kps[i], err = LookupKeypairBody(ctx, w, objKey)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/identity/world/keypairs_release_test.go
+++ b/identity/world/keypairs_release_test.go
@@ -1,0 +1,112 @@
+package identity_world
+
+import (
+	"context"
+	"testing"
+
+	"github.com/s4wave/spacewave/db/world"
+	world_testbed "github.com/s4wave/spacewave/db/world/testbed"
+	"github.com/s4wave/spacewave/identity"
+	identity_domain "github.com/s4wave/spacewave/identity/domain"
+	"github.com/s4wave/spacewave/net/peer"
+)
+
+// countingWorldState counts ObjectState releases issued through GetObject.
+type countingWorldState struct {
+	world.WorldState
+	released *int
+}
+
+func (c *countingWorldState) GetObject(ctx context.Context, key string) (world.ObjectState, bool, error) {
+	obj, found, err := c.WorldState.GetObject(ctx, key)
+	if err != nil || !found || obj == nil {
+		return obj, found, err
+	}
+	return &countingObjectState{ObjectState: obj, released: c.released}, true, nil
+}
+
+// countingObjectState delegates to the wrapped state and counts Release calls.
+type countingObjectState struct {
+	world.ObjectState
+	released *int
+}
+
+func (o *countingObjectState) Release() {
+	*o.released++
+	world.ReleaseObjectState(o.ObjectState)
+}
+
+// TestIdentityBatchLookupsReleaseStates fails if the identity batch lookups
+// leave their remote-releasable ObjectState handles alive.
+func TestIdentityBatchLookupsReleaseStates(t *testing.T) {
+	ctx := context.Background()
+
+	tb, err := world_testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tb.Release()
+	w := tb.WorldState
+
+	// Store one keypair, entity, and domain info fixture each.
+	p, err := peer.NewPeer(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kp, err := identity.NewKeypair(p.GetPubKey(), "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := StoreKeypair(ctx, w, p.GetPeerID(), kp, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := StoreEntity(ctx, w, p.GetPeerID(), identity.NewEntity(
+		"test-domain",
+		"test-entity",
+		"0b6e1d11-1a5f-4c3e-9d2a-7f1e2b3c4d5e",
+	)); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := StoreDomainInfo(ctx, w, p.GetPeerID(), &identity_domain.DomainInfo{
+		DomainId: "test-domain",
+		Name:     "test",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var released int
+	cws := &countingWorldState{WorldState: w, released: &released}
+
+	kps, err := LookupKeypairs(ctx, cws, []string{NewKeypairKey(kp.GetPeerId()), NewKeypairKey("missing-peer")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(kps) != 2 || kps[0] == nil || kps[1] != nil {
+		t.Fatalf("expected one found keypair and one missing, got %#v", kps)
+	}
+	if released != 1 {
+		t.Fatalf("LookupKeypairs: released %d states, want 1", released)
+	}
+
+	ents, err := LookupEntities(ctx, cws, []string{NewEntityKey("test-domain", "test-entity")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ents) != 1 || ents[0] == nil {
+		t.Fatalf("expected one entity, got %#v", ents)
+	}
+	if released != 2 {
+		t.Fatalf("LookupEntities: released %d states total, want 2", released)
+	}
+
+	dis, err := LookupDomainInfos(ctx, cws, []string{NewDomainInfoKey("test-domain")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dis) != 1 || dis[0] == nil {
+		t.Fatalf("expected one domain info, got %#v", dis)
+	}
+	if released != 3 {
+		t.Fatalf("LookupDomainInfos: released %d states total, want 3", released)
+	}
+}

--- a/sdk/sshhost/release_regression_test.go
+++ b/sdk/sshhost/release_regression_test.go
@@ -1,0 +1,69 @@
+package s4wave_sshhost
+
+import (
+	"context"
+	"testing"
+
+	"github.com/s4wave/spacewave/db/world"
+	s4wave_secret "github.com/s4wave/spacewave/sdk/secret"
+	"github.com/s4wave/spacewave/testbed"
+)
+
+// countingWorldState counts ObjectState releases issued through GetObject.
+type countingWorldState struct {
+	world.WorldState
+	released *int
+}
+
+func (c *countingWorldState) GetObject(ctx context.Context, key string) (world.ObjectState, bool, error) {
+	obj, found, err := c.WorldState.GetObject(ctx, key)
+	if err != nil || !found || obj == nil {
+		return obj, found, err
+	}
+	return &countingObjectState{ObjectState: obj, released: c.released}, true, nil
+}
+
+// countingObjectState delegates to the wrapped state and counts Release calls.
+type countingObjectState struct {
+	world.ObjectState
+	released *int
+}
+
+func (o *countingObjectState) Release() {
+	*o.released++
+	world.ReleaseObjectState(o.ObjectState)
+}
+
+// TestValidateSshHostCredentialSecretsReleasesLookedUpStates fails if a
+// body-only Secret lookup leaves its remote-releasable ObjectState alive.
+func TestValidateSshHostCredentialSecretsReleasesLookedUpStates(t *testing.T) {
+	ctx := t.Context()
+	tb, err := testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tb.Release()
+
+	createSecretParent(ctx, t, tb.WorldState, "secrets/ssh/key", s4wave_secret.SecretKindSSHPrivateKey)
+	createSecretParent(ctx, t, tb.WorldState, "secrets/ssh/wrong", s4wave_secret.SecretKindMatrixAccessToken)
+
+	var released int
+	ws := &countingWorldState{WorldState: tb.WorldState, released: &released}
+
+	refs := &SshHostCredentialRefs{PrivateKeySecretObjectKey: "secrets/ssh/key"}
+	if err := ValidateSshHostCredentialSecrets(ctx, ws, refs); err != nil {
+		t.Fatalf("ValidateSshHostCredentialSecrets: %v", err)
+	}
+	if released != 1 {
+		t.Fatalf("success path: released %d states, want 1", released)
+	}
+
+	refs.PrivateKeySecretObjectKey = "secrets/ssh/wrong"
+	err = ValidateSshHostCredentialSecrets(ctx, ws, refs)
+	if err == nil {
+		t.Fatal("expected mismatched SSH credential kind to fail")
+	}
+	if released != 2 {
+		t.Fatalf("error path: released %d states total, want 2", released)
+	}
+}

--- a/sdk/sshhost/secret-refs.go
+++ b/sdk/sshhost/secret-refs.go
@@ -52,7 +52,7 @@ func ValidateSshHostCredentialSecrets(ctx context.Context, ws world.WorldState, 
 		if err := world_types.CheckObjectType(ctx, ws, exp.ObjectKey, s4wave_secret.SecretTypeID); err != nil {
 			return errors.Wrapf(err, "ssh host credential %s", exp.Field)
 		}
-		secret, _, err := world.LookupObject[*s4wave_secret.Secret](
+		secret, err := world.LookupObjectBody[*s4wave_secret.Secret](
 			ctx,
 			ws,
 			exp.ObjectKey,

--- a/sdk/terminal/ssh_connect.go
+++ b/sdk/terminal/ssh_connect.go
@@ -154,7 +154,7 @@ func (r *TerminalResource) lookupSshHost(ctx context.Context, objectKey string) 
 	if err := world_types.CheckObjectType(ctx, r.ws, objectKey, s4wave_sshhost.SshHostTypeID); err != nil {
 		return nil, err
 	}
-	host, _, err := world.LookupObject[*s4wave_sshhost.SshHost](
+	host, err := world.LookupObjectBody[*s4wave_sshhost.SshHost](
 		ctx,
 		r.ws,
 		objectKey,
@@ -256,7 +256,7 @@ func (r *TerminalResource) readSshCredentialPayload(ctx context.Context, objectK
 	if err := world_types.CheckObjectType(ctx, r.ws, objectKey, s4wave_secret.SecretTypeID); err != nil {
 		return nil, err
 	}
-	secret, _, err := world.LookupObject[*s4wave_secret.Secret](
+	secret, err := world.LookupObjectBody[*s4wave_secret.Secret](
 		ctx,
 		r.ws,
 		objectKey,

--- a/sdk/world/wizard/wizard-resource.go
+++ b/sdk/world/wizard/wizard-resource.go
@@ -322,7 +322,7 @@ func (r *WizardResource) replaceSpaceIndexIfWizardIsCurrent(
 	ws world.WorldState,
 	objectKey string,
 ) error {
-	settings, _, err := space_world.LookupSpaceSettings(ctx, ws)
+	settings, err := space_world.LookupSpaceSettingsBody(ctx, ws)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
World lookups return an ObjectState handle that callers must release. Most callers only need the unmarshaled body, and the batch helpers dropped those handles without releasing them, leaking remote-releasable state on every settings, identity, and typed batch lookup.

This change adds body-only lookup forms that release the state on every path: `LookupSpaceSettingsBody` for SpaceSettings (preserving missing => nil semantics), `LookupKeypairBody` for keypairs, and the existing `world.LookupObjectBody` for the remaining body-only callers. It converts the settings, identity, and forge callers that never used the handle. `LookupEntities` and `LookupDomainInfos` release each state inline in their loops, and the single-object lookups (`LookupKeypair`, `LookupEntity`, `LookupDomainInfo`) now release the state when unmarshaling fails instead of leaking it. `ListCollectObjectsWithType` releases the states returned by `CollectObjectBodies`.

The exported state-returning lookups are deliberately retained as the documented handle API for callers that need the state; the new release-count regression tests use them to pin that contract.

Release-count regressions cover the settings boundary, the identity batch boundary, and the typed batch boundary. Each test fails against the previous code with zero releases and passes with the fix.

Verification: gofmt clean; `go build ./...` passes; `go vet` across core/identity/forge/db/sdk passes; focused `go test` over core/space, core/resource/space, core/plugin/space, identity, db/world, forge, sdk/sshhost, sdk/terminal, and sdk/world/wizard is green. This is lifecycle work held for explicit human approval before merge.