### PR TITLE
fix(boot): accept firefox in the BootReport engine vocabulary

### DIFF
--- a/bldr/web/boot/testdata/vocabulary-vectors.txt
+++ b/bldr/web/boot/testdata/vocabulary-vectors.txt
@@ -5,3 +5,10 @@ reject|mark-label|object-id|REPORT_CONTRACT
 reject|detail-string|aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|REPORT_CONTRACT
 reject|operation|aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|SPAN_CONTRACT
 reject|report-id|account-id|REPORT_CONTRACT
+accept|browser-engine|chromium|NONE
+accept|browser-engine|webkit|NONE
+accept|browser-engine|firefox|NONE
+reject|browser-engine|gecko|REPORT_CONTRACT
+accept|os-family|android|NONE
+reject|os-family|solaris|REPORT_CONTRACT
+accept|worker-mode|2|NONE

--- a/bldr/web/boot/validator.go
+++ b/bldr/web/boot/validator.go
@@ -135,7 +135,7 @@ var (
 		"canvas": {}, "computers": {}, "drive": {}, "forge": {}, "space": {},
 	}
 	bootProjects       = map[string]struct{}{"spacewave": {}}
-	bootBrowserEngines = map[string]struct{}{"chromium": {}, "webkit": {}}
+	bootBrowserEngines = map[string]struct{}{"chromium": {}, "firefox": {}, "webkit": {}}
 	bootOSFamilies     = map[string]struct{}{"android": {}, "darwin": {}, "ios": {}, "linux": {}, "windows": {}}
 	bootArchitectures  = map[string]struct{}{"amd64": {}, "arm64": {}, "wasm": {}}
 )

--- a/bldr/web/boot/validator.test.ts
+++ b/bldr/web/boot/validator.test.ts
@@ -197,6 +197,9 @@ describe('validateBootReport', () => {
           value: { case: 'stringValue', value },
         }
       } else if (target === 'operation') report.spans![1].operation = value
+      else if (target === 'browser-engine') report.environment!.browserEngine = value
+      else if (target === 'os-family') report.environment!.osFamily = value
+      else if (target === 'worker-mode') report.build!.workerMode = Number(value)
       else throw new Error(`unknown target ${target}`)
       const validation = validateBootReport(report)
       if (disposition === 'accept') expect(validation.pass).toBe(true)

--- a/bldr/web/boot/validator.ts
+++ b/bldr/web/boot/validator.ts
@@ -220,7 +220,7 @@ const bootEntrypoints = new Set([
 
 const bootProjects = new Set(['spacewave'])
 
-const bootBrowserEngines = new Set(['chromium', 'webkit'])
+const bootBrowserEngines = new Set(['chromium', 'firefox', 'webkit'])
 
 const bootOSFamilies = new Set(['android', 'darwin', 'ios', 'linux', 'windows'])
 

--- a/bldr/web/boot/validator_test.go
+++ b/bldr/web/boot/validator_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -210,6 +211,16 @@ func TestValidateBootReportSharedVocabularyVectors(t *testing.T) {
 				report.Marks[0].Detail[1].Value.Value = &BootValue_StringValue{StringValue: parts[2]}
 			case "operation":
 				report.Spans[1].Operation = parts[2]
+			case "browser-engine":
+				report.Environment.BrowserEngine = parts[2]
+			case "os-family":
+				report.Environment.OsFamily = parts[2]
+			case "worker-mode":
+				mode, err := strconv.Atoi(parts[2])
+				if err != nil {
+					t.Fatal(err)
+				}
+				report.Build.WorkerMode = BootWorkerMode(mode)
 			default:
 				t.Fatalf("unknown target %q", parts[1])
 			}


### PR DESCRIPTION
Firefox reports were rejected by both BootReport validators because the browser engine vocabulary listed only chromium and webkit, so any report captured on Firefox failed the report contract before review.

Add firefox to bootBrowserEngines in the Go and TypeScript validators. Extend the shared vocabulary vectors with accept cases for chromium, webkit, and firefox, a reject case for an unknown engine and unknown os family, plus accept cases proving android os family and dedicated worker mode remain valid. Both language test suites read this one vector file, so Go and TypeScript stay symmetric.

No producer in this repository emits BootReport environments yet; the validators define the accepted wire vocabulary for the upcoming Firefox and Android reporters.