### PR TITLE
fix(provider/local): stop account-settings sync on permanent cloud errors

### DIFF
--- a/core/provider/local/account-settings-cloud-sync.go
+++ b/core/provider/local/account-settings-cloud-sync.go
@@ -11,6 +11,7 @@ import (
 	provider "github.com/s4wave/spacewave/core/provider"
 	provider_spacewave "github.com/s4wave/spacewave/core/provider/spacewave"
 	api "github.com/s4wave/spacewave/core/provider/spacewave/api"
+	"github.com/s4wave/spacewave/core/provider/spacewave/clouderror"
 	"github.com/s4wave/spacewave/core/session"
 	"github.com/s4wave/spacewave/core/sobject"
 	"github.com/s4wave/spacewave/db/kvtx"
@@ -138,7 +139,47 @@ func waitForLinkedCloudSessionRef(
 	}
 }
 
+// runAccountSettingsCloudSync runs the account-settings cloud-sync routine.
+// A non-retryable cloud error stops the routine instead of entering the retry
+// backoff, so a permanent rejection of GET or POST on the account-settings
+// shared object cannot loop. Unauthenticated errors stay retriable: the
+// reauthentication flow owns them and the next attempt succeeds after it.
+// Access-gated errors stay retriable too: role, subscription, or access
+// state may change while the account stays linked, and the routine's
+// account-state waits recover once it does. Deletion and blocked states do
+// not recover through this loop; the existing account lifecycle owns them.
 func (a *ProviderAccount) runAccountSettingsCloudSync(
+	ctx context.Context,
+	cloudAccountID string,
+) error {
+	err := a.syncAccountSettingsToCloud(ctx, cloudAccountID)
+	if accountSettingsSyncTerminalError(err) {
+		a.t.p.le.WithField("routine", "account-settings-cloud-sync").
+			WithError(err).
+			Warn("permanent error syncing account settings, stopping until link changes")
+		return nil
+	}
+	return err
+}
+
+// accountSettingsSyncTerminalError reports whether an error from the
+// account-settings cloud-sync routine must stop the retry loop instead of
+// backing off and retrying. Access-gated errors are excluded: role,
+// subscription, or access state may change while the account stays linked,
+// so the loop keeps backing off until the correction lands. Deletion and
+// blocked states are owned by the existing account lifecycle, not by this
+// loop.
+func accountSettingsSyncTerminalError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return false
+	}
+	if clouderror.IsUnauth(err) || clouderror.IsAccessGated(err) {
+		return false
+	}
+	return clouderror.IsNonRetryable(err)
+}
+
+func (a *ProviderAccount) syncAccountSettingsToCloud(
 	ctx context.Context,
 	cloudAccountID string,
 ) error {

--- a/core/provider/local/account-settings-cloud-sync_test.go
+++ b/core/provider/local/account-settings-cloud-sync_test.go
@@ -1,14 +1,23 @@
 package provider_local
 
 import (
+	"context"
+	"io"
+	"net/http"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/aperturerobotics/controllerbus/controller/resolver"
+	cutil_routine "github.com/aperturerobotics/util/routine"
+	"github.com/pkg/errors"
 	account_settings "github.com/s4wave/spacewave/core/account/settings"
 	provider "github.com/s4wave/spacewave/core/provider"
+	"github.com/s4wave/spacewave/core/provider/spacewave/clouderror"
 	"github.com/s4wave/spacewave/core/session"
 	session_controller "github.com/s4wave/spacewave/core/session/controller"
 	"github.com/s4wave/spacewave/testbed"
+	"github.com/sirupsen/logrus"
 )
 
 func TestBuildAccountSettingsSyncOps(t *testing.T) {
@@ -44,6 +53,192 @@ func TestBuildAccountSettingsSyncOps(t *testing.T) {
 	if len(ops) != 5 {
 		t.Fatalf("expected 5 sync ops, got %d", len(ops))
 	}
+}
+
+func TestAccountSettingsSyncTerminalError(t *testing.T) {
+	wrap := func(err error) error {
+		// Mirror the routine body, which wraps every failure with context.
+		return errors.Wrap(err, "mount cloud account settings")
+	}
+	permanent := &clouderror.Error{
+		StatusCode: http.StatusBadRequest,
+		Code:       "invalid_resource_id",
+		Retryable:  false,
+	}
+	unauth := &clouderror.Error{
+		StatusCode: http.StatusUnauthorized,
+		Code:       "unknown_session",
+		Retryable:  false,
+	}
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"canceled", context.Canceled, false},
+		{"transient network", errors.New("dial tcp: timeout"), false},
+		{"unauth waits for reauth", wrap(unauth), false},
+		{"400 stops the loop", wrap(permanent), true},
+		{"insufficient_role stays retriable", wrap(&clouderror.Error{
+			StatusCode: http.StatusForbidden,
+			Code:       "insufficient_role",
+			Retryable:  false,
+		}), false},
+		{"subscription_required stays retriable", wrap(&clouderror.Error{
+			StatusCode: http.StatusPaymentRequired,
+			Code:       "subscription_required",
+			Retryable:  false,
+		}), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := accountSettingsSyncTerminalError(tc.err); got != tc.want {
+				t.Fatalf("accountSettingsSyncTerminalError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// newAccountSettingsSyncTestRoutine builds a state-routine container wired the
+// same way as the account-settings cloud sync in account.go: same-state
+// compare, provider backoff, and a state routine which classifies stub sync
+// errors through the real terminal predicate. Each invocation of the stub
+// reports its call number on calls.
+func newAccountSettingsSyncTestRoutine(
+	t *testing.T,
+	run cutil_routine.StateRoutine[string],
+) *cutil_routine.StateRoutineContainer[string] {
+	t.Helper()
+	log := logrus.New()
+	log.SetOutput(io.Discard)
+	ctr := cutil_routine.NewStateRoutineContainerWithLogger[string](
+		func(v1, v2 string) bool { return v1 == v2 },
+		logrus.NewEntry(log),
+		cutil_routine.WithRetry(providerBackoff),
+	)
+	ctr.SetStateRoutine(run)
+	t.Cleanup(func() { ctr.ClearContext() })
+	return ctr
+}
+
+// awaitAccountSettingsSyncCall waits a bounded time for the next invocation
+// signal instead of sleeping a fixed interval.
+func awaitAccountSettingsSyncCall(
+	t *testing.T,
+	calls <-chan int32,
+	want int32,
+	timeout time.Duration,
+) {
+	t.Helper()
+	var last int32
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	for {
+		select {
+		case n := <-calls:
+			if n >= want {
+				return
+			}
+			last = n
+		case <-deadline.C:
+			t.Fatalf("routine invoked %d times so far, want at least %d", last, want)
+		}
+	}
+}
+
+func TestAccountSettingsSyncTerminalStopWiring(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("terminal error stops until link state changes", func(t *testing.T) {
+		var calls atomic.Int32
+		callCh := make(chan int32, 16)
+		hardTerminal := &clouderror.Error{
+			StatusCode: http.StatusBadRequest,
+			Code:       "invalid_resource_id",
+			Retryable:  false,
+		}
+		run := func(_ context.Context, _ string) error {
+			n := calls.Add(1)
+			select {
+			case callCh <- n:
+			default:
+			}
+			err := errors.Wrap(hardTerminal, "mount cloud account settings")
+			if accountSettingsSyncTerminalError(err) {
+				return nil
+			}
+			return err
+		}
+		ctr := newAccountSettingsSyncTestRoutine(t, run)
+		ctr.SetState("cloud-account-1")
+		ctr.SetContext(ctx, true)
+
+		awaitAccountSettingsSyncCall(t, callCh, 1, 10*time.Second)
+		if err := ctr.WaitExited(ctx, false, nil); err != nil {
+			t.Fatalf("routine exited with error: %v", err)
+		}
+
+		// The routine must not re-enter through retry backoff while the
+		// linked account state is unchanged.
+		select {
+		case n := <-callCh:
+			t.Fatalf("routine re-entered after terminal stop: call %d", n)
+		case <-time.After(1200 * time.Millisecond):
+		}
+
+		// A different linked cloud account restarts the routine.
+		if _, changed, _, _ := ctr.SetState("cloud-account-2"); !changed {
+			t.Fatal("expected state change")
+		}
+		awaitAccountSettingsSyncCall(t, callCh, 2, 10*time.Second)
+		if err := ctr.WaitExited(ctx, false, nil); err != nil {
+			t.Fatalf("routine exited with error after restart: %v", err)
+		}
+		if got := calls.Load(); got != 2 {
+			t.Fatalf("routine ran %d times, want 2", got)
+		}
+	})
+
+	t.Run("access-gated error keeps retrying and recovers", func(t *testing.T) {
+		var calls atomic.Int32
+		callCh := make(chan int32, 16)
+		gated := &clouderror.Error{
+			StatusCode: http.StatusForbidden,
+			Code:       "insufficient_role",
+			Retryable:  false,
+		}
+		run := func(_ context.Context, _ string) error {
+			n := calls.Add(1)
+			select {
+			case callCh <- n:
+			default:
+			}
+			if n == 1 {
+				err := errors.Wrap(gated, "wait for sync op")
+				if accountSettingsSyncTerminalError(err) {
+					return nil
+				}
+				return err
+			}
+			// The role correction landed; the next attempt succeeds.
+			return nil
+		}
+		ctr := newAccountSettingsSyncTestRoutine(t, run)
+		ctr.SetState("cloud-account-1")
+		ctr.SetContext(ctx, true)
+
+		// The gated rejection must not stop the loop: the second attempt
+		// must start via retry backoff.
+		awaitAccountSettingsSyncCall(t, callCh, 2, 10*time.Second)
+		if err := ctr.WaitExited(ctx, false, nil); err != nil {
+			t.Fatalf("routine exited with error after recovery: %v", err)
+		}
+		if got := calls.Load(); got != 2 {
+			t.Fatalf("routine ran %d times, want 2", got)
+		}
+	})
 }
 
 func TestLoadLinkedCloudAccountID(t *testing.T) {


### PR DESCRIPTION
The account-settings cloud-sync routine retried non-retryable cloud rejections of GET or POST on the account-settings shared object forever. The provider backoff has no max elapsed time, so a permanent 4xx re-entered the cloud roughly every 30 minutes indefinitely.

After each attempt, the routine now classifies the error. A non-retryable cloud error that is neither unauthenticated nor access-gated stops the routine with a warning instead of entering the retry backoff, so a permanent rejection cannot loop.

Unauthenticated errors stay retriable because the reauthentication flow owns them and later attempts succeed after it runs. Access-gated errors (insufficient_role, subscription_required, rbac_denied, account_read_only, resource_not_found) stay retriable too: role, subscription, or access state may change while the account stays linked, and the routine's existing account-state waits recover once it does. Deletion and blocked states do not recover through this loop; the existing account lifecycle (deletion cascade, blocked handling) owns them.

A wiring regression over the real state-routine container proves a terminal error runs exactly once and does not re-enter until the linked account state changes, and that an access-gated rejection retries through the backoff and recovers after correction. Before the fix that regression failed at runtime: an access-gated rejection stopped the loop permanently after one call.