### PR TITLE
fix(release): build darwin helpers per requested architecture

### DIFF
--- a/cmd/entrypoint-handoff/handoff/handoff.go
+++ b/cmd/entrypoint-handoff/handoff/handoff.go
@@ -407,23 +407,15 @@ func prepareSupportFiles(ctx context.Context, repoDir string, platforms []string
 	return nil
 }
 
+// buildHelpers runs one helper build per requested platform. Darwin arches
+// build independently: build-helper.sh builds exactly the requested
+// architecture, so a universal macOS release lists both darwin platforms.
 func buildHelpers(repoDir string, platforms []string) error {
-	needsDarwin := false
 	for _, platform := range platforms {
 		goos, goarch := splitPlatform(platform)
-		if goos == "darwin" {
-			needsDarwin = true
-			continue
-		}
 		if err := runScript(repoDir, filepath.Join("scripts", "release", "build-helper.sh"), goos, goarch); err != nil {
 			return errors.Wrap(err, "build helper "+platform)
 		}
-	}
-	if !needsDarwin {
-		return nil
-	}
-	if err := runScript(repoDir, filepath.Join("scripts", "release", "build-helper.sh"), "darwin", "arm64"); err != nil {
-		return errors.Wrap(err, "build helper darwin")
 	}
 	return nil
 }

--- a/scripts/release/build-helper.sh
+++ b/scripts/release/build-helper.sh
@@ -188,20 +188,42 @@ sign_windows_helper() {
 # wrote all three to dist/helper/spacewave-helper-<arch> which let the linux
 # ELF overwrite the darwin Mach-O on multi-platform release runs, producing
 # a .app bundle whose helper was an unlaunchable Linux binary).
+build_darwin_helper() {
+  local swift_arch="$1"
+  local out_arch="$2"
+  local scratch="$SCRATCH_ROOT/swift/darwin-$out_arch"
+  mkdir -p "$scratch"
+  (cd "$REPO_ROOT/desktop/macos" && \
+    swift build -c release --arch "$swift_arch" --scratch-path "$scratch")
+  # SwiftPM's scratch layout changed across toolchain versions; ask it where
+  # the built products are instead of assuming the <triple>/release path.
+  local bin_dir
+  bin_dir=$(cd "$REPO_ROOT/desktop/macos" && \
+    swift build -c release --arch "$swift_arch" --scratch-path "$scratch" --show-bin-path)
+  if [ -z "$bin_dir" ]; then
+    echo "ERROR: swift build --show-bin-path returned no product directory for darwin-$out_arch" >&2
+    exit 1
+  fi
+  if [ ! -f "$bin_dir/SpacewaveHelper" ]; then
+    echo "ERROR: no SpacewaveHelper in swift product directory $bin_dir for darwin-$out_arch" >&2
+    exit 1
+  fi
+  mkdir -p "$OUT/darwin-$out_arch"
+  cp "$bin_dir/SpacewaveHelper" \
+    "$OUT/darwin-$out_arch/spacewave-helper"
+}
+
+# The requested ARCH selects exactly one Swift target. A universal release
+# requests darwin-arm64 and darwin-amd64 separately (see handoff buildHelpers),
+# so no invocation silently builds the other architecture.
 case "$PLATFORM" in
   darwin)
-    cd "$REPO_ROOT/desktop/macos"
-    SCRATCH_ARM="$SCRATCH_ROOT/swift/darwin-arm64"
-    SCRATCH_AMD="$SCRATCH_ROOT/swift/darwin-amd64"
-    mkdir -p "$SCRATCH_ARM" "$SCRATCH_AMD"
-    swift build -c release --arch arm64 --scratch-path "$SCRATCH_ARM"
-    swift build -c release --arch x86_64 --scratch-path "$SCRATCH_AMD"
-    mkdir -p "$OUT/darwin-arm64" "$OUT/darwin-amd64"
-    cp "$SCRATCH_ARM/arm64-apple-macosx/release/SpacewaveHelper" \
-      "$OUT/darwin-arm64/spacewave-helper"
-    cp "$SCRATCH_AMD/x86_64-apple-macosx/release/SpacewaveHelper" \
-      "$OUT/darwin-amd64/spacewave-helper"
-    echo "Built macOS helpers in $OUT/darwin-{arm64,amd64}/"
+    case "$ARCH" in
+      arm64) build_darwin_helper arm64 arm64 ;;
+      amd64) build_darwin_helper x86_64 amd64 ;;
+      *) echo "ERROR: unsupported darwin helper ARCH: $ARCH" >&2; exit 1 ;;
+    esac
+    echo "Built macOS helper ($ARCH) in $OUT/darwin-$ARCH/"
     ;;
   linux)
     case "$ARCH" in

--- a/scripts/release/build-helper.test.sh
+++ b/scripts/release/build-helper.test.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+set -euo pipefail
+
+# Regression test for scripts/release/build-helper.sh darwin arch handling.
+# A stubbed swift records invocations and fakes build outputs, so the test
+# proves argument routing without compiling anything. It fails on a script
+# that builds an unrequested architecture or accepts an unsupported one.
+
+repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+script="$repo_dir/scripts/release/build-helper.sh"
+temp_dir=$(mktemp -d)
+cleanup() {
+  rm -rf "$temp_dir"
+}
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p "$temp_dir/bin" "$temp_dir/home"
+# The stub mimics modern SwiftPM: products live under <scratch>/out/Products/
+# Release and --show-bin-path prints that directory without building. It never
+# creates the legacy <triple>/release layout, so a script that copies from a
+# hard-coded triple path fails this test.
+cat > "$temp_dir/bin/swift" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+echo "swift $*" >> "${SWIFT_CALL_LOG:?}"
+arch=""
+scratch=""
+show_bin_path=0
+prev=""
+for arg in "$@"; do
+  case "$prev" in
+    --arch) arch="$arg" ;;
+    --scratch-path) scratch="$arg" ;;
+  esac
+  [ "$arg" = "--show-bin-path" ] && show_bin_path=1
+  prev="$arg"
+done
+if [ -z "$arch" ] || [ -z "$scratch" ]; then
+  echo "stub swift: expected --arch and --scratch-path" >&2
+  exit 1
+fi
+product_dir="$scratch/out/Products/Release"
+if [ "$show_bin_path" = 0 ]; then
+  mkdir -p "$product_dir"
+  printf '#!/bin/sh\n' > "$product_dir/SpacewaveHelper"
+  chmod 755 "$product_dir/SpacewaveHelper"
+else
+  echo "$product_dir"
+fi
+EOF
+chmod 755 "$temp_dir/bin/swift"
+
+new_env() {
+  local name="$1"
+  mkdir -p "$temp_dir/$name/scripts/release" "$temp_dir/$name/desktop/macos"
+  cp "$script" "$temp_dir/$name/scripts/release/build-helper.sh"
+}
+
+run_build() {
+  local name="$1"
+  shift
+  env -i PATH="$temp_dir/bin:/usr/bin:/bin" HOME="$temp_dir/home" \
+    SWIFT_CALL_LOG="$temp_dir/$name-swift-calls.log" \
+    bash "$temp_dir/$name/scripts/release/build-helper.sh" "$@"
+}
+
+swift_calls() {
+  cat "$temp_dir/$1-swift-calls.log"
+}
+
+# darwin arm64 builds only arm64.
+new_env arm64-case
+run_build arm64-case darwin arm64 > "$temp_dir/arm64-case-stdout.log"
+calls=$(swift_calls arm64-case)
+[ "$(grep -c '^swift ' "$temp_dir/arm64-case-swift-calls.log")" -eq 2 ]
+printf '%s' "$calls" | grep -q -- '--arch arm64'
+if printf '%s' "$calls" | grep -q -- '--arch x86_64'; then
+  echo 'FAIL: darwin arm64 request also invoked swift for x86_64' >&2
+  exit 1
+fi
+test -x "$temp_dir/arm64-case/dist/helper/darwin-arm64/spacewave-helper"
+if [ -e "$temp_dir/arm64-case/dist/helper/darwin-amd64" ]; then
+  echo 'FAIL: darwin arm64 request produced a darwin-amd64 output' >&2
+  exit 1
+fi
+
+# darwin amd64 builds only x86_64.
+new_env amd64-case
+run_build amd64-case darwin amd64 > "$temp_dir/amd64-case-stdout.log"
+calls=$(swift_calls amd64-case)
+[ "$(grep -c '^swift ' "$temp_dir/amd64-case-swift-calls.log")" -eq 2 ]
+printf '%s' "$calls" | grep -q -- '--arch x86_64'
+test -x "$temp_dir/amd64-case/dist/helper/darwin-amd64/spacewave-helper"
+if [ -e "$temp_dir/amd64-case/dist/helper/darwin-arm64" ]; then
+  echo 'FAIL: darwin amd64 request produced a darwin-arm64 output' >&2
+  exit 1
+fi
+
+# An unsupported darwin ARCH fails before invoking swift.
+new_env badarch-case
+if run_build badarch-case darwin riscv64 > "$temp_dir/badarch-case-stdout.log" 2>&1; then
+  echo 'FAIL: unsupported darwin ARCH was accepted' >&2
+  exit 1
+fi
+if [ -s "$temp_dir/badarch-case-swift-calls.log" ]; then
+  echo 'FAIL: unsupported darwin ARCH invoked swift' >&2
+  exit 1
+fi
+
+echo 'build-helper.test.sh: ok'

--- a/scripts/release/build-macos.sh
+++ b/scripts/release/build-macos.sh
@@ -98,7 +98,16 @@ esac
     -Xlinker __launchd_plist \
     -Xlinker "$PRIV_PLIST_DIR/Launchd.plist"
 )
-PRIV_BIN="$REPO_ROOT/desktop/macos/.build/${SWIFT_ARCH}-apple-macosx/release/SpacewaveHelperPrivileged"
+# SwiftPM's scratch layout changed across toolchain versions; ask it where
+# the built product is instead of assuming the <triple>/release path.
+PRIV_BIN_DIR=$(cd "$REPO_ROOT/desktop/macos" && \
+  swift build --show-bin-path -c release --arch "$SWIFT_ARCH" \
+    --product SpacewaveHelperPrivileged)
+if [ -z "$PRIV_BIN_DIR" ]; then
+  echo "ERROR: swift build --show-bin-path returned no product directory for SpacewaveHelperPrivileged" >&2
+  exit 1
+fi
+PRIV_BIN="$PRIV_BIN_DIR/SpacewaveHelperPrivileged"
 if [ ! -f "$PRIV_BIN" ]; then
   echo "ERROR: privileged helper build did not produce $PRIV_BIN" >&2
   exit 1


### PR DESCRIPTION
## Summary

The macOS release helper build ignored the requested platform list: `buildHelpers` skipped every darwin platform and unconditionally built both arm64 and amd64 helpers in one invocation, while the helper script wrote outputs under fixed legacy SwiftPM scratch paths. Two failures followed:

- On multi-platform release runs the linux ELF overwrote the darwin Mach-O in `dist/helper`, producing a `.app` bundle whose helper was an unlaunchable Linux binary.
- On SwiftPM 6.4 toolchains every darwin helper copy failed because the `<triple>/release` scratch directory no longer exists.

## Changes

- `cmd/entrypoint-handoff/handoff/handoff.go`: `buildHelpers` now runs one helper build per requested platform instead of special-casing darwin.
- `scripts/release/build-helper.sh`: builds exactly one Swift target selected by `ARCH`, rejecting unsupported values; resolves SwiftPM's product directory via `swift build --show-bin-path` with the same target flags as the build, validates the product exists, and copies from the resolved path.
- `scripts/release/build-macos.sh`: same `--show-bin-path` resolution and validation for `SpacewaveHelperPrivileged`.
- `scripts/release/build-helper.test.sh` (new): shell regression with a stubbed swift that emulates the modern scratch layout (`<scratch>/out/Products/Release`) without ever creating the legacy triple layout. It pins per-platform argument routing (arm64 request builds only arm64, amd64 only x86_64, unsupported arch rejected before invoking swift) and fails against any script that hard-codes the triple path.

Universal macOS releases now request darwin-arm64 and darwin-amd64 separately, so no invocation silently builds or overwrites another architecture's helper.

## Verification (local, host arm64)

- `bash scripts/release/build-helper.test.sh` ok; verified it fails when the product-dir resolution is reverted to the hard-coded triple layout.
- `go build ./cmd/entrypoint-handoff/...`, `go vet ./cmd/entrypoint-handoff/handoff`, `go test -count=1 ./cmd/entrypoint-handoff/handoff/` ok on current master.
- `ENABLE_E2E_DESKTOP_DISTRIBUTION_GATE=true` macOS packaged distribution gate on host arm64: all packaging stages pass (metadata, icons, helpers, desktop entrypoint build, runtime staging, app package/sign), and the packaged app launches. Full gate result below.

## Known independent blockers (not introduced or addressed by this change)

1. **x86_64 Swift helper link failure on arm64-only toolchains (pre-existing on clean master).** On a host whose Xcode/CommandLineTools ships only arm64/arm64e Swift compatibility slices, clean master's dual-arch darwin helper build fails at link time for x86_64 (`fat file missing arch 'x86_64'` -> undefined `__swift_FORCE_LOAD_$_swiftCompatibility56`). This range sidesteps it by building only the requested architecture; a durable cross-arch solution still needs attention.
2. **Missing `spacewave-cli` manifest blocks live app launch (pre-existing producer gap).** The launcher controller requires both native (`spacewave-dist`) and CLI (`spacewave-cli`) entrypoint manifests for the desktop platform before staging updates (`core/provider/spacewave/launcher/controller/release-metadata.go`), but the distribution gate's packaging path produces only the dist manifest. With this change applied, packaging fully succeeds and the app starts, but Electron never starts because that routine errors repeatedly, so renderer readiness times out. Live launch remains blocked independently of this diff.

This is qualifying release/lifecycle work: opening for human review; not merging automatically.
