### PR TITLE
fix(bldr/web): serve plugin dist from a single active manifest root

### DIFF
--- a/bldr/web/bldr-react/web-view-error-boundary.test.ts
+++ b/bldr/web/bldr-react/web-view-error-boundary.test.ts
@@ -1,5 +1,5 @@
 import React from 'react'
-import { cleanup, fireEvent, render } from '@testing-library/react'
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { WebViewErrorBoundary } from './web-view-error-boundary.js'
@@ -93,5 +93,49 @@ describe('WebViewErrorBoundary module load diagnostics', () => {
     fireEvent.click(rendered.getByText('Retry now'))
 
     expect(onRecoverableRetry).toHaveBeenCalledOnce()
+  })
+
+  it('recovers a root-changed 409 classification through the bounded retry path', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    const onRecoverableRetry = vi.fn()
+    const error = new WebViewRootAssetLoadError({
+      scriptPath: '/b/pd/spacewave-app/backend.mjs',
+      status: 409,
+      ok: false,
+      fetchSource: 'plugin-dist',
+      runtimeError: 'plugin-root-changed',
+      pluginAssetResult: 'root-changed',
+      contentType: 'application/json',
+      classification: 'root-changed',
+      bodyPrefix: '{"code":"plugin-root-changed"',
+    })
+
+    const rendered = render(
+      React.createElement(
+        WebViewErrorBoundary,
+        { onRecoverableRetry },
+        React.createElement(ThrowError, { error }),
+      ),
+    )
+
+    // The classified failure enters the established exponential-backoff
+    // recovery instead of the manual-only diagnostic path.
+    expect(rendered.container.textContent).toContain('Retrying in 2s…')
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000)
+    })
+    expect(rendered.container.textContent).toContain('Retrying in 1s…')
+    expect(onRecoverableRetry).not.toHaveBeenCalled()
+
+    // The bounded recovery retries exactly once, then backoff escalates for
+    // any repeat failure instead of retrying immediately.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000)
+    })
+    expect(onRecoverableRetry).toHaveBeenCalledOnce()
+    expect(rendered.container.textContent).toContain('Retrying in 4s…')
   })
 })

--- a/bldr/web/bldr-react/web-view-error-boundary.tsx
+++ b/bldr/web/bldr-react/web-view-error-boundary.tsx
@@ -24,6 +24,7 @@ function isRecoverableError(error: Error): boolean {
     return (
       rootAssetError.rootAsset.classification === 'runtime-unavailable' ||
       rootAssetError.rootAsset.classification === 'generation-closed' ||
+      rootAssetError.rootAsset.classification === 'root-changed' ||
       rootAssetError.rootAsset.classification === 'bypass' ||
       rootAssetError.rootAsset.status >= 500
     )
@@ -163,21 +164,21 @@ export class WebViewErrorBoundary extends React.Component<
   private startCountdown(seconds: number) {
     this.clearCountdown()
     this.setState({ countdown: seconds })
+    // The interval callback owns the tick: side effects stay outside setState
+    // updaters, which React may invoke more than once per update.
     this.countdownInterval = setInterval(() => {
-      this.setState((prev) => {
-        const next = prev.countdown - 1
-        if (next <= 0) {
-          this.clearCountdown()
-          this.props.onRecoverableRetry?.()
-          return {
-            ...prev,
-            countdown: 0,
-            caughtError: undefined,
-            retryAttempt: prev.retryAttempt + 1,
-          }
-        }
-        return { ...prev, countdown: next }
-      })
+      const next = this.state.countdown - 1
+      if (next <= 0) {
+        this.clearCountdown()
+        this.props.onRecoverableRetry?.()
+        this.setState({
+          countdown: 0,
+          caughtError: undefined,
+          retryAttempt: this.state.retryAttempt + 1,
+        })
+        return
+      }
+      this.setState({ countdown: next })
     }, 1000)
   }
 

--- a/bldr/web/bldr/service-worker.test.ts
+++ b/bldr/web/bldr/service-worker.test.ts
@@ -163,6 +163,12 @@ async function writeGenerationCacheResponse(
   await cache.put(new Request(new URL(path, self.location.href)), response)
 }
 
+// pluginAssetCachePath builds the root-scoped generation-cache key for a
+// static plugin asset.
+function pluginAssetCachePath(path: string, rootHash: string): string {
+  return `${path}?__bldr_plugin_root=${encodeURIComponent(rootHash)}`
+}
+
 async function writeControlCacheResponse(
   caches: FakeCacheStorage,
   path: string,
@@ -1203,7 +1209,13 @@ describe('service worker fetch release cache routing', () => {
     const generationCache = await caches.open('bldr-generation-gen-a')
     const cached = await generationCache.match(
       new Request(
-        new URL('/b/pa/spacewave-app/v/b/fe/app/App2.mjs', self.location.href),
+        new URL(
+          pluginAssetCachePath(
+            '/b/pa/spacewave-app/v/b/fe/app/App2.mjs',
+            '2abc',
+          ),
+          self.location.href,
+        ),
       ),
     )
     expect(await cached?.text()).toBe(body)
@@ -1231,7 +1243,7 @@ describe('service worker fetch release cache routing', () => {
     await writeGenerationCacheResponse(
       caches,
       release.generationId,
-      path,
+      pluginAssetCachePath(path, '2abc'),
       new Response('cached app', { status: 200 }),
     )
     const revalidation = newDeferred<Response>()
@@ -1249,7 +1261,9 @@ describe('service worker fetch release cache routing', () => {
 
     const cache = await caches.open('bldr-generation-gen-a')
     const cached = await cache.match(
-      new Request(new URL(path, self.location.href)),
+      new Request(
+        new URL(pluginAssetCachePath(path, '2abc'), self.location.href),
+      ),
     )
     expect(await cached?.text()).toBe('fresh app')
   })
@@ -1267,7 +1281,7 @@ describe('service worker fetch release cache routing', () => {
     await writeGenerationCacheResponse(
       caches,
       oldRelease.generationId,
-      path,
+      pluginAssetCachePath(path, '2abc'),
       new Response('old generation', { status: 200 }),
     )
     const controlCache = await caches.open('bldr-control')
@@ -1387,7 +1401,7 @@ describe('service worker fetch release cache routing', () => {
     await writeGenerationCacheResponse(
       caches,
       release.generationId,
-      path,
+      pluginAssetCachePath(path, '2abc'),
       new Response('stale stable entry', { status: 200 }),
     )
     vi.mocked(proxyFetch).mockResolvedValue(
@@ -1429,18 +1443,16 @@ describe('service worker fetch release cache routing', () => {
     expect(fetchEvent.waitUntilPromises).toHaveLength(0)
   })
 
-  it('rehydrates persisted plugin root authority after service worker restart', async () => {
-    await writeBrowserReleaseState(
-      globalThis.caches as unknown as FakeCacheStorage,
-      {
-        ...createEmptyBrowserReleaseState(),
-        promotedCurrent: buildRelease('gen-a'),
-      },
-    )
+  it('does not reactivate a persisted plugin root after a restart', async () => {
+    const caches = globalThis.caches as unknown as FakeCacheStorage
+    await writeBrowserReleaseState(caches, {
+      ...createEmptyBrowserReleaseState(),
+      promotedCurrent: buildRelease('gen-a'),
+    })
     await announcePluginRoot('spacewave-app', '2abc')
-    const body = 'export const App2 = () => null\n'
+    const warmBody = 'export const AppA = () => null\n'
     vi.mocked(proxyFetch).mockResolvedValue(
-      new Response(body, {
+      new Response(warmBody, {
         status: 200,
         headers: { 'Content-Type': 'application/javascript' },
       }),
@@ -1452,87 +1464,31 @@ describe('service worker fetch release cache routing', () => {
     )
     const warmResponse = await swFetch(warm.ev)
     expect(warmResponse.status).toBe(200)
-    expect(await warmResponse.text()).toBe(body)
+    expect(await warmResponse.text()).toBe(warmBody)
     await Promise.all(warm.waitUntilPromises)
-
-    // Simulate a ServiceWorker restart without deleting CacheStorage.
-    resetServiceWorkerTestState()
-    vi.mocked(proxyFetch).mockClear()
-    const restartedResponse = await swFetch(
-      buildFetchOnlyEvent('/b/pd/spacewave-app/backend.mjs'),
-    )
-    expect(restartedResponse.status).toBe(200)
-    expect(await restartedResponse.text()).toBe(body)
-    expect(proxyFetch).not.toHaveBeenCalled()
-  })
-
-  it('rejects plugin root metadata from another service worker release', async () => {
-    const caches = globalThis.caches as unknown as FakeCacheStorage
-    const path = '/b/pd/spacewave-app/backend.mjs'
-    await writeControlCacheResponse(
-      caches,
-      '/__bldr/plugin-manifest-root/spacewave-app.json',
-      new Response(
-        JSON.stringify({
-          pluginId: 'spacewave-app',
-          rootHash: '2abc',
-          serviceWorkerURL: `${self.location.href}?stale=1`,
-        }),
-      ),
-    )
-    resetServiceWorkerTestState()
-    vi.mocked(proxyFetch).mockResolvedValue(
-      new Response('current app', { status: 200 }),
-    )
-
-    const response = await swFetch(
-      buildFetchOnlyEvent(path, undefined, 'client-a'),
-    )
-    expect(response.status).toBe(200)
-    expect(await response.text()).toBe('current app')
-    expect(proxyFetch).toHaveBeenCalledOnce()
-  })
-
-  it('does not activate a plugin root when durable metadata write fails', async () => {
-    const caches = new FakeCacheStorage((cacheName, request) => {
-      if (
-        cacheName === 'bldr-control' &&
-        new URL(request.url).pathname.startsWith(
-          '/__bldr/plugin-manifest-root/',
-        )
-      ) {
-        return newCachePutError()
-      }
-      return undefined
-    })
-    vi.stubGlobal('caches', caches)
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    await announcePluginRoot('spacewave-app', '2abc')
-    const body = 'export const App2 = () => null\n'
-    vi.mocked(proxyFetch).mockImplementation(() =>
-      Promise.resolve(
-        new Response(body, {
-          status: 200,
-          headers: { 'Content-Type': 'application/javascript' },
-        }),
-      ),
-    )
-
-    for (let attempt = 0; attempt < 2; attempt++) {
-      const response = await swFetch(
-        buildFetchOnlyEvent(
-          '/b/pd/spacewave-app/backend.mjs',
-          undefined,
-          'client-a',
+    const generationCache = await caches.open('bldr-generation-gen-a')
+    const cached = await generationCache.match(
+      new Request(
+        new URL(
+          pluginAssetCachePath('/b/pd/spacewave-app/backend.mjs', '2abc'),
+          self.location.href,
         ),
-      )
-      expect(response.status).toBe(200)
-      expect(await response.text()).toBe(body)
-    }
-    expect(proxyFetch).toHaveBeenCalledTimes(2)
+      ),
+    )
+    expect(await cached?.text()).toBe(warmBody)
 
+    // Simulate a ServiceWorker restart without deleting CacheStorage. The
+    // persisted root must not reactivate; the request proxies to the runtime,
+    // which serves its current root.
     resetServiceWorkerTestState()
     vi.mocked(proxyFetch).mockClear()
+    const restartedBody = 'export const AppB = () => null\n'
+    vi.mocked(proxyFetch).mockResolvedValue(
+      new Response(restartedBody, {
+        status: 200,
+        headers: { 'Content-Type': 'application/javascript' },
+      }),
+    )
     const restartedResponse = await swFetch(
       buildFetchOnlyEvent(
         '/b/pd/spacewave-app/backend.mjs',
@@ -1541,9 +1497,130 @@ describe('service worker fetch release cache routing', () => {
       ),
     )
     expect(restartedResponse.status).toBe(200)
-    expect(await restartedResponse.text()).toBe(body)
+    expect(await restartedResponse.text()).toBe(restartedBody)
     expect(proxyFetch).toHaveBeenCalledOnce()
-    expect(warn).toHaveBeenCalled()
+
+    // A later announcement is required before any root activates again. The
+    // stale root-2abc cache entry cannot satisfy the new root-3def request,
+    // so the fetch proxies instead of serving warm bytes.
+    await announcePluginRoot('spacewave-app', '3def')
+    vi.mocked(proxyFetch).mockClear()
+    vi.mocked(proxyFetch).mockResolvedValue(
+      new Response(restartedBody, {
+        status: 200,
+        headers: { 'Content-Type': 'application/javascript' },
+      }),
+    )
+    const announcedResponse = await swFetch(
+      buildClientFetchEvent('/b/pd/spacewave-app/backend.mjs', 'client-a').ev,
+    )
+    expect(announcedResponse.status).toBe(200)
+    expect(await announcedResponse.text()).toBe(restartedBody)
+    expect(proxyFetch).toHaveBeenCalledOnce()
+  })
+
+  it('never serves root A bytes after root B activates', async () => {
+    const caches = globalThis.caches as unknown as FakeCacheStorage
+    const path = '/b/pd/spacewave-app/backend.mjs'
+    await writeBrowserReleaseState(caches, {
+      ...createEmptyBrowserReleaseState(),
+      promotedCurrent: buildRelease('gen-a'),
+    })
+    await announcePluginRoot('spacewave-app', '2abc')
+    const bodyA = 'export const backend = "a"\n'
+    vi.mocked(proxyFetch).mockResolvedValue(
+      new Response(bodyA, {
+        status: 200,
+        headers: { 'Content-Type': 'application/javascript' },
+      }),
+    )
+
+    const warm = buildClientFetchEvent(path, 'client-a')
+    expect(await (await swFetch(warm.ev)).text()).toBe(bodyA)
+    await Promise.all(warm.waitUntilPromises)
+
+    await announcePluginRoot('spacewave-app', '3def')
+    const bodyB = 'export const backend = "b"\n'
+    vi.mocked(proxyFetch).mockResolvedValue(
+      new Response(bodyB, {
+        status: 200,
+        headers: { 'Content-Type': 'application/javascript' },
+      }),
+    )
+
+    const response = await swFetch(buildClientFetchEvent(path, 'client-a').ev)
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe(bodyB)
+
+    // The stale root-A entry stays in place but can never satisfy requests.
+    const generationCache = await caches.open('bldr-generation-gen-a')
+    const staleA = await generationCache.match(
+      new Request(
+        new URL(pluginAssetCachePath(path, '2abc'), self.location.href),
+      ),
+    )
+    expect(await staleA?.text()).toBe(bodyA)
+    const freshB = await generationCache.match(
+      new Request(
+        new URL(pluginAssetCachePath(path, '3def'), self.location.href),
+      ),
+    )
+    expect(await freshB?.text()).toBe(bodyB)
+    const unkeyed = await generationCache.match(
+      new Request(new URL(path, self.location.href)),
+    )
+    expect(unkeyed).toBeUndefined()
+  })
+
+  it('classifies a fetch across a root transition as plugin-root-changed', async () => {
+    const path = '/b/pd/spacewave-app/backend.mjs'
+    await writeBrowserReleaseState(
+      globalThis.caches as unknown as FakeCacheStorage,
+      {
+        ...createEmptyBrowserReleaseState(),
+        promotedCurrent: buildRelease('gen-a'),
+      },
+    )
+    await announcePluginRoot('spacewave-app', '2abc')
+    const firstProxy = newDeferred<Response>()
+    const secondProxy = newDeferred<Response>()
+    vi.mocked(proxyFetch)
+      .mockImplementationOnce(() => firstProxy.promise)
+      .mockImplementation(() => secondProxy.promise)
+
+    const fetchEvent = buildClientFetchEvent(path, 'client-a')
+    const responsePromise = swFetch(fetchEvent.ev)
+    await vi.waitFor(() => expect(proxyFetch).toHaveBeenCalledOnce())
+
+    await announcePluginRoot('spacewave-app', '3def')
+    firstProxy.resolve(
+      new Response('export const backend = "a"\n', {
+        status: 200,
+        headers: { 'Content-Type': 'application/javascript' },
+      }),
+    )
+
+    // The retry re-resolves to the new active root; a second transition while
+    // that attempt is in flight fails the request with the classified code.
+    await vi.waitFor(() => expect(proxyFetch).toHaveBeenCalledTimes(2))
+    await announcePluginRoot('spacewave-app', '4abc')
+    secondProxy.resolve(
+      new Response('export const backend = "b"\n', {
+        status: 200,
+        headers: { 'Content-Type': 'application/javascript' },
+      }),
+    )
+
+    const response = await responsePromise
+    expect(response.status).toBe(409)
+    expect(response.headers.get('X-Bldr-Runtime-Fetch-Error')).toBe(
+      'plugin-root-changed',
+    )
+    expect(response.headers.get('X-Bldr-Plugin-Asset-Fetch-Result')).toBe(
+      'root-changed',
+    )
+    const body = (await response.json()) as { code?: string }
+    expect(body.code).toBe('plugin-root-changed')
   })
 
   it('keeps static plugin asset fetches successful when cache writes fail', async () => {

--- a/bldr/web/bldr/service-worker.ts
+++ b/bldr/web/bldr/service-worker.ts
@@ -49,7 +49,6 @@ const bootAssetPath = '/boot.mjs'
 const browserIndexPath = '/b/__index.html'
 const rootNavigationPath = '/'
 const browserReleaseStatePath = '/__bldr/browser-release-state.json'
-const pluginManifestRootPathPrefix = '/__bldr/plugin-manifest-root/'
 const pluginDistPathPrefix = '/b/pd/'
 const pluginAssetsPathPrefix = '/b/pa/'
 const pluginWebPkgPathPrefix = '/b/pkg/'
@@ -158,12 +157,6 @@ interface CacheRow {
   cacheName: string
 }
 
-interface PluginManifestRootMetadata {
-  pluginId: string
-  rootHash: string
-  serviceWorkerURL: string
-}
-
 // BrowserRuntimeFetchErrorCode is the bounded failure vocabulary for runtime fetches.
 export type BrowserRuntimeFetchErrorCode =
   | 'no-ready-document'
@@ -173,6 +166,7 @@ export type BrowserRuntimeFetchErrorCode =
   | 'runtime-unavailable'
   | 'plugin-asset-missing'
   | 'plugin-asset-unavailable'
+  | 'plugin-root-changed'
   | 'request-canceled'
 
 // BrowserPluginAssetFetchResultCode is the plugin asset lease result surfaced
@@ -182,6 +176,7 @@ export type BrowserPluginAssetFetchResultCode =
   | 'missing'
   | 'unavailable'
   | 'generation-closed'
+  | 'root-changed'
   | 'runtime-unavailable'
   | 'canceled'
 
@@ -391,35 +386,6 @@ async function writeCachedJson(
     operation: 'write control JSON',
     controlRowKind: row.kind,
   })
-}
-
-async function readPluginManifestRoot(
-  pluginId: string,
-): Promise<string | null> {
-  try {
-    const metadata = await readCachedJson<PluginManifestRootMetadata>({
-      path: `${pluginManifestRootPathPrefix}${encodeURIComponent(pluginId)}.json`,
-      cacheName: controlCacheName,
-    })
-    if (
-      !metadata ||
-      metadata.pluginId !== pluginId ||
-      metadata.serviceWorkerURL !== self.location.href ||
-      typeof metadata.rootHash !== 'string' ||
-      metadata.rootHash === ''
-    ) {
-      return null
-    }
-    return metadata.rootHash
-  } catch (error) {
-    console.warn(
-      'ServiceWorker: %s: plugin root metadata read failed: plugin=%s: %s',
-      serviceWorkerId,
-      pluginId,
-      castToError(error, 'unknown error').message,
-    )
-    return null
-  }
 }
 
 async function loadBrowserReleaseState(): Promise<BrowserReleaseState> {
@@ -865,23 +831,16 @@ async function resolveStaticPluginAsset(
     return null
   }
   const pluginId = pathAfterPrefix.slice(0, slash)
+  // Only the currently active announced root may be served or cached. A root
+  // that is not yet active waits for its activation update; it never falls
+  // back to persisted roots, and old roots never satisfy new requests.
   let rootHash = activePluginRoots.get(pluginId)
   if (!rootHash) {
     await pluginRootUpdates.get(pluginId)
     rootHash = activePluginRoots.get(pluginId)
   }
   if (!rootHash) {
-    const persistedRootHash = await readPluginManifestRoot(pluginId)
-    if (!persistedRootHash) {
-      return null
-    }
-    const desiredRootHash = desiredPluginRoots.get(pluginId)
-    if (desiredRootHash && desiredRootHash !== persistedRootHash) {
-      return null
-    }
-    rootHash = persistedRootHash
-    desiredPluginRoots.set(pluginId, rootHash)
-    activePluginRoots.set(pluginId, rootHash)
+    return null
   }
   const state = await loadBrowserReleaseState()
   return {
@@ -891,9 +850,19 @@ async function resolveStaticPluginAsset(
   }
 }
 
-function staticPluginAssetCacheRequest(request: Request): Request {
+// staticPluginAssetCacheRequest builds the generation-cache key for a plugin
+// asset. The key binds the manifest root hash to the pathname and search, so
+// cached bytes from one root can never satisfy a request for another root.
+function staticPluginAssetCacheRequest(
+  asset: StaticPluginAsset,
+  request: Request,
+): Request {
   const url = new URL(request.url)
-  return buildCacheRequest(url.pathname + url.search)
+  const rootParam = `__bldr_plugin_root=${encodeURIComponent(asset.rootHash)}`
+  const search = url.search
+    ? `?${rootParam}&${url.search.slice(1)}`
+    : `?${rootParam}`
+  return buildCacheRequest(`${url.pathname}${search}`)
 }
 
 async function cacheStaticPluginAsset(
@@ -909,7 +878,7 @@ async function cacheStaticPluginAsset(
   ) {
     return
   }
-  const cacheRequest = staticPluginAssetCacheRequest(request)
+  const cacheRequest = staticPluginAssetCacheRequest(asset, request)
   if (!canCacheRequest(cacheRequest)) {
     return
   }
@@ -943,7 +912,9 @@ async function matchStaticPluginAsset(
     return null
   }
   const cache = await caches.open(buildGenerationCacheName(asset.generationId))
-  const response = await cache.match(staticPluginAssetCacheRequest(request))
+  const response = await cache.match(
+    staticPluginAssetCacheRequest(asset, request),
+  )
   if (!response || activePluginRoots.get(asset.pluginId) !== asset.rootHash) {
     return null
   }
@@ -986,40 +957,17 @@ async function revalidateStaticPluginAsset(
   }
 }
 
+// activatePluginManifestRoot activates an announced root when it is still the
+// desired root. Activation is in-memory only; a restarted service worker waits
+// for the next announcement instead of reactivating persisted state.
 async function activatePluginManifestRoot(
   pluginId: string,
   rootHash: string,
 ): Promise<void> {
-  try {
-    if (desiredPluginRoots.get(pluginId) !== rootHash) {
-      return
-    }
-    const persisted = await writeCachedJson(
-      {
-        path: `${pluginManifestRootPathPrefix}${encodeURIComponent(pluginId)}.json`,
-        cacheName: controlCacheName,
-      },
-      {
-        pluginId,
-        rootHash,
-        serviceWorkerURL: self.location.href,
-      },
-    )
-    if (!persisted || desiredPluginRoots.get(pluginId) !== rootHash) {
-      return
-    }
-    activePluginRoots.set(pluginId, rootHash)
-  } catch (error) {
-    activePluginRoots.delete(pluginId)
-    console.warn(
-      'ServiceWorker: %s: plugin manifest root activation failed: plugin=%s root=%s: %s',
-      serviceWorkerId,
-      pluginId,
-      rootHash,
-      castToError(error, 'unknown error').message,
-    )
+  if (desiredPluginRoots.get(pluginId) !== rootHash) {
     return
   }
+  activePluginRoots.set(pluginId, rootHash)
 }
 
 export async function handleBrowserReleaseRequest(
@@ -1490,6 +1438,9 @@ function browserRuntimeFetchStatusForCode(
   if (code === 'generation-closed') {
     return 410
   }
+  if (code === 'plugin-root-changed') {
+    return 409
+  }
   if (code === 'plugin-asset-missing') {
     return 404
   }
@@ -1510,6 +1461,8 @@ function pluginAssetFetchResultForErrorCode(
       return 'canceled'
     case 'generation-closed':
       return 'generation-closed'
+    case 'plugin-root-changed':
+      return 'root-changed'
     case 'runtime-unavailable':
     case 'no-ready-document':
     case 'resume-unavailable':
@@ -2036,9 +1989,25 @@ export async function swFetch(
         staticPluginAsset = await resolveStaticPluginAsset(source)
         continue
       }
-      return new Response('plugin manifest root changed during fetch', {
-        status: 503,
-      })
+      // A request that spans a manifest-root transition must fail with a
+      // classified error so the runtime failure path restarts the graph.
+      // Never pin the client to the old root or serve old-root bytes.
+      return buildBrowserRuntimeFetchErrorResponse(
+        {
+          code: 'plugin-root-changed',
+          source: source.kind,
+          path: source.path,
+          message: 'plugin manifest root changed during fetch',
+          status: browserRuntimeFetchStatusForCode(
+            'plugin-root-changed',
+            undefined,
+          ),
+          pluginAssetFetchResult: pluginAssetFetchResultForErrorCode(
+            'plugin-root-changed',
+          ),
+        },
+        request.method,
+      )
     }
 
     if (staticPluginAssetSource) {

--- a/bldr/web/runtime/quickjs/plugin-host-quickjs.ts
+++ b/bldr/web/runtime/quickjs/plugin-host-quickjs.ts
@@ -201,6 +201,7 @@ export type BackendAssetFetchFailureResult =
   | 'missing'
   | 'unavailable'
   | 'generation-closed'
+  | 'root-changed'
   | 'runtime-unavailable'
   | 'canceled'
 
@@ -627,6 +628,7 @@ function backendAssetFetchFailureResult(
   const result = getHeader('X-Bldr-Plugin-Asset-Fetch-Result')
   if (
     result === 'generation-closed' ||
+    result === 'root-changed' ||
     result === 'runtime-unavailable' ||
     result === 'canceled' ||
     result === 'missing' ||
@@ -665,6 +667,8 @@ function formatBackendAssetFailure(
       return `Missing backend asset ${failure.url}: ${failure.status}${detail}`
     case 'generation-closed':
       return `QuickJS backend asset generation closed ${failure.url}: ${failure.status}${detail}`
+    case 'root-changed':
+      return `QuickJS backend asset root changed ${failure.url}: ${failure.status}${detail}`
     case 'runtime-unavailable':
       return `QuickJS backend asset runtime unavailable ${failure.url}: ${failure.status}${detail}`
     case 'canceled':


### PR DESCRIPTION
A static plugin dist asset was cached under its release generation and pathname alone, so bytes built from one plugin manifest root stayed readable after the runtime switched to a newer root. A restarted service worker could also reactivate a persisted root on its own, pinning clients to dist that the running runtime no longer holds.

The service worker now keeps one in-memory active root per plugin, set only by an announcement from the runtime and cleared whenever a newer root is announced. Generation-cache keys for static plugin dist and plugin assets bind the announced root hash to the pathname and query, so cached bytes from one root can never satisfy a request for another. Old entries stay inert until normal release-cache pruning removes them.

Activation is memory only: a restarted worker waits for the next announcement instead of reactivating persisted state, and requests without an active root proxy to the runtime, which remains the authority for what is currently built.

A request whose proxied fetch spans a root transition now fails with a classified `plugin-root-changed` error (409, asset result `root-changed`) instead of an unclassified 503. The QuickJS backend asset loader surfaces the new result through its failure vocabulary, so the existing reportRuntimeFailure shutdown path restarts the graph on the scheduler's authority, and the web view error boundary treats the classification as recoverable through its established bounded backoff instead of pinning or serving stale bytes.
