### PR TITLE
test(git): cover encrypted-space import-git cursor reopen

### DIFF
--- a/core/git/import_encrypted_srpc_test.go
+++ b/core/git/import_encrypted_srpc_test.go
@@ -1,0 +1,116 @@
+package s4wave_git_test
+
+import (
+	"context"
+	"testing"
+
+	timestamppb "github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
+	resource_client "github.com/s4wave/spacewave/bldr/resource/client"
+	s4wave_git "github.com/s4wave/spacewave/core/git"
+	resource_testbed "github.com/s4wave/spacewave/core/resource/testbed"
+	git_block "github.com/s4wave/spacewave/db/git/block"
+	git_world "github.com/s4wave/spacewave/db/git/world"
+	"github.com/s4wave/spacewave/db/world"
+	world_types "github.com/s4wave/spacewave/db/world/types"
+	s4wave_testbed "github.com/s4wave/spacewave/sdk/testbed"
+	sdk_world_engine "github.com/s4wave/spacewave/sdk/world/engine"
+)
+
+// encryptedSDKWorld drives the SDK cursor path against an encrypted world:
+// the world engine lives behind SRPC and its bucket enforces a block
+// transform, like a daemon serving an encrypted space.
+type encryptedSDKWorld struct {
+	ctx        context.Context
+	resClient  *resource_client.Client
+	resourceID uint32
+	release    func()
+}
+
+func (w *encryptedSDKWorld) openEngine() (world.WorldState, func(), error) {
+	engineRef := w.resClient.CreateResourceReference(w.resourceID)
+	engine, err := sdk_world_engine.NewSDKEngine(w.resClient, engineRef)
+	if err != nil {
+		engineRef.Release()
+		return nil, nil, err
+	}
+	return world.NewEngineWorldState(engine, true), engine.Release, nil
+}
+
+func setupEncryptedSDKWorld(t *testing.T) *encryptedSDKWorld {
+	t.Helper()
+
+	ctx := t.Context()
+	tb, resClient, tbCleanup := resource_testbed.SetupTestbedWithClient(ctx, t)
+
+	gitOpc := world.NewLookupOpController("test-git-encrypted-srpc", tb.EngineID, git_world.LookupGitOp)
+	if _, err := tb.Bus.AddController(ctx, gitOpc, nil); err != nil {
+		tbCleanup()
+		t.Fatal(err.Error())
+	}
+
+	rootRef := resClient.AccessRootResource()
+	srpcClient, err := rootRef.GetClient()
+	if err != nil {
+		rootRef.Release()
+		tbCleanup()
+		t.Fatal(err.Error())
+	}
+	testbedClient := s4wave_testbed.NewSRPCTestbedResourceServiceClient(srpcClient)
+	createResp, err := testbedClient.CreateWorld(ctx, &s4wave_testbed.CreateWorldRequest{})
+	if err != nil {
+		rootRef.Release()
+		tbCleanup()
+		t.Fatal(err.Error())
+	}
+
+	return &encryptedSDKWorld{
+		ctx:        ctx,
+		resClient:  resClient,
+		resourceID: createResp.GetResourceId(),
+		release: func() {
+			rootRef.Release()
+			tbCleanup()
+		},
+	}
+}
+
+func TestCloneGitRepoToRefSurvivesEncryptedCursorReopen(t *testing.T) {
+	w := setupEncryptedSDKWorld(t)
+	defer w.release()
+
+	ws, closeEngine, err := w.openEngine()
+	if err != nil {
+		t.Fatalf("NewSDKEngine: %v", err)
+	}
+	defer closeEngine()
+
+	objectKey := "repo/imported-encrypted"
+	repoRef, err := s4wave_git.CloneGitRepoToRef(w.ctx, ws, &git_block.CloneOpts{
+		Url: createSourceRepo(t),
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("CloneGitRepoToRef: %v", err)
+	}
+
+	initOp := git_world.NewGitInitOp(objectKey, repoRef, true, nil, timestamppb.Now())
+	if _, _, err := ws.ApplyWorldOp(w.ctx, initOp, ""); err != nil {
+		t.Fatalf("ApplyWorldOp(publish): %v", err)
+	}
+	// Keep the first engine open: releasing its resource reference stops the
+	// daemon-side world engine, so reopen here means a fresh SDK cursor that
+	// re-reads the transform config and re-decodes the encrypted repo blocks.
+	// The deferred closeEngine runs at test end.
+	reopenedWS, closeReopened, err := w.openEngine()
+	if err != nil {
+		t.Fatalf("NewSDKEngine(reopen): %v", err)
+	}
+	defer closeReopened()
+
+	typeID, err := world_types.GetObjectType(w.ctx, reopenedWS, objectKey)
+	if err != nil {
+		t.Fatalf("GetObjectType after reopen: %v", err)
+	}
+	if typeID != git_world.GitRepoTypeID {
+		t.Fatalf("expected type %q after reopen, got %q", git_world.GitRepoTypeID, typeID)
+	}
+}

--- a/core/resource/testbed/root.go
+++ b/core/resource/testbed/root.go
@@ -15,6 +15,7 @@ import (
 	"github.com/s4wave/spacewave/db/bucket"
 	"github.com/s4wave/spacewave/db/world"
 	world_block_engine "github.com/s4wave/spacewave/db/world/block/engine"
+	world_testbed "github.com/s4wave/spacewave/db/world/testbed"
 	s4wave_testbed "github.com/s4wave/spacewave/sdk/testbed"
 	s4wave_world "github.com/s4wave/spacewave/sdk/world"
 	"github.com/sirupsen/logrus"
@@ -87,13 +88,19 @@ func (s *TestbedResourceServer) CreateWorld(ctx context.Context, req *s4wave_tes
 		return nil, err
 	}
 
+	// Encrypt the world like the daemon does for space shared objects.
+	transformConf, err := world_testbed.NewEngineTransformConfig(bucketID)
+	if err != nil {
+		return nil, err
+	}
+
 	// Create world engine config
 	engConf := world_block_engine.NewConfig(
 		engineID,
 		volumeID,
 		bucketID,
 		objectStoreID,
-		&bucket.ObjectRef{BucketId: bucketID},
+		&bucket.ObjectRef{BucketId: bucketID, TransformConf: transformConf},
 		nil,
 		false,
 	)

--- a/db/world/testbed/testbed.go
+++ b/db/world/testbed/testbed.go
@@ -74,7 +74,7 @@ func NewTestbed(tb *testbed.Testbed, opts ...Option) (t *Testbed, tbErr error) {
 	t.EngineBucketID = tb.BucketId
 	t.EngineObjectStoreID = t.EngineID + "-store"
 
-	transformConf, err := newEngineTransformConfig(t.EngineBucketID)
+	transformConf, err := NewEngineTransformConfig(t.EngineBucketID)
 	if err != nil {
 		return nil, err
 	}

--- a/db/world/testbed/transform_config.go
+++ b/db/world/testbed/transform_config.go
@@ -11,7 +11,7 @@ import (
 	"github.com/zeebo/blake3"
 )
 
-func newEngineTransformConfig(engineBucketID string) (*block_transform.Config, error) {
+func NewEngineTransformConfig(engineBucketID string) (*block_transform.Config, error) {
 	key := make([]byte, 32)
 	blake3.DeriveKey("hydra/world/testbed "+engineBucketID, []byte("testbed"), key)
 

--- a/db/world/testbed/transform_config_goscript.go
+++ b/db/world/testbed/transform_config_goscript.go
@@ -8,7 +8,7 @@ import (
 	transform_gzip "github.com/s4wave/spacewave/db/block/transform/gzip"
 )
 
-func newEngineTransformConfig(string) (*block_transform.Config, error) {
+func NewEngineTransformConfig(string) (*block_transform.Config, error) {
 	return block_transform.NewConfig([]config.Config{
 		&transform_gzip.Config{},
 	})


### PR DESCRIPTION
CLI `space import-git` writes blocks through the SDK bucket lookup cursor. That cursor must adopt the remote transform config before hashing, or the daemon rejects the write with a block ref hash mismatch: the client hashes raw bytes while the inner store hashes encrypted bytes.

The transform threading lives in the SDK cursor (`sdk/bucket/lookup/cursor.go` since the move in 2195f0ccb). This change adds the missing coverage. The resource testbed's `CreateWorld` built unencrypted worlds, so the encrypted SDK path had no test. Export `NewEngineTransformConfig` from `db/world/testbed` and attach it to the world engine init ref, matching the daemon where encryption is mandatory for space shared objects.

The new regression drives `CloneGitRepoToRef` through an `SDKEngine` over SRPC against an encrypted world, publishes a git init op, then reopens a fresh cursor and asserts the repo object survives. With the client transform nilled it fails with the exact staging symptom: "clone: block: block ref hash mismatch".

Block encryption is AES-256-GCM with a nonce derived by SHA-256 over the plaintext, so encoding is deterministic: client and daemon ciphertext agree and forced block refs stay consistent.

Fail-before: nil `buildCursorTransform` in `sdk/bucket/lookup/cursor.go`, run `go test ./core/git/ -run TestCloneGitRepoToRefSurvivesEncryptedCursorReopen` -> fails with that exact error. Pass-after: focused suites for `core/git`, `sdk/bucket/lookup`, `core/resource/world`, `db/bucket/lookup`, plus `core/resource/testbed`, `sdk/world/engine`, `db/world/testbed`, `core/resource/bucket/lookup`, `core/sobject/world/engine`, `core/e2e` all green; vet clean on touched packages.