### PR TITLE
feat(forge/runtime): add durable Worker capacity owner claims

### DIFF
--- a/forge/runtime/admission.go
+++ b/forge/runtime/admission.go
@@ -11,6 +11,30 @@ import (
 // owner does not configure a duration.
 const DefaultLeaseDuration = 10 * time.Minute
 
+// DefaultOwnerLeaseDuration is the owner claim lease applied when the
+// admission owner does not configure a duration.
+const DefaultOwnerLeaseDuration = time.Minute
+
+// WorkerClaimRef identifies one daemon instance's durable owner claim on a
+// capacity record. The reference is presented by the caller and checked
+// against the record's stored claim inside each write transaction.
+type WorkerClaimRef struct {
+	// DeviceObjectKey is the enrolled Device object key of the instance.
+	DeviceObjectKey string
+	// ClaimID is the per-instance claim identifier. A new claim id on the same
+	// Device replaces a previous instance after reclaim.
+	ClaimID string
+}
+
+// OwnedWorkerCapacity pairs an owned capacity record with the Forge Worker
+// object key it describes, so scans can name workers for reclaim.
+type OwnedWorkerCapacity struct {
+	// WorkerObjectKey is the Forge Worker object key of the record.
+	WorkerObjectKey string
+	// Capacity is the owned capacity record.
+	Capacity *WorkerCapacity
+}
+
 // ReservationState describes whether capacity remains held and whether the
 // runtime outcome is known.
 type ReservationState uint8
@@ -168,6 +192,18 @@ var (
 	// reservation whose lease already expired but is not swept yet. Run the
 	// expiry sweep; the retry then requires a new attempt.
 	ErrReservationExpired = errors.New("reservation lease expired")
+	// ErrCapacityUnowned is returned when a capacity record carries no live
+	// owner claim, including legacy ownerless records.
+	ErrCapacityUnowned = errors.New("worker capacity has no live owner claim")
+	// ErrCapacityOwned is returned when a different Device holds the live
+	// owner claim on a capacity record.
+	ErrCapacityOwned = errors.New("worker capacity claimed by another device")
+	// ErrCapacityOwnerExpired is returned when the live claim's lease expired
+	// without renewal or reclaim.
+	ErrCapacityOwnerExpired = errors.New("worker capacity owner claim expired")
+	// ErrCapacityDraining is returned when the record's claim is live but in
+	// the draining state and cannot accept new work.
+	ErrCapacityDraining = errors.New("worker capacity is draining")
 )
 
 // Cleanup reasons recorded on receipts.
@@ -190,8 +226,11 @@ type RuntimeAdmission interface {
 	// restart reads the same object and resumes observation without relaunch.
 	LookupReservation(ctx context.Context, reservationObjectKey string) (*Reservation, error)
 	// StopAndRelease stops the fenced runtime, credits capacity exactly once,
-	// and returns the persisted cleanup facts. A stale generation is rejected
-	// without touching the current runtime or capacity. Until the stop is
-	// confirmed the reservation sits in the durable pending-stop state.
-	StopAndRelease(ctx context.Context, reservationObjectKey string, generation uint64) (*CleanupReceipt, error)
+	// and returns the persisted cleanup facts. The caller must present the
+	// live owner claim (ref and current owner epoch) of the Worker's capacity
+	// record; a deposed or stale instance is rejected before the stopper runs.
+	// A stale reservation generation is rejected without touching the current
+	// runtime or capacity. Until the stop is confirmed the reservation sits in
+	// the durable pending-stop state.
+	StopAndRelease(ctx context.Context, ref WorkerClaimRef, ownerEpoch uint64, reservationObjectKey string, generation uint64) (*CleanupReceipt, error)
 }

--- a/forge/runtime/admission_test.go
+++ b/forge/runtime/admission_test.go
@@ -66,9 +66,13 @@ var testRequest = ResourceRequest{MilliCPU: 1_000, MemoryBytes: 1 << 30, Backend
 func TestReserveActivateStopRoundTrip(t *testing.T) {
 	ctx, eng, _ := newTestbed(t)
 	stopper := newTestStopper()
-	admission := NewWorldRuntimeAdmission(eng, stopper, time.Minute)
+	admission := NewWorldRuntimeAdmission(eng, stopper, time.Minute, time.Minute)
 
-	if _, err := admission.ObserveWorker(ctx, "worker/a", 2_000, 4<<30, []string{"docker", "v86"}); err != nil {
+	claimed, err := admission.ClaimWorkerCapacity(ctx, "worker/a", selfRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.ObserveWorker(ctx, "worker/a", selfRef, claimed.OwnerEpoch, 2_000, 4<<30, []string{"docker", "v86"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -108,7 +112,7 @@ func TestReserveActivateStopRoundTrip(t *testing.T) {
 		t.Fatalf("expected active outcome, got %d", loaded.Outcome(time.Now()))
 	}
 
-	receipt, err := admission.StopAndRelease(ctx, res.ObjectKey(), 1)
+	receipt, err := admission.StopAndRelease(ctx, selfRef, claimed.OwnerEpoch, res.ObjectKey(), 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +124,7 @@ func TestReserveActivateStopRoundTrip(t *testing.T) {
 	}
 
 	// Idempotent stop returns the persisted receipt without re-stopping.
-	receipt2, err := admission.StopAndRelease(ctx, res.ObjectKey(), 1)
+	receipt2, err := admission.StopAndRelease(ctx, selfRef, claimed.OwnerEpoch, res.ObjectKey(), 1)
 	if err != nil || receipt2 == nil || !receipt2.Complete() {
 		t.Fatalf("expected persisted receipt on retry: %+v err=%v", receipt2, err)
 	}
@@ -145,8 +149,12 @@ func TestReserveActivateStopRoundTrip(t *testing.T) {
 
 func TestReserveConcurrentOversubscribeRejected(t *testing.T) {
 	ctx, eng, _ := newTestbed(t)
-	admission := NewWorldRuntimeAdmission(eng, newTestStopper(), time.Minute)
-	if _, err := admission.ObserveWorker(ctx, "worker/a", 2_000, 2<<30, []string{"docker"}); err != nil {
+	admission := NewWorldRuntimeAdmission(eng, newTestStopper(), time.Minute, time.Minute)
+	claimed, err := admission.ClaimWorkerCapacity(ctx, "worker/a", selfRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.ObserveWorker(ctx, "worker/a", selfRef, claimed.OwnerEpoch, 2_000, 2<<30, []string{"docker"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -190,8 +198,12 @@ func TestReserveConcurrentOversubscribeRejected(t *testing.T) {
 func TestRestartReconcileResumesWithoutRelaunch(t *testing.T) {
 	ctx, eng, _ := newTestbed(t)
 	stopper := newTestStopper()
-	admission := NewWorldRuntimeAdmission(eng, stopper, time.Hour)
-	if _, err := admission.ObserveWorker(ctx, "worker/a", 4_000, 8<<30, []string{"docker"}); err != nil {
+	admission := NewWorldRuntimeAdmission(eng, stopper, time.Hour, time.Hour)
+	claimed, err := admission.ClaimWorkerCapacity(ctx, "worker/a", selfRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.ObserveWorker(ctx, "worker/a", selfRef, claimed.OwnerEpoch, 4_000, 8<<30, []string{"docker"}); err != nil {
 		t.Fatal(err)
 	}
 	res, err := admission.Reserve(ctx, "worker/a", "exec/restart", testRequest)
@@ -204,7 +216,7 @@ func TestRestartReconcileResumesWithoutRelaunch(t *testing.T) {
 	}
 
 	// A fresh admission over the same durable engine reconciles by lookup.
-	restarted := NewWorldRuntimeAdmission(eng, stopper, time.Hour)
+	restarted := NewWorldRuntimeAdmission(eng, stopper, time.Hour, time.Hour)
 	loaded, err := restarted.LookupReservation(ctx, res.ObjectKey())
 	if err != nil {
 		t.Fatal(err)
@@ -220,8 +232,12 @@ func TestRestartReconcileResumesWithoutRelaunch(t *testing.T) {
 func TestUncertainRetainsDebitAndResumeRefencesGeneration(t *testing.T) {
 	ctx, eng, _ := newTestbed(t)
 	stopper := newTestStopper()
-	admission := NewWorldRuntimeAdmission(eng, stopper, time.Hour)
-	if _, err := admission.ObserveWorker(ctx, "worker/a", 2_000, 4<<30, []string{"docker"}); err != nil {
+	admission := NewWorldRuntimeAdmission(eng, stopper, time.Hour, time.Hour)
+	claimed, err := admission.ClaimWorkerCapacity(ctx, "worker/a", selfRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.ObserveWorker(ctx, "worker/a", selfRef, claimed.OwnerEpoch, 2_000, 4<<30, []string{"docker"}); err != nil {
 		t.Fatal(err)
 	}
 	res, err := admission.Reserve(ctx, "worker/a", "exec/uncertain", testRequest)
@@ -258,7 +274,7 @@ func TestUncertainRetainsDebitAndResumeRefencesGeneration(t *testing.T) {
 	}
 
 	// Late return from the replaced runtime instance is stale and inert.
-	if _, err := admission.StopAndRelease(ctx, res.ObjectKey(), 1); !errors.Is(err, ErrStaleGeneration) {
+	if _, err := admission.StopAndRelease(ctx, selfRef, claimed.OwnerEpoch, res.ObjectKey(), 1); !errors.Is(err, ErrStaleGeneration) {
 		t.Fatalf("expected stale generation error, got %v", err)
 	}
 	if stopper.count("container-u1") != 0 && stopper.count("container-u2") != 0 {
@@ -272,7 +288,7 @@ func TestUncertainRetainsDebitAndResumeRefencesGeneration(t *testing.T) {
 		t.Fatal("stale late-return must not credit capacity")
 	}
 
-	receipt, err := admission.StopAndRelease(ctx, res.ObjectKey(), 2)
+	receipt, err := admission.StopAndRelease(ctx, selfRef, claimed.OwnerEpoch, res.ObjectKey(), 2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -287,8 +303,12 @@ func TestUncertainRetainsDebitAndResumeRefencesGeneration(t *testing.T) {
 func TestExpiryFencesGenerationReleasesOnceAndStopsLateReturn(t *testing.T) {
 	ctx, eng, _ := newTestbed(t)
 	stopper := newTestStopper()
-	admission := NewWorldRuntimeAdmission(eng, stopper, time.Minute)
-	if _, err := admission.ObserveWorker(ctx, "worker/a", 2_000, 4<<30, []string{"docker"}); err != nil {
+	admission := NewWorldRuntimeAdmission(eng, stopper, time.Minute, time.Minute)
+	claimed, err := admission.ClaimWorkerCapacity(ctx, "worker/a", selfRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.ObserveWorker(ctx, "worker/a", selfRef, claimed.OwnerEpoch, 2_000, 4<<30, []string{"docker"}); err != nil {
 		t.Fatal(err)
 	}
 	now := time.Now().UTC().Truncate(time.Second)
@@ -304,13 +324,13 @@ func TestExpiryFencesGenerationReleasesOnceAndStopsLateReturn(t *testing.T) {
 	}
 
 	// Not yet expired: expiry is a no-op.
-	receipts, err := admission.ExpireLeases(ctx, now.Add(30*time.Second))
+	receipts, err := admission.ExpireLeases(ctx, selfRef, now.Add(30*time.Second))
 	if err != nil || len(receipts) != 0 {
 		t.Fatalf("expected no expiries: %+v err=%v", receipts, err)
 	}
 
 	expiredAt := now.Add(2 * time.Minute)
-	receipts, err = admission.ExpireLeases(ctx, expiredAt)
+	receipts, err = admission.ExpireLeases(ctx, selfRef, expiredAt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -332,7 +352,7 @@ func TestExpiryFencesGenerationReleasesOnceAndStopsLateReturn(t *testing.T) {
 	}
 
 	// Post-expiry old-runtime calls are stale: the fence moved.
-	if _, err := admission.StopAndRelease(ctx, res.ObjectKey(), 1); !errors.Is(err, ErrStaleGeneration) {
+	if _, err := admission.StopAndRelease(ctx, selfRef, claimed.OwnerEpoch, res.ObjectKey(), 1); !errors.Is(err, ErrStaleGeneration) {
 		t.Fatalf("expected stale generation after expiry, got %v", err)
 	}
 	if stopper.count("container-exp") != 1 {
@@ -350,11 +370,11 @@ func TestExpiryFencesGenerationReleasesOnceAndStopsLateReturn(t *testing.T) {
 	}
 
 	// Nothing remains pending for reconciliation.
-	done, err := admission.ReconcilePendingStops(ctx)
+	done, err := admission.ReconcilePendingStops(ctx, selfRef)
 	if err != nil || len(done) != 0 {
 		t.Fatalf("expected no pending stops after a confirmed sweep: %+v err=%v", done, err)
 	}
-	final, err := admission.StopAndRelease(ctx, res.ObjectKey(), 2)
+	final, err := admission.StopAndRelease(ctx, selfRef, claimed.OwnerEpoch, res.ObjectKey(), 2)
 	if err != nil || final == nil || !final.Complete() {
 		t.Fatalf("expected terminal-idempotent receipt for fencing generation: %+v err=%v", final, err)
 	}
@@ -373,8 +393,12 @@ func TestExpiryWithFailingStopperKeepsPendingStopForReconcile(t *testing.T) {
 	stopper := newTestStopper()
 	stopper.failFor = "container-flaky"
 	stopper.stopErr = errors.New("docker daemon unreachable")
-	admission := NewWorldRuntimeAdmission(eng, stopper, time.Minute)
-	if _, err := admission.ObserveWorker(ctx, "worker/a", 1_000, 1<<30, []string{"docker"}); err != nil {
+	admission := NewWorldRuntimeAdmission(eng, stopper, time.Minute, time.Minute)
+	claimed, err := admission.ClaimWorkerCapacity(ctx, "worker/a", selfRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.ObserveWorker(ctx, "worker/a", selfRef, claimed.OwnerEpoch, 1_000, 1<<30, []string{"docker"}); err != nil {
 		t.Fatal(err)
 	}
 	now := time.Now().UTC()
@@ -387,7 +411,7 @@ func TestExpiryWithFailingStopperKeepsPendingStopForReconcile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	receipts, err := admission.ExpireLeases(ctx, now.Add(2*time.Minute))
+	receipts, err := admission.ExpireLeases(ctx, selfRef, now.Add(2*time.Minute))
 	if err != nil || len(receipts) != 1 {
 		t.Fatalf("expected expiry receipt despite failed stop: %+v err=%v", receipts, err)
 	}
@@ -408,13 +432,13 @@ func TestExpiryWithFailingStopperKeepsPendingStopForReconcile(t *testing.T) {
 	}
 
 	// Graceful stop of the flaky runtime also fails while it is unreachable.
-	if _, err := admission.StopAndRelease(ctx, res.ObjectKey(), 2); err == nil {
+	if _, err := admission.StopAndRelease(ctx, selfRef, claimed.OwnerEpoch, res.ObjectKey(), 2); err == nil {
 		t.Fatal("expected stop failure to surface")
 	}
 
 	// The daemon recovers; reconciliation finishes the pending stop once.
 	stopper.failFor = ""
-	done, err := admission.ReconcilePendingStops(ctx)
+	done, err := admission.ReconcilePendingStops(ctx, selfRef)
 	if err != nil || len(done) != 1 || !done[0].Complete() {
 		t.Fatalf("expected completed receipt: %+v err=%v", done, err)
 	}
@@ -439,8 +463,12 @@ func TestStopperErrorDuringGracefulStopKeepsReservationLive(t *testing.T) {
 	stopper := newTestStopper()
 	stopper.failFor = "container-graceful"
 	stopper.stopErr = errors.New("stop timeout")
-	admission := NewWorldRuntimeAdmission(eng, stopper, time.Hour)
-	if _, err := admission.ObserveWorker(ctx, "worker/a", 1_000, 1<<30, []string{"docker"}); err != nil {
+	admission := NewWorldRuntimeAdmission(eng, stopper, time.Hour, time.Hour)
+	claimed, err := admission.ClaimWorkerCapacity(ctx, "worker/a", selfRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.ObserveWorker(ctx, "worker/a", selfRef, claimed.OwnerEpoch, 1_000, 1<<30, []string{"docker"}); err != nil {
 		t.Fatal(err)
 	}
 	res, err := admission.Reserve(ctx, "worker/a", "exec/graceful", testRequest)
@@ -450,7 +478,7 @@ func TestStopperErrorDuringGracefulStopKeepsReservationLive(t *testing.T) {
 	if _, err := admission.Activate(ctx, res.ObjectKey(), BackendRuntimeIdentity{Backend: "docker", ID: "container-graceful"}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := admission.StopAndRelease(ctx, res.ObjectKey(), 1); err == nil {
+	if _, err := admission.StopAndRelease(ctx, selfRef, claimed.OwnerEpoch, res.ObjectKey(), 1); err == nil {
 		t.Fatal("expected stopper error to surface")
 	}
 	loaded, err := admission.LookupReservation(ctx, res.ObjectKey())
@@ -470,7 +498,7 @@ func TestStopperErrorDuringGracefulStopKeepsReservationLive(t *testing.T) {
 
 	// The stopper recovers; a retry with the same fenced generation completes.
 	stopper.failFor = ""
-	receipt, err := admission.StopAndRelease(ctx, res.ObjectKey(), 1)
+	receipt, err := admission.StopAndRelease(ctx, selfRef, claimed.OwnerEpoch, res.ObjectKey(), 1)
 	if err != nil || !receipt.Complete() {
 		t.Fatalf("expected completed receipt: %+v err=%v", receipt, err)
 	}
@@ -478,14 +506,18 @@ func TestStopperErrorDuringGracefulStopKeepsReservationLive(t *testing.T) {
 
 func TestObserveWorkerPreservesDebitsAndRejectsUnknownBackend(t *testing.T) {
 	ctx, eng, _ := newTestbed(t)
-	admission := NewWorldRuntimeAdmission(eng, newTestStopper(), time.Minute)
-	if _, err := admission.ObserveWorker(ctx, "worker/a", 2_000, 4<<30, []string{"docker"}); err != nil {
+	admission := NewWorldRuntimeAdmission(eng, newTestStopper(), time.Minute, time.Minute)
+	claimed, err := admission.ClaimWorkerCapacity(ctx, "worker/a", selfRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.ObserveWorker(ctx, "worker/a", selfRef, claimed.OwnerEpoch, 2_000, 4<<30, []string{"docker"}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := admission.Reserve(ctx, "worker/a", "exec/backend", testRequest); err != nil {
 		t.Fatal(err)
 	}
-	updated, err := admission.ObserveWorker(ctx, "worker/a", 4_000, 8<<30, []string{"docker"})
+	updated, err := admission.ObserveWorker(ctx, "worker/a", selfRef, claimed.OwnerEpoch, 4_000, 8<<30, []string{"docker"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -520,4 +552,32 @@ func LookupWorkerCapacityEngine(ctx context.Context, eng world.Engine, workerObj
 		return err
 	})
 	return out, err
+}
+
+// TestReserveDrainingRejectionOnIdempotentPath proves the fail-before
+// ordering: a draining capacity record rejects Reserve on the fresh path and
+// on the idempotent existing path before any debit-proof read.
+func TestReserveDrainingRejectionOnIdempotentPath(t *testing.T) {
+	ctx, eng, _ := newTestbed(t)
+	admission := NewWorldRuntimeAdmission(eng, newTestStopper(), time.Minute, time.Minute)
+	ref := WorkerClaimRef{DeviceObjectKey: "devices/self", ClaimID: "claim-1"}
+	capacity, err := admission.ClaimWorkerCapacity(ctx, "worker/a", ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.ObserveWorker(ctx, "worker/a", ref, capacity.OwnerEpoch, 2_000, 4<<30, []string{"docker"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.Reserve(ctx, "worker/a", "exec/1", testRequest); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.BeginDrainCapacity(ctx, "worker/a", ref, capacity.OwnerEpoch); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.Reserve(ctx, "worker/a", "exec/2", testRequest); !errors.Is(err, ErrCapacityDraining) {
+		t.Fatalf("expected draining rejection on fresh path, got %v", err)
+	}
+	if _, err := admission.Reserve(ctx, "worker/a", "exec/1", testRequest); !errors.Is(err, ErrCapacityDraining) {
+		t.Fatalf("expected draining rejection on idempotent path, got %v", err)
+	}
 }

--- a/forge/runtime/cancel-unreachable_test.go
+++ b/forge/runtime/cancel-unreachable_test.go
@@ -14,8 +14,12 @@ import (
 func TestCancelWhileUncertainHoldsDebitUntilCleanupOrExpiry(t *testing.T) {
 	ctx, eng, _ := newTestbed(t)
 	stopper := newTestStopper()
-	admission := NewWorldRuntimeAdmission(eng, stopper, time.Minute)
-	if _, err := admission.ObserveWorker(ctx, "worker/a", 1_000, 1<<30, []string{"docker"}); err != nil {
+	admission := NewWorldRuntimeAdmission(eng, stopper, time.Minute, time.Minute)
+	claimed, err := admission.ClaimWorkerCapacity(ctx, "worker/a", selfRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.ObserveWorker(ctx, "worker/a", selfRef, claimed.OwnerEpoch, 1_000, 1<<30, []string{"docker"}); err != nil {
 		t.Fatal(err)
 	}
 	res, err := admission.Reserve(ctx, "worker/a", "exec/cancel-unreach", testRequest)
@@ -35,7 +39,7 @@ func TestCancelWhileUncertainHoldsDebitUntilCleanupOrExpiry(t *testing.T) {
 	// Cancel arrives while the runtime is unreachable: the stop fails.
 	stopper.failFor = rt.ID
 	stopper.stopErr = errors.New("runtime unreachable")
-	if _, err := admission.StopAndRelease(ctx, res.ObjectKey(), 1); err == nil {
+	if _, err := admission.StopAndRelease(ctx, selfRef, claimed.OwnerEpoch, res.ObjectKey(), 1); err == nil {
 		t.Fatal("expected stop failure to surface")
 	}
 	loaded, err := admission.LookupReservation(ctx, res.ObjectKey())
@@ -58,13 +62,13 @@ func TestCancelWhileUncertainHoldsDebitUntilCleanupOrExpiry(t *testing.T) {
 
 	// A repeated cancel for the same fenced generation stays inert while
 	// the runtime remains unreachable.
-	if _, err := admission.StopAndRelease(ctx, res.ObjectKey(), 1); err == nil {
+	if _, err := admission.StopAndRelease(ctx, selfRef, claimed.OwnerEpoch, res.ObjectKey(), 1); err == nil {
 		t.Fatal("expected repeated unreachable stop failure to surface")
 	}
 
 	// The runtime becomes reachable; reconciliation confirms the stop once.
 	stopper.failFor = ""
-	done, err := admission.ReconcilePendingStops(ctx)
+	done, err := admission.ReconcilePendingStops(ctx, selfRef)
 	if err != nil || len(done) != 1 || !done[0].Complete() {
 		t.Fatalf("expected one completed receipt: %+v err=%v", done, err)
 	}
@@ -82,14 +86,62 @@ func TestCancelWhileUncertainHoldsDebitUntilCleanupOrExpiry(t *testing.T) {
 	if capacity.MilliCPUReserved != 0 {
 		t.Fatalf("capacity must credit exactly once: %+v", capacity)
 	}
-	finalReceipt, err := admission.StopAndRelease(ctx, res.ObjectKey(), 1)
+	finalReceipt, err := admission.StopAndRelease(ctx, selfRef, claimed.OwnerEpoch, res.ObjectKey(), 1)
 	if err != nil || finalReceipt == nil || !finalReceipt.Complete() {
 		t.Fatalf("expected terminal-idempotent receipt for the fencing generation: %+v err=%v", finalReceipt, err)
 	}
-	if _, err := admission.StopAndRelease(ctx, res.ObjectKey(), 2); !errors.Is(err, ErrStaleGeneration) {
+	if _, err := admission.StopAndRelease(ctx, selfRef, claimed.OwnerEpoch, res.ObjectKey(), 2); !errors.Is(err, ErrStaleGeneration) {
 		t.Fatalf("expected post-release future-generation call to be stale, got %v", err)
 	}
 	if stopper.count(rt.ID) != 1 {
 		t.Fatalf("stopper invoked more than once: %d", stopper.count(rt.ID))
+	}
+}
+
+// TestStaleRefStopAndReleaseRejectedWithoutStopper proves the pre-stop fence:
+// a deposed instance holding the old owner epoch cannot stop runtimes or
+// credit capacity; the stopper must not fire.
+func TestStaleRefStopAndReleaseRejectedWithoutStopper(t *testing.T) {
+	ctx, eng, _ := newTestbed(t)
+	stopper := newTestStopper()
+	admission := NewWorldRuntimeAdmission(eng, stopper, time.Minute, time.Minute)
+	ref := WorkerClaimRef{DeviceObjectKey: "devices/self", ClaimID: "claim-1"}
+	capacity, err := admission.ClaimWorkerCapacity(ctx, "worker/a", ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.ObserveWorker(ctx, "worker/a", ref, capacity.OwnerEpoch, 2_000, 4<<30, []string{"docker"}); err != nil {
+		t.Fatal(err)
+	}
+	res, err := admission.Reserve(ctx, "worker/a", "exec/cancel-1", testRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt := BackendRuntimeIdentity{Backend: "docker", ID: "container-cancel"}
+	if _, err := admission.Activate(ctx, res.ObjectKey(), rt); err != nil {
+		t.Fatal(err)
+	}
+
+	// Depose the instance: same Device, new claim id bumps the epoch.
+	newRef := WorkerClaimRef{DeviceObjectKey: ref.DeviceObjectKey, ClaimID: "claim-2"}
+	fresh, err := admission.ClaimWorkerCapacity(ctx, "worker/a", newRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The deposed epoch cannot stop the runtime it no longer owns.
+	if _, err := admission.StopAndRelease(ctx, ref, capacity.OwnerEpoch, res.ObjectKey(), res.Generation); err == nil {
+		t.Fatal("deposed instance stop must fail")
+	}
+	if stopper.count("container-cancel") != 0 {
+		t.Fatal("rejected stop still invoked the stopper")
+	}
+
+	// The new owner stops the runtime with its own epoch.
+	if _, err := admission.StopAndRelease(ctx, newRef, fresh.OwnerEpoch, res.ObjectKey(), res.Generation); err != nil {
+		t.Fatal(err)
+	}
+	if stopper.count("container-cancel") != 1 {
+		t.Fatalf("expected exactly one stop, got %d", stopper.count("container-cancel"))
 	}
 }

--- a/forge/runtime/expired-retry_test.go
+++ b/forge/runtime/expired-retry_test.go
@@ -9,8 +9,12 @@ import (
 
 func TestReserveRejectsExpiredUnsweptIdempotentReturn(t *testing.T) {
 	ctx, eng, _ := newTestbed(t)
-	admission := NewWorldRuntimeAdmission(eng, newTestStopper(), time.Minute)
-	if _, err := admission.ObserveWorker(ctx, "worker/a", 2_000, 4<<30, []string{"docker"}); err != nil {
+	admission := NewWorldRuntimeAdmission(eng, newTestStopper(), time.Minute, time.Minute)
+	claimed, err := admission.ClaimWorkerCapacity(ctx, "worker/a", selfRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.ObserveWorker(ctx, "worker/a", selfRef, claimed.OwnerEpoch, 2_000, 4<<30, []string{"docker"}); err != nil {
 		t.Fatal(err)
 	}
 	now := time.Now().UTC()
@@ -26,12 +30,47 @@ func TestReserveRejectsExpiredUnsweptIdempotentReturn(t *testing.T) {
 		t.Fatalf("expected expired reservation error, got %v", err)
 	}
 
+	// The owner claim lapsed under the same shifted clock: renewal falls
+	// back to reclaim with an epoch bump before the sweep can run.
+	if _, err := admission.RenewWorkerClaim(ctx, "worker/a", selfRef); err != nil {
+		t.Fatal(err)
+	}
+
 	// The sweep releases once; the attempt stays terminal for its key.
-	receipts, err := admission.ExpireLeases(ctx, now.Add(2*time.Minute))
+	receipts, err := admission.ExpireLeases(ctx, selfRef, now.Add(2*time.Minute))
 	if err != nil || len(receipts) != 1 {
 		t.Fatalf("expected one expiry receipt: %+v err=%v", receipts, err)
 	}
 	if _, err := admission.Reserve(ctx, "worker/a", "exec/late", testRequest); !errors.Is(err, ErrReservationTerminal) {
 		t.Fatalf("expected terminal error after sweep, got %v", err)
+	}
+}
+
+// TestOldEpochMutationsFailAfterOwnerReclaim proves the owner-epoch fence:
+// after reclaim following lease expiry, mutations carrying the old epoch fail
+// deterministically and the reservation lease sweep belongs to the new epoch.
+func TestOldEpochMutationsFailAfterOwnerReclaim(t *testing.T) {
+	ctx, eng, _ := newTestbed(t)
+	admission := NewWorldRuntimeAdmission(eng, newTestStopper(), time.Minute, time.Minute)
+	ref := WorkerClaimRef{DeviceObjectKey: "devices/self", ClaimID: "claim-1"}
+	capacity, err := admission.ClaimWorkerCapacity(ctx, "worker/a", ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldEpoch := capacity.OwnerEpoch
+	now := time.Now().UTC()
+	admission.SetTimeNow(func() time.Time { return now.Add(2 * time.Minute) })
+	reclaimed, err := admission.ClaimWorkerCapacity(ctx, "worker/a", ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reclaimed.OwnerEpoch != oldEpoch+1 {
+		t.Fatalf("reclaim must bump the epoch: %+v", reclaimed)
+	}
+	if _, err := admission.ObserveWorker(ctx, "worker/a", ref, oldEpoch, 2_000, 4<<30, []string{"docker"}); err == nil {
+		t.Fatal("old-epoch observe must fail")
+	}
+	if _, err := admission.BeginDrainCapacity(ctx, "worker/a", ref, oldEpoch); err == nil {
+		t.Fatal("old-epoch drain must fail")
 	}
 }

--- a/forge/runtime/owner-claim_test.go
+++ b/forge/runtime/owner-claim_test.go
@@ -1,0 +1,547 @@
+package forge_runtime
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	timestamp "github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
+	"github.com/pkg/errors"
+	"github.com/s4wave/spacewave/db/block"
+	"github.com/s4wave/spacewave/db/world"
+)
+
+// selfRef is the owning instance claim used across the owner-state tests.
+var selfRef = WorkerClaimRef{DeviceObjectKey: "devices/self", ClaimID: "claim-1"}
+
+// otherRef is a foreign Device claim used to prove cross-instance rejection.
+var otherRef = WorkerClaimRef{DeviceObjectKey: "devices/other", ClaimID: "claim-x"}
+
+// persistLegacyCapacity writes an old-format capacity record without owner
+// fields directly into world state, bypassing the gated API.
+func persistLegacyCapacity(ctx context.Context, eng world.Engine, workerObjectKey string) error {
+	return world.ExecTransaction(ctx, eng, true, func(ctx context.Context, ws world.WorldState) error {
+		legacy := &WorkerCapacity{
+			MilliCPUTotal:    2_000,
+			MemoryBytesTotal: 4 << 30,
+			Generation:       1,
+			ObservedAt:       timestamp.Now(),
+		}
+		return persistWorkerCapacity(ctx, ws, workerObjectKey, legacy)
+	})
+}
+
+func TestClaimCreateAdoptAndReclaimPreserveDraining(t *testing.T) {
+	ctx, eng, _ := newTestbed(t)
+	admission := NewWorldRuntimeAdmission(eng, newTestStopper(), time.Minute, time.Minute)
+
+	// Create-on-claim: absent record starts owned at epoch 1, state ACTIVE.
+	capacity, err := admission.ClaimWorkerCapacity(ctx, "worker/a", selfRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if capacity.OwnerEpoch != 1 || capacity.OwnerState != CapacityOwnerStateActive {
+		t.Fatalf("unexpected created claim: %+v", capacity)
+	}
+	if capacity.WorkerObjectKey != "worker/a" || capacity.OwnerDeviceObjectKey != selfRef.DeviceObjectKey {
+		t.Fatalf("claim did not persist key fields: %+v", capacity)
+	}
+
+	// Same ref renews idempotently without bumping the epoch.
+	capacity, err = admission.ClaimWorkerCapacity(ctx, "worker/a", selfRef)
+	if err != nil || capacity.OwnerEpoch != 1 {
+		t.Fatalf("same-ref claim must renew in place: %+v err=%v", capacity, err)
+	}
+
+	// Drain, then let the lease lapse; reclaim must keep DRAINING so a
+	// drained worker never silently re-enters scheduling.
+	if _, err := admission.BeginDrainCapacity(ctx, "worker/a", selfRef, capacity.OwnerEpoch); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	admission.SetTimeNow(func() time.Time { return now.Add(2 * time.Minute) })
+	capacity, err = admission.ClaimWorkerCapacity(ctx, "worker/a", selfRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if capacity.OwnerEpoch != 2 || capacity.OwnerState != CapacityOwnerStateDraining {
+		t.Fatalf("reclaim must bump epoch and preserve DRAINING: %+v", capacity)
+	}
+}
+
+func TestClaimAdoptsLegacyOwnerlessRecord(t *testing.T) {
+	ctx, eng, _ := newTestbed(t)
+	admission := NewWorldRuntimeAdmission(eng, newTestStopper(), time.Minute, time.Minute)
+	if err := persistLegacyCapacity(ctx, eng, "worker/legacy"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Before adoption every gated operation refuses the record.
+	if _, err := admission.Reserve(ctx, "worker/legacy", "exec/0", testRequest); !errors.Is(err, ErrCapacityUnowned) {
+		t.Fatalf("expected unowned rejection on legacy record, got %v", err)
+	}
+
+	// Adoption preserves debits (none here) and activates under epoch 1.
+	capacity, err := admission.ClaimWorkerCapacity(ctx, "worker/legacy", selfRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if capacity.OwnerEpoch != 1 || capacity.MilliCPUTotal != 2_000 {
+		t.Fatalf("adoption lost observed totals: %+v", capacity)
+	}
+}
+
+func TestForeignLiveClaimRejected(t *testing.T) {
+	ctx, eng, _ := newTestbed(t)
+	admission := NewWorldRuntimeAdmission(eng, newTestStopper(), time.Minute, time.Minute)
+	if _, err := admission.ClaimWorkerCapacity(ctx, "worker/a", selfRef); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.ClaimWorkerCapacity(ctx, "worker/a", otherRef); !errors.Is(err, ErrCapacityOwned) {
+		t.Fatalf("expected foreign Device conflict, got %v", err)
+	}
+}
+
+func TestEpochFencesObserveDrainAndComplete(t *testing.T) {
+	ctx, eng, _ := newTestbed(t)
+	admission := NewWorldRuntimeAdmission(eng, newTestStopper(), time.Minute, time.Minute)
+	capacity, err := admission.ClaimWorkerCapacity(ctx, "worker/a", selfRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale := capacity.OwnerEpoch
+
+	// A new claim id on the same Device reclaims and bumps the epoch; every
+	// stale-epoch mutation from the replaced instance rejects without
+	// touching the record.
+	newRef := WorkerClaimRef{DeviceObjectKey: selfRef.DeviceObjectKey, ClaimID: "claim-2"}
+	capacity, err = admission.ClaimWorkerCapacity(ctx, "worker/a", newRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if capacity.OwnerEpoch != stale+1 {
+		t.Fatalf("reclaim must bump the epoch: %+v", capacity)
+	}
+	if _, err := admission.ObserveWorker(ctx, "worker/a", selfRef, stale, 2_000, 4<<30, []string{"docker"}); err == nil {
+		t.Fatal("stale-epoch observe must fail")
+	}
+	if _, err := admission.BeginDrainCapacity(ctx, "worker/a", selfRef, stale); err == nil {
+		t.Fatal("stale-epoch drain must fail")
+	}
+	if err := admission.CompleteDrainCapacity(ctx, "worker/a", selfRef, stale); err == nil {
+		t.Fatal("stale-epoch complete-drain must fail")
+	}
+	if _, err := admission.StopAndRelease(ctx, selfRef, stale, "forge/runtime/reservation/x", 1); err == nil {
+		t.Fatal("stale-epoch stop must fail")
+	}
+}
+
+func TestRenewAfterExpiryFallsBackToReclaimWithBump(t *testing.T) {
+	ctx, eng, _ := newTestbed(t)
+	admission := NewWorldRuntimeAdmission(eng, newTestStopper(), time.Minute, time.Minute)
+	capacity, err := admission.ClaimWorkerCapacity(ctx, "worker/a", selfRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	admission.SetTimeNow(func() time.Time { return now.Add(2 * time.Minute) })
+	renewed, err := admission.RenewWorkerClaim(ctx, "worker/a", selfRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if renewed.OwnerEpoch != capacity.OwnerEpoch+1 {
+		t.Fatalf("expired renewal must fall back to reclaim with an epoch bump: %+v", renewed)
+	}
+}
+
+func TestReserveRejectionPrecedenceUnderClaims(t *testing.T) {
+	ctx, eng, _ := newTestbed(t)
+	admission := NewWorldRuntimeAdmission(eng, newTestStopper(), time.Minute, time.Minute)
+
+	// Unowned legacy record: Reserve rejects before backend checks even
+	// though the record declares the backend and ample totals.
+	if err := persistLegacyCapacity(ctx, eng, "worker/legacy"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.Reserve(ctx, "worker/legacy", "exec/1", testRequest); !errors.Is(err, ErrCapacityUnowned) {
+		t.Fatalf("expected unowned rejection, got %v", err)
+	}
+
+	// Draining record with fitting totals still rejects new work.
+	capacity, err := admission.ClaimWorkerCapacity(ctx, "worker/a", selfRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.ObserveWorker(ctx, "worker/a", selfRef, capacity.OwnerEpoch, 2_000, 4<<30, []string{"docker"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.BeginDrainCapacity(ctx, "worker/a", selfRef, capacity.OwnerEpoch); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.Reserve(ctx, "worker/a", "exec/2", testRequest); !errors.Is(err, ErrCapacityDraining) {
+		t.Fatalf("expected draining rejection, got %v", err)
+	}
+}
+
+func TestCompleteDrainWaitsForTerminalThenDeletesOnce(t *testing.T) {
+	ctx, eng, _ := newTestbed(t)
+	admission := NewWorldRuntimeAdmission(eng, newTestStopper(), time.Minute, time.Minute)
+	capacity, err := admission.ClaimWorkerCapacity(ctx, "worker/a", selfRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.ObserveWorker(ctx, "worker/a", selfRef, capacity.OwnerEpoch, 2_000, 4<<30, []string{"docker"}); err != nil {
+		t.Fatal(err)
+	}
+	res, err := admission.Reserve(ctx, "worker/a", "exec/1", testRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.BeginDrainCapacity(ctx, "worker/a", selfRef, capacity.OwnerEpoch); err != nil {
+		t.Fatal(err)
+	}
+	// A live reservation blocks completion.
+	if err := admission.CompleteDrainCapacity(ctx, "worker/a", selfRef, capacity.OwnerEpoch); err == nil {
+		t.Fatal("complete-drain must wait for terminal reservations")
+	}
+	if _, err := admission.StopAndRelease(ctx, selfRef, capacity.OwnerEpoch, res.ObjectKey(), res.Generation); err != nil {
+		t.Fatal(err)
+	}
+	if err := admission.CompleteDrainCapacity(ctx, "worker/a", selfRef, capacity.OwnerEpoch); err != nil {
+		t.Fatal(err)
+	}
+	// Post-delete stragglers are impossible: the record is gone.
+	if _, err := admission.Reserve(ctx, "worker/a", "exec/3", testRequest); !errors.Is(err, ErrWorkerNotObserved) {
+		t.Fatalf("expected not-observed after deletion, got %v", err)
+	}
+}
+
+func TestStaleRefSweepsSkipWithoutInvokingStopper(t *testing.T) {
+	ctx, eng, _ := newTestbed(t)
+	stopper := newTestStopper()
+	admission := NewWorldRuntimeAdmission(eng, stopper, time.Minute, time.Minute)
+	capacity, err := admission.ClaimWorkerCapacity(ctx, "worker/a", selfRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.ObserveWorker(ctx, "worker/a", selfRef, capacity.OwnerEpoch, 2_000, 4<<30, []string{"docker"}); err != nil {
+		t.Fatal(err)
+	}
+	res, err := admission.Reserve(ctx, "worker/a", "exec/1", testRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.Activate(ctx, res.ObjectKey(), BackendRuntimeIdentity{Backend: "docker", ID: "container-1"}); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+
+	// A foreign ref must not expire or stop work it does not own; the
+	// stopper must never fire for it.
+	if _, err := admission.ExpireLeases(ctx, otherRef, now.Add(2*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if stopper.count("container-1") != 0 {
+		t.Fatal("foreign sweep invoked the stopper")
+	}
+
+	// The matching owner sweeps normally and fences the generation.
+	receipts, err := admission.ExpireLeases(ctx, selfRef, now.Add(2*time.Minute))
+	if err != nil || len(receipts) != 1 {
+		t.Fatalf("expected one expiry receipt: %+v err=%v", receipts, err)
+	}
+	if receipts[0].Generation != res.Generation+1 {
+		t.Fatalf("expiry must fence the generation: %+v", receipts[0])
+	}
+}
+
+func TestScanOwnedCapacityReturnsKeysAndRecords(t *testing.T) {
+	ctx, eng, _ := newTestbed(t)
+	admission := NewWorldRuntimeAdmission(eng, newTestStopper(), time.Minute, time.Minute)
+	for _, key := range []string{"worker/a", "worker/b"} {
+		if _, err := admission.ClaimWorkerCapacity(ctx, key, selfRef); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := admission.ClaimWorkerCapacity(ctx, "worker/other", otherRef); err != nil {
+		t.Fatal(err)
+	}
+	owned, err := admission.ScanOwnedCapacity(ctx, selfRef.DeviceObjectKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(owned) != 2 {
+		t.Fatalf("expected two owned records, got %+v", owned)
+	}
+	keys := map[string]bool{}
+	for _, oc := range owned {
+		if oc.WorkerObjectKey == "" || oc.Capacity == nil {
+			t.Fatalf("scan must pair key with record: %+v", oc)
+		}
+		keys[oc.WorkerObjectKey] = true
+	}
+	if !keys["worker/a"] || !keys["worker/b"] {
+		t.Fatalf("scan missed owned workers: %+v", keys)
+	}
+}
+
+func TestGatedRenewLeaseRejectsStaleRef(t *testing.T) {
+	ctx, eng, _ := newTestbed(t)
+	admission := NewWorldRuntimeAdmission(eng, newTestStopper(), time.Minute, time.Minute)
+	capacity, err := admission.ClaimWorkerCapacity(ctx, "worker/a", selfRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.ObserveWorker(ctx, "worker/a", selfRef, capacity.OwnerEpoch, 2_000, 4<<30, []string{"docker"}); err != nil {
+		t.Fatal(err)
+	}
+	res, err := admission.Reserve(ctx, "worker/a", "exec/1", testRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.RenewLease(ctx, otherRef, res.ObjectKey()); err == nil {
+		t.Fatal("deposed-instance lease renewal must be rejected")
+	}
+	if _, err := admission.RenewLease(ctx, selfRef, res.ObjectKey()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestLegacyRawJSONDecodesUnavailableAndAdopts pins the raw legacy wire shape:
+// a record written before owner claims carries none of the owner keys, decodes
+// cleanly, stays unavailable to every gated operation, and is adopted by a
+// claim with its observed totals intact. It also pins forward compatibility:
+// the new JSON form round-trips every pre-existing field unchanged.
+func TestLegacyRawJSONDecodesUnavailableAndAdopts(t *testing.T) {
+	legacyJSON := `{"milliCpuTotal":2000,"memoryBytesTotal":4294967296,` +
+		`"milliCpuReserved":1000,"memoryBytesReserved":1073741824,` +
+		`"backends":["docker"],"observedAt":"1970-01-01T00:00:10Z",` +
+		`"generation":3}`
+	var decoded WorkerCapacity
+	if err := decoded.UnmarshalJSON([]byte(legacyJSON)); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.MilliCPUTotal != 2_000 || decoded.MilliCPUReserved != 1_000 ||
+		decoded.MemoryBytesTotal != 4<<30 || decoded.MemoryBytesReserved != 1<<30 ||
+		len(decoded.Backends) != 1 || decoded.Generation != 3 {
+		t.Fatalf("legacy decode lost pre-existing fields: %+v", decoded)
+	}
+	if err := decoded.Validate(); err != nil {
+		t.Fatalf("legacy ownerless shape must validate: %v", err)
+	}
+
+	ctx, eng, _ := newTestbed(t)
+	admission := NewWorldRuntimeAdmission(eng, newTestStopper(), time.Minute, time.Minute)
+	if err := world.ExecTransaction(ctx, eng, true, func(ctx context.Context, ws world.WorldState) error {
+		_, _, err := world.AccessWorldObject(ctx, ws, BuildWorkerCapacityObjectKey("worker/legacy"), true,
+			func(bcs *block.Cursor) error {
+				bcs.SetBlock(&decoded, true)
+				return nil
+			})
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Unavailable: Reserve refuses the ownerless record despite ample totals.
+	if _, err := admission.Reserve(ctx, "worker/legacy", "exec/legacy", testRequest); !errors.Is(err, ErrCapacityUnowned) {
+		t.Fatalf("expected unowned rejection, got %v", err)
+	}
+
+	// Adopt: the claim preserves observed totals and debits under epoch 1.
+	capacity, err := admission.ClaimWorkerCapacity(ctx, "worker/legacy", selfRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if capacity.OwnerEpoch != 1 || capacity.MilliCPUReserved != 1_000 ||
+		capacity.WorkerObjectKey != "worker/legacy" {
+		t.Fatalf("adoption lost durable facts: %+v", capacity)
+	}
+	if _, err := admission.Reserve(ctx, "worker/legacy", "exec/legacy2", testRequest); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestObserveFitDrainsAndCreditReactivates pins the desired-state write and
+// the credit-only reactivation rule end to end.
+func TestObserveFitDrainsAndCreditReactivates(t *testing.T) {
+	ctx, eng, _ := newTestbed(t)
+	admission := NewWorldRuntimeAdmission(eng, newTestStopper(), time.Minute, time.Minute)
+	claimed, err := admission.ClaimWorkerCapacity(ctx, "worker/a", selfRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.ObserveWorker(ctx, "worker/a", selfRef, claimed.OwnerEpoch, 2_000, 4<<30, []string{"docker"}); err != nil {
+		t.Fatal(err)
+	}
+	res, err := admission.Reserve(ctx, "worker/a", "exec/fit", testRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Shrink below the debit: observe drains and blocks new work.
+	shrunk, err := admission.ObserveWorker(ctx, "worker/a", selfRef, claimed.OwnerEpoch, 500, 1<<29, []string{"docker"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if shrunk.OwnerState != CapacityOwnerStateDraining {
+		t.Fatalf("shrink below debits must drain: %+v", shrunk)
+	}
+	if _, err := admission.Reserve(ctx, "worker/a", "exec/fit-2", testRequest); !errors.Is(err, ErrCapacityDraining) {
+		t.Fatalf("drained record must refuse work: %v", err)
+	}
+
+	// A fitting observation reactivates directly.
+	fit, err := admission.ObserveWorker(ctx, "worker/a", selfRef, claimed.OwnerEpoch, 2_000, 4<<30, []string{"docker"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fit.OwnerState != CapacityOwnerStateActive {
+		t.Fatalf("fitting totals must reactivate on observe: %+v", fit)
+	}
+
+	// Shrink again, then credit via terminal release: reactivation happens in
+	// creditCapacity because the declared backends remain non-empty.
+	if _, err := admission.ObserveWorker(ctx, "worker/a", selfRef, claimed.OwnerEpoch, 500, 1<<29, []string{"docker"}); err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := admission.StopAndRelease(ctx, selfRef, claimed.OwnerEpoch, res.ObjectKey(), res.Generation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !receipt.Complete() {
+		t.Fatalf("unexpected receipt: %+v", receipt)
+	}
+	final, err := lookupCapacityViaAdmission(ctx, admission, "worker/a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if final.OwnerState != CapacityOwnerStateActive {
+		t.Fatalf("credit must reactivate a drained-with-backends record: %+v", final)
+	}
+
+	// Empty backends never self-activate: drain empties them, a later credit
+	// keeps the record draining until CompleteDrain deletes it. Restore
+	// fitting totals first so the reservation succeeds.
+	if _, err := admission.ObserveWorker(ctx, "worker/a", selfRef, claimed.OwnerEpoch, 2_000, 4<<30, []string{"docker"}); err != nil {
+		t.Fatal(err)
+	}
+	res2, err := admission.Reserve(ctx, "worker/a", "exec/fit-3", testRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.BeginDrainCapacity(ctx, "worker/a", selfRef, claimed.OwnerEpoch); err != nil {
+		t.Fatal(err)
+	}
+	drained, err := lookupCapacityViaAdmission(ctx, admission, "worker/a")
+	if err != nil || len(drained.Backends) != 0 {
+		t.Fatalf("begin-drain must empty backends: %+v err=%v", drained, err)
+	}
+	if _, err := admission.StopAndRelease(ctx, selfRef, claimed.OwnerEpoch, res2.ObjectKey(), res2.Generation); err != nil {
+		t.Fatal(err)
+	}
+	final, err = lookupCapacityViaAdmission(ctx, admission, "worker/a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if final.OwnerState != CapacityOwnerStateDraining || len(final.Backends) != 0 {
+		t.Fatalf("empty-backend record must never self-activate: %+v", final)
+	}
+}
+
+// TestEmptyBackendsObserveRejected pins that observations cannot clear the
+// backend list; only BeginDrainCapacity drains with empty backends.
+func TestEmptyBackendsObserveRejected(t *testing.T) {
+	ctx, eng, _ := newTestbed(t)
+	admission := NewWorldRuntimeAdmission(eng, newTestStopper(), time.Minute, time.Minute)
+	claimed, err := admission.ClaimWorkerCapacity(ctx, "worker/a", selfRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.ObserveWorker(ctx, "worker/a", selfRef, claimed.OwnerEpoch, 2_000, 4<<30, nil); err == nil {
+		t.Fatal("nil backends observation must be rejected")
+	}
+	if _, err := admission.ObserveWorker(ctx, "worker/a", selfRef, claimed.OwnerEpoch, 2_000, 4<<30, []string{}); err == nil {
+		t.Fatal("empty backends observation must be rejected")
+	}
+}
+
+// TestStaleClaimIdentitiesAreStaleGeneration pins that both a foreign claim id
+// on the same Device and an old epoch surface as ErrStaleGeneration for gated
+// mutations, and that stale-ref reconcile never invokes the stopper.
+func TestStaleClaimIdentitiesAreStaleGeneration(t *testing.T) {
+	ctx, eng, _ := newTestbed(t)
+	stopper := newTestStopper()
+	admission := NewWorldRuntimeAdmission(eng, stopper, time.Minute, time.Minute)
+	claimed, err := admission.ClaimWorkerCapacity(ctx, "worker/a", selfRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admission.ObserveWorker(ctx, "worker/a", selfRef, claimed.OwnerEpoch, 2_000, 4<<30, []string{"docker"}); err != nil {
+		t.Fatal(err)
+	}
+	res, err := admission.Reserve(ctx, "worker/a", "exec/stale", testRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt := BackendRuntimeIdentity{Backend: "docker", ID: "container-stale"}
+	if _, err := admission.Activate(ctx, res.ObjectKey(), rt); err != nil {
+		t.Fatal(err)
+	}
+
+	// Turnover: same Device, new claim id bumps the epoch.
+	newRef := WorkerClaimRef{DeviceObjectKey: selfRef.DeviceObjectKey, ClaimID: "claim-new"}
+	fresh, err := admission.ClaimWorkerCapacity(ctx, "worker/a", newRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	staleRef := WorkerClaimRef{DeviceObjectKey: selfRef.DeviceObjectKey, ClaimID: selfRef.ClaimID}
+
+	// Old claim id and old epoch both fence to ErrStaleGeneration.
+	if _, err := admission.ObserveWorker(ctx, "worker/a", staleRef, fresh.OwnerEpoch, 2_000, 4<<30, []string{"docker"}); !errors.Is(err, ErrStaleGeneration) {
+		t.Fatalf("old claim id must be stale generation, got %v", err)
+	}
+	if _, err := admission.ObserveWorker(ctx, "worker/a", newRef, claimed.OwnerEpoch, 2_000, 4<<30, []string{"docker"}); !errors.Is(err, ErrStaleGeneration) {
+		t.Fatalf("old epoch must be stale generation, got %v", err)
+	}
+
+	// Expire past the reservation lease with the stopper failing so the
+	// pending-stop stays durable across reconciliation attempts. Reconcile
+	// belongs to the new owner.
+	now := time.Now().UTC()
+	later := now.Add(2 * time.Minute)
+	admission.SetTimeNow(func() time.Time { return later })
+	stopper.failFor = "container-stale"
+	stopper.stopErr = errors.New("runtime unreachable")
+	if _, err := admission.RenewWorkerClaim(ctx, "worker/a", newRef); err != nil {
+		t.Fatal(err)
+	}
+	receipts, err := admission.ExpireLeases(ctx, newRef, later)
+	if err != nil || len(receipts) != 1 || receipts[0].Complete() {
+		t.Fatalf("expected partial expiry receipt: %+v err=%v", receipts, err)
+	}
+	stoppedBefore := stopper.count("container-stale")
+
+	// The deposed instance's reconcile must neither stop the runtime nor
+	// touch state; the stopper count proves the pre-stop fence.
+	done, err := admission.ReconcilePendingStops(ctx, staleRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(done) != 0 {
+		t.Fatalf("stale ref reconcile must be skipped: %+v", done)
+	}
+	if stopper.count("container-stale") != stoppedBefore {
+		t.Fatal("stale-ref reconcile invoked the stopper")
+	}
+
+	// The runtime recovers; the current owner reconciles and stops once.
+	stopper.failFor = ""
+	done, err = admission.ReconcilePendingStops(ctx, newRef)
+	if err != nil || len(done) != 1 || !done[0].Complete() {
+		t.Fatalf("expected completed receipt from live owner: %+v err=%v", done, err)
+	}
+	if stopper.count("container-stale") != stoppedBefore+1 {
+		t.Fatalf("stopper invoked %d times", stopper.count("container-stale"))
+	}
+}

--- a/forge/runtime/persist.go
+++ b/forge/runtime/persist.go
@@ -48,6 +48,26 @@ func listReservationKeys(ctx context.Context, ws world.WorldState) ([]string, er
 	return keys, it.Err()
 }
 
+// listWorkerCapacityKeys lists all persisted worker capacity object keys.
+func listWorkerCapacityKeys(ctx context.Context, ws world.WorldState) ([]string, error) {
+	var keys []string
+	it := ws.IterateObjects(ctx, workerCapacityObjectKeyPrefix, false)
+	defer it.Close()
+	for it.Next() {
+		if !it.Valid() {
+			break
+		}
+		keys = append(keys, it.Key())
+	}
+	return keys, it.Err()
+}
+
+// deleteWorkerCapacity deletes the capacity record of one Worker.
+func deleteWorkerCapacity(ctx context.Context, ws world.WorldState, workerObjectKey string) error {
+	_, err := ws.DeleteObject(ctx, BuildWorkerCapacityObjectKey(workerObjectKey))
+	return err
+}
+
 // persistWorkerCapacity writes the capacity record of one Worker.
 func persistWorkerCapacity(ctx context.Context, ws world.WorldState, workerObjectKey string, capacity *WorkerCapacity) error {
 	if _, _, err := world.AccessWorldObject(
@@ -98,7 +118,9 @@ func debitCapacity(ctx context.Context, ws world.WorldState, workerObjectKey str
 }
 
 // creditCapacity removes one released reservation's request from the Worker's
-// reserved totals exactly once per release.
+// reserved totals exactly once per release. This is the only path that
+// reactivates a draining record whose declared backends remain: once the
+// remaining debits fit the declared totals, the claim returns to ACTIVE.
 func creditCapacity(ctx context.Context, ws world.WorldState, workerObjectKey string, request ResourceRequest) error {
 	capacity, err := LookupWorkerCapacity(ctx, ws, workerObjectKey)
 	if err != nil {
@@ -112,6 +134,11 @@ func creditCapacity(ctx context.Context, ws world.WorldState, workerObjectKey st
 	}
 	capacity.MilliCPUReserved -= request.MilliCPU
 	capacity.MemoryBytesReserved -= request.MemoryBytes
+	if capacity.OwnerState == CapacityOwnerStateDraining && len(capacity.Backends) > 0 &&
+		capacity.MilliCPUReserved <= capacity.MilliCPUTotal &&
+		capacity.MemoryBytesReserved <= capacity.MemoryBytesTotal {
+		capacity.OwnerState = CapacityOwnerStateActive
+	}
 	capacity.Generation++
 	if err := capacity.Validate(); err != nil {
 		return errors.Wrapf(err, "credit worker %s", workerObjectKey)

--- a/forge/runtime/worker-capacity.go
+++ b/forge/runtime/worker-capacity.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"slices"
 	"strconv"
+	"time"
 
 	"github.com/aperturerobotics/fastjson"
 	timestamp "github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
@@ -29,8 +30,33 @@ func NewWorkerCapacityBlock() block.Block {
 	return &WorkerCapacity{}
 }
 
+// CapacityOwnerState describes the lifecycle state of a capacity record's
+// durable owner claim.
+type CapacityOwnerState uint8
+
+const (
+	// CapacityOwnerStateUnspecified is the zero value: no live owner claim.
+	// Legacy records written before owner claims decode with this state and
+	// stay unavailable to every gated operation.
+	CapacityOwnerStateUnspecified CapacityOwnerState = iota
+	// CapacityOwnerStateActive means the claim is live and admits new work.
+	CapacityOwnerStateActive
+	// CapacityOwnerStateDraining means the claim is live but blocks new work
+	// until reserved debits clear or declared totals grow to fit them.
+	CapacityOwnerStateDraining
+)
+
+// Valid reports whether the state is a defined value.
+func (s CapacityOwnerState) Valid() bool {
+	return s <= CapacityOwnerStateDraining
+}
+
 // WorkerCapacity is the observed and reserved capacity for one Forge Worker.
 type WorkerCapacity struct {
+	// WorkerObjectKey is the Forge Worker object key this record describes.
+	// The record's own object key is a one-way hash of this value, so scans
+	// and reclaim need it stored to name the Worker.
+	WorkerObjectKey string
 	// MilliCPUTotal is the observed total CPU in milli-cores.
 	MilliCPUTotal uint64
 	// MilliCPUReserved is the CPU currently debited by live reservations.
@@ -46,6 +72,19 @@ type WorkerCapacity struct {
 	// Generation increments on every mutation of this record so observers can
 	// fence stale capacity views.
 	Generation uint64
+	// OwnerDeviceObjectKey is the enrolled Device object key of the owning
+	// daemon instance. Empty together with every other owner field marks a
+	// legacy ownerless record.
+	OwnerDeviceObjectKey string
+	// ClaimID identifies one owning daemon instance claim.
+	ClaimID string
+	// OwnerEpoch increments on every claim transition; calls fencing against
+	// an older epoch are stale.
+	OwnerEpoch uint64
+	// OwnerLeaseExpiresAt is when an unrenewed owner claim expires.
+	OwnerLeaseExpiresAt *timestamp.Timestamp
+	// OwnerState is the claim lifecycle state.
+	OwnerState CapacityOwnerState
 }
 
 // SupportsBackend reports whether the Worker declares the backend.
@@ -53,18 +92,66 @@ func (w *WorkerCapacity) SupportsBackend(backend string) bool {
 	return slices.Contains(w.Backends, backend)
 }
 
-// Validate validates the capacity record.
+// owned reports whether the record carries any owner-claim field.
+func (w *WorkerCapacity) owned() bool {
+	return w.OwnerDeviceObjectKey != "" || w.ClaimID != "" ||
+		w.WorkerObjectKey != "" || w.OwnerEpoch != 0 ||
+		w.OwnerLeaseExpiresAt != nil || w.OwnerState != CapacityOwnerStateUnspecified
+}
+
+// Validate validates the capacity record. A record carries either no owner
+// fields at all (legacy ownerless shape) or all six; partial owner shapes are
+// invalid so a half-written claim can never decode as available.
 func (w *WorkerCapacity) Validate() error {
-	switch {
-	case w.MilliCPUReserved > w.MilliCPUTotal:
-		return errors.New("reserved milli_cpu exceeds total")
-	case w.MemoryBytesReserved > w.MemoryBytesTotal:
-		return errors.New("reserved memory_bytes exceeds total")
-	case w.Generation == 0:
+	// An ACTIVE record never over-commits; a DRAINING record may hold debits
+	// above shrunk declared totals until credits land or the claim deletes it.
+	if w.OwnerState == CapacityOwnerStateActive {
+		switch {
+		case w.MilliCPUReserved > w.MilliCPUTotal:
+			return errors.New("reserved milli_cpu exceeds total")
+		case w.MemoryBytesReserved > w.MemoryBytesTotal:
+			return errors.New("reserved memory_bytes exceeds total")
+		}
+	}
+	if w.Generation == 0 {
 		return errors.New("generation must be set")
 	}
 	if err := w.ObservedAt.Validate(false); err != nil {
 		return errors.Wrap(err, "observed_at")
+	}
+	if !w.owned() {
+		return nil
+	}
+	switch {
+	case w.WorkerObjectKey == "":
+		return errors.New("worker_object_key must be set when owned")
+	case w.OwnerDeviceObjectKey == "":
+		return errors.New("owner_device_object_key must be set when owned")
+	case w.ClaimID == "":
+		return errors.New("claim_id must be set when owned")
+	case w.OwnerEpoch == 0:
+		return errors.New("owner_epoch must be set when owned")
+	case w.OwnerState == CapacityOwnerStateUnspecified || !w.OwnerState.Valid():
+		return errors.New("invalid owner_state")
+	}
+	if err := w.OwnerLeaseExpiresAt.Validate(false); err != nil {
+		return errors.Wrap(err, "owner_lease_expires_at")
+	}
+	return nil
+}
+
+// OwnerClaimActive reports whether the record carries a live owner claim at
+// the given time: owned, lease unexpired, and state ACTIVE. It returns typed
+// sentinel errors so callers can distinguish unavailable, expired, and
+// draining records without string matching.
+func (w *WorkerCapacity) OwnerClaimActive(now time.Time) error {
+	switch {
+	case !w.owned():
+		return ErrCapacityUnowned
+	case w.OwnerLeaseExpiresAt == nil || !now.Before(w.OwnerLeaseExpiresAt.AsTime()):
+		return ErrCapacityOwnerExpired
+	case w.OwnerState != CapacityOwnerStateActive:
+		return ErrCapacityDraining
 	}
 	return nil
 }
@@ -88,6 +175,16 @@ func (w *WorkerCapacity) UnmarshalBlock(data []byte) error {
 func (w *WorkerCapacity) MarshalJSON() ([]byte, error) {
 	var arena fastjson.Arena
 	obj := arena.NewObject()
+	setStringJSONField(&arena, obj, "workerObjectKey", w.WorkerObjectKey)
+	setStringJSONField(&arena, obj, "ownerDeviceObjectKey", w.OwnerDeviceObjectKey)
+	setStringJSONField(&arena, obj, "claimId", w.ClaimID)
+	obj.Set("ownerEpoch", arena.NewNumberString(strconv.FormatUint(w.OwnerEpoch, 10)))
+	ownerLease, err := marshalTimestampField(&arena, w.OwnerLeaseExpiresAt)
+	if err != nil {
+		return nil, err
+	}
+	obj.Set("ownerLeaseExpiresAt", ownerLease)
+	obj.Set("ownerState", arena.NewNumberInt(int(w.OwnerState)))
 	obj.Set("milliCpuTotal", arena.NewNumberString(strconv.FormatUint(w.MilliCPUTotal, 10)))
 	obj.Set("milliCpuReserved", arena.NewNumberString(strconv.FormatUint(w.MilliCPUReserved, 10)))
 	obj.Set("memoryBytesTotal", arena.NewNumberString(strconv.FormatUint(w.MemoryBytesTotal, 10)))
@@ -124,6 +221,15 @@ func (w *WorkerCapacity) UnmarshalJSON(data []byte) error {
 	w.MilliCPUReserved = value.GetUint64("milliCpuReserved")
 	w.MemoryBytesTotal = value.GetUint64("memoryBytesTotal")
 	w.MemoryBytesReserved = value.GetUint64("memoryBytesReserved")
+	w.WorkerObjectKey = string(value.GetStringBytes("workerObjectKey"))
+	w.OwnerDeviceObjectKey = string(value.GetStringBytes("ownerDeviceObjectKey"))
+	w.ClaimID = string(value.GetStringBytes("claimId"))
+	w.OwnerEpoch = value.GetUint64("ownerEpoch")
+	w.OwnerLeaseExpiresAt, err = unmarshalTimestampField(value, "ownerLeaseExpiresAt")
+	if err != nil {
+		return err
+	}
+	w.OwnerState = CapacityOwnerState(value.GetInt("ownerState"))
 	w.Backends = nil
 	for _, b := range value.GetArray("backends") {
 		w.Backends = append(w.Backends, string(b.GetStringBytes()))

--- a/forge/runtime/world-admission.go
+++ b/forge/runtime/world-admission.go
@@ -36,6 +36,8 @@ type WorldRuntimeAdmission struct {
 	stopper RuntimeStopper
 	// lease is the reservation lease duration.
 	lease time.Duration
+	// ownerLease is the owner claim lease duration.
+	ownerLease time.Duration
 	// now returns the current time; overridable in tests.
 	now func() time.Time
 
@@ -45,15 +47,20 @@ type WorldRuntimeAdmission struct {
 }
 
 // NewWorldRuntimeAdmission constructs a world-backed RuntimeAdmission.
-// A zero lease uses DefaultLeaseDuration.
-func NewWorldRuntimeAdmission(eng world.Engine, stopper RuntimeStopper, lease time.Duration) *WorldRuntimeAdmission {
+// A zero lease uses DefaultLeaseDuration; a zero ownerLease uses
+// DefaultOwnerLeaseDuration.
+func NewWorldRuntimeAdmission(eng world.Engine, stopper RuntimeStopper, lease, ownerLease time.Duration) *WorldRuntimeAdmission {
 	if lease == 0 {
 		lease = DefaultLeaseDuration
+	}
+	if ownerLease == 0 {
+		ownerLease = DefaultOwnerLeaseDuration
 	}
 	return &WorldRuntimeAdmission{
 		eng:         eng,
 		stopper:     stopper,
 		lease:       lease,
+		ownerLease:  ownerLease,
 		now:         time.Now,
 		workerLocks: make(map[string]*sync.Mutex),
 	}
@@ -88,16 +95,75 @@ func (a *WorldRuntimeAdmission) withTx(
 	})
 }
 
-// ObserveWorker upserts the Worker's observed capacity totals and backends.
-// Reserved debits are preserved; every observation bumps the record generation.
-func (a *WorldRuntimeAdmission) ObserveWorker(
+// loadOwnedCapacity loads the capacity record inside the transaction and
+// verifies the caller's ref and epoch against its durable claim. The record
+// must be owned by the same Device and claim with the current epoch and an
+// unexpired lease. This is the in-transaction half of every gated mutation.
+func loadOwnedCapacity(
+	ctx context.Context,
+	ws world.WorldState,
+	workerObjectKey string,
+	ref WorkerClaimRef,
+	epoch uint64,
+	now time.Time,
+) (*WorkerCapacity, error) {
+	capacity, err := LookupWorkerCapacity(ctx, ws, workerObjectKey)
+	if err != nil {
+		return nil, err
+	}
+	if !capacity.owned() {
+		return nil, ErrCapacityUnowned
+	}
+	expired := capacity.OwnerLeaseExpiresAt == nil || !now.Before(capacity.OwnerLeaseExpiresAt.AsTime())
+	switch {
+	case capacity.OwnerDeviceObjectKey != ref.DeviceObjectKey:
+		if expired {
+			return nil, ErrCapacityOwnerExpired
+		}
+		return nil, ErrCapacityOwned
+	case expired:
+		return nil, ErrCapacityOwnerExpired
+	case capacity.ClaimID != ref.ClaimID || capacity.OwnerEpoch != epoch:
+		return nil, ErrStaleGeneration
+	}
+	return capacity, nil
+}
+
+// verifyLiveClaim checks that the record's durable claim matches the caller's
+// reference and is unexpired. Sweeps use this variant: they carry no epoch
+// argument because the stored epoch is current for the live owner.
+func verifyLiveClaim(capacity *WorkerCapacity, ref WorkerClaimRef, now time.Time) error {
+	if !capacity.owned() {
+		return ErrCapacityUnowned
+	}
+	if capacity.OwnerDeviceObjectKey != ref.DeviceObjectKey || capacity.ClaimID != ref.ClaimID {
+		if capacity.OwnerLeaseExpiresAt == nil || !now.Before(capacity.OwnerLeaseExpiresAt.AsTime()) {
+			return ErrCapacityOwnerExpired
+		}
+		return ErrCapacityOwned
+	}
+	if capacity.OwnerLeaseExpiresAt == nil || !now.Before(capacity.OwnerLeaseExpiresAt.AsTime()) {
+		return ErrCapacityOwnerExpired
+	}
+	return nil
+}
+
+// ClaimWorkerCapacity claims or reclaims the Worker's capacity record for the
+// calling instance. An absent record is created at epoch 1 with zero totals; a
+// legacy ownerless record or an expired lease is reclaimed with an epoch bump
+// that preserves OwnerState so resumed drains stay draining. A live foreign
+// Device claim fails with ErrCapacityOwned. The same Device and claim id renew
+// idempotently without bumping the epoch.
+func (a *WorldRuntimeAdmission) ClaimWorkerCapacity(
 	ctx context.Context,
 	workerObjectKey string,
-	milliCPUTotal, memoryBytesTotal uint64,
-	backends []string,
+	ref WorkerClaimRef,
 ) (*WorkerCapacity, error) {
 	if workerObjectKey == "" {
 		return nil, errors.Wrap(world.ErrEmptyObjectKey, "worker_object_key")
+	}
+	if ref.DeviceObjectKey == "" || ref.ClaimID == "" {
+		return nil, errors.New("claim reference must be complete")
 	}
 	unlock := a.lockWorker(workerObjectKey)
 	defer unlock()
@@ -108,12 +174,154 @@ func (a *WorldRuntimeAdmission) ObserveWorker(
 		if err != nil && !errors.Is(err, ErrWorkerNotObserved) {
 			return err
 		}
+		now := a.now().UTC()
 		if capacity == nil {
-			capacity = &WorkerCapacity{}
+			capacity = &WorkerCapacity{
+				WorkerObjectKey:      workerObjectKey,
+				MilliCPUTotal:        0,
+				MemoryBytesTotal:     0,
+				ObservedAt:           timestamp.New(now),
+				OwnerDeviceObjectKey: ref.DeviceObjectKey,
+				ClaimID:              ref.ClaimID,
+				OwnerEpoch:           1,
+				OwnerLeaseExpiresAt:  timestamp.New(now.Add(a.ownerLease)),
+				OwnerState:           CapacityOwnerStateActive,
+			}
+			capacity.Generation = 1
+		} else {
+			live := capacity.owned() &&
+				capacity.OwnerLeaseExpiresAt != nil &&
+				now.Before(capacity.OwnerLeaseExpiresAt.AsTime())
+			if live && capacity.OwnerDeviceObjectKey != ref.DeviceObjectKey {
+				return ErrCapacityOwned
+			}
+			sameClaim := live &&
+				capacity.OwnerDeviceObjectKey == ref.DeviceObjectKey &&
+				capacity.ClaimID == ref.ClaimID
+			if sameClaim {
+				// Idempotent renew: extend the lease in place.
+				capacity.OwnerLeaseExpiresAt = timestamp.New(now.Add(a.ownerLease))
+			} else {
+				// Reclaim: legacy ownerless, expired lease, or a new claim id
+				// on the same Device. Preserve OwnerState and observed totals;
+				// bump the epoch so stale instances fence out.
+				prevEpoch := capacity.OwnerEpoch
+				capacity.OwnerDeviceObjectKey = ref.DeviceObjectKey
+				capacity.ClaimID = ref.ClaimID
+				capacity.OwnerEpoch = prevEpoch + 1
+				capacity.OwnerLeaseExpiresAt = timestamp.New(now.Add(a.ownerLease))
+				if capacity.OwnerState == CapacityOwnerStateUnspecified {
+					capacity.OwnerState = CapacityOwnerStateActive
+				}
+			}
+		}
+		if capacity.WorkerObjectKey == "" {
+			capacity.WorkerObjectKey = workerObjectKey
+		}
+		capacity.Generation++
+		if err := capacity.Validate(); err != nil {
+			return err
+		}
+		if err := persistWorkerCapacity(ctx, ws, workerObjectKey, capacity); err != nil {
+			return err
+		}
+		out = capacity
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// RenewWorkerClaim extends the owner claim lease of one Worker. Renewal on an
+// expired lease falls back to reclaim: the same ref reclaims with an epoch
+// bump and preserved state instead of stalling its own sweeps.
+func (a *WorldRuntimeAdmission) RenewWorkerClaim(
+	ctx context.Context,
+	workerObjectKey string,
+	ref WorkerClaimRef,
+) (*WorkerCapacity, error) {
+	unlock := a.lockWorker(workerObjectKey)
+	defer unlock()
+
+	var out *WorkerCapacity
+	err := a.withTx(ctx, true, func(ctx context.Context, ws world.WorldState) error {
+		capacity, err := LookupWorkerCapacity(ctx, ws, workerObjectKey)
+		if err != nil {
+			return err
+		}
+		now := a.now().UTC()
+		if !capacity.owned() {
+			return ErrCapacityUnowned
+		}
+		if capacity.OwnerDeviceObjectKey != ref.DeviceObjectKey {
+			return ErrCapacityOwned
+		}
+		if capacity.ClaimID != ref.ClaimID {
+			return ErrStaleGeneration
+		}
+		expired := capacity.OwnerLeaseExpiresAt == nil ||
+			!now.Before(capacity.OwnerLeaseExpiresAt.AsTime())
+		if expired {
+			capacity.OwnerEpoch++
+		}
+		capacity.OwnerLeaseExpiresAt = timestamp.New(now.Add(a.ownerLease))
+		capacity.Generation++
+		if err := capacity.Validate(); err != nil {
+			return err
+		}
+		if err := persistWorkerCapacity(ctx, ws, workerObjectKey, capacity); err != nil {
+			return err
+		}
+		out = capacity
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ObserveWorker upserts the Worker's observed capacity totals and backends
+// under a live owner claim at the given epoch. Reserved debits are preserved;
+// every observation bumps the record generation and stamps ObservedAt.
+// Declared totals below current debits move the record to DRAINING until
+// credits land; fitting totals return it to ACTIVE. Empty backends are a
+// validation error: only BeginDrainCapacity empties the backend list.
+func (a *WorldRuntimeAdmission) ObserveWorker(
+	ctx context.Context,
+	workerObjectKey string,
+	ref WorkerClaimRef,
+	epoch uint64,
+	milliCPUTotal, memoryBytesTotal uint64,
+	backends []string,
+) (*WorkerCapacity, error) {
+	if workerObjectKey == "" {
+		return nil, errors.Wrap(world.ErrEmptyObjectKey, "worker_object_key")
+	}
+	if len(backends) == 0 {
+		return nil, errors.New("backends must not be empty")
+	}
+	unlock := a.lockWorker(workerObjectKey)
+	defer unlock()
+
+	var out *WorkerCapacity
+	err := a.withTx(ctx, true, func(ctx context.Context, ws world.WorldState) error {
+		capacity, err := loadOwnedCapacity(ctx, ws, workerObjectKey, ref, epoch, a.now())
+		if err != nil {
+			return err
 		}
 		capacity.MilliCPUTotal = milliCPUTotal
 		capacity.MemoryBytesTotal = memoryBytesTotal
 		capacity.Backends = append([]string(nil), backends...)
+		fits := capacity.MilliCPUReserved <= capacity.MilliCPUTotal &&
+			capacity.MemoryBytesReserved <= capacity.MemoryBytesTotal
+		if fits {
+			capacity.OwnerState = CapacityOwnerStateActive
+		} else {
+			capacity.OwnerState = CapacityOwnerStateDraining
+		}
 		capacity.ObservedAt = timestamp.Now()
 		capacity.Generation++
 		if err := capacity.Validate(); err != nil {
@@ -129,6 +337,116 @@ func (a *WorldRuntimeAdmission) ObserveWorker(
 		return nil, err
 	}
 	return out, nil
+}
+
+// BeginDrainCapacity moves the record to DRAINING with empty backends under a
+// live claim at the given epoch. Reserved debits stay held; sweeps continue.
+// Idempotent.
+func (a *WorldRuntimeAdmission) BeginDrainCapacity(
+	ctx context.Context,
+	workerObjectKey string,
+	ref WorkerClaimRef,
+	epoch uint64,
+) (*WorkerCapacity, error) {
+	unlock := a.lockWorker(workerObjectKey)
+	defer unlock()
+
+	var out *WorkerCapacity
+	err := a.withTx(ctx, true, func(ctx context.Context, ws world.WorldState) error {
+		capacity, err := loadOwnedCapacity(ctx, ws, workerObjectKey, ref, epoch, a.now())
+		if err != nil {
+			return err
+		}
+		capacity.OwnerState = CapacityOwnerStateDraining
+		capacity.Backends = nil
+		capacity.Generation++
+		if err := capacity.Validate(); err != nil {
+			return err
+		}
+		if err := persistWorkerCapacity(ctx, ws, workerObjectKey, capacity); err != nil {
+			return err
+		}
+		out = capacity
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// CompleteDrainCapacity deletes a fully drained capacity record exactly once.
+// It requires the DRAINING state and no non-terminal reservation referencing
+// the Worker; the scan runs inside the same transaction as the deletion.
+func (a *WorldRuntimeAdmission) CompleteDrainCapacity(
+	ctx context.Context,
+	workerObjectKey string,
+	ref WorkerClaimRef,
+	epoch uint64,
+) error {
+	unlock := a.lockWorker(workerObjectKey)
+	defer unlock()
+
+	return a.withTx(ctx, true, func(ctx context.Context, ws world.WorldState) error {
+		capacity, err := loadOwnedCapacity(ctx, ws, workerObjectKey, ref, epoch, a.now())
+		if err != nil {
+			return err
+		}
+		if capacity.OwnerState != CapacityOwnerStateDraining {
+			return errors.New("capacity record is not draining")
+		}
+		resKeys, err := listReservationKeys(ctx, ws)
+		if err != nil {
+			return err
+		}
+		for _, resKey := range resKeys {
+			res, err := LookupReservation(ctx, ws, resKey)
+			if errors.Is(err, ErrReservationNotFound) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if res.WorkerObjectKey == workerObjectKey && !res.State.Terminal() {
+				return errors.Errorf("worker %s still holds active reservation %s",
+					workerObjectKey, resKey)
+			}
+		}
+		return deleteWorkerCapacity(ctx, ws, workerObjectKey)
+	})
+}
+
+// ScanOwnedCapacity returns the capacity records owned by one Device, paired
+// with their Worker object keys.
+func (a *WorldRuntimeAdmission) ScanOwnedCapacity(
+	ctx context.Context,
+	deviceObjectKey string,
+) ([]OwnedWorkerCapacity, error) {
+	var out []OwnedWorkerCapacity
+	err := a.withTx(ctx, false, func(ctx context.Context, ws world.WorldState) error {
+		keys, err := listWorkerCapacityKeys(ctx, ws)
+		if err != nil {
+			return err
+		}
+		for _, objKey := range keys {
+			capacity, err := world.LookupObjectBody[*WorkerCapacity](ctx, ws, objKey, NewWorkerCapacityBlock)
+			if errors.Is(err, world.ErrObjectNotFound) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if capacity.OwnerDeviceObjectKey != deviceObjectKey {
+				continue
+			}
+			out = append(out, OwnedWorkerCapacity{
+				WorkerObjectKey: capacity.WorkerObjectKey,
+				Capacity:        capacity,
+			})
+		}
+		return nil
+	})
+	return out, err
 }
 
 // Reserve implements RuntimeAdmission. Creation and the capacity debit apply
@@ -171,6 +489,9 @@ func (a *WorldRuntimeAdmission) Reserve(
 			if err != nil {
 				return err
 			}
+			if err := capacity.OwnerClaimActive(a.now()); err != nil {
+				return err
+			}
 			if remainingMilliCPU(capacity)+existing.Request.MilliCPU < existing.Request.MilliCPU ||
 				capacity.MilliCPUReserved < existing.Request.MilliCPU ||
 				capacity.MemoryBytesReserved < existing.Request.MemoryBytes {
@@ -182,6 +503,9 @@ func (a *WorldRuntimeAdmission) Reserve(
 
 		capacity, err := LookupWorkerCapacity(ctx, ws, workerObjectKey)
 		if err != nil {
+			return err
+		}
+		if err := capacity.OwnerClaimActive(a.now()); err != nil {
 			return err
 		}
 		if !capacity.SupportsBackend(request.Backend) {
@@ -278,15 +602,48 @@ func (a *WorldRuntimeAdmission) ResumeFromUncertain(
 	})
 }
 
-// RenewLease extends the lease of a live reservation from the observing owner.
-func (a *WorldRuntimeAdmission) RenewLease(ctx context.Context, reservationObjectKey string) (*Reservation, error) {
-	return a.transitionReservation(ctx, reservationObjectKey, func(res *Reservation) error {
-		if !res.State.Live() {
+// RenewLease extends the lease of a live reservation from the owning
+// instance. The claim reference is verified against the worker record's
+// durable live claim inside the transition transaction: a deposed instance
+// renewing leases in a loop must not starve the new owner's expiry sweep.
+func (a *WorldRuntimeAdmission) RenewLease(ctx context.Context, ref WorkerClaimRef, reservationObjectKey string) (*Reservation, error) {
+	res, err := a.LookupReservation(ctx, reservationObjectKey)
+	if err != nil {
+		return nil, err
+	}
+	unlock := a.lockWorker(res.WorkerObjectKey)
+	defer unlock()
+
+	var out *Reservation
+	err = a.withTx(ctx, true, func(ctx context.Context, ws world.WorldState) error {
+		capacity, err := LookupWorkerCapacity(ctx, ws, res.WorkerObjectKey)
+		if err != nil {
+			return err
+		}
+		if err := verifyLiveClaim(capacity, ref, a.now()); err != nil {
+			return err
+		}
+		current, err := LookupReservation(ctx, ws, reservationObjectKey)
+		if err != nil {
+			return err
+		}
+		if !current.State.Live() {
 			return ErrReservationTerminal
 		}
-		renewLease(res, a.now(), a.lease)
+		renewLease(current, a.now(), a.lease)
+		if err := current.Validate(); err != nil {
+			return err
+		}
+		if err := persistReservation(ctx, ws, reservationObjectKey, current); err != nil {
+			return err
+		}
+		out = current
 		return nil
 	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // LookupReservation implements RuntimeAdmission.
@@ -312,10 +669,12 @@ func (a *WorldRuntimeAdmission) LookupReservation(ctx context.Context, reservati
 // finishes it with the same idempotent stopper.
 func (a *WorldRuntimeAdmission) StopAndRelease(
 	ctx context.Context,
+	ref WorkerClaimRef,
+	ownerEpoch uint64,
 	reservationObjectKey string,
 	generation uint64,
 ) (*CleanupReceipt, error) {
-	res, receipt, err := a.beginStopLocked(ctx, reservationObjectKey, generation)
+	res, receipt, err := a.beginStopLocked(ctx, ref, ownerEpoch, reservationObjectKey, generation)
 	if err != nil {
 		return nil, err
 	}
@@ -332,7 +691,7 @@ func (a *WorldRuntimeAdmission) StopAndRelease(
 		}
 		runtimeStopped = stopped
 	}
-	return a.finalizeStop(ctx, res.ObjectKey(), res.WorkerObjectKey, res.ExecutionObjectKey, res.Runtime.ID, res.Generation, runtimeStopped, CleanupReasonStop)
+	return a.finalizeStop(ctx, ref, ownerEpoch, res.ObjectKey(), res.WorkerObjectKey, res.ExecutionObjectKey, res.Runtime.ID, res.Generation, runtimeStopped, CleanupReasonStop, false)
 }
 
 // ExpireLeases fences every live reservation whose lease expired at or
@@ -345,7 +704,7 @@ func (a *WorldRuntimeAdmission) StopAndRelease(
 // receipt and credits the debit exactly once. Failure leaves the work to
 // ReconcilePendingStops. Post-expiry calls fenced against the old generation
 // are stale and cannot receive the terminal receipt.
-func (a *WorldRuntimeAdmission) ExpireLeases(ctx context.Context, now time.Time) ([]*CleanupReceipt, error) {
+func (a *WorldRuntimeAdmission) ExpireLeases(ctx context.Context, ref WorkerClaimRef, now time.Time) ([]*CleanupReceipt, error) {
 	keys, err := a.listReservationKeys(ctx)
 	if err != nil {
 		return nil, err
@@ -353,11 +712,26 @@ func (a *WorldRuntimeAdmission) ExpireLeases(ctx context.Context, now time.Time)
 	var receipts []*CleanupReceipt
 	for _, key := range keys {
 		workerKey, err := a.resolveWorkerForReservation(ctx, key)
+		if errors.Is(err, ErrReservationNotFound) {
+			continue
+		}
 		if err != nil {
 			return receipts, err
 		}
+
+		// Entry check: only records carrying this live claim are swept.
+		// Missing, legacy ownerless, foreign-held, and expired-claim records
+		// are skipped without invoking the stopper.
+		live, err := a.claimLiveForWorker(ctx, workerKey, ref)
+		if err != nil {
+			return receipts, err
+		}
+		if !live {
+			continue
+		}
+
 		unlock := a.lockWorker(workerKey)
-		receipt, err := a.expireOne(ctx, key, now)
+		receipt, err := a.expireOne(ctx, ref, key, now)
 		unlock()
 		if err != nil {
 			return receipts, err
@@ -370,7 +744,7 @@ func (a *WorldRuntimeAdmission) ExpireLeases(ctx context.Context, now time.Time)
 		// Best-effort immediate stop outside the Worker lock;
 		// ReconcilePendingStops retries later. When the stop confirms here,
 		// report the completed truthful receipt instead of the partial one.
-		done, err := a.reconcilePendingStop(ctx, receipt.ReservationObjectKey)
+		done, err := a.reconcilePendingStop(ctx, ref, receipt.ReservationObjectKey)
 		if err == nil && done != nil {
 			receipts[len(receipts)-1] = done
 		}
@@ -378,17 +752,51 @@ func (a *WorldRuntimeAdmission) ExpireLeases(ctx context.Context, now time.Time)
 	return receipts, nil
 }
 
+// claimLiveForWorker reports whether the Worker's capacity record carries the
+// caller's live claim. It is the entry check for sweeps; the in-transaction
+// recheck inside each mutation remains authoritative. Missing records are
+// simply not live; other read failures propagate to the caller.
+func (a *WorldRuntimeAdmission) claimLiveForWorker(ctx context.Context, workerObjectKey string, ref WorkerClaimRef) (bool, error) {
+	var live bool
+	err := a.withTx(ctx, false, func(ctx context.Context, ws world.WorldState) error {
+		capacity, err := LookupWorkerCapacity(ctx, ws, workerObjectKey)
+		if errors.Is(err, ErrWorkerNotObserved) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		live = verifyLiveClaim(capacity, ref, a.now()) == nil
+		return nil
+	})
+	return live, err
+}
+
 // ReconcilePendingStops confirms stops for every pending-stop reservation by
 // running the idempotent stopper and finalizing the receipt. It completes the
 // work of a crashed StopAndRelease or an unreachable expired runtime.
-func (a *WorldRuntimeAdmission) ReconcilePendingStops(ctx context.Context) ([]*CleanupReceipt, error) {
+func (a *WorldRuntimeAdmission) ReconcilePendingStops(ctx context.Context, ref WorkerClaimRef) ([]*CleanupReceipt, error) {
 	keys, err := a.listReservationKeys(ctx)
 	if err != nil {
 		return nil, err
 	}
 	var receipts []*CleanupReceipt
 	for _, key := range keys {
-		receipt, err := a.reconcilePendingStop(ctx, key)
+		workerKey, err := a.resolveWorkerForReservation(ctx, key)
+		if errors.Is(err, ErrReservationNotFound) {
+			continue
+		}
+		if err != nil {
+			return receipts, err
+		}
+		live, err := a.claimLiveForWorker(ctx, workerKey, ref)
+		if err != nil {
+			return receipts, err
+		}
+		if !live {
+			continue
+		}
+		receipt, err := a.reconcilePendingStop(ctx, ref, key)
 		if err != nil {
 			return receipts, err
 		}
@@ -402,7 +810,7 @@ func (a *WorldRuntimeAdmission) ReconcilePendingStops(ctx context.Context) ([]*C
 // expireOne expires one expired live reservation in one transaction.
 // Caller holds the Worker lock. Returns nil when the reservation is not
 // expirable.
-func (a *WorldRuntimeAdmission) expireOne(ctx context.Context, objKey string, now time.Time) (*CleanupReceipt, error) {
+func (a *WorldRuntimeAdmission) expireOne(ctx context.Context, ref WorkerClaimRef, objKey string, now time.Time) (*CleanupReceipt, error) {
 	var out *CleanupReceipt
 	err := a.withTx(ctx, true, func(ctx context.Context, ws world.WorldState) error {
 		res, err := LookupReservation(ctx, ws, objKey)
@@ -410,6 +818,13 @@ func (a *WorldRuntimeAdmission) expireOne(ctx context.Context, objKey string, no
 			return err
 		}
 		if !res.State.Live() || !res.LeaseExpired(now) {
+			return nil
+		}
+		capacity, err := LookupWorkerCapacity(ctx, ws, res.WorkerObjectKey)
+		if err != nil {
+			return err
+		}
+		if err := verifyLiveClaim(capacity, ref, a.now()); err != nil {
 			return nil
 		}
 		// Fence custody: every old-generation call becomes stale. The debit
@@ -453,6 +868,8 @@ func (a *WorldRuntimeAdmission) expireOne(ctx context.Context, objKey string, no
 // generation.
 func (a *WorldRuntimeAdmission) beginStopLocked(
 	ctx context.Context,
+	ref WorkerClaimRef,
+	ownerEpoch uint64,
 	reservationObjectKey string,
 	generation uint64,
 ) (*Reservation, *CleanupReceipt, error) {
@@ -465,6 +882,9 @@ func (a *WorldRuntimeAdmission) beginStopLocked(
 
 	var out *Reservation
 	err = a.withTx(ctx, true, func(ctx context.Context, ws world.WorldState) error {
+		if _, err := loadOwnedCapacity(ctx, ws, res.WorkerObjectKey, ref, ownerEpoch, a.now()); err != nil {
+			return err
+		}
 		current, err := LookupReservation(ctx, ws, reservationObjectKey)
 		if err != nil {
 			return err
@@ -516,16 +936,28 @@ func (a *WorldRuntimeAdmission) beginStopLocked(
 // once: only the released state releases capacity.
 func (a *WorldRuntimeAdmission) finalizeStop(
 	ctx context.Context,
+	ref WorkerClaimRef,
+	ownerEpoch uint64,
 	objKey, workerObjectKey, executionObjectKey, runtimeIdentity string,
 	generation uint64,
 	runtimeStopped bool,
 	reason string,
+	benignOnFence bool,
 ) (*CleanupReceipt, error) {
 	unlock := a.lockWorker(workerObjectKey)
 	defer unlock()
 
 	var out *CleanupReceipt
 	err := a.withTx(ctx, true, func(ctx context.Context, ws world.WorldState) error {
+		if _, err := loadOwnedCapacity(ctx, ws, workerObjectKey, ref, ownerEpoch, a.now()); err != nil {
+			// Claim turnover between stop and finalize: for sweep/reconcile
+			// this is a benign skip. The partial receipt and debit stay
+			// durable so the new owner's reconcile finishes the release.
+			if benignOnFence && isClaimFenceError(err) {
+				return nil
+			}
+			return err
+		}
 		res, err := LookupReservation(ctx, ws, objKey)
 		if err != nil {
 			return err
@@ -603,12 +1035,21 @@ func (a *WorldRuntimeAdmission) finalizeStop(
 
 // reconcilePendingStop confirms the stop of one pending-stop reservation.
 // Returns the completed receipt, or nil when the key is not pending-stop.
-func (a *WorldRuntimeAdmission) reconcilePendingStop(ctx context.Context, objKey string) (*CleanupReceipt, error) {
+func (a *WorldRuntimeAdmission) reconcilePendingStop(ctx context.Context, ref WorkerClaimRef, objKey string) (*CleanupReceipt, error) {
 	res, err := a.LookupReservation(ctx, objKey)
 	if err != nil {
 		return nil, err
 	}
 	if res.State != ReservationStatePendingStop {
+		return nil, nil
+	}
+	// Entry check before any stopper invocation: a deposed or stale instance
+	// must not stop runtimes it no longer owns.
+	capacity, err := a.LookupWorkerCapacityAdmission(ctx, res.WorkerObjectKey)
+	if err != nil {
+		return nil, err
+	}
+	if err := verifyLiveClaim(capacity, ref, a.now()); err != nil {
 		return nil, nil
 	}
 	runtimeStopped := true
@@ -626,8 +1067,10 @@ func (a *WorldRuntimeAdmission) reconcilePendingStop(ctx context.Context, objKey
 	if priorReason == "" {
 		priorReason = CleanupReasonStop
 	}
-	return a.finalizeStop(
+	receipt, err := a.finalizeStop(
 		ctx,
+		ref,
+		capacity.OwnerEpoch,
 		objKey,
 		res.WorkerObjectKey,
 		res.ExecutionObjectKey,
@@ -635,7 +1078,35 @@ func (a *WorldRuntimeAdmission) reconcilePendingStop(ctx context.Context, objKey
 		res.Generation,
 		runtimeStopped,
 		priorReason,
+		true,
 	)
+	if receipt == nil && err == nil {
+		// Claim turnover during finalize: benign skip, debit preserved for
+		// the new owner's reconcile.
+		return nil, nil
+	}
+	return receipt, err
+}
+
+// isClaimFenceError reports whether an error came from the owner-claim fence
+// rather than from storage or validation.
+func isClaimFenceError(err error) bool {
+	return errors.Is(err, ErrCapacityUnowned) ||
+		errors.Is(err, ErrCapacityOwned) ||
+		errors.Is(err, ErrCapacityOwnerExpired) ||
+		errors.Is(err, ErrStaleGeneration)
+}
+
+// LookupWorkerCapacityAdmission loads one capacity record through the
+// admission instance's read transaction.
+func (a *WorldRuntimeAdmission) LookupWorkerCapacityAdmission(ctx context.Context, workerObjectKey string) (*WorkerCapacity, error) {
+	var out *WorkerCapacity
+	err := a.withTx(ctx, false, func(ctx context.Context, ws world.WorldState) error {
+		capacity, err := LookupWorkerCapacity(ctx, ws, workerObjectKey)
+		out = capacity
+		return err
+	})
+	return out, err
 }
 
 // stopRuntimeChecked invokes the configured stopper and wraps failures.


### PR DESCRIPTION
Worker capacity records had no durable owner: any process holding the world engine could observe totals, drain a record, or stop runtimes concurrently with another instance, and nothing tied a capacity record to the daemon that owns the linked Worker.

Each WorkerCapacity world record now carries a durable owner claim: the owning Device object key, a per-instance claim id, a monotonically fenced owner epoch, and a lease deadline in an ACTIVE or DRAINING lifecycle state. Claim-gated methods cover create, adoption of legacy records, reclaim with preserved drain state, renewal with an expired-lease fallback to reclaim, observation, drain begin and completion, and owned scans. Reserve rejects unowned, expired, and draining records before backend and capacity checks. StopAndRelease now authenticates the caller's claim and epoch through begin, finalize, and both sweeps, verifying before any stopper invocation and again inside each write transaction. Reservation lease renewal is claim-gated so a deposed instance cannot starve the new owner's expiry sweep. Reactivation after a declared shrink happens only when credits land; empty-backend drains never self-activate. The owner epoch is deliberately not persisted on reservations, because takeover requires the new owner to finish the previous epoch's work.

Legacy ownerless records decode cleanly but stay unavailable to every gated operation. There is no migration because no production producer exists; tests pin both the decode shape and the unavailability.

Tests: go test ./forge/runtime/ -count=1 and -race cover the full claim matrix (create/adopt/reclaim, epoch fencing, foreign-Device conflicts, drain preservation, credit-only reactivation, sweep fencing without stopper invocation) plus all pre-existing regressions.
