### PR TITLE
fix(e2e/wasm/session): exclude the QUIC RWC fixture from tinygo builds

### DIFF
--- a/e2e/wasm/harness_test.go
+++ b/e2e/wasm/harness_test.go
@@ -247,6 +247,13 @@ const quicRwcFixtureDeadline = 45 * time.Second
 // exchange a stream payload over detached RTCDataChannels transferred into one
 // browser worker.
 func TestBrowserWorkerQuicRwcFixture(t *testing.T) {
+	compiler, err := ResolveE2EWasmCompiler()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compiler == E2EWasmCompilerTinyGo {
+		t.Skip("browser QUIC fixture requires a compiler with pion/webrtc support")
+	}
 	sess := harness(t).NewCleanSession(t)
 	ctx, cancel := context.WithTimeout(harness(t).Context(), quicRwcFixtureDeadline)
 	defer cancel()

--- a/e2e/wasm/session/quic-rwc-fixture.go
+++ b/e2e/wasm/session/quic-rwc-fixture.go
@@ -1,3 +1,5 @@
+//go:build !tinygo
+
 package e2e_wasm_session
 
 import (

--- a/e2e/wasm/session/quic-rwc-fixture_tinygo.go
+++ b/e2e/wasm/session/quic-rwc-fixture_tinygo.go
@@ -1,0 +1,23 @@
+//go:build tinygo
+
+package e2e_wasm_session
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+)
+
+// ErrQuicRwcUnavailable reports the QUIC RWC fixture cannot run under tinygo.
+// The manual signal transport behind the fixture uses pion/webrtc, which is
+// excluded from tinygo builds.
+var ErrQuicRwcUnavailable = errors.New("quic rwc fixture requires a non-tinygo compiler")
+
+// RunQuicRwcFixture keeps the QUIC RWC fixture service registered under
+// tinygo builds; the real browser WebRTC fixture excludes tinygo.
+func (c *Controller) RunQuicRwcFixture(
+	ctx context.Context,
+	req *RunQuicRwcFixtureRequest,
+) (*RunQuicRwcFixtureResponse, error) {
+	return nil, ErrQuicRwcUnavailable
+}


### PR DESCRIPTION
The QUIC RWC fixture calls NewManualSignalTransport, which lives behind `//go:build !tinygo` because pion/webrtc cannot compile under tinygo. The fixture itself carried no constraint, so every tinygo-compiled slice of `./e2e/wasm` failed package load with undefined symbols before any test could boot.

Constrain the fixture to non-tinygo builds and add a tinygo-tagged stub with the same signature returning a typed unavailable error, keeping the controller SRPC registration and interface assertion compiling under both configurations. Skip TestBrowserWorkerQuicRwcFixture when the selected compiler is tinygo; the fixture cannot run without the manual signal transport.