### PR TITLE
fix(sobject/sync): validate inbound snapshots and remote ops

### DIFF
--- a/core/provider/local/p2p-sync.go
+++ b/core/provider/local/p2p-sync.go
@@ -494,7 +494,7 @@ func (a *ProviderAccount) startP2PSyncControllers(
 		}
 
 		if !state.hasSO(soID) {
-			if err := a.startSOSync(syncCtx, childBus, ref, soID, state); err != nil {
+			if err := a.startSOSync(syncCtx, childBus, sessionTransport.GetPeerID(), ref, soID, state); err != nil {
 				if syncCtx.Err() != nil {
 					return syncCtx.Err()
 				}
@@ -664,7 +664,14 @@ func (a *ProviderAccount) stopP2PSyncState(state *p2pSyncState) {
 }
 
 // startSOSync mounts the shared object and starts an SOSync instance for it.
-func (a *ProviderAccount) startSOSync(ctx context.Context, childBus bus.Bus, ref *sobject.SharedObjectRef, soID string, state *p2pSyncState) error {
+func (a *ProviderAccount) startSOSync(
+	ctx context.Context,
+	childBus bus.Bus,
+	localPeerID peer.ID,
+	ref *sobject.SharedObjectRef,
+	soID string,
+	state *p2pSyncState,
+) error {
 	// Mount the SO to ensure the tracker is initialized with the ref.
 	// This is necessary when StartP2PSync is called from auto-start
 	// (before any UI-driven mount).
@@ -674,7 +681,7 @@ func (a *ProviderAccount) startSOSync(ctx context.Context, childBus bus.Bus, ref
 	}
 
 	localSO := so.(*SharedObject)
-	soSync := sobject_sync.NewSOSync(a.le, childBus, soID, localSO.soHost)
+	soSync := sobject_sync.NewSOSync(a.le, childBus, soID, localPeerID, localSO.soHost)
 	state.addWorker()
 	go func() {
 		defer state.workerDone()

--- a/core/provider/spacewave/p2p-sync.go
+++ b/core/provider/spacewave/p2p-sync.go
@@ -130,7 +130,7 @@ func (a *ProviderAccount) startP2PSyncForSession(
 				a.le.WithError(err).WithField("bucket-id", bucketID).Warn("failed to start dex solicit")
 			}
 
-			if err := a.startSOSync(syncCtx, childBus, ref, soID, state); err != nil {
+			if err := a.startSOSync(syncCtx, childBus, sessionTransport.GetPeerID(), ref, soID, state); err != nil {
 				a.le.WithError(err).WithField("so-id", soID).Warn("failed to start so sync")
 			}
 		}
@@ -167,8 +167,8 @@ func (a *ProviderAccount) stopP2PSyncForSession(sessionID string) {
 func (a *ProviderAccount) startSOSync(
 	ctx context.Context,
 	childBus bus.Bus,
+	localPeerID peer.ID,
 	ref *sobject.SharedObjectRef,
-
 	soID string,
 	state *p2pSyncState,
 ) error {
@@ -183,7 +183,7 @@ func (a *ProviderAccount) startSOSync(
 		return errors.New("unexpected session shared object type")
 	}
 
-	soSync := sobject_sync.NewSOSync(a.le, childBus, soID, swSO.GetSOHost())
+	soSync := sobject_sync.NewSOSync(a.le, childBus, soID, localPeerID, swSO.GetSOHost())
 	state.wg.Go(func() {
 		defer relSO.Release()
 		if err := soSync.Execute(ctx); err != nil && ctx.Err() == nil {

--- a/core/sobject/sync/sync-gate_test.go
+++ b/core/sobject/sync/sync-gate_test.go
@@ -1,0 +1,339 @@
+package sobject_sync
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/aperturerobotics/util/ccontainer"
+	ulid "github.com/aperturerobotics/util/ulid"
+	"github.com/s4wave/spacewave/core/sobject"
+	block_transform "github.com/s4wave/spacewave/db/block/transform"
+	transform_blockenc "github.com/s4wave/spacewave/db/block/transform/blockenc"
+	"github.com/s4wave/spacewave/db/util/blockenc"
+	"github.com/s4wave/spacewave/net/crypto"
+	"github.com/s4wave/spacewave/net/peer"
+	stream_packet "github.com/s4wave/spacewave/net/stream/packet"
+	"github.com/sirupsen/logrus"
+)
+
+// gateLogger returns a logger that discards output.
+func gateLogger() *logrus.Entry {
+	log := logrus.New()
+	log.SetOutput(io.Discard)
+	return logrus.NewEntry(log)
+}
+
+// newMemHost builds an SOHost backed by an in-memory state container.
+func newMemHost(soID string, initial *sobject.SOState) (*sobject.SOHost, *ccontainer.CContainer[*sobject.SOState]) {
+	if initial == nil {
+		initial = &sobject.SOState{}
+	}
+	ctr := ccontainer.NewCContainerVT[*sobject.SOState](initial)
+	watchFn := func(_ context.Context, _ string, _ func()) (ccontainer.Watchable[*sobject.SOState], func(), error) {
+		return ctr, func() {}, nil
+	}
+	lockFn := func(_ context.Context, _ string) (sobject.SOStateLock, error) {
+		return sobject.NewSOStateLock(ctr.GetValue(), func(_ context.Context, s *sobject.SOState) error {
+			ctr.SetValue(s)
+			return nil
+		}, func() {}), nil
+	}
+	return sobject.NewSOHost(context.Background(), watchFn, lockFn, soID), ctr
+}
+
+func mustKeyPair(t *testing.T) crypto.PrivKey {
+	t.Helper()
+	priv, _, err := crypto.GenerateKeyPair(crypto.KeyType_Ed25519, 0)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	return priv
+}
+
+func mustPeerIDStr(t *testing.T, priv crypto.PrivKey) string {
+	t.Helper()
+	id, err := peer.IDFromPrivateKey(priv)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	return id.String()
+}
+
+func participantCfg(peerIDStr string, role sobject.SOParticipantRole) *sobject.SOParticipantConfig {
+	return &sobject.SOParticipantConfig{PeerId: peerIDStr, Role: role}
+}
+
+// pipeSessions builds a paired send/receive packet session.
+func pipeSessions(t *testing.T) (local *stream_packet.Session, remote *stream_packet.Session) {
+	t.Helper()
+	left, right := net.Pipe()
+	t.Cleanup(func() {
+		left.Close()
+		right.Close()
+	})
+	return stream_packet.NewSession(left, maxMessageSize), stream_packet.NewSession(right, maxMessageSize)
+}
+
+// buildGrant constructs a valid transform grant from the owner to the local peer.
+func buildGrant(t *testing.T, soID string, ownerPriv crypto.PrivKey, localPub crypto.PubKey) *sobject.SOGrant {
+	t.Helper()
+	grant, err := sobject.EncryptSOGrant(ownerPriv, localPub, soID, &sobject.SOGrantInner{
+		TransformConf: &block_transform.Config{
+			Steps: []*block_transform.StepConfig{{
+				Id: transform_blockenc.ConfigID,
+				Config: func() []byte {
+					cfg := &transform_blockenc.Config{
+						BlockEnc: blockenc.BlockEnc_BlockEnc_XCHACHA20_POLY1305,
+						Key:      []byte("0123456789abcdef0123456789abcdef"),
+					}
+					data, err := cfg.MarshalVT()
+					if err != nil {
+						t.Fatal(err.Error())
+					}
+					return data
+				}(),
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("EncryptSOGrant: %v", err)
+	}
+	return grant
+}
+
+// runSnapshotExchange drives exchangeSnapshots with the peer snapshot as the
+// remote side and returns any error from the local side.
+func runSnapshotExchange(t *testing.T, s *SOSync, ctx context.Context, peerSnap *SOSyncMessage) error {
+	t.Helper()
+	localSess, remoteSess := pipeSessions(t)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.exchangeSnapshots(ctx, gateLogger(), localSess)
+	}()
+
+	// The local side sends its snapshot first; consume it.
+	in := &SOSyncMessage{}
+	if err := remoteSess.RecvMsg(in); err != nil {
+		t.Fatalf("remote recv local snapshot: %v", err)
+	}
+	if err := remoteSess.SendMsg(peerSnap); err != nil {
+		t.Fatalf("remote send snapshot: %v", err)
+	}
+	return <-errCh
+}
+
+func TestSnapshotExchangeRejectsExcludedLocalPeer(t *testing.T) {
+	ctx := context.Background()
+	soID := "gate-object"
+	localPriv := mustKeyPair(t)
+	localPeerStr := mustPeerIDStr(t, localPriv)
+	ownerPriv := mustKeyPair(t)
+	ownerPeerStr := mustPeerIDStr(t, ownerPriv)
+
+	localHost, ctr := newMemHost(soID, &sobject.SOState{
+		Config: &sobject.SharedObjectConfig{},
+		Root:   &sobject.SORoot{InnerSeqno: 1},
+	})
+	s := NewSOSync(gateLogger(), nil, soID, peer.ID(localPeerStr), localHost)
+
+	peerState := &sobject.SOState{
+		Config: &sobject.SharedObjectConfig{
+			Participants: []*sobject.SOParticipantConfig{participantCfg(ownerPeerStr, sobject.SOParticipantRole_SOParticipantRole_OWNER)},
+		},
+		Root: &sobject.SORoot{InnerSeqno: 5},
+	}
+	snapData, err := peerState.MarshalVT()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	err = runSnapshotExchange(t, s, ctx, &SOSyncMessage{
+		Body: &SOSyncMessage_Snapshot{Snapshot: &SOSyncSnapshot{SoState: snapData, RootSeqno: 5}},
+	})
+	if err == nil {
+		t.Fatal("expected snapshot from config excluding the local peer to be rejected")
+	}
+	if got := ctr.GetValue().GetRoot().GetInnerSeqno(); got != 1 {
+		t.Fatalf("local state advanced to seqno %d; expected rejection to keep seqno 1", got)
+	}
+}
+
+func TestSnapshotExchangeRejectsTamperedGrant(t *testing.T) {
+	ctx := context.Background()
+	soID := "gate-object-grant"
+	localPriv, localPub, err := crypto.GenerateKeyPair(crypto.KeyType_Ed25519, 0)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	localPeer, err := peer.IDFromPrivateKey(localPriv)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	ownerPriv := mustKeyPair(t)
+	ownerPeerStr := mustPeerIDStr(t, ownerPriv)
+
+	localHost, ctr := newMemHost(soID, &sobject.SOState{
+		Config: &sobject.SharedObjectConfig{},
+		Root:   &sobject.SORoot{InnerSeqno: 1},
+	})
+	s := NewSOSync(gateLogger(), nil, soID, localPeer, localHost)
+
+	grant := buildGrant(t, soID, ownerPriv, localPub)
+	grant.InnerData[0] ^= 0xFF
+
+	peerState := &sobject.SOState{
+		Config: &sobject.SharedObjectConfig{
+			Participants: []*sobject.SOParticipantConfig{
+				participantCfg(ownerPeerStr, sobject.SOParticipantRole_SOParticipantRole_OWNER),
+				participantCfg(localPeer.String(), sobject.SOParticipantRole_SOParticipantRole_READER),
+			},
+		},
+		Root:       &sobject.SORoot{InnerSeqno: 5},
+		RootGrants: []*sobject.SOGrant{grant},
+	}
+	snapData, err := peerState.MarshalVT()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	err = runSnapshotExchange(t, s, ctx, &SOSyncMessage{
+		Body: &SOSyncMessage_Snapshot{Snapshot: &SOSyncSnapshot{SoState: snapData, RootSeqno: 5}},
+	})
+	if err == nil {
+		t.Fatal("expected snapshot with tampered root grant to be rejected")
+	}
+	if got := ctr.GetValue().GetRoot().GetInnerSeqno(); got != 1 {
+		t.Fatalf("local state advanced to seqno %d; expected rejection to keep seqno 1", got)
+	}
+}
+
+func TestSnapshotExchangeAcceptsValidatedConvergence(t *testing.T) {
+	ctx := context.Background()
+	soID := "gate-object-valid"
+	localPriv, localPub, err := crypto.GenerateKeyPair(crypto.KeyType_Ed25519, 0)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	localPeer, err := peer.IDFromPrivateKey(localPriv)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	ownerPriv := mustKeyPair(t)
+	ownerPeerStr := mustPeerIDStr(t, ownerPriv)
+
+	localHost, ctr := newMemHost(soID, &sobject.SOState{
+		Config: &sobject.SharedObjectConfig{},
+		Root:   &sobject.SORoot{InnerSeqno: 1},
+	})
+	s := NewSOSync(gateLogger(), nil, soID, localPeer, localHost)
+
+	grant := buildGrant(t, soID, ownerPriv, localPub)
+	peerState := &sobject.SOState{
+		Config: &sobject.SharedObjectConfig{
+			Participants: []*sobject.SOParticipantConfig{
+				participantCfg(ownerPeerStr, sobject.SOParticipantRole_SOParticipantRole_OWNER),
+				participantCfg(localPeer.String(), sobject.SOParticipantRole_SOParticipantRole_READER),
+			},
+		},
+		Root:       &sobject.SORoot{InnerSeqno: 5},
+		RootGrants: []*sobject.SOGrant{grant},
+	}
+	snapData, err := peerState.MarshalVT()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if err := runSnapshotExchange(t, s, ctx, &SOSyncMessage{
+		Body: &SOSyncMessage_Snapshot{Snapshot: &SOSyncSnapshot{SoState: snapData, RootSeqno: 5}},
+	}); err != nil {
+		t.Fatalf("validated snapshot should converge: %v", err)
+	}
+	got := ctr.GetValue()
+	if got.GetRoot().GetInnerSeqno() != 5 {
+		t.Fatalf("expected converged root seqno 5, got %d", got.GetRoot().GetInnerSeqno())
+	}
+	if len(got.GetConfig().GetParticipants()) != 2 {
+		t.Fatalf("expected applied config participants, got %d", len(got.GetConfig().GetParticipants()))
+	}
+}
+
+func TestRemoteOpNonparticipantRejected(t *testing.T) {
+	ctx := context.Background()
+	soID := "gate-object-op"
+	localPriv := mustKeyPair(t)
+	localPeer, err := peer.IDFromPrivateKey(localPriv)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	strangerPriv := mustKeyPair(t)
+
+	ownerPriv := mustKeyPair(t)
+	ownerPeerStr := mustPeerIDStr(t, ownerPriv)
+
+	host, ctr := newMemHost(soID, &sobject.SOState{
+		Config: &sobject.SharedObjectConfig{
+			Participants: []*sobject.SOParticipantConfig{
+				participantCfg(ownerPeerStr, sobject.SOParticipantRole_SOParticipantRole_OWNER),
+				participantCfg(localPeer.String(), sobject.SOParticipantRole_SOParticipantRole_WRITER),
+			},
+		},
+		Root: &sobject.SORoot{InnerSeqno: 1},
+	})
+	s := NewSOSync(gateLogger(), nil, soID, localPeer, host)
+
+	opLocalID := ulid.NewULID()
+	op, err := sobject.BuildSOOperation(soID, strangerPriv, []byte("op-data"), 1, opLocalID)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	s.handleRemoteOp(ctx, gateLogger(), &SOSyncOp{Operation: func() []byte {
+		data, err := op.MarshalVT()
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		return data
+	}()})
+
+	if got := len(ctr.GetValue().GetOps()); got != 0 {
+		t.Fatalf("nonparticipant op was queued (%d ops)", got)
+	}
+}
+
+func TestRemoteOpTamperedSignatureRejected(t *testing.T) {
+	ctx := context.Background()
+	soID := "gate-object-optamper"
+	writerPriv := mustKeyPair(t)
+	writerPeer, err := peer.IDFromPrivateKey(writerPriv)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	host, ctr := newMemHost(soID, &sobject.SOState{
+		Config: &sobject.SharedObjectConfig{
+			Participants: []*sobject.SOParticipantConfig{
+				participantCfg(writerPeer.String(), sobject.SOParticipantRole_SOParticipantRole_WRITER),
+			},
+		},
+		Root: &sobject.SORoot{InnerSeqno: 1},
+	})
+	s := NewSOSync(gateLogger(), nil, soID, writerPeer, host)
+
+	opLocalID := ulid.NewULID()
+	op, err := sobject.BuildSOOperation(soID, writerPriv, []byte("op-data"), 1, opLocalID)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	op.Inner[0] ^= 0xFF
+
+	s.handleRemoteOp(ctx, gateLogger(), &SOSyncOp{Operation: func() []byte {
+		data, err := op.MarshalVT()
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		return data
+	}()})
+
+	if got := len(ctr.GetValue().GetOps()); got != 0 {
+		t.Fatalf("tampered op was queued (%d ops)", got)
+	}
+}

--- a/core/sobject/sync/sync.go
+++ b/core/sobject/sync/sync.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aperturerobotics/controllerbus/bus"
 	"github.com/aperturerobotics/controllerbus/directive"
+	"github.com/pkg/errors"
 	"github.com/s4wave/spacewave/core/sobject"
 	link_solicit "github.com/s4wave/spacewave/net/link/solicit"
 	"github.com/s4wave/spacewave/net/peer"
@@ -24,19 +25,23 @@ const maxMessageSize = 10 * 1024 * 1024
 // over a solicit protocol stream. Each instance syncs one SharedObject
 // with peers connected via the session transport's child bus.
 type SOSync struct {
-	le     *logrus.Entry
-	b      bus.Bus
-	soID   string
-	soHost *sobject.SOHost
+	le          *logrus.Entry
+	b           bus.Bus
+	soID        string
+	localPeerID peer.ID
+	soHost      *sobject.SOHost
 }
 
 // NewSOSync constructs a new SOSync.
-func NewSOSync(le *logrus.Entry, b bus.Bus, soID string, soHost *sobject.SOHost) *SOSync {
+//
+// localPeerID is the local session peer checked against inbound state.
+func NewSOSync(le *logrus.Entry, b bus.Bus, soID string, localPeerID peer.ID, soHost *sobject.SOHost) *SOSync {
 	return &SOSync{
-		le:     le.WithField("so-sync", soID),
-		b:      b,
-		soID:   soID,
-		soHost: soHost,
+		le:          le.WithField("so-sync", soID),
+		b:           b,
+		soID:        soID,
+		localPeerID: localPeerID,
+		soHost:      soHost,
 	}
 }
 
@@ -140,11 +145,18 @@ func (s *SOSync) exchangeSnapshots(ctx context.Context, le *logrus.Entry, sess *
 	// The full state includes config (participants, grants) and root,
 	// which is necessary for paired devices that share the same SO but
 	// may have divergent configs until the first sync.
+	// A matched solicit stream proves routing agreement, never content
+	// trust: validate the snapshot elements before adopting them.
 	if peerSnap.GetRootSeqno() > localSeqno {
 		peerState := &sobject.SOState{}
 		if err := peerState.UnmarshalVT(peerSnap.GetSoState()); err != nil {
 			le.WithError(err).Warn("failed to unmarshal peer snapshot")
 			return err
+		}
+
+		if err := s.validateSnapshotElements(peerState); err != nil {
+			le.WithError(err).Warn("rejected peer snapshot failing element validation")
+			return errors.Wrap(err, "invalid peer snapshot")
 		}
 
 		if err := s.soHost.UpdateSOState(ctx, func(state *sobject.SOState) error {
@@ -154,9 +166,51 @@ func (s *SOSync) exchangeSnapshots(ctx context.Context, le *logrus.Entry, sess *
 			le.WithError(err).Warn("failed to apply peer snapshot")
 			return err
 		}
-		le.Debug("applied peer snapshot with higher seqno")
+		le.Debug("applied validated peer snapshot with higher seqno")
 	}
 
+	return nil
+}
+
+// validateSnapshotElements checks an inbound snapshot before it may replace
+// local shared-object state. The sending peer may have self-authored the
+// received config: nothing here verifies who wrote it or its lineage. The
+// checks only require the local session peer to keep readable membership in
+// the resulting config, and the grants and ops carried in the snapshot to
+// carry internally valid signatures against that untrusted config.
+//
+// Full config-head authorization requires VerifyConfigChain over the
+// sender's SOConfigChange entries. Neither SOSyncMessage nor any p2p-side
+// store carries those entries today; closing that chain-lineage gap is a
+// separate prerequisite.
+func (s *SOSync) validateSnapshotElements(peerState *sobject.SOState) error {
+	cfg := peerState.GetConfig()
+	if cfg == nil || len(cfg.GetParticipants()) == 0 {
+		return errors.New("snapshot has no participants")
+	}
+
+	localPeerIDStr := s.localPeerID.String()
+	var localParticipant bool
+	for _, p := range cfg.GetParticipants() {
+		if p.GetPeerId() == localPeerIDStr && sobject.CanReadState(p.GetRole()) {
+			localParticipant = true
+			break
+		}
+	}
+	if !localParticipant {
+		return errors.Errorf("local peer %s is not a participant of the snapshot config", localPeerIDStr)
+	}
+
+	for _, g := range peerState.GetRootGrants() {
+		if err := g.ValidateSignature(s.soID, cfg.GetParticipants()); err != nil {
+			return errors.Wrap(err, "root grant")
+		}
+	}
+	for _, op := range peerState.GetOps() {
+		if err := op.ValidateSignature(s.soID, cfg.GetParticipants()); err != nil {
+			return errors.Wrap(err, "queued op")
+		}
+	}
 	return nil
 }
 
@@ -256,6 +310,20 @@ func (s *SOSync) handleRemoteOp(ctx context.Context, le *logrus.Entry, syncOp *S
 	peerID, err := peer.IDB58Decode(peerIDStr)
 	if err != nil {
 		le.WithError(err).Warn("invalid peer id in remote op")
+		return
+	}
+
+	// Verify the op signer against the current local participants before
+	// queueing. SOState.QueueOperation re-validates under the state lock;
+	// this check surfaces rejection of unauthorized ops at warn level.
+	localState, err := s.soHost.GetHostState(ctx)
+	if err != nil {
+		le.WithError(err).Warn("failed to load local state for op authorization")
+		return
+	}
+	if err := op.ValidateSignature(s.soID, localState.GetConfig().GetParticipants()); err != nil {
+		le.WithError(err).WithField("op-peer", peerIDStr).
+			Warn("rejected unauthorized remote op")
 		return
 	}
 

--- a/core/sobject/sync/sync_test.go
+++ b/core/sobject/sync/sync_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"testing"
 
+	"github.com/s4wave/spacewave/net/peer"
 	"github.com/sirupsen/logrus"
 )
 
@@ -168,8 +169,11 @@ func TestSyncProtocolID(t *testing.T) {
 func TestNewSOSync(t *testing.T) {
 	le := logrus.NewEntry(logrus.New())
 	le.Logger.SetOutput(io.Discard)
-	s := NewSOSync(le, nil, "test-so-id", nil)
+	s := NewSOSync(le, nil, "test-so-id", peer.ID("test-peer"), nil)
 	if s.soID != "test-so-id" {
 		t.Errorf("expected test-so-id, got %s", s.soID)
+	}
+	if s.localPeerID != peer.ID("test-peer") {
+		t.Errorf("expected test-peer local peer id, got %s", s.localPeerID)
 	}
 }


### PR DESCRIPTION
A matched solicit stream proves routing agreement between two peers, never content trust. `exchangeSnapshots` adopted a peer's full `SOState` wholesale whenever its root seqno was higher, so any peer that matched the solicitation could replace local shared-object state with an unverified config, grants, and ops.

This change validates inbound snapshot elements before the higher-seqno adoption rule: the resulting config must keep the local session peer as a readable participant, and every root grant and queued op carried in the snapshot must hold a signature that validates against that config's participants. A failing snapshot closes the stream. Remote ops now verify the signer against the current local participants at the sync layer before queueing; `SOState.QueueOperation` already re-validates under the state lock, so this surfaces rejection at warn level instead of a debug-level swallow.

Scope note: this is defense in depth against misdirected or corrupted state. It does **not** verify config authorship or lineage. The sending peer may have self-authored the received config; nothing here verifies who wrote it. Full config-head verification requires `VerifyConfigChain` over the sender's `SOConfigChange` entries, which neither `SOSyncMessage` nor any p2p-side store carries today; closing that chain-lineage gap is a separate prerequisite.

Tests: two snapshot rejections fail against the ungated code and pass after (excluded local peer, tampered root grant); one convergence test pins that legitimate higher-seqno adoption still works; two op tests pin the existing host-level signature enforcement through the sync path.
