### PR TITLE
refactor(world): drop dead cached Cayley handle variant

### DIFF
--- a/db/world/graph-util.go
+++ b/db/world/graph-util.go
@@ -224,28 +224,21 @@ func iterateQuadResults(ctx context.Context, h CayleyHandle, it iterator.Scanner
 	}
 }
 
-// NewCachedCayleyHandle wraps a Cayley handle with per-operation read caches.
-func NewCachedCayleyHandle(h CayleyHandle) CayleyHandle {
-	return newCachedCayleyHandle(h, true)
-}
-
 // NewReadOperationCayleyHandle wraps a Cayley handle for a batched read operation.
+//
+// The returned handle caches ValueOf, NameOf, QuadIteratorSize, and
+// QuadDirection results for one read operation. It does not cache resolved
+// quad refs; batch reads resolve each quad ref at most once, so caching them
+// only costs memory.
 func NewReadOperationCayleyHandle(h CayleyHandle) CayleyHandle {
-	return newCachedCayleyHandle(h, false)
-}
-
-func newCachedCayleyHandle(h CayleyHandle, cacheQuadRefs bool) CayleyHandle {
 	return &cachedCayleyHandle{
 		CayleyHandle:        h,
-		cacheQuadRefs:       cacheQuadRefs,
 		valueRefs:           make(map[string]graph.Ref),
 		valueRefFound:       make(map[string]bool),
 		names:               make(map[any]quad.Value),
 		nameFound:           make(map[any]bool),
 		quadIteratorSizes:   make(map[quadIteratorSizeKey]refs.Size),
 		quadIteratorErrors:  make(map[quadIteratorSizeKey]error),
-		quads:               make(map[any]quad.Quad),
-		quadErrors:          make(map[any]error),
 		quadDirections:      make(map[quadDirectionKey]graph.Ref),
 		quadDirectionErrors: make(map[quadDirectionKey]error),
 	}
@@ -254,15 +247,12 @@ func newCachedCayleyHandle(h CayleyHandle, cacheQuadRefs bool) CayleyHandle {
 type cachedCayleyHandle struct {
 	CayleyHandle
 
-	cacheQuadRefs       bool
 	valueRefs           map[string]graph.Ref
 	valueRefFound       map[string]bool
 	names               map[any]quad.Value
 	nameFound           map[any]bool
 	quadIteratorSizes   map[quadIteratorSizeKey]refs.Size
 	quadIteratorErrors  map[quadIteratorSizeKey]error
-	quads               map[any]quad.Quad
-	quadErrors          map[any]error
 	quadDirections      map[quadDirectionKey]graph.Ref
 	quadDirectionErrors map[quadDirectionKey]error
 }
@@ -329,49 +319,17 @@ func (h *cachedCayleyHandle) Quad(ctx context.Context, ref graph.Ref) (quad.Quad
 	if err := ctx.Err(); err != nil {
 		return quad.Quad{}, err
 	}
-	if !h.cacheQuadRefs {
-		q, ok, err := h.quadFromDirectionsUncached(ctx, ref)
-		if err == nil && !ok {
-			q, err = h.CayleyHandle.Quad(ctx, ref)
-		}
-		return q, err
-	}
-	key := graphRefCacheKey(ref)
-	if q, ok := h.quads[key]; ok {
-		return q, h.quadErrors[key]
-	}
 	q, ok, err := h.quadFromDirections(ctx, ref)
 	if err == nil && !ok {
 		q, err = h.CayleyHandle.Quad(ctx, ref)
 	}
-	h.quads[key] = q
-	h.quadErrors[key] = err
 	return q, err
 }
 
+// quadFromDirections resolves a quad ref through its four directions.
+// Direction refs are resolved on every Quad call; NameOf remains cached
+// within the read operation.
 func (h *cachedCayleyHandle) quadFromDirections(ctx context.Context, ref graph.Ref) (quad.Quad, bool, error) {
-	var q quad.Quad
-	for _, dir := range quad.Directions {
-		dirRef, err := h.QuadDirection(ctx, ref, dir)
-		if err != nil {
-			return q, false, err
-		}
-		if dirRef == nil {
-			if dir == quad.Label {
-				continue
-			}
-			return q, false, nil
-		}
-		val, err := h.NameOf(ctx, dirRef)
-		if err != nil {
-			return q, false, err
-		}
-		q.Set(dir, val)
-	}
-	return q, true, nil
-}
-
-func (h *cachedCayleyHandle) quadFromDirectionsUncached(ctx context.Context, ref graph.Ref) (quad.Quad, bool, error) {
 	var q quad.Quad
 	for _, dir := range quad.Directions {
 		dirRef, err := h.CayleyHandle.QuadDirection(ctx, ref, dir)

--- a/db/world/graph-util_test.go
+++ b/db/world/graph-util_test.go
@@ -30,63 +30,6 @@ func TestQuadFilterIteratorDirectionsPreferEndpointIndexes(t *testing.T) {
 	}
 }
 
-func TestCachedCayleyHandleCachesReadOperations(t *testing.T) {
-	ctx := context.Background()
-	fake := &cachedCayleyHandleTestStore{
-		valueRef: testGraphRef("value-ref"),
-		quadRef:  testGraphRef("quad-ref"),
-	}
-	handle := NewCachedCayleyHandle(fake)
-	value := quad.IRI("<rel>")
-
-	for range 2 {
-		ref, err := handle.ValueOf(ctx, value)
-		if err != nil {
-			t.Fatal(err.Error())
-		}
-		if ref.Key() != fake.valueRef.Key() {
-			t.Fatalf("value ref = %v, want %v", ref.Key(), fake.valueRef.Key())
-		}
-		size, err := handle.QuadIteratorSize(ctx, quad.Predicate, ref)
-		if err != nil {
-			t.Fatal(err.Error())
-		}
-		if size.Value != 7 {
-			t.Fatalf("size = %d, want 7", size.Value)
-		}
-		q, err := handle.Quad(ctx, fake.quadRef)
-		if err != nil {
-			t.Fatal(err.Error())
-		}
-		if q.Predicate.String() != value.String() {
-			t.Fatalf("quad predicate = %s, want %s", q.Predicate.String(), value.String())
-		}
-		dirRef, err := handle.QuadDirection(ctx, fake.quadRef, quad.Predicate)
-		if err != nil {
-			t.Fatal(err.Error())
-		}
-		if dirRef.Key() != fake.valueRef.Key() {
-			t.Fatalf("direction ref = %v, want %v", dirRef.Key(), fake.valueRef.Key())
-		}
-	}
-
-	if fake.valueOfCalls != 1 {
-		t.Fatalf("ValueOf calls = %d, want 1", fake.valueOfCalls)
-	}
-	if fake.sizeCalls != 1 {
-		t.Fatalf("QuadIteratorSize calls = %d, want 1", fake.sizeCalls)
-	}
-	if fake.nameOfCalls != 1 {
-		t.Fatalf("NameOf calls = %d, want 1", fake.nameOfCalls)
-	}
-	if fake.quadCalls != 0 {
-		t.Fatalf("Quad calls = %d, want 0", fake.quadCalls)
-	}
-	if fake.directionCalls != 4 {
-		t.Fatalf("QuadDirection calls = %d, want 4", fake.directionCalls)
-	}
-}
-
 func TestReadOperationCayleyHandleSkipsQuadRefCaches(t *testing.T) {
 	ctx := context.Background()
 	fake := &cachedCayleyHandleTestStore{


### PR DESCRIPTION
The World Graph read path caches Cayley read operations for the lifetime of one read operation through `NewReadOperationCayleyHandle`. A second constructor, `NewCachedCayleyHandle`, cached resolved quad refs for the lifetime of the handle and had no callers outside its own test. Batch reads resolve each quad ref at most once per read operation, so caching them only costs memory; the production batch path already skipped that cache.

This change deletes the dead constructor, its cacheQuadRefs switch, and the unbounded quads maps. NewReadOperationCayleyHandle becomes the only cached-handle constructor, so a future caller cannot pick residency for the handle's lifetime by name. Behavior of every production call site is unchanged; db/world/block/world-graph.go is not touched.

Removing an unused exported symbol is intentional under the project's pre-release no-compatibility policy; no deprecated stub is added.