### PR TITLE
feat(bldr): collect durable startup boot reports

### DIFF
--- a/bldr/dist.go
+++ b/bldr/dist.go
@@ -18,6 +18,7 @@ import (
 //
 //go:embed web/bldr-react/*.ts web/bldr-react/*.tsx
 //go:embed web/bldr/*.ts web/bldr/*.tsx
+//go:embed web/boot/*.ts
 //go:embed web/devtool-status/*.tsx web/devtool-status/*.css
 //go:embed web/wasi-shim/*.ts
 //go:embed web/document/*.ts web/view/*.ts web/view/handler/*.ts

--- a/bldr/web/bldr/startup-marks.ts
+++ b/bldr/web/bldr/startup-marks.ts
@@ -24,6 +24,7 @@ declare global {
       }>
     | undefined
   var __swStartupMarkSequence: number | undefined
+  var __swStartupMarkOverflows: number | undefined
 }
 
 let nextStartupMarkSequence = 1
@@ -34,11 +35,27 @@ function getPerformance(): Performance | undefined {
     : undefined
 }
 
+// startupMarkBufferLimit bounds the document-global mark store. The inline
+// shell seeds the first mark and shares this bound; appends past the limit
+// increment __swStartupMarkOverflows instead of pushing, and the BootReport
+// collector turns that count into a persisted validation failure.
+export const startupMarkBufferLimit = 4096
+
 function nextSequence(): number {
-  const next = globalThis.__swStartupMarkSequence ?? nextStartupMarkSequence
-  globalThis.__swStartupMarkSequence = next + 1
-  nextStartupMarkSequence = next + 1
-  return next
+  if (globalThis.__swStartupMarkSequence !== undefined) {
+    const seeded = globalThis.__swStartupMarkSequence
+    globalThis.__swStartupMarkSequence = seeded + 1
+    nextStartupMarkSequence = seeded + 1
+    return seeded
+  }
+  // The inline shell's first mark already used sequence 1, so continue
+  // after the last buffered mark instead of restarting at 1.
+  const lastBuffered = globalThis.__swStartupMarks?.at(-1)?.sequence
+  const seeded =
+    lastBuffered !== undefined ? lastBuffered + 1 : nextStartupMarkSequence
+  globalThis.__swStartupMarkSequence = seeded
+  nextStartupMarkSequence = seeded + 1
+  return seeded
 }
 
 export function markStartupBoundary(
@@ -52,10 +69,6 @@ export function markStartupBoundary(
     label,
     sequence,
   }
-  globalThis.__swStartupMarks = [
-    ...(globalThis.__swStartupMarks ?? []),
-    { name, label, sequence, detail: markDetail },
-  ]
   const perf = getPerformance()
   if (perf) {
     try {
@@ -63,6 +76,20 @@ export function markStartupBoundary(
     } catch {
       perf.mark(name)
     }
+  }
+  const bufferedMarks =
+    globalThis.__swStartupMarks ??
+    (globalThis.__swStartupMarks = [])
+  if (bufferedMarks.length >= startupMarkBufferLimit) {
+    globalThis.__swStartupMarkOverflows =
+      (globalThis.__swStartupMarkOverflows ?? 0) + 1
+  } else {
+    bufferedMarks.push({
+      name,
+      label,
+      sequence,
+      detail: markDetail,
+    })
   }
   if (
     typeof globalThis.dispatchEvent === 'function' &&

--- a/bldr/web/boot/bootreport.e2e.test.ts
+++ b/bldr/web/boot/bootreport.e2e.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { BootReport, BootReportState } from './report.pb.js'
+import { initBootReportCollector } from './collector.js'
+import { openBootReportStore } from './store.js'
+
+// These specs run in the real browser project against Chromium's native
+// IndexedDB and Web Locks APIs. They prove the two behaviors unit doubles
+// cannot fully exercise: cross-store boot-lock contention and persistence of
+// a boot that seals before the durable store finishes opening.
+
+type BootReportStoreHandle = Awaited<ReturnType<typeof openBootReportStore>>
+
+function uniqueReportId(): string {
+  return `boot-report-e2e-${crypto.randomUUID().replaceAll('-', '')}`
+}
+
+function recordingReport(reportId: string): BootReport {
+  return BootReport.create({
+    schemaVersion: 1,
+    reportId,
+    startedUnixMicros: BigInt(Date.now()) * 1000n,
+    entrypointId: 'drive',
+    usableMark: 'boot-status.app',
+    state: BootReportState.RECORDING,
+  })
+}
+
+// releaseAll seals every tracked holder so each acquired Web Lock resolves
+// its hold callback even when an assertion failed mid-test; IndexedDB record
+// deletion alone cannot release a lock.
+async function releaseAll(
+  holders: BootReportStoreHandle[],
+  reportId: string,
+): Promise<void> {
+  for (const store of holders) {
+    await store
+      .sealReport(recordingReport(reportId), BootReportState.ABORTED)
+      .catch(() => undefined)
+    await store.delete(reportId).catch(() => undefined)
+  }
+}
+
+describe('BootReport durability in a real browser', () => {
+  it('resolves two-store boot-lock contention through native Web Locks', async () => {
+    const reportId = uniqueReportId()
+    const holders: BootReportStoreHandle[] = []
+    try {
+      const first = await openBootReportStore()
+      await expect(first.holdBootLock(reportId)).resolves.toBe(true)
+      holders.push(first)
+
+      // A second store must learn denial from the manager itself, never
+      // from an optimistic synchronous read.
+      const second = await openBootReportStore()
+      await expect(second.holdBootLock(reportId)).resolves.toBe(false)
+
+      // sealReport releases the hold after the terminal commit so a later
+      // store can acquire the same report's lock.
+      await first.sealReport(recordingReport(reportId), BootReportState.READY)
+      holders.pop()
+      const third = await openBootReportStore()
+      await expect(third.holdBootLock(reportId)).resolves.toBe(true)
+      holders.push(third)
+    } finally {
+      await releaseAll(holders, reportId)
+    }
+  })
+
+  it('persists a fast-sealed READY boot through the lazy durable attach', async () => {
+    const globals = globalThis as {
+      __swStartupMarks?: unknown[]
+      __swBootReport?: BootReport
+    }
+    // The inline buffer already holds the usable mark, so the collector
+    // seals during construction - before the lazy store open can finish.
+    globals.__swStartupMarks = [
+      {
+        name: 'spacewave.startup.boot.started',
+        label: 'boot.started',
+        sequence: 1,
+        detail: { source: 'browser' },
+      },
+      {
+        name: 'spacewave.startup.boot-status.app',
+        label: 'boot-status.app',
+        sequence: 2,
+        detail: {},
+      },
+    ]
+    let collector: { stop(): void } | undefined
+    try {
+      collector = initBootReportCollector({
+        entrypointId: 'drive',
+        usableMark: 'boot-status.app',
+      })
+      expect(collector?.isSealed()).toBe(true)
+      const reportId = globals.__swBootReport?.reportId ?? ''
+      expect(reportId).toMatch(/^boot-report-/)
+
+      const store = await openBootReportStore()
+      await vi.waitFor(async () => {
+        const stored = await store.get(reportId)
+        expect(stored?.state).toBe(BootReportState.READY)
+      })
+      await store.delete(reportId)
+    } finally {
+      collector?.stop()
+      delete globals.__swStartupMarks
+      delete globals.__swBootReport
+    }
+  })
+})

--- a/bldr/web/boot/bootreport.e2e.test.ts
+++ b/bldr/web/boot/bootreport.e2e.test.ts
@@ -88,7 +88,7 @@ describe('BootReport durability in a real browser', () => {
         detail: {},
       },
     ]
-    let collector: { stop(): void } | undefined
+    let collector: ReturnType<typeof initBootReportCollector>
     try {
       collector = initBootReportCollector({
         entrypointId: 'drive',

--- a/bldr/web/boot/collector.test.ts
+++ b/bldr/web/boot/collector.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import React, { type ReactNode } from 'react'
+
+const initBootReportCollectorMock = vi.hoisted(() =>
+  vi.fn(() => ({ start: () => {}, stop: () => {}, seal: () => ({}) })),
+)
+const createRootMock = vi.hoisted(() =>
+  vi.fn(() => ({
+    render: vi.fn(),
+    unmount: vi.fn(),
+  })),
+)
+const hydrateRootMock = vi.hoisted(() =>
+  vi.fn(() => ({ render: vi.fn(), unmount: vi.fn() })),
+)
+
+// The collector does not exist yet at the red-confirmed gate. Mocking its
+// module keeps this wiring test focused on the entrypoint contract: bootstrap
+// installs exactly one BootReport collector per document.
+vi.mock('./collector.js', () => ({
+  initBootReportCollector: initBootReportCollectorMock,
+}))
+
+vi.mock('react-dom/client', () => ({
+  createRoot: createRootMock,
+  hydrateRoot: hydrateRootMock,
+}))
+
+vi.mock('@aptre/bldr-react', () => ({
+  BldrRoot: ({ children }: { children?: ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+  WebViewErrorBoundary: ({ children }: { children?: ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}))
+
+vi.mock('@aptre/bldr', () => ({
+  isDesktop: false,
+  WebDocument: class {
+    waitConn() {
+      return Promise.resolve(true)
+    }
+  },
+}))
+
+vi.mock('../bldr/browser-release-update.js', () => ({
+  initBrowserReleaseAutoReload: vi.fn(),
+}))
+
+vi.mock('../bldr/startup-marks.js', () => ({
+  markStartupBoundary: vi.fn(),
+}))
+
+vi.mock('../entrypoint/app-path.js', () => ({
+  setAppPath: vi.fn(),
+}))
+
+vi.mock('../entrypoint/boot-status.js', () => ({
+  bindBrowserBootStatusToStartupMarks: vi.fn(),
+  writeBrowserBootStatus: vi.fn(),
+}))
+
+describe('entrypoint BootReport collector wiring', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    initBootReportCollectorMock.mockClear()
+    document.body.innerHTML = '<div id="bldr-root"></div>'
+    window.history.replaceState({}, '', '/')
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    window.history.replaceState({}, '', '/')
+  })
+
+  it('installs the boot report collector at bootstrap', async () => {
+    await import('../entrypoint/entrypoint.js')
+
+    expect(
+      initBootReportCollectorMock.mock.calls.length,
+      'missing BootReport durability behavior (no collector installed in ' +
+        'entrypoint): bldr/web/entrypoint/entrypoint.tsx never installs the ' +
+        'BootReport collector at bootstrap',
+    ).toBe(1)
+  })
+})

--- a/bldr/web/boot/collector.ts
+++ b/bldr/web/boot/collector.ts
@@ -1,0 +1,537 @@
+import {
+  BootAccounting,
+  BootBuild,
+  BootValidationViolationKind,
+  BootBuildType,
+  BootEnvironment,
+  BootEnvironmentClass,
+  BootCacheState,
+  BootPrivacy,
+  BootRecoveryDecision,
+  BootReport,
+  BootReportState,
+  BootRuntimeKind,
+  BootServiceWorkerState,
+  BootWorkerMode,
+} from './report.pb.js'
+import type {
+  BootValidationViolation,
+} from './report.pb.js'
+import { validateBootReport } from './validator.js'
+import { bootMarkErrorCodes, bootMarkLabels, bootMarkPhases } from './vocabulary.js'
+
+// The collector composes the browser's existing startup-mark stream into one
+// durable BootReport using the frozen validator contract. It installs at
+// entrypoint-bundle evaluation, replays the inline shell's earlier marks, then
+// journals live marks through the BootReportStore until the entrypoint's
+// declared usable mark seals the report READY or a failure mark seals it
+// FAILED.
+
+export const bootReportGlobalKey = '__swBootReport'
+
+// BootReportStoreLike is the persistence surface the collector needs. The
+// durable implementation comes from store.ts; tests may pass a double.
+export interface BootReportStoreLike {
+  recoverOnStartup(): Promise<void>
+  put(report: BootReport): Promise<unknown>
+  // HoldBootLock resolves true only after the Web Locks grant, so attachStore
+  // awaits it before journaling a recording boot.
+  holdBootLock?(reportId: string): Promise<boolean>
+  sealReport?(
+    report: BootReport,
+    state: BootReportState,
+    terminalErrorCode?: string,
+  ): Promise<unknown>
+  applyRetention?(): Promise<unknown>
+}
+
+export interface BootReportCollectorOptions {
+  // EntrypointId is the public entrypoint contract name (canvas, computers,
+  // drive, forge, or space).
+  entrypointId: string
+  // UsableMark is the single mark label that completes this entrypoint's
+  // startup. The first occurrence seals the report READY.
+  usableMark: string
+  // Commit is the public source commit when available.
+  commit?: string
+  // ReleaseGeneration is the immutable public release generation when known.
+  releaseGeneration?: string
+}
+
+export interface BootReportCollectorDeps {
+  // Store persists recording journals and sealed reports. When omitted, the
+  // collector stays memory-only and opens the real store lazily in a browser
+  // that provides IndexedDB.
+  store?: BootReportStoreLike
+}
+
+// Optional persistence extensions live on the durable store only; memory
+// doubles in tests omit them.
+
+interface StartupMarkRecord {
+  name: string
+  label: string
+  sequence: number
+  detail: Record<string, unknown>
+}
+
+type CollectorGlobals = typeof globalThis & {
+  __swStartupMarks?: StartupMarkRecord[]
+  __swStartupMarkOverflows?: number
+  __swBootReport?: BootReport
+  __swGenerationId?: string
+  performance: Performance
+}
+
+// This module is one instance per document per bundle evaluation. A hot
+// module replacement would create a second module instance, but the collector
+// remains a single document-global owner through liveCollector and the
+// __swBootReport seam; no second global owner exists or is added.
+
+
+// readReleaseGeneration returns the validator-compatible release-generation
+// identifier from the inline shell's loaded browser-release manifest. Asset
+// path characters outside the report vocabulary are folded to hyphens so the
+// value stays a stable coarse identity.
+function readReleaseGeneration(globals: CollectorGlobals): string {
+  const raw = globals.__swGenerationId ?? ''
+  const folded = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  return /^[a-z]/.test(folded) ? folded.slice(0, 128) : 'unknown'
+}
+
+// randomBootReportId returns a device-local report id that satisfies the
+// validator's `boot-report-` identity contract without any account meaning.
+function randomBootReportId(): string {
+  const random =
+    globalThis.crypto?.randomUUID?.().replaceAll('-', '') ??
+    Math.random().toString(16).slice(2).padEnd(12, '0')
+  return `boot-report-${random}`
+}
+
+// readStartupMonotonicMicros returns the monotonic offset of one startup mark
+// in microseconds relative to the collector origin.
+function readStartupMonotonicMicros(
+  perf: Performance,
+  originMs: number,
+  record: StartupMarkRecord,
+): bigint {
+  let elapsedMs: number | undefined
+  try {
+    const entries = perf.getEntriesByName(record.name)
+    elapsedMs = entries.at(-1)?.startTime
+  } catch {
+    elapsedMs = undefined
+  }
+  if (elapsedMs === undefined) return BigInt(Math.round(perf.now() * 1000))
+  const micros =
+    BigInt(Math.round(elapsedMs * 1000)) - BigInt(Math.round(originMs * 1000))
+  return micros > 0n ? micros : 0n
+}
+
+// detectBrowserEngine reports the lowercase engine name the validator accepts.
+function detectBrowserEngine(): string {
+  const nav = globalThis.navigator
+  if (!nav) return 'chromium'
+  const webkit = /applewebkit/i.test(nav.userAgent)
+  const blink = /chrome|chromium|crios/i.test(nav.userAgent)
+  return webkit && !blink ? 'webkit' : 'chromium'
+}
+
+export class BootReportCollector {
+  private readonly options: BootReportCollectorOptions
+  private readonly globals: CollectorGlobals
+  private deps: BootReportCollectorDeps
+  private readonly perf: Performance
+  private readonly originMs: number
+  private readonly report: BootReport
+  private readonly inlineOverflowMarks: number
+  private sealed = false
+  // leaseHeld gates every durable RECORDING write: without this report's
+  // held boot lease the collector stays memory-only until the terminal seal.
+  private leaseHeld = false
+
+  constructor(
+    options: BootReportCollectorOptions,
+    globals: CollectorGlobals,
+    deps: BootReportCollectorDeps,
+  ) {
+    this.options = options
+    this.globals = globals
+    this.deps = deps
+    this.perf = globals.performance
+    this.originMs = this.perf.now()
+    this.inlineOverflowMarks = Number(globals.__swStartupMarkOverflows ?? 0)
+    if (this.inlineOverflowMarks > 0) {
+      // Overflow is never silent: the exact count is logged here and becomes
+      // a persisted REPORT_CONTRACT validation failure at seal time.
+      console.warn(
+        `bootreport: inline startup-mark buffer overflowed; ` +
+          `${this.inlineOverflowMarks} mark(s) dropped before collection`,
+      )
+    }
+    const nowUnixMicros = BigInt(Date.now()) * 1000n
+    this.report = BootReport.create({
+      schemaVersion: 1,
+      reportId: randomBootReportId(),
+      startedUnixMicros: nowUnixMicros,
+      monotonicOriginUnixMicros:
+        nowUnixMicros - BigInt(Math.round(this.originMs * 1000)),
+      entrypointId: options.entrypointId,
+      usableMark: options.usableMark,
+      state: BootReportState.RECORDING,
+      build: BootBuild.create({
+        commit: options.commit,
+        releaseGeneration:
+          options.releaseGeneration ?? readReleaseGeneration(globals),
+        projectId: 'spacewave',
+        buildType: this.detectBuildType(),
+        runtimeKind: this.detectRuntimeKind(),
+        // The browser runtime defaults to a dedicated worker today.
+        workerMode: BootWorkerMode.DEDICATED,
+      }),
+      environment: BootEnvironment.create({
+        class: this.detectEnvironmentClass(),
+        browserEngine: detectBrowserEngine(),
+        osFamily: this.detectOsFamily(),
+        architecture: 'wasm',
+        serviceWorkerState: BootServiceWorkerState.UNAVAILABLE,
+        cacheState: BootCacheState.COLD,
+        recoveryDecision: BootRecoveryDecision.NONE,
+      }),
+      // Accounting and privacy start empty; counter samples arrive with the
+      // later attribution phases, and local-only capture keeps the v1 export
+      // policy with nothing shared.
+      accounting: BootAccounting.create({}),
+      privacy: BootPrivacy.create({ exportPolicyVersion: 1 }),
+    })
+    this.replayStartupMarks()
+  }
+
+  // start subscribes to the live startup-mark stream, recovers stale boots,
+  // takes this report's recording lease before any durable write, and
+  // publishes the recording report on the document-global diagnostic seam.
+  start(): void {
+    globalThis.addEventListener(
+      'spacewave-startup-mark',
+      this.onStartupMark as EventListener,
+    )
+    void this.takeLeaseAndJournal().catch((cause: unknown) => {
+      console.warn('bootreport: startup recovery failed', cause)
+    })
+    this.publish()
+  }
+
+  // takeLeaseAndJournal orders the durable lifecycle: recover stale boots,
+  // hold this report's lease, then allow durable RECORDING writes. A denied
+  // or unavailable lease leaves no durable RECORDING row; collection keeps
+  // running in memory until the terminal seal.
+  private async takeLeaseAndJournal(): Promise<void> {
+    const store = this.deps.store
+    if (!store) return
+    await store.recoverOnStartup()
+    if (this.deps.store !== store || this.sealed) return
+    if (!store.holdBootLock) return
+    this.leaseHeld = await store.holdBootLock(this.report.reportId ?? '')
+    if (this.leaseHeld) {
+      this.journal()
+    } else {
+      console.warn('bootreport: recording memory-only without a boot lease')
+    }
+  }
+
+  stop(): void {
+    globalThis.removeEventListener(
+      'spacewave-startup-mark',
+      this.onStartupMark as EventListener,
+    )
+  }
+
+  // IsSealed reports whether this collector already wrote its terminal state.
+  isSealed(): boolean {
+    return this.sealed
+  }
+
+  // AttachStore binds persistence after construction so the entrypoint can
+  // install synchronously while the durable store opens asynchronously. The
+  // collector owns exactly one report: on attachment it recovers stale boots,
+  // then either takes its unique Web Lock before the first durable RECORDING
+  // write (memory-only when the lease is denied) or, when this document
+  // already sealed, persists the complete sealed snapshot and applies
+  // retention. A terminal snapshot needs no lease: the report key is a
+  // device-local random id minted once per boot, so the write cannot
+  // overwrite or race a live recorder's row.
+  attachStore(store: BootReportStoreLike): void {
+    if (this.deps.store === store) return
+    this.deps = { ...this.deps, store }
+    void store
+      .recoverOnStartup()
+      .then(async () => {
+        if (this.deps.store !== store) return
+        if (this.sealed) {
+          await store.put({ ...this.report })
+          await store.applyRetention?.()
+          return
+        }
+        if (!store.holdBootLock) return
+        this.leaseHeld = await store.holdBootLock(
+          this.report.reportId ?? '',
+        )
+        if (!this.leaseHeld) {
+          console.warn(
+            'bootreport: recording memory-only without a boot lease',
+          )
+          return
+        }
+        await store.put({ ...this.report })
+        this.journal()
+      })
+      .catch((cause: unknown) => {
+        console.warn('bootreport: durable attach failed', cause)
+      })
+  }
+
+  // journal persists one snapshot of the recording report without blocking
+  // the boot: producers enqueue and never await storage on the critical path.
+  // Durable RECORDING writes require the held lease; without it the report
+  // stays memory-only until seal persists its terminal record.
+  private journal(): void {
+    if (!this.sealed && this.leaseHeld) {
+      void this.deps.store
+        ?.put({ ...this.report })
+        .catch((cause: unknown) => {
+          console.warn('bootreport: journal write failed', cause)
+        })
+    }
+  }
+
+  // seal completes the report, validates it against the frozen contract,
+  // writes the complete sealed record atomically, applies retention after the
+  // seal, and publishes the sealed result. Later marks are ignored after
+  // sealing and repeated seals are no-ops.
+  seal(state: BootReportState, terminalErrorCode?: string): BootReport {
+    if (this.sealed) return this.report
+    this.sealed = true
+    if (liveCollector === this) liveCollector = undefined
+    this.stop()
+    const marks = this.report.marks ?? []
+    const terminal = marks.at(-1)
+    this.report.state = state
+    this.report.terminalMark = terminal?.label
+    this.report.terminalErrorCode = terminalErrorCode
+    this.report.terminalMonotonicMicros = terminal?.monotonicMicros ?? 0n
+    this.report.validation = validateBootReport(this.report)
+    if (this.inlineOverflowMarks > 0) {
+      // Dropped inline marks are a report contract failure, persisted with
+      // the sealed record so overflow can never pass silently.
+      const violation: BootValidationViolation = {
+        kind: BootValidationViolationKind.REPORT_CONTRACT,
+        markSequence: terminal?.sequence ?? 0n,
+      }
+      this.report.validation.pass = false
+      this.report.validation.violations = [
+        ...(this.report.validation.violations ?? []),
+        violation,
+      ]
+    }
+    const sealedCopy: BootReport = { ...this.report }
+    void this.deps.store
+      ?.sealReport?.(sealedCopy, state, terminalErrorCode)
+      .then((sealed) => {
+        this.publish(sealed ?? sealedCopy)
+      })
+      .catch((cause: unknown) => {
+        console.warn('bootreport: seal write failed', cause)
+      })
+    void this.deps.store?.applyRetention?.().catch((cause: unknown) => {
+      console.warn('bootreport: retention failed', cause)
+    })
+    this.publish()
+    return this.report
+  }
+
+  private readonly onStartupMark = (event: Event): void => {
+    if (this.sealed) return
+    const detail = (
+      event as CustomEvent<{ detail: Record<string, unknown> }>
+    ).detail?.detail
+    if (!detail || typeof detail.label !== 'string') return
+    // Live marks share the document-global sequence counter with the inline
+    // shell's earlier marks, so an incoming sequence at or below the last
+    // accepted one is bumped to keep the timeline strictly increasing.
+    const lastSequence = Number((this.report.marks ?? []).at(-1)?.sequence ?? 0n)
+    const sequence = Math.max(Number(detail.sequence ?? 0), lastSequence + 1)
+    const monotonicMicros = BigInt(Math.round(this.perf.now() * 1000)) -
+      BigInt(Math.round(this.originMs * 1000))
+    this.acceptMark(detail.label, sequence, monotonicMicros < 0n ? 0n : monotonicMicros, detail)
+  }
+
+  // replayStartupMarks converts the inline shell's already-emitted marks into
+  // accepted report marks before the live subscription begins, then clears
+  // the inline buffer so a re-install cannot replay it twice.
+  private replayStartupMarks(): void {
+    const records = this.globals.__swStartupMarks ?? []
+    for (const record of records) {
+      const micros = readStartupMonotonicMicros(
+        this.perf,
+        this.originMs,
+        record,
+      )
+      this.acceptMark(record.label, record.sequence, micros, record.detail)
+      if (this.sealed) break
+    }
+    delete this.globals.__swStartupMarks
+  }
+
+  private acceptMark(
+    label: string,
+    sequence: number,
+    monotonicMicros: bigint,
+    detail: Record<string, unknown>,
+  ): void {
+    if (this.sealed) return
+    if (!bootMarkLabels.has(label)) return
+    const marks = this.report.marks ?? []
+    const previous = marks.at(-1)
+    if (previous && BigInt(sequence) <= (previous.sequence ?? 0n)) return
+    const mark = {
+      sequence: BigInt(sequence),
+      label,
+      sourceOwner: this.markOwner(label, detail),
+      monotonicMicros:
+        previous && monotonicMicros < (previous.monotonicMicros ?? 0n)
+          ? previous.monotonicMicros
+          : monotonicMicros,
+      phase: bootMarkPhases.get(label),
+    }
+    marks.push(mark)
+    this.report.marks = marks
+
+    if (label === this.options.usableMark) {
+      this.seal(BootReportState.READY)
+      return
+    }
+    const errorCode = bootMarkErrorCodes.get(label)
+    if (errorCode !== undefined) this.seal(BootReportState.FAILED, errorCode)
+    this.journal()
+  }
+
+  // markOwner maps the emitting producer to the validator's stable owner set.
+  private markOwner(label: string, detail: Record<string, unknown>): string {
+    const source = typeof detail.source === 'string' ? detail.source : ''
+    switch (source) {
+      case 'browser':
+      case 'runtime':
+      case 'scheduler':
+      case 'service-worker':
+      case 'webview':
+      case 'worker':
+        return source
+      default:
+        break
+    }
+    if (label.startsWith('service-worker.')) return 'service-worker'
+    if (label.startsWith('manifest-copy.')) return 'scheduler'
+    if (label.startsWith('webview.')) return 'webview'
+    if (label.startsWith('runtime.')) return 'runtime'
+    if (label.startsWith('worker.')) return 'worker'
+    if (label.startsWith('shell.') || label.startsWith('boot-status.')) {
+      return 'browser'
+    }
+    return 'browser'
+  }
+
+  private detectBuildType(): BootBuildType {
+    // The bundled app always ships minified release bytes today.
+    return BootBuildType.RELEASE
+  }
+
+  private detectRuntimeKind(): BootRuntimeKind {
+    // The GoScript runtime worker sets its own mode mark before connect.
+    return BootRuntimeKind.GOSCRIPT
+  }
+
+  private detectEnvironmentClass(): BootEnvironmentClass {
+    const host = globalThis.location?.hostname ?? ''
+    if (host === 'localhost' || host === '127.0.0.1') {
+      return BootEnvironmentClass.LOCAL
+    }
+    if (host.endsWith('.spacewave.app')) return BootEnvironmentClass.PRODUCTION
+    return BootEnvironmentClass.DEV
+  }
+
+  private detectOsFamily(): string {
+    // Android reports the Linux platform string, so classify it from the
+    // user agent before any platform fallback.
+    const nav = globalThis.navigator
+    const platform = nav?.platform ?? ''
+    if (/android/i.test(nav?.userAgent ?? '')) return 'android'
+    if (/mac/i.test(platform)) return 'darwin'
+    if (/win/i.test(platform)) return 'windows'
+    if (/iphone|ipad|ios/i.test(platform)) return 'ios'
+    if (/linux/i.test(platform)) return 'linux'
+    return 'linux'
+  }
+
+  private publish(sealed?: BootReport): void {
+    ;(globalThis as { [bootReportGlobalKey]?: BootReport })[bootReportGlobalKey] =
+      sealed ?? this.report
+  }
+}
+
+// readSealedBootReport returns this document's sealed report, or undefined
+// while startup is still recording or before the collector installed. This
+// document-global handle is a diagnostic test seam only and never the durable
+// owner.
+export function readSealedBootReport(): BootReport | undefined {
+  const report = (globalThis as CollectorGlobals)[bootReportGlobalKey]
+  if (!report || report.state === BootReportState.RECORDING) return undefined
+  return report
+}
+
+// liveCollector holds this document's recording collector so repeated
+// initBootReportCollector calls reuse one subscriber instead of installing a
+// second listener on the same startup-mark stream.
+let liveCollector: BootReportCollector | undefined
+
+// initBootReportCollector installs the production collector for this document.
+// The collector replays the inline shell's marks, records live marks, journals
+// them through the BootReportStore, and seals the report at the declared
+// usable boundary. Only one collector runs per document: a later call returns
+// the live collector while startup is still recording, and keeps the sealed
+// report once one exists. Without an injected store the collector opens the
+// real IndexedDB-backed store lazily when the document provides IndexedDB and
+// otherwise stays memory-only with a warning.
+export function initBootReportCollector(
+  options: BootReportCollectorOptions,
+  deps: BootReportCollectorDeps = {},
+): BootReportCollector | undefined {
+  const globals = globalThis as CollectorGlobals
+  const existing = globals[bootReportGlobalKey]
+  if (existing && existing.state !== BootReportState.RECORDING) return undefined
+  if (liveCollector) return liveCollector
+  const collector = new BootReportCollector(options, globals, deps)
+  liveCollector = collector
+  collector.start()
+  if (!deps.store && globals.indexedDB) {
+    import('./store.js')
+      .then((storeModule) =>
+        storeModule.openBootReportStore({
+          locks: globals.navigator?.locks,
+        }),
+      )
+      .then((store) => {
+        // A fast seal can land before the store finishes opening; attach
+        // anyway so attachStore persists the complete sealed snapshot. Skip
+        // only when a different live collector took over this document.
+        if (liveCollector && liveCollector !== collector) return
+        collector.attachStore(store)
+      })
+      .catch((cause: unknown) => {
+        console.warn('bootreport: durable store unavailable', cause)
+      })
+  }
+  return collector
+}

--- a/bldr/web/boot/store.test.ts
+++ b/bldr/web/boot/store.test.ts
@@ -388,7 +388,7 @@ function lockManagerDenied(): LockManager {
 // settles, and contending requests observe null asynchronously exactly like
 // the native manager.
 function lockManagerShared(): LockManager {
-  const held = new Map<string, () => void>()
+  const held = new Map<string, boolean>()
   const manager = {
     request: (
       name: string,
@@ -500,7 +500,10 @@ describe('BootReportStore durability', () => {
         store.createIndex('state', 'state')
         store.createIndex('sealedAt', 'sealedAt')
         const future = recordingReport('boot-report-future', ['boot.started'])
-        store.records.set('boot-report-future', future)
+        store.records.set(
+          'boot-report-future',
+          future as unknown as Record<string, unknown>,
+        )
       },
     )
 
@@ -699,24 +702,26 @@ describe('BootReportStore durability', () => {
     const result = await store.applyRetention()
 
     const survivors = await store.list()
-    expect(survivors.some((r) => r.reportId === 'boot-report-recording')).toBe(
+    expect(survivors.some((r: BootReport) => r.reportId === 'boot-report-recording')).toBe(
       true,
     )
-    expect(survivors.some((r) => r.reportId === 'boot-report-failed-new')).toBe(
+    expect(survivors.some((r: BootReport) => r.reportId === 'boot-report-failed-new')).toBe(
       true,
     )
-    expect(survivors.some((r) => r.reportId === 'boot-report-failed-old')).toBe(
+    expect(survivors.some((r: BootReport) => r.reportId === 'boot-report-failed-old')).toBe(
       false,
     )
-    expect(survivors.some((r) => r.reportId === 'boot-report-ready-1')).toBe(
+    expect(survivors.some((r: BootReport) => r.reportId === 'boot-report-ready-1')).toBe(
       false,
     )
-    const terminals = survivors.filter(
-      (r) => r.state !== BootReportState.RECORDING,
-    )
+    const terminals = survivors.filter((r: BootReport) => r.state !== BootReportState.RECORDING)
     expect(terminals.length).toBeLessThanOrEqual(100)
     expect(result.evicted.length).toBeGreaterThanOrEqual(2)
-    for (const eviction of result.evicted) {
+    const evictions = result.evicted as Array<{
+      reportId: string
+      reason: string
+    }>
+    for (const eviction of evictions) {
       expect(eviction.reason.length).toBeGreaterThan(0)
     }
   })
@@ -756,12 +761,16 @@ describe('BootReportStore durability', () => {
       bodyBudgetBytes: Math.floor((wideBytes + smallBytes) / 2),
     })
     const survivors = await store.list()
-    expect(survivors.some((r) => r.reportId === 'boot-report-small')).toBe(
+    expect(survivors.some((r: BootReport) => r.reportId === 'boot-report-small')).toBe(
       true,
     )
-    const evictedIds = result.evicted.map((eviction) => eviction.reportId)
+    const evictedIds = result.evicted.map((eviction: { reportId: string; reason: string }) => eviction.reportId)
     expect(evictedIds).toContain('boot-report-wide')
-    for (const eviction of result.evicted) {
+    const evictions = result.evicted as Array<{
+      reportId: string
+      reason: string
+    }>
+    for (const eviction of evictions) {
       expect(eviction.reason).toBe('body-budget')
     }
   })
@@ -793,10 +802,10 @@ describe('BootReportStore durability', () => {
     })
 
     const survivors = await store.list()
-    expect(survivors.map((r) => r.reportId)).toEqual([
+    expect(survivors.map((r: BootReport) => r.reportId)).toEqual([
       'boot-report-failed-huge',
     ])
-    expect(result.evicted.map((eviction) => eviction.reportId)).toEqual([
+    expect(result.evicted.map((eviction: { reportId: string; reason: string }) => eviction.reportId)).toEqual([
       'boot-report-old-ready',
     ])
     expect(result.evicted[0]?.reason).toBe('sealed-limit')
@@ -826,8 +835,8 @@ describe('BootReportStore durability', () => {
 
     // Number() coercion would collapse both stamps to the same double and
     // could evict the wrong side; BigInt comparison keeps the newer report.
-    expect(survivors.map((r) => r.reportId)).toEqual(['boot-report-big-new'])
-    expect(result.evicted.map((eviction) => eviction.reportId)).toEqual([
+    expect(survivors.map((r: BootReport) => r.reportId)).toEqual(['boot-report-big-new'])
+    expect(result.evicted.map((eviction: { reportId: string; reason: string }) => eviction.reportId)).toEqual([
       'boot-report-big-old',
     ])
   })
@@ -866,6 +875,7 @@ describe('BootReportStore durability', () => {
       { entrypointId: 'drive', usableMark: 'webview.revealed' },
       { store },
     )
+    if (!collector) throw new Error('boot report collector missing')
     try {
       const persisted = await waitForStoreRecord(store)
       expect(persisted.length).toBeGreaterThanOrEqual(1)
@@ -910,6 +920,7 @@ describe('BootReportStore durability', () => {
       { entrypointId: 'drive', usableMark: 'webview.revealed' },
       { store },
     )
+    if (!collector) throw new Error('boot report collector missing')
     try {
       window.dispatchEvent(
         new CustomEvent('spacewave-startup-mark', {
@@ -1036,17 +1047,16 @@ describe('BootReport lock and lazy-attach races', () => {
     const factory = new FakeIDBFactory()
     const previousIndexedDB = globals.indexedDB
     globals.indexedDB = factory as unknown as IDBFactory
-    let collector: { stop(): void } | undefined
+    let collector: ReturnType<typeof collectorModule.initBootReportCollector>
     try {
       collector = collectorModule.initBootReportCollector({
         entrypointId: 'drive',
         usableMark: 'boot-status.app',
       })
       expect(collector?.isSealed()).toBe(true)
-      const reportId = (
-        (globalThis as { __swBootReport?: BootReport }).__swBootReport ??
-        {}
-      ).reportId ?? ''
+      const sealedReport = (globalThis as { __swBootReport?: BootReport })
+        .__swBootReport
+      const reportId = sealedReport?.reportId ?? ''
       expect(reportId).toMatch(/^boot-report-/)
 
       // The lazy durable attach must land even though the boot sealed while
@@ -1094,6 +1104,7 @@ describe('BootReport lock and lazy-attach races', () => {
       { entrypointId: 'drive', usableMark: 'webview.revealed' },
       { store },
     )
+    if (!collector) throw new Error('boot report collector missing')
     try {
       window.dispatchEvent(
         new CustomEvent('spacewave-startup-mark', {
@@ -1111,7 +1122,9 @@ describe('BootReport lock and lazy-attach races', () => {
       // Attach order is recover -> lease -> first durable write: the stale
       // row aborts, this boot's own row persists RECORDING under its held
       // lease, and a contender is denied that same lease.
-      const reportId = globals.__swBootReport?.reportId ?? ''
+      const published = (globalThis as { __swBootReport?: BootReport })
+        .__swBootReport
+      const reportId = published?.reportId ?? ''
       await vi.waitFor(async () => {
         const dead = await store.get('boot-report-dead')
         expect(dead?.state).toBe(BootReportState.ABORTED)
@@ -1148,6 +1161,7 @@ describe('BootReport lock and lazy-attach races', () => {
       { entrypointId: 'drive', usableMark: 'webview.revealed' },
       { store },
     )
+    if (!collector) throw new Error('boot report collector missing')
     try {
       // Live marks keep collecting in memory while the lease is denied.
       window.dispatchEvent(

--- a/bldr/web/boot/store.test.ts
+++ b/bldr/web/boot/store.test.ts
@@ -1,0 +1,1259 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  BootMark,
+  BootReport,
+  BootReportState,
+  BootValidationViolationKind,
+} from './report.pb.js'
+
+// The red-confirmed gate landed these durability tests before any store
+// implementation existed. They load ./store.js through requireStoreModule so
+// a missing implementation names the missing durability behavior instead of
+// failing on an unresolved module import.
+// The computed specifier keeps Vite from analyzing this import during
+// transformation; resolution then fails inside the guarded call at test time.
+const storeModuleSpecifier = './store.js'
+
+async function requireStoreModule(
+  behavior: string,
+): Promise<any> {
+  try {
+    return await import(/* @vite-ignore */ storeModuleSpecifier)
+  } catch (cause) {
+    throw new Error(
+      `missing BootReportStore durability behavior (${behavior}): ` +
+        'bldr/web/boot/store.ts is not implemented yet',
+      { cause },
+    )
+  }
+}
+
+// The fake IndexedDB implements the native request/transaction callback
+// surface only: requests settle through onsuccess/onerror, transactions
+// settle through oncomplete/onabort/onerror, and requests expose no
+// promise interface. This forces the production wrappers to own the
+// request-to-promise conversion and transaction-completion discipline.
+
+interface FakeIDBEvent {
+  target: unknown
+}
+
+type RequestCompletion = () => void
+
+class FakeIDBRequest<T> {
+  result!: T
+  error: Error | null = null
+  onsuccess: ((event: FakeIDBEvent) => unknown) | null = null
+  onerror: ((event: FakeIDBEvent) => unknown) | null = null
+
+  // _onSettled is invoked by the owning transaction once this request has
+  // been executed, so the transaction can count down to completion.
+  _onSettled: RequestCompletion | null = null
+
+  constructor(
+    private readonly transaction: FakeIDBTransaction,
+    private readonly produce: () => T,
+  ) {}
+
+  _execute(): void {
+    try {
+      this.result = this.produce()
+      this.onsuccess?.({ target: this })
+    } catch (cause) {
+      this.error = cause as Error
+      this.onerror?.({ target: this })
+    }
+    this.transaction._requestSettled()
+  }
+}
+
+export class FakeIDBOpenRequest {
+  result!: FakeIDatabase
+  error: Error | null = null
+  onupgradeneeded: ((event: FakeIDBEvent) => unknown) | null = null
+  onerror: ((event: FakeIDBEvent) => unknown) | null = null
+  onsuccess: ((event: FakeIDBEvent) => unknown) | null = null
+}
+
+class FakeIDBObjectStore {
+  readonly indexes = new Map<string, string>()
+
+  constructor(
+    private readonly database: FakeIDatabase,
+    private readonly transaction: FakeIDBTransaction,
+    readonly name: string,
+    readonly keyPath: string,
+    readonly records: Map<string, Record<string, unknown>>,
+  ) {}
+
+  createIndex(name: string, keyPath: string): void {
+    this.indexes.set(name, keyPath)
+  }
+
+  index(name: string): {
+    getAll: (value?: unknown) => FakeIDBRequest<Record<string, unknown>[]>
+  } {
+    const keyPath = this.indexes.get(name)
+    if (keyPath === undefined) {
+      throw new Error(`no such index ${name} on ${this.name}`)
+    }
+    return {
+      getAll: (value?: unknown) =>
+        this.transaction._track(() =>
+          [...this.records.values()].filter(
+            (record) => value === undefined || record[keyPath] === value,
+          ),
+        ),
+    }
+  }
+
+  get(key: string): FakeIDBRequest<Record<string, unknown> | undefined> {
+    return this.transaction._track(() => this.records.get(key))
+  }
+
+  getAll(): FakeIDBRequest<Record<string, unknown>[]> {
+    return this.transaction._track(() => [...this.records.values()])
+  }
+
+  put(value: Record<string, unknown>): FakeIDBRequest<string> {
+    const key = value[this.keyPath] as string
+    return this.transaction._track(
+      () => {
+        if (this.database.factory.putFailure) throw this.database.factory.putFailure
+        this.records.set(key, value)
+        return key
+      },
+      { key },
+    )
+  }
+
+  delete(key: string): FakeIDBRequest<undefined> {
+    return this.transaction._track(
+      () => {
+        this.records.delete(key)
+        return undefined
+      },
+      { key },
+    )
+  }
+}
+
+class FakeIDBTransaction {
+  oncomplete: ((event: FakeIDBEvent) => unknown) | null = null
+  onabort: ((event: FakeIDBEvent) => unknown) | null = null
+  onerror: ((event: FakeIDBEvent) => unknown) | null = null
+
+  private outstanding = 0
+  private finished = false
+
+  constructor(
+    private readonly database: FakeIDatabase,
+    readonly mode: 'readonly' | 'readwrite',
+  ) {}
+
+  objectStore(name: string): FakeIDBObjectStore {
+    if (this.finished) throw new Error('transaction already finished')
+    const store = this.database.stores.get(name)
+    if (!store) throw new Error(`no such object store ${name}`)
+    return new FakeIDBObjectStore(
+      this.database,
+      this,
+      store.name,
+      store.keyPath,
+      store.records,
+    )
+  }
+
+  // Abort marks the transaction so completion rejects through onabort even
+  // after every individual request succeeded.
+  abort(): void {
+    this.database.commitFailure = true
+  }
+
+  _track<T>(produce: () => T, meta?: { key?: string }): FakeIDBRequest<T> {
+    const request = new FakeIDBRequest<T>(this, produce)
+    if (this.database.factory.holdPredicate?.(meta)) {
+      // Held requests stay unsettled until the factory releases them, which
+      // lets tests discriminate serialized execution from concurrent
+      // execution.
+      this.database.factory.held.push({
+        execute: () => request._execute(),
+        settle: () => {
+          this.outstanding += 1
+          queueMicrotask(() => request._execute())
+        },
+      })
+      return request
+    }
+    this.outstanding += 1
+    queueMicrotask(() => request._execute())
+    return request
+  }
+
+  _requestSettled(): void {
+    this.outstanding -= 1
+    if (this.outstanding <= 0 && !this.finished) {
+      this.finished = true
+      queueMicrotask(() => this._settle())
+    }
+  }
+
+  _settle(): void {
+    if (this.database.factory.commitFailure) {
+      const error = new Error('fake indexeddb transaction aborted')
+      this.onabort?.({ target: this })
+      this.onerror?.({ target: this })
+      void error
+      return
+    }
+    this.oncomplete?.({ target: this })
+  }
+}
+
+class FakeIDatabase {
+  readonly stores = new Map<
+    string,
+    { name: string; keyPath: string; records: Map<string, Record<string, unknown>> }
+  >()
+  putFailure: Error | null = null
+  commitFailure = false
+
+  constructor(
+    readonly name: string,
+    public version: number,
+    readonly factory: FakeIDBFactory,
+  ) {}
+
+  createObjectStore(
+    name: string,
+    options: { keyPath: string },
+  ): {
+    name: string
+    keyPath: string
+    records: Map<string, Record<string, unknown>>
+    indexes: Map<string, string>
+    createIndex(indexName: string, indexKeyPath: string): void
+  } {
+    const store = {
+      name,
+      keyPath: options.keyPath,
+      records: new Map<string, Record<string, unknown>>(),
+      indexes: new Map<string, string>(),
+      createIndex(indexName: string, indexKeyPath: string): void {
+        store.indexes.set(indexName, indexKeyPath)
+      },
+    }
+    this.stores.set(name, store)
+    return store
+  }
+
+  // Transaction mirrors the native IDBDatabase signature and rejects an
+  // unknown store name so a mode-only caller cannot regress silently.
+  transactionCalls: Array<{
+    storeName: string
+    mode: 'readonly' | 'readwrite'
+  }> = []
+
+  transaction(
+    storeName: string,
+    mode: 'readonly' | 'readwrite',
+  ): FakeIDBTransaction {
+    if (!this.stores.has(storeName)) {
+      throw new Error(`no such object store ${storeName}`)
+    }
+    this.transactionCalls.push({ storeName, mode })
+    return new FakeIDBTransaction(this, mode)
+  }
+}
+
+class FakeIDBFactory {
+  readonly databases = new Map<string, FakeIDatabase>()
+  putFailure: Error | null = null
+  commitFailure = false
+  holdPredicate:
+    | ((meta?: { key?: string }) => boolean)
+    | null = null
+  readonly held: Array<{
+    execute: () => void
+    settle: () => void
+  }> = []
+
+  open(name: string, version?: number): FakeIDBOpenRequest {
+    const requestedVersion = version ?? 1
+    const request = new FakeIDBOpenRequest()
+    queueMicrotask(() => {
+      let database = this.databases.get(name)
+      if (database && database.version > requestedVersion) {
+        const failure = new Error(
+          `The requested version (${requestedVersion}) is less than ` +
+            `the existing version (${database.version}).`,
+        )
+        failure.name = 'VersionError'
+        request.error = failure
+        request.onerror?.({ target: request })
+        return
+      }
+      const upgrading = !database || database.version < requestedVersion
+      if (!database) {
+        database = new FakeIDatabase(name, requestedVersion, this)
+        this.databases.set(name, database)
+      } else {
+        database.version = requestedVersion
+      }
+      if (upgrading) {
+        request.result = database
+        request.onupgradeneeded?.({ target: request })
+      }
+      request.result = database
+      request.onsuccess?.({ target: request })
+    })
+    return request
+  }
+
+  seedDatabaseAtVersion(
+    name: string,
+    version: number,
+    configure: (database: FakeIDatabase) => void,
+  ): FakeIDatabase {
+    const database = new FakeIDatabase(name, version, this)
+    this.databases.set(name, database)
+    configure(database)
+    return database
+  }
+
+  // Release every held request in FIFO order.
+  settleHeld(): void {
+    const held = [...this.held]
+    this.held.length = 0
+    for (const entry of held) entry.execute()
+    for (const entry of held) entry.settle()
+  }
+}
+
+function lockManagerAcquirable(): LockManager {
+  const manager = {
+    // With ifAvailable an acquirable lock hands the lock object to the
+    // callback, proving the previous holder died.
+    request: async (
+      name: string,
+      _options: unknown,
+      callback: (lock: unknown) => unknown,
+    ) => callback({ name, mode: 'exclusive' }),
+  }
+  return manager as unknown as LockManager
+}
+
+function lockManagerHeldElsewhere(): LockManager {
+  const manager = {
+    // With ifAvailable a held lock hands null to the callback, proving
+    // another live tab owns the boot.
+    request: async (
+      _name: string,
+      _options: unknown,
+      callback: (lock: unknown) => unknown,
+    ) => callback(null),
+  }
+  return manager as unknown as LockManager
+}
+
+// lockManagerRejecting models a manager whose request promise rejects,
+// exercising holdBootLock's failure cleanup without granting anything.
+function lockManagerRejecting(): LockManager {
+  const manager = {
+    request: (
+      _name: string,
+      _options: unknown,
+      _callback: (lock: unknown) => unknown,
+    ) => Promise.reject(new Error('lock manager unavailable')),
+  }
+  return manager as unknown as LockManager
+}
+
+// lockManagerDenied denies every request asynchronously the way a native
+// manager reports held-elsewhere.
+function lockManagerDenied(): LockManager {
+  const manager = {
+    request: (
+      _name: string,
+      _options: unknown,
+      callback: (lock: unknown) => unknown,
+    ) => Promise.resolve().then(() => callback(null)),
+  }
+  return manager as unknown as LockManager
+}
+
+// lockManagerShared is one minimal exclusive Web Locks stand-in shared by
+// every store in a test: a name stays held until the holder's release promise
+// settles, and contending requests observe null asynchronously exactly like
+// the native manager.
+function lockManagerShared(): LockManager {
+  const held = new Map<string, () => void>()
+  const manager = {
+    request: (
+      name: string,
+      _options: unknown,
+      callback: (lock: unknown) => unknown,
+    ) =>
+      Promise.resolve().then(() => {
+        if (held.has(name)) {
+          callback(null)
+          return undefined
+        }
+        held.set(name, true)
+        return Promise.resolve(callback({ name, mode: 'exclusive' })).then(
+          (result) => {
+            held.delete(name)
+            return result
+          },
+        )
+      }),
+  }
+  return manager as unknown as LockManager
+}
+
+function recordingReport(reportId: string, labels: string[]): BootReport {
+  return BootReport.create({
+    schemaVersion: 1,
+    reportId,
+    startedUnixMicros: 1_000_000n,
+    entrypointId: 'drive',
+    usableMark: 'boot-status.app',
+    state: BootReportState.RECORDING,
+    marks: labels.map((label, index): BootMark => ({
+      sequence: BigInt(index + 1),
+      label,
+    })),
+  })
+}
+
+interface InlineShellGlobals {
+  __swStartupMarks?:
+    | {
+        name: string
+        label: string
+        sequence: number
+        detail: Record<string, unknown>
+      }[]
+  __swStartupMarkOverflows?: number
+  __swBootReport?: unknown
+}
+
+async function openStore(options: {
+  idbFactory: IDBFactory
+  locks?: LockManager | null
+}): Promise<any> {
+  const storeModule = await requireStoreModule('openBootReportStore')
+  return storeModule.openBootReportStore(options)
+}
+
+// waitForStoreRecord polls the store until the collector's asynchronous
+// attach/journal path has persisted at least one record.
+async function waitForStoreRecord(
+  store: { list(): Promise<unknown[]> },
+): Promise<unknown[]> {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    const listed = await store.list()
+    if (listed.length > 0) return listed
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  return []
+}
+
+describe('BootReportStore durability', () => {
+  it('opens every transaction on the reports store with the native signature', async () => {
+    const factory = new FakeIDBFactory()
+    const store = await openStore({
+      idbFactory: factory as unknown as IDBFactory,
+    })
+    const report = recordingReport('boot-report-txn', ['boot.started'])
+    await store.put(report)
+    await store.get('boot-report-txn')
+    await store.list()
+    await store.delete('boot-report-txn')
+
+    // Native IDBDatabase.transaction takes (storeNames, mode); a mode-only
+    // call asks the browser for a store literally named "readwrite".
+    expect(
+      factory.databases.get('bldr-boot-reports')!.transactionCalls,
+    ).toEqual([
+      { storeName: 'reports', mode: 'readwrite' },
+      { storeName: 'reports', mode: 'readonly' },
+      { storeName: 'reports', mode: 'readonly' },
+      { storeName: 'reports', mode: 'readwrite' },
+    ])
+  })
+
+  it('fails closed against a newer schema version without resetting data', async () => {
+    const storeModule = await requireStoreModule(
+      'unknown/newer schema version fails closed without destructive reset',
+    )
+
+    const factory = new FakeIDBFactory()
+    factory.seedDatabaseAtVersion(
+      'bldr-boot-reports',
+      99,
+      (database) => {
+        const store = database.createObjectStore('reports', {
+          keyPath: 'reportId',
+        })
+        store.createIndex('state', 'state')
+        store.createIndex('sealedAt', 'sealedAt')
+        const future = recordingReport('boot-report-future', ['boot.started'])
+        store.records.set('boot-report-future', future)
+      },
+    )
+
+    await expect(
+      storeModule.openBootReportStore({
+        idbFactory: factory as unknown as IDBFactory,
+      }),
+    ).rejects.toThrow(/version/i)
+
+    const surviving = factory.databases.get('bldr-boot-reports')
+    expect(surviving?.version).toBe(99)
+    expect(surviving?.stores.get('reports')?.records.size).toBe(1)
+  })
+
+  it('marks stale RECORDING aborted when the crash released its web lock', async () => {
+    const storeModule = await requireStoreModule(
+      'crash-released web lock recovers stale RECORDING to ABORTED',
+    )
+
+    const factory = new FakeIDBFactory()
+    const writer = await openStore({
+      idbFactory: factory as unknown as IDBFactory,
+      locks: lockManagerAcquirable(),
+    })
+    const prior = recordingReport('boot-report-deadtab', ['boot.started'])
+    await writer.put(prior)
+
+    const recovery = await storeModule.openBootReportStore({
+      idbFactory: factory as unknown as IDBFactory,
+      locks: lockManagerAcquirable(),
+    })
+    await recovery.recoverOnStartup()
+
+    const recovered = await recovery.get('boot-report-deadtab')
+    expect(recovered?.state).toBe(BootReportState.ABORTED)
+    // The exact prior partial timeline survives for recovery reading.
+    expect(recovered?.marks.map((mark: BootMark) => mark.label)).toEqual([
+      'boot.started',
+    ])
+  })
+
+  it('keeps a live tab recording and preserves its partial timeline across reload', async () => {
+    const storeModule = await requireStoreModule(
+      'live tab stays RECORDING untouched while its web lock is held',
+    )
+
+    const factory = new FakeIDBFactory()
+    const liveTab = await openStore({
+      idbFactory: factory as unknown as IDBFactory,
+      locks: lockManagerHeldElsewhere(),
+    })
+    const partial = recordingReport('boot-report-livetab', [
+      'boot.started',
+      'content-ready',
+    ])
+    await liveTab.put(partial)
+
+    const recovery = await storeModule.openBootReportStore({
+      idbFactory: factory as unknown as IDBFactory,
+      locks: lockManagerAcquirable(),
+    })
+    await recovery.recoverOnStartup()
+
+    const recovered = await recovery.get('boot-report-livetab')
+    expect(recovered?.state).toBe(BootReportState.RECORDING)
+
+    // A reload reopens the same database and reads the exact prior partial
+    // timeline back without mutation.
+    const reopened = await storeModule.openBootReportStore({
+      idbFactory: factory as unknown as IDBFactory,
+      locks: lockManagerAcquirable(),
+    })
+    const readback = await reopened.get('boot-report-livetab')
+    expect(readback?.state).toBe(BootReportState.RECORDING)
+    expect(readback?.marks.map((mark: BootMark) => mark.label)).toEqual([
+      'boot.started',
+      'content-ready',
+    ])
+  })
+
+  it('surfaces quota failures instead of dropping writes', async () => {
+    await requireStoreModule(
+      'store/quota errors surface instead of silently dropping writes',
+    )
+
+    const factory = new FakeIDBFactory()
+    factory.putFailure = Object.assign(new Error('write failed'), {
+      name: 'QuotaExceededError',
+    })
+
+    const store = await openStore({
+      idbFactory: factory as unknown as IDBFactory,
+    })
+    await expect(
+      store.put(recordingReport('boot-report-quota', ['boot.started'])),
+    ).rejects.toMatchObject({ name: 'QuotaExceededError' })
+  })
+
+  it('rejects a write when the transaction aborts after request success', async () => {
+    await requireStoreModule(
+      'transaction abort after request success rejects the operation',
+    )
+    const factory = new FakeIDBFactory()
+    factory.commitFailure = true
+    const store = await openStore({
+      idbFactory: factory as unknown as IDBFactory,
+    })
+    await expect(
+      store.put(recordingReport('boot-report-abort', ['boot.started'])),
+    ).rejects.toThrow(/abort/i)
+  })
+
+  it('serializes concurrent writes in schedule order', async () => {
+    await requireStoreModule(
+      'serialized writer applies writes one at a time in schedule order',
+    )
+    const factory = new FakeIDBFactory()
+    // Hold only the first scheduled write: a concurrent (non-serialized)
+    // implementation would land writes two and three first and the record
+    // order would come out reversed. The serialized writer must not issue
+    // the later operations until the held one commits.
+    const ids = ['boot-report-s1', 'boot-report-s2', 'boot-report-s3']
+    factory.holdPredicate = (meta) => meta?.key === 'boot-report-s1' 
+    const store = await openStore({
+      idbFactory: factory as unknown as IDBFactory,
+    })
+    const pending = ids.map((reportId) =>
+      store.put(recordingReport(reportId, ['boot.started'])),
+    )
+    // Let the serialized writer schedule the first operation only.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(factory.held.length).toBe(1)
+    factory.settleHeld()
+    await Promise.all(pending)
+
+    const keys = [
+      ...factory.databases.get('bldr-boot-reports')!.stores
+        .get('reports')!.records.keys(),
+    ]
+    expect(keys).toEqual(ids)
+  })
+
+  it('seals a report atomically in one terminal write', async () => {
+    await requireStoreModule(
+      'seal atomicity writes one complete terminal record',
+    )
+    const factory = new FakeIDBFactory()
+    const store = await openStore({
+      idbFactory: factory as unknown as IDBFactory,
+    })
+    await store.put(recordingReport('boot-report-seal', ['boot.started']))
+
+    const sealed = await store.sealReport(
+      recordingReport('boot-report-seal', ['boot.started']),
+      BootReportState.READY,
+    )
+    expect(sealed.state).toBe(BootReportState.READY)
+    expect(sealed.sealedAt).toBeDefined()
+
+    const records = factory.databases
+      .get('bldr-boot-reports')
+      ?.stores.get('reports')?.records
+    expect(records?.size).toBe(1)
+    const readback = await store.get('boot-report-seal')
+    expect(readback?.state).toBe(BootReportState.READY)
+    expect(readback?.sealedAt).toBeDefined()
+  })
+
+  it('applies retention limits without evicting RECORDING or newest FAILED', async () => {
+    await requireStoreModule(
+      'retention keeps the newest sealed reports and protects live boots and the newest FAILED',
+    )
+    const factory = new FakeIDBFactory()
+    const store = await openStore({
+      idbFactory: factory as unknown as IDBFactory,
+    })
+    for (let index = 1; index <= 101; index += 1) {
+      const ready = recordingReport(`boot-report-ready-${index}`, [
+        'boot.started',
+      ])
+      ready.state = BootReportState.READY
+      ;(ready as { sealedAt?: bigint }).sealedAt = BigInt(1000 + index)
+      await store.put(ready)
+    }
+    const failedOld = recordingReport('boot-report-failed-old', ['boot.started'])
+    failedOld.state = BootReportState.FAILED
+    ;(failedOld as { sealedAt?: bigint }).sealedAt = 0n
+    await store.put(failedOld)
+    const failedNew = recordingReport('boot-report-failed-new', ['boot.started'])
+    failedNew.state = BootReportState.FAILED
+    ;(failedNew as { sealedAt?: bigint }).sealedAt = 5000n
+    await store.put(failedNew)
+    const live = recordingReport('boot-report-recording', ['boot.started'])
+    await store.put(live)
+
+    const result = await store.applyRetention()
+
+    const survivors = await store.list()
+    expect(survivors.some((r) => r.reportId === 'boot-report-recording')).toBe(
+      true,
+    )
+    expect(survivors.some((r) => r.reportId === 'boot-report-failed-new')).toBe(
+      true,
+    )
+    expect(survivors.some((r) => r.reportId === 'boot-report-failed-old')).toBe(
+      false,
+    )
+    expect(survivors.some((r) => r.reportId === 'boot-report-ready-1')).toBe(
+      false,
+    )
+    const terminals = survivors.filter(
+      (r) => r.state !== BootReportState.RECORDING,
+    )
+    expect(terminals.length).toBeLessThanOrEqual(100)
+    expect(result.evicted.length).toBeGreaterThanOrEqual(2)
+    for (const eviction of result.evicted) {
+      expect(eviction.reason.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('uses encoded byte length for the body budget across multibyte content', async () => {
+    await requireStoreModule(
+      'body budget counts encoded bytes, not characters',
+    )
+    const factory = new FakeIDBFactory()
+    const store = await openStore({
+      idbFactory: factory as unknown as IDBFactory,
+    })
+
+    // A multibyte-heavy label encodes to more bytes than its character
+    // count suggests; the budget must measure the encoded body.
+    const wide = recordingReport('boot-report-wide', [
+      '\u{1F600}'.repeat(24),
+    ])
+    wide.state = BootReportState.READY
+    ;(wide as { sealedAt?: bigint }).sealedAt = 10n
+    await store.put(wide)
+    const small = recordingReport('boot-report-small', ['ok'])
+    small.state = BootReportState.READY
+    ;(small as { sealedAt?: bigint }).sealedAt = 11n
+    await store.put(small)
+
+    const wideBytes = (
+      await import(/* @vite-ignore */ './report.pb.js')
+    ).BootReport.toBinary(wide).byteLength
+    const smallBytes = (
+      await import(/* @vite-ignore */ './report.pb.js')
+    ).BootReport.toBinary(small).byteLength
+    expect(wideBytes).toBeGreaterThan(smallBytes)
+
+    const result = await store.applyRetention({
+      sealedLimit: 2,
+      bodyBudgetBytes: Math.floor((wideBytes + smallBytes) / 2),
+    })
+    const survivors = await store.list()
+    expect(survivors.some((r) => r.reportId === 'boot-report-small')).toBe(
+      true,
+    )
+    const evictedIds = result.evicted.map((eviction) => eviction.reportId)
+    expect(evictedIds).toContain('boot-report-wide')
+    for (const eviction of result.evicted) {
+      expect(eviction.reason).toBe('body-budget')
+    }
+  })
+
+  it('never evicts the newest FAILED even when it exceeds the whole body budget', async () => {
+    await requireStoreModule(
+      'newest FAILED over budget is protected while other sealed reports are evicted',
+    )
+    const factory = new FakeIDBFactory()
+    const store = await openStore({
+      idbFactory: factory as unknown as IDBFactory,
+    })
+
+    const hugeFailed = recordingReport('boot-report-failed-huge', [
+      'x'.repeat(512),
+    ])
+    hugeFailed.state = BootReportState.FAILED
+    ;(hugeFailed as { sealedAt?: bigint }).sealedAt = 9007199254740995n
+    await store.put(hugeFailed)
+
+    const oldReady = recordingReport('boot-report-old-ready', ['old'])
+    oldReady.state = BootReportState.READY
+    ;(oldReady as { sealedAt?: bigint }).sealedAt = 9007199254740993n
+    await store.put(oldReady)
+
+    const result = await store.applyRetention({
+      sealedLimit: 1,
+      bodyBudgetBytes: 64,
+    })
+
+    const survivors = await store.list()
+    expect(survivors.map((r) => r.reportId)).toEqual([
+      'boot-report-failed-huge',
+    ])
+    expect(result.evicted.map((eviction) => eviction.reportId)).toEqual([
+      'boot-report-old-ready',
+    ])
+    expect(result.evicted[0]?.reason).toBe('sealed-limit')
+  })
+
+  it('orders retention recency with BigInt-safe comparisons', async () => {
+    await requireStoreModule(
+      'retention recency compares sealed timestamps beyond the safe integer range',
+    )
+    const factory = new FakeIDBFactory()
+    const store = await openStore({
+      idbFactory: factory as unknown as IDBFactory,
+    })
+
+    const bigBase = 9007199254740990n
+    const older = recordingReport('boot-report-big-old', ['older'])
+    older.state = BootReportState.READY
+    ;(older as { sealedAt?: bigint }).sealedAt = bigBase + 1n
+    await store.put(older)
+    const newer = recordingReport('boot-report-big-new', ['newer'])
+    newer.state = BootReportState.READY
+    ;(newer as { sealedAt?: bigint }).sealedAt = bigBase + 2n
+    await store.put(newer)
+
+    const result = await store.applyRetention({ sealedLimit: 1 })
+    const survivors = await store.list()
+
+    // Number() coercion would collapse both stamps to the same double and
+    // could evict the wrong side; BigInt comparison keeps the newer report.
+    expect(survivors.map((r) => r.reportId)).toEqual(['boot-report-big-new'])
+    expect(result.evicted.map((eviction) => eviction.reportId)).toEqual([
+      'boot-report-big-old',
+    ])
+  })
+
+  it('hands the inline shell buffer and first mark to the durable store through the collector', async () => {
+    await requireStoreModule(
+      'inline input-buffer and first-mark handoff journaled into IndexedDB',
+    )
+    const collectorModule = await import(
+      /* @vite-ignore */ './collector.js'
+    )
+    const globals = globalThis as InlineShellGlobals
+    globals.__swStartupMarks = [
+      {
+        name: 'spacewave.startup.boot.started',
+        label: 'boot.started',
+        sequence: 1,
+        detail: { source: 'browser' },
+      },
+      {
+        name: 'spacewave.startup.content-ready',
+        label: 'content-ready',
+        sequence: 2,
+        detail: {},
+      },
+    ]
+
+    const factory = new FakeIDBFactory()
+    // Durable RECORDING journaling requires a held boot lease, so the store
+    // opens with a granting lock manager.
+    const store = await openStore({
+      idbFactory: factory as unknown as IDBFactory,
+      locks: lockManagerShared(),
+    })
+    const collector = collectorModule.initBootReportCollector(
+      { entrypointId: 'drive', usableMark: 'webview.revealed' },
+      { store },
+    )
+    try {
+      const persisted = await waitForStoreRecord(store)
+      expect(persisted.length).toBeGreaterThanOrEqual(1)
+      const labels = (persisted[0] as BootReport).marks?.map(
+        (mark: BootMark) => mark.label,
+      )
+      expect(labels).toEqual(['boot.started', 'content-ready'])
+      expect(collector.isSealed()).toBe(false)
+    } finally {
+      // Sealing clears the module-global live collector so later tests start
+      // from a clean document state.
+      collector.seal(BootReportState.ABORTED, 'test-cleanup')
+      collector.stop()
+      delete globals.__swStartupMarks
+    }
+  })
+
+  it('persists inline buffer overflow as a REPORT_CONTRACT validation failure at seal', async () => {
+    await requireStoreModule(
+      'inline overflow becomes a persisted validation failure',
+    )
+    const collectorModule = await import(
+      /* @vite-ignore */ './collector.js'
+    )
+    const globals = globalThis as InlineShellGlobals
+    delete globals.__swBootReport
+    globals.__swStartupMarks = [
+      {
+        name: 'spacewave.startup.boot.started',
+        label: 'boot.started',
+        sequence: 1,
+        detail: { source: 'browser' },
+      },
+    ]
+    globals.__swStartupMarkOverflows = 3
+
+    const factory = new FakeIDBFactory()
+    const store = await openStore({
+      idbFactory: factory as unknown as IDBFactory,
+    })
+    const collector = collectorModule.initBootReportCollector(
+      { entrypointId: 'drive', usableMark: 'webview.revealed' },
+      { store },
+    )
+    try {
+      window.dispatchEvent(
+        new CustomEvent('spacewave-startup-mark', {
+          detail: {
+            detail: {
+              name: 'spacewave.startup.webview.revealed',
+              label: 'webview.revealed',
+              sequence: 2,
+              detail: {},
+            },
+          },
+        }),
+      )
+
+      const sealed = await vi.waitFor(() => {
+        const report = collectorModule.readSealedBootReport() as BootReport
+        expect(report?.validation?.violations?.length ?? 0).toBeGreaterThan(0)
+        return report
+      })
+      expect(sealed.validation?.pass).toBe(false)
+      expect(sealed.validation?.violations?.at(-1)?.kind).toBe(
+        BootValidationViolationKind.REPORT_CONTRACT,
+      )
+
+      const persisted = await waitForStoreRecord(store)
+      const sealedPersisted = persisted.find(
+        (report) => (report as BootReport).state === BootReportState.READY,
+      ) as BootReport
+      expect(sealedPersisted?.validation?.pass).toBe(false)
+    } finally {
+      collector.stop()
+      delete globals.__swBootReport
+      delete globals.__swStartupMarks
+      delete globals.__swStartupMarkOverflows
+    }
+  })
+})
+
+describe('BootReport lock and lazy-attach races', () => {
+  it('grants one boot lock across stores through web locks contention', async () => {
+    const factory = new FakeIDBFactory()
+    const locks = lockManagerShared()
+    const first = await openStore({
+      idbFactory: factory as unknown as IDBFactory,
+      locks,
+    })
+    const second = await openStore({
+      idbFactory: factory as unknown as IDBFactory,
+      locks,
+    })
+
+    await expect(first.holdBootLock('boot-report-contend')).resolves.toBe(true)
+    // The contender learns its denial through the asynchronous Web Locks
+    // callback; an optimistic synchronous read would answer true here.
+    await expect(second.holdBootLock('boot-report-contend')).resolves.toBe(
+      false,
+    )
+
+    // sealReport releases the hold after the terminal commit, so a later
+    // store can acquire the lock again.
+    await first.sealReport(
+      recordingReport('boot-report-contend', ['boot.started']),
+      BootReportState.READY,
+    )
+    const third = await openStore({
+      idbFactory: factory as unknown as IDBFactory,
+      locks,
+    })
+    await expect(third.holdBootLock('boot-report-contend')).resolves.toBe(true)
+  })
+
+  it('keeps the held boot lock releasable when a contender request fails', async () => {
+    const factory = new FakeIDBFactory()
+    const locks = lockManagerShared()
+    const first = await openStore({
+      idbFactory: factory as unknown as IDBFactory,
+      locks,
+    })
+    await expect(first.holdBootLock('boot-report-fail')).resolves.toBe(true)
+
+    // A contender whose manager rejects must not disturb the live hold's
+    // registration; only its own failed request cleans up.
+    const failing = await openStore({
+      idbFactory: factory as unknown as IDBFactory,
+      locks: lockManagerRejecting(),
+    })
+    await expect(failing.holdBootLock('boot-report-fail')).resolves.toBe(false)
+
+    // The first store still owns the release handle, so sealReport releases
+    // the lock and a later store can acquire it.
+    await first.sealReport(
+      recordingReport('boot-report-fail', ['boot.started']),
+      BootReportState.READY,
+    )
+    const third = await openStore({
+      idbFactory: factory as unknown as IDBFactory,
+      locks,
+    })
+    await expect(third.holdBootLock('boot-report-fail')).resolves.toBe(true)
+  })
+
+  it('persists the sealed snapshot when the boot seals before the durable store opens', async () => {
+    const collectorModule = await import(
+      /* @vite-ignore */ './collector.js'
+    )
+    const globals = globalThis as InlineShellGlobals & {
+      indexedDB?: IDBFactory
+    }
+    delete globals.__swBootReport
+    globals.__swStartupMarks = [
+      {
+        name: 'spacewave.startup.boot.started',
+        label: 'boot.started',
+        sequence: 1,
+        detail: {},
+      },
+      {
+        name: 'spacewave.startup.boot-status.app',
+        label: 'boot-status.app',
+        sequence: 2,
+        detail: {},
+      },
+    ]
+    const factory = new FakeIDBFactory()
+    const previousIndexedDB = globals.indexedDB
+    globals.indexedDB = factory as unknown as IDBFactory
+    let collector: { stop(): void } | undefined
+    try {
+      collector = collectorModule.initBootReportCollector({
+        entrypointId: 'drive',
+        usableMark: 'boot-status.app',
+      })
+      expect(collector?.isSealed()).toBe(true)
+      const reportId = (
+        (globalThis as { __swBootReport?: BootReport }).__swBootReport ??
+        {}
+      ).reportId ?? ''
+      expect(reportId).toMatch(/^boot-report-/)
+
+      // The lazy durable attach must land even though the boot sealed while
+      // the store was still opening.
+      await vi.waitFor(() => {
+        const stored = factory.databases
+          .get('bldr-boot-reports')
+          ?.stores.get('reports')
+          ?.records.get(reportId) as BootReport | undefined
+        expect(stored?.state).toBe(BootReportState.READY)
+      })
+    } finally {
+      collector?.stop()
+      delete globals.__swBootReport
+      delete globals.__swStartupMarks
+      globals.indexedDB = previousIndexedDB
+    }
+  })
+
+  it('recovers stale boots before taking the lease and writing recording', async () => {
+    // Fresh module registry keeps the document-global collector state
+    // hermetic against earlier construction-time seals.
+    vi.resetModules()
+    const collectorModule = await import(
+      /* @vite-ignore */ './collector.js'
+    )
+    const globals = globalThis as InlineShellGlobals & { __swBootReport?: BootReport }
+    delete globals.__swBootReport
+    const factory = new FakeIDBFactory()
+    // One shared exclusive manager across every store in this boot, so the
+    // lease contention is real rather than per-instance.
+    const locks = lockManagerShared()
+    // A crashed tab left a stale RECORDING row whose web lock died with it.
+    const seeded = await openStore({
+      idbFactory: factory as unknown as IDBFactory,
+      locks,
+    })
+    await seeded.put(recordingReport('boot-report-dead', ['boot.started']))
+
+    const store = await openStore({
+      idbFactory: factory as unknown as IDBFactory,
+      locks,
+    })
+    const collector = collectorModule.initBootReportCollector(
+      { entrypointId: 'drive', usableMark: 'webview.revealed' },
+      { store },
+    )
+    try {
+      window.dispatchEvent(
+        new CustomEvent('spacewave-startup-mark', {
+          detail: {
+            detail: {
+              name: 'spacewave.startup.runtime.started',
+              label: 'runtime.started',
+              sequence: 1,
+              detail: {},
+            },
+          },
+        }),
+      )
+
+      // Attach order is recover -> lease -> first durable write: the stale
+      // row aborts, this boot's own row persists RECORDING under its held
+      // lease, and a contender is denied that same lease.
+      const reportId = globals.__swBootReport?.reportId ?? ''
+      await vi.waitFor(async () => {
+        const dead = await store.get('boot-report-dead')
+        expect(dead?.state).toBe(BootReportState.ABORTED)
+        const mine = await store.get(reportId)
+        expect(mine?.state).toBe(BootReportState.RECORDING)
+      })
+      const contender = await openStore({
+        idbFactory: factory as unknown as IDBFactory,
+        locks,
+      })
+      await expect(contender.holdBootLock(reportId)).resolves.toBe(false)
+    } finally {
+      collector.seal(BootReportState.ABORTED, 'test-cleanup')
+      collector.stop()
+      delete globals.__swBootReport
+    }
+  })
+
+  it('keeps a lease-denied boot memory-only until its terminal seal', async () => {
+    // Fresh module registry keeps the document-global collector state
+    // hermetic against earlier construction-time seals.
+    vi.resetModules()
+    const collectorModule = await import(
+      /* @vite-ignore */ './collector.js'
+    )
+    const globals = globalThis as InlineShellGlobals & { __swBootReport?: BootReport }
+    delete globals.__swBootReport
+    const factory = new FakeIDBFactory()
+    const store = await openStore({
+      idbFactory: factory as unknown as IDBFactory,
+      locks: lockManagerDenied(),
+    })
+    const collector = collectorModule.initBootReportCollector(
+      { entrypointId: 'drive', usableMark: 'webview.revealed' },
+      { store },
+    )
+    try {
+      // Live marks keep collecting in memory while the lease is denied.
+      window.dispatchEvent(
+        new CustomEvent('spacewave-startup-mark', {
+          detail: {
+            detail: {
+              name: 'spacewave.startup.runtime.started',
+              label: 'runtime.started',
+              sequence: 1,
+              detail: {},
+            },
+          },
+        }),
+      )
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      expect(await store.list()).toEqual([])
+
+      // The terminal seal persists without a lease: the report key is a
+      // device-local random id minted once per boot, so the write cannot
+      // overwrite or race a live recorder's row.
+      window.dispatchEvent(
+        new CustomEvent('spacewave-startup-mark', {
+          detail: {
+            detail: {
+              name: 'spacewave.startup.webview.revealed',
+              label: 'webview.revealed',
+              sequence: 2,
+              detail: {},
+            },
+          },
+        }),
+      )
+      await vi.waitFor(async () => {
+        const rows = await store.list()
+        expect(rows.length).toBe(1)
+        expect(rows[0]?.state).toBe(BootReportState.READY)
+      })
+    } finally {
+      collector.seal(BootReportState.ABORTED, 'test-cleanup')
+      collector.stop()
+      delete globals.__swBootReport
+    }
+  })
+
+  it('accumulates zero durable RECORDING rows across repeated lockless boots', async () => {
+    const globals = globalThis as InlineShellGlobals & {
+      indexedDB?: IDBFactory
+    }
+    const factory = new FakeIDBFactory()
+    const previousIndexedDB = globals.indexedDB
+    globals.indexedDB = factory as unknown as IDBFactory
+    try {
+      for (let boot = 1; boot <= 2; boot += 1) {
+        // Fresh module registry per boot mirrors separate document loads;
+        // happy-dom exposes no navigator.locks, so both boots run lockless.
+        vi.resetModules()
+        const collectorModule = await import(
+          /* @vite-ignore */ './collector.js'
+        )
+        delete globals.__swBootReport
+        globals.__swStartupMarks = [
+          {
+            name: 'spacewave.startup.boot.started',
+            label: 'boot.started',
+            sequence: 1,
+            detail: {},
+          },
+          {
+            name: 'spacewave.startup.webview.revealed',
+            label: 'webview.revealed',
+            sequence: 2,
+            detail: {},
+          },
+        ]
+        const collector = collectorModule.initBootReportCollector({
+          entrypointId: 'drive',
+          usableMark: 'webview.revealed',
+        })
+        expect(collector?.isSealed()).toBe(true)
+        collector?.stop()
+        const expectedRows = boot
+        await vi.waitFor(() => {
+          const records = [
+            ...factory.databases
+              .get('bldr-boot-reports')!
+              .stores.get('reports')!.records.values(),
+          ]
+          expect(records.length).toBe(expectedRows)
+        })
+        delete globals.__swBootReport
+        delete globals.__swStartupMarks
+      }
+
+      const records = [
+        ...factory.databases
+          .get('bldr-boot-reports')!
+          .stores.get('reports')!.records.values(),
+      ] as BootReport[]
+      expect(records.length).toBe(2)
+      for (const record of records) {
+        expect(record.state).toBe(BootReportState.READY)
+      }
+    } finally {
+      delete globals.__swStartupMarks
+      delete globals.__swBootReport
+      globals.indexedDB = previousIndexedDB
+    }
+  })
+})

--- a/bldr/web/boot/store.ts
+++ b/bldr/web/boot/store.ts
@@ -36,6 +36,8 @@ interface IDBRequestLike<T> {
 }
 
 interface IDBTransactionLike {
+  // Error mirrors the native transaction error surfaced on abort.
+  readonly error?: Error | null
   objectStore(name: string): {
     get(key: string): IDBRequestLike<unknown>
     getAll(): IDBRequestLike<unknown[]>
@@ -420,8 +422,8 @@ export async function openBootReportStore(
         a: BootReport,
         b: BootReport,
       ): number => {
-        const aAt = a.sealedAt ?? 0n
-        const bAt = b.sealedAt ?? 0n
+        const aAt = (a as { sealedAt?: bigint }).sealedAt ?? 0n
+        const bAt = (b as { sealedAt?: bigint }).sealedAt ?? 0n
         // BigInt-safe comparison: microsecond stamps may exceed the safe
         // integer range in future schemas.
         if (aAt === bAt) return 0

--- a/bldr/web/boot/store.ts
+++ b/bldr/web/boot/store.ts
@@ -1,0 +1,469 @@
+import { BootReport, BootReportState } from './report.pb.js'
+
+// The database contract is frozen at version 1: one `reports` object store
+// keyed reportId with state and sealedAt indexes. First deployment creates
+// version 1. Opening a database at an unknown or newer version fails closed:
+// the store refuses reads and writes and never deletes or resets anything.
+// Future shape changes bump the IndexedDB version and land an explicit
+// versionchange migration here; destructive reset is prohibited.
+export const bootReportDatabaseName = 'bldr-boot-reports'
+export const bootReportDatabaseVersion = 1
+export const bootReportObjectName = 'reports'
+
+// Retention resolves OQ-1: keep the last retentionSealedLimit sealed reports
+// within retentionBodyBudgetBytes of encoded BootReport body bytes. RECORDING
+// reports and the newest FAILED report are never eviction candidates, but the
+// newest FAILED report counts toward both limits. v1 stores no attachments
+// (attachment budget 0); a later attachment phase must version-migrate.
+export const retentionSealedLimit = 100
+export const retentionBodyBudgetBytes = 10 << 20
+
+interface IDBFactoryLike {
+  open(name: string, version?: number): IDBOpenRequestLike
+}
+
+interface IDBOpenRequestLike {
+  onupgradeneeded: ((event: unknown) => unknown) | null
+  onerror: ((event: unknown) => unknown) | null
+  onsuccess: ((event: unknown) => unknown) | null
+}
+
+interface IDBRequestLike<T> {
+  result: T
+  error: Error | null
+  onsuccess: ((event: unknown) => unknown) | null
+  onerror: ((event: unknown) => unknown) | null
+}
+
+interface IDBTransactionLike {
+  objectStore(name: string): {
+    get(key: string): IDBRequestLike<unknown>
+    getAll(): IDBRequestLike<unknown[]>
+    put(value: Record<string, unknown>): IDBRequestLike<unknown>
+    delete(key: string): IDBRequestLike<undefined>
+  }
+  oncomplete: ((event: unknown) => unknown) | null
+  onabort: ((event: unknown) => unknown) | null
+  onerror: ((event: unknown) => unknown) | null
+}
+
+interface IDBDatabaseLike {
+  // Transaction mirrors the native IDBDatabase signature: the object store
+  // name comes first, then the mode. The mode-only call asks the browser for
+  // an object store literally named "readwrite" and fails there.
+  transaction(
+    storeName: string,
+    mode: 'readonly' | 'readwrite',
+  ): IDBTransactionLike
+}
+
+type LockManagerLike =
+  | {
+      request(
+        name: string,
+        options: { ifAvailable: boolean },
+        callback: (lock: unknown) => unknown,
+      ): Promise<unknown>
+    }
+  | undefined
+  | null
+
+export interface OpenBootReportStoreOptions {
+  // IdbFactory overrides the global IndexedDB factory for tests.
+  idbFactory?: IDBFactoryLike | null
+  // Locks overrides the global Web Locks manager for tests. Null disables
+  // locking and selects the conservative non-destructive recovery default.
+  locks?: LockManagerLike
+}
+
+export interface BootReportStore {
+  // Put journals one report write through the serialized writer and resolves
+  // only after the IndexedDB transaction commits. It rejects on storage,
+  // quota, or abort failure instead of dropping the write.
+  put(report: BootReport): Promise<void>
+  // Get returns one persisted report by id.
+  get(reportId: string): Promise<BootReport | undefined>
+  // List returns every persisted report.
+  list(): Promise<BootReport[]>
+  // Delete removes one report by id.
+  delete(reportId: string): Promise<void>
+  // RecoverOnStartup aborts stale RECORDING reports whose crash released
+  // their Web Lock and leaves live concurrent boots untouched.
+  recoverOnStartup(): Promise<void>
+  // HoldBootLock takes this tab's unique recording lock for one report and
+  // keeps it until sealReport releases it after the terminal commit. It
+  // resolves true only after the manager granted the lock to this document,
+  // and false when the lock is held elsewhere, locking is unavailable, or
+  // the request fails.
+  holdBootLock(reportId: string): Promise<boolean>
+  // SealReport writes the complete sealed record in one atomic put and
+  // releases the report's boot lock after the terminal commit.
+  sealReport(
+    report: BootReport,
+    state: BootReportState,
+    terminalErrorCode?: string,
+  ): Promise<BootReport>
+  // ApplyRetention evicts sealed reports beyond the accepted limits after
+  // seal and returns the eviction count with reasons. Defaults are the
+  // accepted OQ-1 recommendation; overrides exist for focused tests.
+  applyRetention(overrides?: {
+    sealedLimit?: number
+    bodyBudgetBytes?: number
+  }): Promise<{ evicted: Array<{ reportId: string; reason: string }> }>
+}
+
+type GlobalsWithBootStore = typeof globalThis & {
+  indexedDB?: IDBFactoryLike
+  navigator?: { locks?: LockManagerLike }
+  __swStartupMarkOverflows?: number
+}
+
+function lockNameFor(reportId: string): string {
+  return `boot-report-lock:${reportId}`
+}
+
+// requestToPromise settles with the request result and rejects with the
+// request error through the native onsuccess/onerror callbacks only.
+function requestToPromise<T>(request: IDBRequestLike<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () =>
+      reject(request.error ?? new Error('indexeddb request failed'))
+  })
+}
+
+// transactionDone resolves when the transaction commits and rejects on abort
+// or error, so a request success followed by a transaction abort still
+// rejects the operation.
+function transactionDone(transaction: IDBTransactionLike): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    transaction.oncomplete = () => resolve()
+    transaction.onabort = () =>
+      reject(transaction.error ?? new Error('indexeddb transaction aborted'))
+    transaction.onerror = () =>
+      reject(new Error('indexeddb transaction failed'))
+  })
+}
+
+// ProbeLock distinguishes a dead holder (the lock grants to us, so the
+// previous tab crashed or closed) from a live holder (the lock stays
+// elsewhere, so another tab still owns the boot). An absent manager reports
+// unavailable and every caller takes the conservative non-destructive path.
+async function probeLock(
+  locks: LockManagerLike,
+  name: string,
+): Promise<'acquired' | 'held-elsewhere' | 'unavailable'> {
+  if (!locks || typeof locks.request !== 'function') return 'unavailable'
+  let outcome: 'acquired' | 'held-elsewhere' = 'held-elsewhere'
+  await locks.request(name, { ifAvailable: true }, (lock) => {
+    outcome = lock ? 'acquired' : 'held-elsewhere'
+  })
+  return outcome
+}
+
+function encodedBodyBytes(report: BootReport): number {
+  try {
+    return BootReport.toBinary(report).byteLength
+  } catch {
+    return Number.MAX_SAFE_INTEGER
+  }
+}
+
+// heldBootLocks maps report ids of live recordings to the release function
+// for this document's own Web Lock hold. sealReport releases the hold after
+// the terminal commit.
+const heldBootLocks = new Map<string, () => void>()
+
+// externalHolders tracks report ids whose lock probe answered held-elsewhere
+// inside this document realm. A live foreign tab registered here is never
+// aborted by recovery; real cross-tab liveness is proven by the Web Lock
+// itself when the realm differs.
+const externalHolders = new Set<string>()
+
+// SerializedWriter executes enqueued operations strictly one at a time in
+// schedule order and never lets one failure break the chain.
+class SerializedWriter {
+  private tail: Promise<unknown> = Promise.resolve()
+
+  run<T>(operation: () => Promise<T>): Promise<T> {
+    const next = this.tail.then(operation, operation)
+    this.tail = next.catch(() => undefined)
+    return next
+  }
+}
+
+export async function openBootReportStore(
+  options: OpenBootReportStoreOptions = {},
+): Promise<BootReportStore> {
+  const globals = globalThis as GlobalsWithBootStore
+  const factory = options.idbFactory ?? globals.indexedDB
+  if (!factory) {
+    throw new Error('BootReportStore requires an IndexedDB factory')
+  }
+  const database = await openDatabase(factory)
+
+  function openDatabase(factory: IDBFactoryLike): Promise<IDBDatabaseLike> {
+    return new Promise((resolve, reject) => {
+      const request = factory.open(
+        bootReportDatabaseName,
+        bootReportDatabaseVersion,
+      )
+      request.onupgradeneeded = (event) => {
+        try {
+          const target = (event as { target: unknown }).target as {
+            result: {
+              createObjectStore(
+                name: string,
+                options: { keyPath: string },
+              ): {
+                createIndex(name: string, keyPath: string): void
+              }
+            }
+          }
+          const store = target.result.createObjectStore(bootReportObjectName, {
+            keyPath: 'reportId',
+          })
+          store.createIndex('state', 'state')
+          store.createIndex('sealedAt', 'sealedAt')
+        } catch (cause) {
+          // An upgrade failure must reject the open instead of escaping as an
+          // uncaught exception while the open request stays pending.
+          reject(cause as Error)
+        }
+      }
+      request.onerror = () => {
+        const error = (request as unknown as { error?: Error }).error
+        reject(error ?? new Error('BootReportStore open failed'))
+      }
+      request.onsuccess = () => {
+        resolve((request as unknown as { result: IDBDatabaseLike }).result)
+      }
+    })
+  }
+
+  const writer = new SerializedWriter()
+
+  const store: BootReportStore = {
+    async put(report: BootReport): Promise<void> {
+      return writer.run(async () => {
+        if (
+          report.state === BootReportState.RECORDING &&
+          !externalHolders.has(report.reportId ?? '')
+        ) {
+          // A RECORDING report written while our own probe answers
+          // held-elsewhere belongs to a live foreign tab: register it so a
+          // same-realm recovery pass never aborts an active boot.
+          const probe = await probeLock(
+            options.locks,
+            lockNameFor(report.reportId ?? ''),
+          )
+          if (probe === 'held-elsewhere') {
+            externalHolders.add(report.reportId ?? '')
+          }
+        }
+        const transaction = database.transaction(
+          bootReportObjectName,
+          'readwrite',
+        )
+        const done = transactionDone(transaction)
+        await requestToPromise(
+          writeObjectStore(transaction).put(
+            report as unknown as Record<string, unknown>,
+          ),
+        )
+        await done
+      })
+    },
+
+    async get(reportId: string): Promise<BootReport | undefined> {
+      return writer.run(async () => {
+        const transaction = database.transaction(
+          bootReportObjectName,
+          'readonly',
+        )
+        const done = transactionDone(transaction)
+        const stored = await requestToPromise(
+          transaction.objectStore(bootReportObjectName).get(reportId),
+        )
+        await done
+        return stored == null ? undefined : (stored as BootReport)
+      })
+    },
+
+    async list(): Promise<BootReport[]> {
+      return writer.run(async () => {
+        const transaction = database.transaction(
+          bootReportObjectName,
+          'readonly',
+        )
+        const done = transactionDone(transaction)
+        const all = await requestToPromise(
+          transaction.objectStore(bootReportObjectName).getAll(),
+        )
+        await done
+        return (all as unknown[]).filter(Boolean) as BootReport[]
+      })
+    },
+
+    async delete(reportId: string): Promise<void> {
+      return writer.run(async () => {
+        const transaction = database.transaction(
+          bootReportObjectName,
+          'readwrite',
+        )
+        const done = transactionDone(transaction)
+        await requestToPromise(
+          transaction.objectStore(bootReportObjectName).delete(reportId),
+        )
+        await done
+      })
+    },
+
+    async recoverOnStartup(): Promise<void> {
+      const reports = await store.list()
+      for (const report of reports) {
+        if (report.state !== BootReportState.RECORDING) continue
+        const reportId = report.reportId ?? ''
+        if (heldBootLocks.has(reportId)) continue
+        if (externalHolders.has(reportId)) continue
+        const probe = await probeLock(options.locks, lockNameFor(reportId))
+        if (probe !== 'acquired') continue
+        await store.put({ ...report, state: BootReportState.ABORTED })
+      }
+    },
+
+    holdBootLock(reportId: string): Promise<boolean> {
+      const locks =
+        options.locks ?? (globals.navigator?.locks as LockManagerLike)
+      if (!locks || typeof locks.request !== 'function') {
+        console.warn(
+          'bootreport: Web Locks unavailable; running without a cross-tab ' +
+            'recording lease',
+        )
+        return Promise.resolve(false)
+      }
+      let release!: () => void
+      const released = new Promise<void>((resolve) => {
+        release = resolve
+      })
+      // The grant settles only inside the manager callback, so the result
+      // resolves there: concurrent contenders all observe the manager's own
+      // answer instead of an optimistic local registration.
+      return new Promise<boolean>((resolveHold) => {
+        try {
+          void locks
+            .request(
+              lockNameFor(reportId),
+              { ifAvailable: true },
+              (lock) => {
+                if (!lock) {
+                  resolveHold(false)
+                  return undefined
+                }
+                // Granted: install the hold now and keep the lock until
+                // sealReport releases it after the terminal commit or the
+                // tab dies, whichever comes first.
+                heldBootLocks.set(reportId, release)
+                resolveHold(true)
+                return released
+              },
+            )
+            ?.catch((cause: unknown) => {
+              // Drop the registration only when this request installed it;
+              // a failed contender must never release another holder's lock.
+              if (heldBootLocks.get(reportId) === release) {
+                heldBootLocks.delete(reportId)
+              }
+              console.warn('bootreport: lock hold failed', cause)
+              resolveHold(false)
+            })
+        } catch (cause) {
+          console.warn('bootreport: lock hold failed', cause)
+          resolveHold(false)
+        }
+      })
+    },
+
+    async sealReport(report, state, terminalErrorCode) {
+      const terminal = (report.marks ?? []).at(-1)
+      const sealed: BootReport = {
+        ...report,
+        state,
+        terminalMark: terminal?.label,
+        terminalErrorCode,
+        sealedAt: BigInt(Date.now()) * 1000n,
+      } as BootReport
+      await this.put(sealed)
+      const release = heldBootLocks.get(sealed.reportId ?? '')
+      if (release) {
+        heldBootLocks.delete(sealed.reportId ?? '')
+        release()
+      }
+      return sealed
+    },
+
+    async applyRetention(overrides) {
+      const evicted: Array<{ reportId: string; reason: string }> = []
+      const sealedLimit =
+        overrides?.sealedLimit ?? retentionSealedLimit
+      const bodyBudget =
+        overrides?.bodyBudgetBytes ?? retentionBodyBudgetBytes
+      const reports = await store.list()
+      const terminals = reports.filter((report) => {
+        return (
+          report.state === BootReportState.READY ||
+          report.state === BootReportState.FAILED ||
+          report.state === BootReportState.ABORTED
+        )
+      })
+      const recency = (
+        a: BootReport,
+        b: BootReport,
+      ): number => {
+        const aAt = a.sealedAt ?? 0n
+        const bAt = b.sealedAt ?? 0n
+        // BigInt-safe comparison: microsecond stamps may exceed the safe
+        // integer range in future schemas.
+        if (aAt === bAt) return 0
+        return aAt > bAt ? -1 : 1
+      }
+      const newestFailed = terminals
+        .filter((report) => report.state === BootReportState.FAILED)
+        .sort(recency)
+        .at(0)
+      const ordered = terminals.sort(recency)
+      let kept = 0
+      let budget = bodyBudget
+      for (const report of ordered) {
+        const reportId = report.reportId ?? ''
+        if (newestFailed && reportId === newestFailed.reportId) {
+          // The newest FAILED report is never evicted, but it still consumes
+          // both the count and byte budgets.
+          kept += 1
+          budget -= encodedBodyBytes(report)
+          continue
+        }
+        const size = encodedBodyBytes(report)
+        if (kept >= sealedLimit) {
+          evicted.push({ reportId, reason: 'sealed-limit' })
+          await store.delete(reportId)
+          continue
+        }
+        if (size > budget) {
+          evicted.push({ reportId, reason: 'body-budget' })
+          await store.delete(reportId)
+          continue
+        }
+        budget -= size
+        kept += 1
+      }
+      return { evicted }
+    },
+  }
+
+  function writeObjectStore(transaction: IDBTransactionLike) {
+    return transaction.objectStore(bootReportObjectName)
+  }
+
+  return store
+}

--- a/bldr/web/boot/vocabulary.ts
+++ b/bldr/web/boot/vocabulary.ts
@@ -1,0 +1,262 @@
+import { BootPhase } from './report.pb.js'
+
+// This module is the single TypeScript source of the BootReport startup
+// vocabulary. The validator and the collector both consume it so accepted
+// labels, owners, operations, and phases cannot drift between them.
+
+export const bootMarkLabels = new Set([
+  'boot.started',
+  'boot.aborted',
+  'boot.sealed',
+  'content-ready',
+  'runtime.started',
+  'runtime.failed',
+  'runtime.last-observed',
+  'worker.ready',
+  'boot-status.loading',
+  'boot-status.manifest',
+  'boot-status.manifest-ready',
+  'boot-status.wasm',
+  'boot-status.entrypoint',
+  'boot-status.entrypoint-error',
+  'shell.entrypoint-loaded',
+  'shell.container-resolved',
+  'boot-status.runtime',
+  'runtime.wait-start',
+  'runtime.mode-selected',
+  'service-worker.install-start',
+  'service-worker.register-start',
+  'runtime.client-open-start',
+  'service-worker.install-ready',
+  'service-worker.register-ready',
+  'service-worker.update-ready',
+  'service-worker.activate-ready',
+  'service-worker.control-ready',
+  'service-worker.port-started',
+  'service-worker.port-sent',
+  'runtime.worker-create-start',
+  'runtime.worker-created',
+  'runtime.opfs-bridge-ready',
+  'runtime.client-open-sent',
+  'runtime.client-channel-opened',
+  'runtime.client-channel-acked',
+  'runtime.connected',
+  'runtime.client-connect-ack',
+  'runtime.event-connected',
+  'runtime.wait-conn-ready',
+  'runtime.wait-ready',
+  'shell.deferred-boot-ready',
+  'shell.immediate-boot-ready',
+  'boot-status.ready',
+  'manifest-copy.selected',
+  'manifest-copy.waiting-for-running',
+  'manifest-copy.copying',
+  'manifest-copy.done',
+  'manifest-copy.failed',
+  'boot-status.app',
+  'shell.boot-requested',
+  'quickstart.static-handoff-requested',
+  'webview.loading-surface-mounted',
+  'webview.registered',
+  'worker.first-ready',
+  'plugin.frontend-ready',
+  'plugin.capability-ready',
+  'webview.stylesheet-ready',
+  'webview.component-ready',
+  'webview.revealed',
+  'webview.loading-surface-revealed',
+])
+
+export const bootOwners = new Set([
+  'bldr',
+  'browser',
+  'cdn',
+  'entrypoint',
+  'fixture',
+  'manifest-materializer',
+  'network',
+  'opfs',
+  'plugin-host',
+  'runtime',
+  'scheduler',
+  'service-worker',
+  'shell',
+  'webview',
+  'worker',
+])
+
+export const bootOperations = new Set([
+  'access-manifest',
+  'checksum',
+  'copy-manifest',
+  'decode',
+  'dist-main',
+  'download-entrypoint',
+  'execute-plugin',
+  'load-dist-main',
+  'open-release-world',
+  'opfs-read',
+  'opfs-write',
+  'publish-local-ref',
+  'read-release-blocks',
+  'release-block-request',
+  'release-pack-range',
+  'release-world-provider',
+  'runtime',
+  'select-startup-manifests',
+  'sync-manifest',
+  'wait-for-provider',
+  'wait-for-running',
+  'worker-request',
+])
+
+export const bootDetailKeys = new Set([
+  'attempt-count',
+  'blocks-copied',
+  'blocks-deduped',
+  'blocks-existing',
+  'blocks-seen',
+  'blocks-written',
+  'cache-mode',
+  'candidate-count',
+  'copied-bytes',
+  'demand-read-bytes',
+  'demand-read-count',
+  'duration-ratio',
+  'logical-source-bytes',
+  'phase',
+  'revision-count',
+  'skipped-subtrees',
+  'written-bytes',
+])
+
+export const bootDetailStrings = new Set([
+  'cold',
+  'warm',
+  'hot',
+  'selected',
+  'waiting-for-running',
+  'copying',
+  'local-ref-publication',
+  'sync',
+  'done',
+  'failed',
+])
+
+export const bootCounterNames = new Set([
+  'blocks-copied',
+  'blocks-deduped',
+  'blocks-existing',
+  'blocks-seen',
+  'blocks-written',
+  'copied-bytes',
+  'demand-read-bytes',
+  'demand-read-count',
+  'download-bytes',
+  'logical-source-bytes',
+  'revision-count',
+  'selected-candidates',
+  'skipped-subtrees',
+  'written-bytes',
+])
+
+export const bootTerminalErrorCodes = new Set([
+  'boot-interrupted',
+  'entrypoint-load-failed',
+  'manifest-copy-failed',
+  'runtime-init-failed',
+  'startup-aborted',
+  'startup-timeout',
+])
+
+export const bootEntrypoints = new Set([
+  'canvas',
+  'computers',
+  'drive',
+  'forge',
+  'space',
+])
+
+export const bootProjects = new Set(['spacewave'])
+
+export const bootBrowserEngines = new Set(['chromium', 'webkit'])
+
+export const bootOSFamilies = new Set(['android', 'darwin', 'ios', 'linux', 'windows'])
+
+export const bootArchitectures = new Set(['amd64', 'arm64', 'wasm'])
+
+// bootMarkPhases partitions every accepted startup mark into the report's
+// phase timeline. The mapping mirrors the app's startup-mark phase ladder in
+// app/loading/status/browser-runtime-state.ts.
+export const bootMarkPhases: ReadonlyMap<string, BootPhase> = new Map([
+  ['boot.started', BootPhase.PREPARE],
+  ['boot.aborted', BootPhase.DONE],
+  ['boot.sealed', BootPhase.DONE],
+  ['content-ready', BootPhase.DONE],
+  ['runtime.started', BootPhase.RUNTIME],
+  ['runtime.failed', BootPhase.RUNTIME],
+  ['runtime.last-observed', BootPhase.RUNTIME],
+  ['worker.ready', BootPhase.RUNTIME],
+  ['boot-status.loading', BootPhase.PREPARE],
+  ['boot-status.manifest', BootPhase.PREPARE],
+  ['boot-status.manifest-ready', BootPhase.PREPARE],
+  ['boot-status.wasm', BootPhase.CONNECT],
+  ['boot-status.entrypoint', BootPhase.CONNECT],
+  ['boot-status.entrypoint-error', BootPhase.CONNECT],
+  ['shell.entrypoint-loaded', BootPhase.CONNECT],
+  ['shell.container-resolved', BootPhase.CONNECT],
+  ['boot-status.runtime', BootPhase.RUNTIME],
+  ['runtime.wait-start', BootPhase.RUNTIME],
+  ['runtime.mode-selected', BootPhase.RUNTIME],
+  ['service-worker.install-start', BootPhase.CONNECT],
+  ['service-worker.register-start', BootPhase.CONNECT],
+  ['runtime.client-open-start', BootPhase.CONNECT],
+  ['service-worker.install-ready', BootPhase.CONNECT],
+  ['service-worker.register-ready', BootPhase.CONNECT],
+  ['service-worker.update-ready', BootPhase.CONNECT],
+  ['service-worker.activate-ready', BootPhase.CONNECT],
+  ['service-worker.control-ready', BootPhase.CONNECT],
+  ['service-worker.port-started', BootPhase.CONNECT],
+  ['service-worker.port-sent', BootPhase.CONNECT],
+  ['runtime.worker-create-start', BootPhase.RUNTIME],
+  ['runtime.worker-created', BootPhase.RUNTIME],
+  ['runtime.opfs-bridge-ready', BootPhase.RUNTIME],
+  ['runtime.client-open-sent', BootPhase.RUNTIME],
+  ['runtime.client-channel-opened', BootPhase.RUNTIME],
+  ['runtime.client-channel-acked', BootPhase.RUNTIME],
+  ['runtime.connected', BootPhase.RUNTIME],
+  ['runtime.client-connect-ack', BootPhase.RUNTIME],
+  ['runtime.event-connected', BootPhase.RUNTIME],
+  ['runtime.wait-conn-ready', BootPhase.RUNTIME],
+  ['runtime.wait-ready', BootPhase.RUNTIME],
+  ['shell.deferred-boot-ready', BootPhase.RUNTIME],
+  ['shell.immediate-boot-ready', BootPhase.RUNTIME],
+  ['boot-status.ready', BootPhase.RUNTIME],
+  ['manifest-copy.selected', BootPhase.RUNTIME],
+  ['manifest-copy.waiting-for-running', BootPhase.RUNTIME],
+  ['manifest-copy.copying', BootPhase.RUNTIME],
+  ['manifest-copy.done', BootPhase.RUNTIME],
+  ['manifest-copy.failed', BootPhase.RUNTIME],
+  ['boot-status.app', BootPhase.FRAME],
+  ['shell.boot-requested', BootPhase.FRAME],
+  ['quickstart.static-handoff-requested', BootPhase.FRAME],
+  ['webview.loading-surface-mounted', BootPhase.FRAME],
+  ['webview.registered', BootPhase.FRAME],
+  ['worker.first-ready', BootPhase.FRAME],
+  ['plugin.frontend-ready', BootPhase.FRAME],
+  ['plugin.capability-ready', BootPhase.FRAME],
+  ['webview.stylesheet-ready', BootPhase.FRAME],
+  ['webview.component-ready', BootPhase.FRAME],
+  ['webview.revealed', BootPhase.DONE],
+  ['webview.loading-surface-revealed', BootPhase.DONE],
+])
+
+// bootMarkErrorCodes maps failure marks to the stable terminal error codes the
+// validator accepts. Marks absent from the map do not fail a boot.
+// boot-status.entrypoint-error and manifest-copy.failed are timeline labels
+// only today: their producers recover or retry, so sealing on them would make
+// transient failures terminal. A mark joins this map only when an explicitly
+// non-retryable producer owns it.
+export const bootMarkErrorCodes: ReadonlyMap<string, string> = new Map([
+  ['runtime.failed', 'runtime-init-failed'],
+])

--- a/bldr/web/entrypoint/entrypoint.tsx
+++ b/bldr/web/entrypoint/entrypoint.tsx
@@ -8,6 +8,7 @@ import {
 import { isDesktop, WebDocument as BldrWebDocument } from '@aptre/bldr'
 import type { WebDocumentOptions } from '@aptre/bldr'
 
+import { initBootReportCollector } from '../boot/collector.js'
 import { initBrowserReleaseAutoReload } from '../bldr/browser-release-update.js'
 import { markStartupBoundary } from '../bldr/startup-marks.js'
 import { setAppPath } from './app-path.js'
@@ -93,6 +94,30 @@ if (!isDesktop) {
 }
 bindBrowserBootStatusToStartupMarks()
 markStartupBoundary('shell.entrypoint-loaded', { source: 'browser' })
+
+// Install the BootReport collector exactly once per document at bootstrap.
+// The entrypoint id maps the public route to the validator's entrypoint
+// vocabulary, and webview.revealed is the declared usable boundary. The
+// collector is observation only: it never reorders, retries, or gates
+// startup or pairing work.
+try {
+  const pathSegment = window.location.pathname
+    .split('/')
+    .filter(Boolean)
+    .at(0)
+  const entrypointContractIds = [
+    'canvas',
+    'computers',
+    'drive',
+    'forge',
+    'space',
+  ] as const
+  const entrypointId =
+    entrypointContractIds.find((id) => id === pathSegment) ?? 'space'
+  initBootReportCollector({ entrypointId, usableMark: 'webview.revealed' })
+} catch (cause) {
+  console.warn('bootreport: collector install failed', cause)
+}
 
 type StartupModule = {
   default: React.LazyExoticComponent<React.ComponentType>

--- a/bldr/web/entrypoint/index/index.html
+++ b/bldr/web/entrypoint/index/index.html
@@ -100,6 +100,31 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app. </noscript>
+    <script>
+      // Bldr inline boot recorder: bounded synchronous enqueue buffer for the
+      // earliest startup marks. This script runs before any module and before
+      // manifest lookup; it loads no TypeScript and touches no storage. The
+      // BootReportStore module drains this buffer into IndexedDB once it
+      // opens, and overflow past the bound is counted, never silent.
+      ;(function () {
+        var limit = 4096
+        window.__swStartupMarks = window.__swStartupMarks || []
+        window.__swStartupMarkOverflows = 0
+        window.__swStartupMarkPush = function (mark) {
+          if (window.__swStartupMarks.length >= limit) {
+            window.__swStartupMarkOverflows += 1
+            return
+          }
+          window.__swStartupMarks.push(mark)
+        }
+        window.__swStartupMarkPush({
+          name: 'spacewave.startup.boot.started',
+          label: 'boot.started',
+          sequence: 1,
+          detail: { source: 'browser' },
+        })
+      })()
+    </script>
     <script type="importmap">
       {{ .ImportMap.String }}
     </script>


### PR DESCRIPTION
Collect the browser startup-mark stream into one durable BootReport per document boot.

The inline shell seeds the collector with the marks emitted before bundle evaluation. A bounded document-global buffer counts overflow past its limit, and the collector persists that count as a REPORT_CONTRACT validation failure at seal time.

Durability runs through an IndexedDB store keyed by reportId with a frozen version-1 schema that fails closed against unknown or newer versions instead of resetting data. Every recording write requires this boot's Web Locks lease: recovery first aborts stale RECORDING rows whose lock died with their tab, the lease grants before the first durable write, and a denied or unavailable lease keeps the boot memory-only until it terminates. Terminal READY, FAILED, and ABORTED records persist without a lease because each boot mints one device-local random report id that cannot overwrite or race a live recorder's row. Retention keeps the newest sealed reports under a count and encoded-byte budget while protecting live boots and the newest FAILED record.

The entrypoint installs exactly one collector per document at bootstrap. It replays the inline shell's earlier marks, journals live marks through the store, seals READY at the entrypoint's declared usable mark or FAILED on a terminal failure mark, and enforces the frozen report contract through a validator shared by producer and store.