### PR TITLE
fix(bldr): gate runtime client open on dedicated host election

### DIFF
--- a/bldr/web/bldr/web-document.test.ts
+++ b/bldr/web/bldr/web-document.test.ts
@@ -574,6 +574,75 @@ describe('WebDocument service worker startup', () => {
 
     expect(startRuntimeOnce).toHaveBeenCalledOnce()
   })
+
+  it('holds the runtime client open until the DedicatedWorker host election resolves', async () => {
+    const messageListeners: Array<(ev: MessageEvent) => void> = []
+    const controllerChangeListeners: Array<(ev: Event) => void> = []
+    installSessionStorage()
+    vi.stubGlobal('location', {
+      href: 'https://example.test/app',
+      reload: vi.fn(),
+    })
+    const sw = { postMessage: vi.fn() } as unknown as ServiceWorker
+    const serviceWorker = {
+      controller: sw as ServiceWorker | null,
+      addEventListener: vi.fn((type: string, listener: EventListener) => {
+        if (type === 'message') {
+          messageListeners.push(listener as (ev: MessageEvent) => void)
+        }
+        if (type === 'controllerchange') {
+          controllerChangeListeners.push(listener as (ev: Event) => void)
+        }
+      }),
+      register: vi.fn(),
+    }
+    vi.stubGlobal('navigator', { serviceWorker })
+
+    // The election is in flight: DedicatedWorkerHostOwner.start() requested
+    // the host Web Lock, but neither the grant callback nor the attach query
+    // has run, so the role is still pending and no runtime port is bound.
+    const doc = buildTestWebDocument()
+    doc.runtimeConnected = false
+    doc.dedicatedRuntimeHost = { role: 'pending' }
+    vi.spyOn(
+      doc as unknown as { initServiceWorkerPort: (sw: ServiceWorker) => void },
+      'initServiceWorkerPort',
+    ).mockImplementation(() => {})
+    // Deliberately unresolved: the test asserts the open attempt happened, not
+    // that the connection succeeded, so no resume-ready seeding outlives the
+    // test.
+    const waitConn = vi.fn().mockReturnValue(new Promise(() => {}))
+    doc.webRuntimeClient.waitConn = waitConn
+    const wb: TestWorkbox = {
+      register: vi
+        .fn()
+        .mockResolvedValue({
+          scope: 'https://example.test/',
+        } as ServiceWorkerRegistration),
+      update: vi.fn().mockResolvedValue(undefined),
+      controlling: Promise.resolve(sw),
+    }
+
+    await doc.initServiceWorker(wb, '/sw.mjs')
+
+    // Both control-observation routes fire while the role is still pending.
+    // Neither may attempt a client open: the attach relay and the runtime port
+    // do not exist yet, so the attempt throws webRuntimePort not initialized.
+    messageListeners[0](
+      new MessageEvent('message', { data: { from: 'sw', init: true } }),
+    )
+    controllerChangeListeners[0](new Event('controllerchange'))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(waitConn).not.toHaveBeenCalled()
+
+    // The election callback resolved the role (startHost ran and bound the
+    // runtime port). A control observation on the other handler retries and
+    // opens one client.
+    doc.dedicatedRuntimeHost!.role = 'host'
+    controllerChangeListeners[0](new Event('controllerchange'))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(waitConn).toHaveBeenCalledOnce()
+  })
 })
 
 describe('shouldForceDedicatedWorkers', () => {

--- a/bldr/web/bldr/web-document.ts
+++ b/bldr/web/bldr/web-document.ts
@@ -1779,9 +1779,7 @@ export class WebDocument extends SimpleEventEmitter<WebDocumentEvents> {
       // A service worker talking to this document is proof that one controls
       // it, which is the condition the runtime start is waiting for.
       this.startRuntimeOnce?.()
-      if (!this.runtimeConnected) {
-        this.taskEnsureWebRuntimeConn()
-      }
+      this.taskEnsureWebRuntimeConnAfterStartGate()
     }
 
     const attachSwMessageListener = () => {
@@ -1808,9 +1806,7 @@ export class WebDocument extends SimpleEventEmitter<WebDocumentEvents> {
       // settle, so this route must start the runtime rather than only rebind
       // the port to it.
       this.startRuntimeOnce?.()
-      if (!this.runtimeConnected) {
-        this.taskEnsureWebRuntimeConn()
-      }
+      this.taskEnsureWebRuntimeConnAfterStartGate()
     })
 
     // register the service worker
@@ -2998,6 +2994,20 @@ export class WebDocument extends SimpleEventEmitter<WebDocumentEvents> {
           this.webDocumentLivenessLockState = 'idle'
         }
       })
+  }
+
+  // taskEnsureWebRuntimeConnAfterStartGate ensures the runtime connection once
+  // the control observation can route a client open. While the DedicatedWorker
+  // host election is pending, neither the attach relay nor the runtime port
+  // exists, so an immediate open fails with webRuntimePort not initialized;
+  // the election callbacks own the first attempt until they resolve the role.
+  private taskEnsureWebRuntimeConnAfterStartGate() {
+    if (this.dedicatedRuntimeHost?.role === 'pending') {
+      return
+    }
+    if (!this.runtimeConnected) {
+      this.taskEnsureWebRuntimeConn()
+    }
   }
 
   // taskEnsureWebRuntimeConn ensures an active connection with the WebRuntime.


### PR DESCRIPTION
WebDocument's ServiceWorker control handlers ensured a runtime connection immediately after startRuntimeOnce(). In DedicatedWorker mode the host election is still pending at that point: neither the attach relay nor webRuntimePort exists until an election callback fires, so the attempt failed with "webRuntimePort not initialized" and logged a failed connect on every control observation during the election window.

The fix gates the immediate ensure on the election role inside WebDocument, the component that owns the start gate. While the role is pending the handler skips the attempt; the existing election callbacks and later control observations own the first connection instead. No new readiness state, promise, timeout, or retry path, and DedicatedWorkerHostOwner is unchanged. SharedWorker, Electron, and saucer paths are untouched because the gate only applies when a DedicatedWorkerHostOwner exists.

A focused unit test holds the role pending through both ServiceWorker control routes and proves no client open until the role resolves, then exactly one open after resolution.

Verification: bun run bldr:typecheck clean; focused vitest suite bldr/web/bldr/web-document.test.ts 49/49 passed; live Playwright run of the worker-comms singleton coordinator suite in Chromium with SharedWorker disabled passed 2/2 with zero occurrences of the failure signature.