### PR TITLE
chore(deps): retarget goscript pin to eae27eef master merge

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 tool github.com/s4wave/goscript/cmd/goscript
 
-require github.com/s4wave/goscript v0.2.27-0.20260823085407-dff344f35d60 // master
+require github.com/s4wave/goscript v0.2.27-0.20260823203705-eae27eef3a5a // master
 
 replace (
 	// aperture: use compatibility forks

--- a/go.sum
+++ b/go.sum
@@ -313,8 +313,8 @@ github.com/restic/chunker v0.5.0/go.mod h1:z0cH2BejpW636LXw0R/BGyv+Ey8+m9QGiOanD
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/s4wave/goscript v0.2.27-0.20260823085407-dff344f35d60 h1:5GmvbYTBHy0OwfCYX94VYxCb3BEj4f7iRd8OkZ14zaI=
-github.com/s4wave/goscript v0.2.27-0.20260823085407-dff344f35d60/go.mod h1:2PkLvl4v5IXRzAh+HpOQymrS7Z6mNmAOKY89EoAhv8A=
+github.com/s4wave/goscript v0.2.27-0.20260823203705-eae27eef3a5a h1:AFZ8TdaaBC+OtwWwCR8mLCdCZ318CF20M/OhSS2Sh14=
+github.com/s4wave/goscript v0.2.27-0.20260823203705-eae27eef3a5a/go.mod h1:2PkLvl4v5IXRzAh+HpOQymrS7Z6mNmAOKY89EoAhv8A=
 github.com/sasha-s/go-deadlock v0.3.9 h1:fiaT9rB7g5sr5ddNZvlwheclN9IP86eFW9WgqlEQV+w=
 github.com/sasha-s/go-deadlock v0.3.9/go.mod h1:KuZj51ZFmx42q/mPaYbRk0P1xcwe697zsJKE03vD4/Y=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=


### PR DESCRIPTION
Retarget the GoScript tool and library pin to the published master merge eae27eef3a5af286b4904e35fb0c8c871d954660 (PR s4wave/goscript#158).\n\nThat merge fixes the protobuf TypeScript binding constructor resolver: imported message constructors are now derived from the declared field type through exactly one qualifying non-type-only lowered import, instead of guessing the alias from the package name or directory basename. This is the fix for the goscript/protobuf-ts-binding:unresolved family that stops nine Spacewave producer CI jobs before browser runtime.\n\ngo.mod and go.sum only; no source changes.