### PR TITLE
fix(core): make listener yield policy compile for js

### DIFF
--- a/core/resource/listener/yieldpolicy/broker.go
+++ b/core/resource/listener/yieldpolicy/broker.go
@@ -1,5 +1,3 @@
-//go:build !js
-
 // Package yieldpolicy implements the yield-policy broker used by the
 // desktop resource listener. The broker lets the local UI surface an
 // interactive prompt when a peer (typically "spacewave serve") asks the

--- a/core/resource/listener/yieldpolicy/broker_test.go
+++ b/core/resource/listener/yieldpolicy/broker_test.go
@@ -1,5 +1,3 @@
-//go:build !js
-
 package yieldpolicy
 
 import (


### PR DESCRIPTION
The wasm startup manifest chain loads the resource listener package, but every file in yieldpolicy carried a //go:build !js constraint since b01e7deb7, so any js-target build failed with 'build constraints exclude all Go files'. The bldr/goscript loader surfaced this on CI as 'package load failed ... invalid package name', which has been failing the wasm E2E family on master.

The broker itself is pure Go state machinery: its imports are context, slices, strconv, strings, time, util/broadcast, and pkg/errors, with no syscall/js, os, or net usage. The desktop-only boundary is the Unix socket prompt path in execute.go, which stays behind !js, and controller-js.go already makes Execute a no-op under js. This change drops the stale tags so the single broker implementation builds everywhere instead of forking a second js-only broker that could drift. Under js, an unresolved prompt reaches the existing timeout-deny path.