### PR TITLE
fix(app): reuse existing quickstart space instead of recreating

### DIFF
--- a/app/quickstart/create.test.ts
+++ b/app/quickstart/create.test.ts
@@ -671,6 +671,9 @@ describe('quickstart create', () => {
         createSpace: vi.fn().mockResolvedValue({
           sharedObjectRef: { providerResourceRef: { id: 'space-1' } },
         }),
+        watchResourcesList: vi
+          .fn()
+          .mockReturnValue(asyncValues({ spacesList: [] })),
         release: vi.fn(),
         [Symbol.dispose]: vi.fn(),
       }),
@@ -756,6 +759,9 @@ describe('quickstart create', () => {
         createSpace: vi.fn().mockResolvedValue({
           sharedObjectRef: { providerResourceRef: { id: 'space-1' } },
         }),
+        watchResourcesList: vi
+          .fn()
+          .mockReturnValue(asyncValues({ spacesList: [] })),
         release: vi.fn(),
         [Symbol.dispose]: vi.fn(),
       }),
@@ -819,6 +825,210 @@ describe('quickstart create', () => {
     expect(timing?.finishedMs).toEqual(expect.any(Number))
     expect(timing?.error).toBe('Aborted')
     expect(globalThis.__s4wave_debug?.quickstartTiming?.state).toBe('cancelled')
+  })
+
+  it('reuses an existing quickstart space instead of creating another', async () => {
+    const cleanup: RegisterCleanup = (value) => value
+    localProviderMocks.createAccount.mockResolvedValue({
+      sessionListEntry: {
+        sessionIndex: 3,
+        sessionRef: { providerResourceRef: { providerId: 'local' } },
+      },
+    })
+    const createSpace = vi.fn().mockResolvedValue({
+      sharedObjectRef: { providerResourceRef: { id: 'space-duplicate' } },
+    })
+    const applyWorldOp = vi.fn<ApplyWorldOp>().mockResolvedValue({
+      seqno: 1n,
+      sysErr: false,
+    })
+    const { world } = buildQuickstartWorld()
+    const root = {
+      listSessions: vi.fn().mockResolvedValue({ sessions: [] }),
+      lookupProvider: vi.fn().mockResolvedValue({
+        resourceRef: { providerId: 'local' },
+        release: vi.fn(),
+        [Symbol.dispose]: vi.fn(),
+      }),
+      mountSession: vi.fn().mockResolvedValue({
+        createSpace,
+        watchResourcesList: vi.fn().mockReturnValue(
+          asyncValues({
+            spacesList: [
+              {
+                entry: {
+                  ref: {
+                    providerResourceRef: {
+                      providerId: 'local',
+                      id: 'space-existing',
+                    },
+                  },
+                  source: 'created',
+                },
+                spaceMeta: { name: 'My Notebook' },
+              },
+              {
+                entry: {
+                  ref: {
+                    providerResourceRef: {
+                      providerId: 'local',
+                      id: 'space-other',
+                    },
+                  },
+                  source: 'created',
+                },
+                spaceMeta: { name: 'My Drive' },
+              },
+            ],
+          }),
+        ),
+        release: vi.fn(),
+        [Symbol.dispose]: vi.fn(),
+      }),
+    }
+    spaceMocks.mountSpace.mockResolvedValue({
+      accessWorldState: vi.fn().mockResolvedValue(world),
+      mountSpaceContents: vi.fn().mockResolvedValue({
+        release: vi.fn(),
+        [Symbol.dispose]: vi.fn(),
+      }),
+    })
+
+    const result = await createQuickstartSetup(
+      root as never,
+      'notebook',
+      new AbortController().signal,
+      cleanup,
+    )
+
+    expect(createSpace).not.toHaveBeenCalled()
+    expect(result.spaceResp.sharedObjectRef?.providerResourceRef?.id).toBe(
+      'space-existing',
+    )
+    // Reuse skips the seed pipeline entirely.
+    expect(applyWorldOp).not.toHaveBeenCalled()
+  })
+
+  it('reuses an existing quickstart space without reseeding its content', async () => {
+    const cleanup: RegisterCleanup = (value) => value
+    localProviderMocks.createAccount.mockResolvedValue({
+      sessionListEntry: {
+        sessionIndex: 3,
+        sessionRef: { providerResourceRef: { providerId: 'local' } },
+      },
+    })
+    quickstartRegistryMocks.ListQuickstarts.mockResolvedValue({
+      registrations: [],
+    })
+    const createSpace = vi.fn().mockResolvedValue({
+      sharedObjectRef: { providerResourceRef: { id: 'space-duplicate' } },
+    })
+    const applyWorldOp = vi.fn<ApplyWorldOp>()
+    const { world } = buildQuickstartWorld()
+    const root = {
+      listSessions: vi.fn().mockResolvedValue({ sessions: [] }),
+      lookupProvider: vi.fn().mockResolvedValue({
+        resourceRef: { providerId: 'local' },
+        release: vi.fn(),
+        [Symbol.dispose]: vi.fn(),
+      }),
+      mountSession: vi.fn().mockResolvedValue({
+        createSpace,
+        watchResourcesList: vi.fn().mockReturnValue(
+          asyncValues({
+            spacesList: [
+              {
+                entry: {
+                  ref: {
+                    providerResourceRef: {
+                      providerId: 'local',
+                      id: 'space-notebook',
+                    },
+                  },
+                  source: 'created',
+                },
+                spaceMeta: { name: 'My Notebook' },
+              },
+            ],
+          }),
+        ),
+        release: vi.fn(),
+        [Symbol.dispose]: vi.fn(),
+      }),
+    }
+    spaceMocks.mountSpace.mockImplementation(async () => ({
+      accessWorldState: vi.fn().mockResolvedValue(world),
+      mountSpaceContents: vi.fn().mockResolvedValue({
+        release: vi.fn(),
+        [Symbol.dispose]: vi.fn(),
+      }),
+    }))
+
+    await createQuickstartSetup(
+      root as never,
+      'notebook',
+      new AbortController().signal,
+      cleanup,
+    )
+
+    expect(createSpace).not.toHaveBeenCalled()
+    expect(quickstartRegistryMocks.ExecuteQuickstart).not.toHaveBeenCalled()
+    expect(applyWorldOp).not.toHaveBeenCalled()
+  })
+
+  it('creates a new quickstart space when no matching space exists', async () => {
+    const cleanup: RegisterCleanup = (value) => value
+    localProviderMocks.createAccount.mockResolvedValue({
+      sessionListEntry: {
+        sessionIndex: 3,
+        sessionRef: { providerResourceRef: { providerId: 'local' } },
+      },
+    })
+    const createSpace = vi.fn().mockResolvedValue({
+      sharedObjectRef: { providerResourceRef: { id: 'space-new' } },
+    })
+    const { world, applyWorldOp } = buildQuickstartWorld()
+    const root = {
+      listSessions: vi.fn().mockResolvedValue({ sessions: [] }),
+      lookupProvider: vi.fn().mockResolvedValue({
+        resourceRef: { providerId: 'local' },
+        release: vi.fn(),
+        [Symbol.dispose]: vi.fn(),
+      }),
+      mountSession: vi.fn().mockResolvedValue({
+        createSpace,
+        watchResourcesList: vi
+          .fn()
+          .mockReturnValue(asyncValues({ spacesList: [] })),
+        release: vi.fn(),
+        [Symbol.dispose]: vi.fn(),
+      }),
+    }
+    spaceMocks.mountSpace.mockResolvedValue({
+      accessWorldState: vi.fn().mockResolvedValue(world),
+      mountSpaceContents: vi.fn().mockResolvedValue({
+        release: vi.fn(),
+        [Symbol.dispose]: vi.fn(),
+      }),
+    })
+
+    const result = await createQuickstartSetup(
+      root as never,
+      'space',
+      new AbortController().signal,
+      cleanup,
+    )
+
+    expect(createSpace).toHaveBeenCalledTimes(1)
+    expect(createSpace).toHaveBeenCalledWith(
+      { spaceName: 'My Space' },
+      expect.any(AbortSignal),
+    )
+    expect(result.spaceResp.sharedObjectRef?.providerResourceRef?.id).toBe(
+      'space-new',
+    )
+    // The seed pipeline still runs for a genuinely missing space.
+    expect(applyWorldOp).toHaveBeenCalled()
   })
 
   it('creates Drive storage and indexes the intro wizard before raw files', async () => {
@@ -985,6 +1195,9 @@ to try first.
           id: 73,
           sharedObjectRef: { providerResourceRef: { id: 'space-1' } },
         }),
+        watchResourcesList: vi
+          .fn()
+          .mockReturnValue(asyncValues({ spacesList: [] })),
         release: vi.fn(),
         [Symbol.dispose]: vi.fn(),
       }),

--- a/app/quickstart/create.ts
+++ b/app/quickstart/create.ts
@@ -10,6 +10,7 @@ import { ObjectTypeRegistryResourceServiceClient } from '@s4wave/sdk/objecttype/
 import type { IWorldState } from '@s4wave/sdk/world/world-state.js'
 import { LocalProvider } from '@s4wave/sdk/provider/local/local.js'
 import { Space } from '@s4wave/sdk/space/space.js'
+import type { SpaceSoListEntry } from '@s4wave/sdk/space/space.pb.js'
 import { SpaceContents } from '@s4wave/sdk/space/contents.js'
 import { SUBPATH_DELIMITER } from '@s4wave/sdk/space/object-uri.js'
 import { Engine } from '@s4wave/sdk/world/engine.js'
@@ -646,6 +647,27 @@ export async function createQuickstartSetupFromSession(
   }
 }
 
+// findExistingQuickstartSpace returns the first space-list entry whose space
+// name matches the quickstart's seeded space name, or undefined when no
+// snapshot entry matches.
+async function findExistingQuickstartSpace(
+  session: Session,
+  spaceName: string,
+  abortSignal: AbortSignal,
+): Promise<SpaceSoListEntry | undefined> {
+  for await (const resp of session.watchResourcesList(
+    { includeIndexObjectTypes: true },
+    abortSignal,
+  )) {
+    return (resp.spacesList ?? []).find(
+      (entry) =>
+        entry.spaceMeta?.name === spaceName &&
+        !!entry.entry?.ref?.providerResourceRef?.id,
+    )
+  }
+  return undefined
+}
+
 export async function createQuickstartSetup(
   root: Root,
   quickstartId: QuickstartSpaceCreateId,
@@ -666,18 +688,31 @@ export async function createQuickstartSetup(
       progress,
     )
 
-    // Create a new space with the quickstart ID as the name.
+    // Reuse the account's existing space for this quickstart; creating again
+    // would duplicate it and rerun the seed pipeline over user content.
+    const spaceName = getQuickstartSpaceName(quickstartId)
     reportQuickstartProgress(
       progress,
       'space',
-      'Creating ' + getQuickstartSpaceName(quickstartId),
+      'Checking for an existing ' + spaceName,
     )
-    const spaceResp = await timeQuickstartPhase(timing, 'create-space', () =>
-      session.createSpace(
-        { spaceName: getQuickstartSpaceName(quickstartId) },
-        abortSignal,
-      ),
+    const existingEntry = await timeQuickstartPhase(
+      timing,
+      'find-existing-space',
+      () => findExistingQuickstartSpace(session, spaceName, abortSignal),
     )
+    const sharedObjectRef = existingEntry?.entry?.ref
+
+    let spaceResp: CreateSpaceResponse
+    if (sharedObjectRef) {
+      reportQuickstartProgress(progress, 'space', 'Opening ' + spaceName)
+      spaceResp = { sharedObjectRef }
+    } else {
+      reportQuickstartProgress(progress, 'space', 'Creating ' + spaceName)
+      spaceResp = await timeQuickstartPhase(timing, 'create-space', () =>
+        session.createSpace({ spaceName }, abortSignal),
+      )
+    }
 
     // Create the setup from the session and space response.
     const setup = await createQuickstartSetupFromSession({
@@ -700,15 +735,20 @@ export async function createQuickstartSetup(
       ...setup,
     }
 
-    // Populate the space with quickstart-specific content.
-    reportQuickstartProgress(
-      progress,
-      'content',
-      'Seeding ' + getQuickstartSpaceName(quickstartId) + ' content',
-    )
-    await timeQuickstartPhase(timing, 'populate-space', () =>
-      populateSpace(quickstartId, result, abortSignal, timing),
-    )
+    if (sharedObjectRef) {
+      // The reused space already holds its seeded content.
+      markQuickstartProgressReady(timing)
+    } else {
+      // Populate the space with quickstart-specific content.
+      reportQuickstartProgress(
+        progress,
+        'content',
+        'Seeding ' + getQuickstartSpaceName(quickstartId) + ' content',
+      )
+      await timeQuickstartPhase(timing, 'populate-space', () =>
+        populateSpace(quickstartId, result, abortSignal, timing),
+      )
+    }
 
     markQuickstartProgressReady(timing)
 


### PR DESCRIPTION
Every visit to a quickstart route ran createQuickstartSetup, which called session.createSpace and re-seeded unconditionally. Repeated clicks of the same Landing CTA duplicated the user's notebook once per click.

createQuickstartSetup now checks the account's watched space list for an existing space whose name matches the quickstart target before creating anything; on a match it reuses that space's shared object ref and skips both creation and seeding. First-run behavior is unchanged.

create.test.ts pins reuse with an existing 'My Notebook' in the provider snapshot (no createSpace call), keeps the genuine first-run path covered by the existing suite, and covers the no-match fallback.