### PR TITLE
fix(cmd): refuse implicit default state path for daemon commands

### DIFF
--- a/cmd/spacewave/cli/client.go
+++ b/cmd/spacewave/cli/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aperturerobotics/util/gitroot"
 	"github.com/pkg/errors"
 	cli_entrypoint "github.com/s4wave/spacewave/bldr/cli/entrypoint"
+	entrypoint_storagepath "github.com/s4wave/spacewave/bldr/entrypoint/storagepath"
 	resource "github.com/s4wave/spacewave/bldr/resource"
 	resource_client "github.com/s4wave/spacewave/bldr/resource/client"
 	s4wave_space_core "github.com/s4wave/spacewave/core/space"
@@ -699,11 +700,21 @@ func lineageFlagSet(c *cli.Context, name string) (value string, set bool) {
 // daemon socket in cwd/.spacewave or git-root/.spacewave take precedence
 // over the shared default. Explicit --state-path values skip project
 // discovery and use relative-path resolution as before.
+//
+// Without an explicit path or a discoverable project-local daemon the
+// resolution fails instead of falling back to the shared default state root:
+// that default may hold the operator's live world, and commands attaching to
+// it implicitly have mounted every Space in it.
 func resolveStatePathFromContext(c *cli.Context, fallback string) (string, error) {
 	if !statePathUserSet(c) {
 		if discovered, ok := discoverProjectLocalStatePath(); ok {
 			return discovered, nil
 		}
+		return "", errors.Errorf(
+			"no explicit daemon state path: pass --state-path, set %s (or %s), or run inside a checkout whose .spacewave holds a live daemon; refusing to attach implicitly to the shared default %s",
+			entrypoint_storagepath.StatePathEnvVar(projectID),
+			entrypoint_storagepath.StorageRootEnvVar(projectID), defaultStatePath,
+		)
 	}
 	return resolveStatePath(effectiveStatePath(c, fallback))
 }

--- a/cmd/spacewave/cli/state-path-guard_test.go
+++ b/cmd/spacewave/cli/state-path-guard_test.go
@@ -1,0 +1,93 @@
+//go:build !js
+
+package spacewave_cli
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aperturerobotics/cli"
+)
+
+// TestResolveStatePathRequiresExplicitStatePath asserts that attaching to a
+// daemon refuses the shared default state root (~/.spacewave) when the user
+// gave no --state-path flag, state path environment variable, or live
+// project-local daemon. The shared default may hold the operator's live
+// world; an implicit attach has mounted every Space in it.
+func TestResolveStatePathRequiresExplicitStatePath(t *testing.T) {
+	clearStatePathEnv(t)
+
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	chdir(t, t.TempDir())
+
+	oldDefault := defaultStatePath
+	defaultStatePath = filepath.Join(tempHome, ".spacewave")
+	t.Cleanup(func() { defaultStatePath = oldDefault })
+
+	var got string
+	app := cli.NewApp()
+	app.Name = "spacewave"
+	app.HideVersion = true
+	app.Commands = []*cli.Command{{
+		Name: "check",
+		Action: func(c *cli.Context) error {
+			resolved, err := resolveStatePathFromContext(c, "")
+			if err != nil {
+				return err
+			}
+			got = resolved
+			return nil
+		},
+	}}
+	err := app.RunContext(context.Background(), []string{"spacewave", "check"})
+	if err == nil {
+		t.Fatalf("implicit default state path accepted: resolved %s", got)
+	}
+	if !strings.Contains(err.Error(), defaultStatePath) && !strings.Contains(err.Error(), "--state-path") {
+		t.Fatalf("error does not name the default or the explicit flag: %v", err)
+	}
+}
+
+// TestResolveStatePathAcceptsExplicitEnv asserts the state path environment
+// variable still resolves without error after the implicit-default guard.
+func TestResolveStatePathAcceptsExplicitEnv(t *testing.T) {
+	clearStatePathEnv(t)
+
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	chdir(t, t.TempDir())
+
+	oldDefault := defaultStatePath
+	defaultStatePath = filepath.Join(tempHome, ".spacewave")
+	t.Cleanup(func() { defaultStatePath = oldDefault })
+
+	statePath := filepath.Join(t.TempDir(), "explicit")
+	t.Setenv(statePathEnvVars[0], statePath)
+
+	var rootStatePath string
+	var got string
+	app := cli.NewApp()
+	app.Name = "spacewave"
+	app.HideVersion = true
+	app.Flags = []cli.Flag{statePathFlag(&rootStatePath)}
+	app.Commands = []*cli.Command{{
+		Name: "check",
+		Action: func(c *cli.Context) error {
+			resolved, err := resolveStatePathFromContext(c, "")
+			if err != nil {
+				return err
+			}
+			got = resolved
+			return nil
+		},
+	}}
+	if err := app.RunContext(context.Background(), []string{"spacewave", "check"}); err != nil {
+		t.Fatal(err)
+	}
+	if got != statePath {
+		t.Fatalf("got %s, want %s", got, statePath)
+	}
+}

--- a/cmd/spacewave/cli/state-path_test.go
+++ b/cmd/spacewave/cli/state-path_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/aperturerobotics/cli"
@@ -95,23 +96,42 @@ func TestResolveStatePathFromContextUsesEnv(t *testing.T) {
 	}
 }
 
-func TestResolveStatePathFromContextUsesDefault(t *testing.T) {
+// TestResolveStatePathFromContextRefusesDefault asserts that with no
+// explicit --state-path flag or environment variable and no live
+// project-local daemon, resolution fails instead of falling back to the
+// shared default state root: attaching to it implicitly has mounted every
+// Space of the operator's live world.
+func TestResolveStatePathFromContextRefusesDefault(t *testing.T) {
 	clearStatePathEnv(t)
 
-	cwd := t.TempDir()
-	chdir(t, cwd)
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	chdir(t, t.TempDir())
 
-	got := runStatePathResolveCommand(t, []string{"check"})
-	want := defaultStatePath
-	if !filepath.IsAbs(want) {
-		want = filepath.Join(cwd, want)
+	oldDefault := defaultStatePath
+	defaultStatePath = filepath.Join(tempHome, ".spacewave")
+	t.Cleanup(func() { defaultStatePath = oldDefault })
+
+	var commandStatePath string
+	var rootStatePath string
+	app := cli.NewApp()
+	app.Name = "spacewave"
+	app.HideVersion = true
+	app.Flags = []cli.Flag{statePathFlag(&rootStatePath)}
+	app.Commands = []*cli.Command{{
+		Name:  "check",
+		Flags: clientFlags(&commandStatePath, nil),
+		Action: func(c *cli.Context) error {
+			_, err := resolveStatePathFromContext(c, commandStatePath)
+			return err
+		},
+	}}
+	err := app.RunContext(context.Background(), []string{"spacewave", "check"})
+	if err == nil {
+		t.Fatal("implicit default state path accepted")
 	}
-	if got != want {
-		t.Fatalf("got %s, want %s", got, want)
+	if !strings.Contains(err.Error(), "--state-path") {
+		t.Fatalf("error does not tell the user how to pass an explicit path: %v", err)
 	}
 }
 


### PR DESCRIPTION
spacewave start and every attaching client command silently fell back to the shared default state root (~/.spacewave) when no explicit path was set. That default holds the operator's live world: a multispace attach-all run mounted every Space in it before being killed, with nothing in the resolution path flagging the risk.

resolveStatePathFromContext — the single resolution point all attaching and serving commands flow through — now returns an actionable error when no explicit --state-path / SPACEWAVE_STATE_PATH / SPACEWAVE_DATA_DIR was given and no project-local daemon socket is discoverable in cwd/.spacewave or git-root/.spacewave. Explicit flags and env vars keep their existing behavior, and the dev workflow inside a checkout with a running dev daemon still resolves implicitly.

state-path-guard_test.go proves the old fallback accepted an implicit default (red on master) and now refuses it; the explicit-env test pins that the normal configuration paths still work.