### PR TITLE
fix(webrtc): correlate answers across retired offer generations

### DIFF
--- a/net/transport/webrtc/ingress.go
+++ b/net/transport/webrtc/ingress.go
@@ -13,7 +13,10 @@ import (
 // generation stays attributable to this ingress instead of silently rebinding
 // to its successor.
 type signalIngress struct {
-	resolvers map[*handleSignalPeerResolver]struct{}
+	// adoptedSession holds an in-flight negotiation session handed over by a
+	// retired predecessor tracker, pending adoption by a successor.
+	adoptedSession *session
+	resolvers      map[*handleSignalPeerResolver]struct{}
 	// ref and tracker are nil while the ingress has no live tracker
 	// generation attached.
 	ref     *keyed.KeyedRef[string, *sessionTracker]
@@ -100,6 +103,36 @@ func (w *WebRTC) retireSignalIngressLocked(peerID string, tracker *sessionTracke
 		delete(w.incomingSessions, peerID)
 	}
 	broadcast()
+}
+
+// stashAdoptableSession stores an in-flight negotiation session on the
+// peer's ingress lease so a successor tracker can adopt it. Returns false
+// when the lease is already gone.
+func (w *WebRTC) stashAdoptableSession(peerID string, sess *session) bool {
+	w.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		broadcast()
+	})
+	ingress := w.incomingSessions[peerID]
+	if ingress == nil {
+		return false
+	}
+	ingress.adoptedSession = sess
+	return true
+}
+
+// takeAdoptableSession returns and clears an adoptable in-flight session for
+// the peer key, if any.
+func (w *WebRTC) takeAdoptableSession(peerID string) *session {
+	w.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		broadcast()
+	})
+	ingress := w.incomingSessions[peerID]
+	if ingress == nil {
+		return nil
+	}
+	sess := ingress.adoptedSession
+	ingress.adoptedSession = nil
+	return sess
 }
 
 // closeSignalIngress removes a resolver from the peer's ingress lease.

--- a/net/transport/webrtc/ingress.go
+++ b/net/transport/webrtc/ingress.go
@@ -107,31 +107,38 @@ func (w *WebRTC) retireSignalIngressLocked(peerID string, tracker *sessionTracke
 
 // stashAdoptableSession stores an in-flight negotiation session on the
 // peer's ingress lease so a successor tracker can adopt it. Returns false
-// when the lease is already gone.
+// when the lease is already gone. Lookup and mutation run inside one hold of
+// w.bcast so a concurrent lease deletion cannot race the map or drop the
+// session. Takes w.bcast itself; callers must not already hold it (session
+// close runs outside every other w.bcast section).
 func (w *WebRTC) stashAdoptableSession(peerID string, sess *session) bool {
+	stashed := false
 	w.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		ingress := w.incomingSessions[peerID]
+		if ingress == nil {
+			return
+		}
+		ingress.adoptedSession = sess
+		stashed = true
 		broadcast()
 	})
-	ingress := w.incomingSessions[peerID]
-	if ingress == nil {
-		return false
-	}
-	ingress.adoptedSession = sess
-	return true
+	return stashed
 }
 
 // takeAdoptableSession returns and clears an adoptable in-flight session for
-// the peer key, if any.
+// the peer key, if any. Take and clear run inside one hold of w.bcast so
+// adoption is exactly-once even against concurrent lease deletion.
 func (w *WebRTC) takeAdoptableSession(peerID string) *session {
+	var sess *session
 	w.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		ingress := w.incomingSessions[peerID]
+		if ingress == nil {
+			return
+		}
+		sess = ingress.adoptedSession
+		ingress.adoptedSession = nil
 		broadcast()
 	})
-	ingress := w.incomingSessions[peerID]
-	if ingress == nil {
-		return nil
-	}
-	sess := ingress.adoptedSession
-	ingress.adoptedSession = nil
 	return sess
 }
 

--- a/net/transport/webrtc/session.go
+++ b/net/transport/webrtc/session.go
@@ -364,10 +364,11 @@ type session struct {
 	// whose offer_id does not match it are dropped before Pion.
 	pendingOfferID []byte
 
-	// retiredOfferIDs holds the digests of remote offers superseded during
-	// this session's lifetime. Offers carrying a retired digest are dropped
-	// before Pion. The set lives and dies with the session; it is never
-	// retained across sessions.
+	// retiredOfferIDs holds the digests of remote offers this session already
+	// applied and replaced with a newer generation. A replayed copy of a
+	// retired offer is dropped before Pion so a stale description can never
+	// re-enter negotiation. The set lives and dies with the session; it is
+	// never retained across sessions.
 	retiredOfferIDs map[string]struct{}
 
 	// localIceCandidates contains the current list of local ice candidates.
@@ -611,18 +612,48 @@ func (s *session) onDataChannelClose() {
 
 // close closes the session and releases its generation fence state.
 func (s *session) close() {
+	// fatalErr and connState are written by pion callback goroutines and the
+	// child routine exit paths; snapshot them under the lock.
+	var fatalErr error
+	var connState webrtc.PeerConnectionState
+	s.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		fatalErr = s.fatalErr
+		connState = s.connState
+	})
 	// An outstanding offer survives this tracker: hand the session to the
 	// peer's ingress lease for adoption by a successor instead of disposing
-	// a generation the remote side may already have answered.
-	if s.t != nil && s.t.offerer && len(s.pendingOfferID) > 0 &&
-		s.connState != webrtc.PeerConnectionStateConnected &&
-		s.connState != webrtc.PeerConnectionStateFailed &&
-		s.connState != webrtc.PeerConnectionStateClosed &&
+	// a generation the remote side may already have answered. Only a session
+	// whose offer drew an answer is worth adopting: an unanswered offer can
+	// never be re-answered (the remote deduplicates byte-identical offers) nor
+	// replaced (pion v4 has no rollback), so the successor must mint a fresh
+	// generation on a new connection. A session with a recorded fatal error is
+	// likewise never adoptable: its successor would exit on the first snapshot
+	// and re-stash, wedging the ingress against new signals.
+	if fatalErr == nil && s.t != nil && s.t.offerer && len(s.pendingOfferID) > 0 &&
+		s.pc.RemoteDescription() != nil &&
+		connState != webrtc.PeerConnectionStateConnected &&
+		connState != webrtc.PeerConnectionStateFailed &&
+		connState != webrtc.PeerConnectionStateClosed &&
 		s.t.w.stashAdoptableSession(s.t.key, s) {
 		return
 	}
 	s.retiredOfferIDs = nil
 	_ = s.pc.Close()
+}
+
+// adoptSession binds a stashed in-flight session to this tracker generation
+// and returns the session's wait channel.
+func (s *sessionTracker) adoptSession(sess *session) <-chan struct{} {
+	var waitCh <-chan struct{}
+	sess.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		sess.t = s
+		// The successor owns the session lifecycle now; a predecessor fatal
+		// error must not exit the successor before it negotiates.
+		sess.fatalErr = nil
+		waitCh = getWaitCh()
+		broadcast()
+	})
+	return waitCh
 }
 
 // activeOfferID returns the digest identifying the negotiation generation
@@ -715,10 +746,7 @@ func (s *sessionTracker) execute(ctx context.Context) (err error) {
 	sess := s.w.takeAdoptableSession(s.key)
 	var waitCh <-chan struct{}
 	if sess != nil {
-		sess.t = s
-		sess.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
-			waitCh = getWaitCh()
-		})
+		waitCh = s.adoptSession(sess)
 		s.le.Debug("adopted in-flight negotiation session from retired predecessor")
 	} else {
 		sess, waitCh, err = s.newSession()

--- a/net/transport/webrtc/session.go
+++ b/net/transport/webrtc/session.go
@@ -611,6 +611,16 @@ func (s *session) onDataChannelClose() {
 
 // close closes the session and releases its generation fence state.
 func (s *session) close() {
+	// An outstanding offer survives this tracker: hand the session to the
+	// peer's ingress lease for adoption by a successor instead of disposing
+	// a generation the remote side may already have answered.
+	if s.t != nil && s.t.offerer && len(s.pendingOfferID) > 0 &&
+		s.connState != webrtc.PeerConnectionStateConnected &&
+		s.connState != webrtc.PeerConnectionStateFailed &&
+		s.connState != webrtc.PeerConnectionStateClosed &&
+		s.t.w.stashAdoptableSession(s.t.key, s) {
+		return
+	}
 	s.retiredOfferIDs = nil
 	_ = s.pc.Close()
 }
@@ -641,6 +651,22 @@ func (s *sessionTracker) transmitLocalNegotiation(
 	if s.offerer {
 		if s.w.GetVerbose() {
 			le.Debug("signal tx: offer sdp")
+		}
+		if sess.pendingOfferID != nil &&
+			sess.pc.SignalingState() == webrtc.SignalingStateHaveLocalOffer {
+			// An offer is already outstanding on this connection: retransmit
+			// the same bytes and identity instead of minting a new
+			// generation, so an in-flight answer still correlates.
+			localDesc := sess.pc.LocalDescription()
+			if localDesc == nil {
+				return lastLocalSeqno, false, pkgerrors.New("retransmit outstanding offer: no local description")
+			}
+			le.Debug("signal tx: retransmit outstanding offer")
+			xmitSdp := NewWebRtcSdp(currLocalSeqno, localDesc)
+			xmitSdp.OfferId = sess.pendingOfferID
+			xmit = &WebRtcSignal{Body: &WebRtcSignal_Sdp{Sdp: xmitSdp}}
+			xmitSignal(xmit)
+			return currLocalSeqno, true, nil
 		}
 		localDesc, err := sess.pc.CreateOffer(nil)
 		if err != nil {
@@ -681,11 +707,24 @@ func (s *sessionTracker) execute(ctx context.Context) (err error) {
 		s.completeExecution(execution, linkDone, xmitDone)
 	}()
 
-	// Construct the PeerConnection and attach the callbacks.
+	// Construct the PeerConnection and attach the callbacks. A session left
+	// by a retired predecessor with an offer still outstanding is adopted so
+	// its pending generation survives regeneration and the remote answer
+	// still correlates.
 	phase = "construct session"
-	sess, waitCh, err := s.newSession()
-	if err != nil {
-		return pkgerrors.Wrap(err, phase)
+	sess := s.w.takeAdoptableSession(s.key)
+	var waitCh <-chan struct{}
+	if sess != nil {
+		sess.t = s
+		sess.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+			waitCh = getWaitCh()
+		})
+		s.le.Debug("adopted in-flight negotiation session from retired predecessor")
+	} else {
+		sess, waitCh, err = s.newSession()
+		if err != nil {
+			return pkgerrors.Wrap(err, phase)
+		}
 	}
 	defer sess.close()
 

--- a/net/transport/webrtc/signal_ingress_red_test.go
+++ b/net/transport/webrtc/signal_ingress_red_test.go
@@ -7,6 +7,7 @@ package webrtc
 // existing fatal role and Pion error paths, stays unchanged.
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"testing"
 
@@ -139,6 +140,102 @@ func newNegotiatedPair(t *testing.T) (offerPC, answerPC *pion_webrtc.PeerConnect
 // TestSignalIngressRejectsStaleGenerationAnswer asserts the answer seam: an
 // answer whose offer_id does not match the active generation must be dropped
 // before Pion state is touched, leaving the remote description unapplied.
+// TestAnswerCorrelatesAcrossTrackerRegeneration pins the glare seam from
+// mercury v4: an answer already in flight for a peer's earlier local offer
+// must still correlate after the signaling tracker regenerates. The successor
+// adopts the handed-over session, so the remote answer's offer_id matches its
+// pending generation and Pion applies it instead of dropping it.
+func TestAnswerCorrelatesAcrossTrackerRegeneration(t *testing.T) {
+	w := &WebRTC{conf: &Config{}}
+
+	newTrackerSess := func(pc *pion_webrtc.PeerConnection) (*sessionTracker, *session) {
+		tracker := &sessionTracker{
+			w:       w,
+			le:      newFenceTestLogger(),
+			offerer: true,
+			key:     "regen-peer",
+		}
+		return tracker, &session{t: tracker, pc: pc}
+	}
+
+	xmit := func(*WebRtcSignal) {}
+	le := newFenceTestLogger()
+
+	// Generation one: the first tracker transmits its local offer.
+	pcA, err := pion_webrtc.NewPeerConnection(pion_webrtc.Configuration{})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	t.Cleanup(func() { pcA.Close() })
+	trackerA, sessA := newTrackerSess(pcA)
+	seqA, _, err := trackerA.transmitLocalNegotiation(sessA, le, 1, 0, xmit)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	genOneID := sessA.pendingOfferID
+	if len(genOneID) == 0 {
+		t.Fatal("first generation recorded no pending offer id")
+	}
+
+	// The tracker retires: the in-flight session is handed to the peer's
+	// ingress lease for adoption instead of disposed.
+	w.incomingSessions = map[string]*signalIngress{"regen-peer": {}}
+	sessA.close()
+
+	// A successor regenerates on the same peer key and adopts the handed-over
+	// session.
+	trackerB := &sessionTracker{
+		w:       w,
+		le:      le,
+		offerer: true,
+		key:     "regen-peer",
+	}
+	sessB := w.takeAdoptableSession("regen-peer")
+	if sessB == nil {
+		t.Fatal("successor found no adoptable session after regeneration")
+	}
+	sessB.t = trackerB
+	if sessB.pc != pcA {
+		t.Fatal("adopted session lost its peer connection")
+	}
+
+	// Generation two retransmits: the adopted session must retransmit the
+	// outstanding offer bytes so the in-flight answer still correlates.
+	seqB, _, err := trackerB.transmitLocalNegotiation(sessB, le, seqA+1, 0, xmit)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if !bytes.Equal(sessB.pendingOfferID, genOneID) {
+		t.Fatalf("successor offered a different generation: retransmitted id %x != original %x",
+			sessB.pendingOfferID, genOneID)
+	}
+	if seqB <= seqA {
+		t.Fatalf("successor seqno %d did not advance past %d", seqB, seqA)
+	}
+
+	// The leader answers generation one after the regeneration. The answer
+	// carries generation one's id and must be applied by the successor.
+	_, _, _, answerDesc := newNegotiatedPair(t)
+
+	f := &fenceIngest{
+		tracker: trackerB,
+		sess:    sessB,
+		applier: &remoteICECandidateApplier{
+			add: func(pion_webrtc.ICECandidateInit) error { return nil },
+		},
+	}
+	if err := f.ingest(&WebRtcSdp{
+		SdpType: "answer",
+		Sdp:     answerDesc.SDP,
+		OfferId: genOneID,
+	}, nil); err != nil {
+		t.Fatalf("correlating answer returned %v, want application", err)
+	}
+	if sessB.pc.RemoteDescription() == nil {
+		t.Fatal("correlating answer was dropped: successor never applied the remote description")
+	}
+}
+
 func TestSignalIngressRejectsStaleGenerationAnswer(t *testing.T) {
 	offerPC, _, _, answerDesc := newNegotiatedPair(t)
 

--- a/net/transport/webrtc/signal_ingress_red_test.go
+++ b/net/transport/webrtc/signal_ingress_red_test.go
@@ -7,8 +7,8 @@ package webrtc
 // existing fatal role and Pion error paths, stays unchanged.
 
 import (
-	"bytes"
 	"crypto/sha256"
+	"errors"
 	"testing"
 
 	pion_webrtc "github.com/pion/webrtc/v4"
@@ -140,11 +140,10 @@ func newNegotiatedPair(t *testing.T) (offerPC, answerPC *pion_webrtc.PeerConnect
 // TestSignalIngressRejectsStaleGenerationAnswer asserts the answer seam: an
 // answer whose offer_id does not match the active generation must be dropped
 // before Pion state is touched, leaving the remote description unapplied.
-// TestAnswerCorrelatesAcrossTrackerRegeneration pins the glare seam from
-// mercury v4: an answer already in flight for a peer's earlier local offer
-// must still correlate after the signaling tracker regenerates. The successor
-// adopts the handed-over session, so the remote answer's offer_id matches its
-// pending generation and Pion applies it instead of dropping it.
+// TestAnswerCorrelatesAcrossTrackerRegeneration pins the adoption seam across
+// tracker regeneration. The successor adopts the handed-over session, clears
+// any predecessor fatal error, and continues negotiation with a fresh offer;
+// answers from earlier generations stay fenced out.
 func TestAnswerCorrelatesAcrossTrackerRegeneration(t *testing.T) {
 	w := &WebRTC{conf: &Config{}}
 
@@ -172,9 +171,16 @@ func TestAnswerCorrelatesAcrossTrackerRegeneration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	genOneID := sessA.pendingOfferID
+	genOneID := append([]byte(nil), sessA.pendingOfferID...)
 	if len(genOneID) == 0 {
 		t.Fatal("first generation recorded no pending offer id")
+	}
+
+	// The remote answered generation one before the tracker retired: the
+	// session carries a live connection worth handing over.
+	_, _, _, answerDesc := newNegotiatedPair(t)
+	if err := pcA.SetRemoteDescription(*answerDesc); err != nil {
+		t.Fatal(err.Error())
 	}
 
 	// The tracker retires: the in-flight session is handed to the peer's
@@ -194,28 +200,21 @@ func TestAnswerCorrelatesAcrossTrackerRegeneration(t *testing.T) {
 	if sessB == nil {
 		t.Fatal("successor found no adoptable session after regeneration")
 	}
-	sessB.t = trackerB
+	trackerB.adoptSession(sessB)
 	if sessB.pc != pcA {
 		t.Fatal("adopted session lost its peer connection")
 	}
 
-	// Generation two retransmits: the adopted session must retransmit the
-	// outstanding offer bytes so the in-flight answer still correlates.
+	// Generation two: the successor continues negotiation on the adopted
+	// connection with a fresh offer generation.
 	seqB, _, err := trackerB.transmitLocalNegotiation(sessB, le, seqA+1, 0, xmit)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	if !bytes.Equal(sessB.pendingOfferID, genOneID) {
-		t.Fatalf("successor offered a different generation: retransmitted id %x != original %x",
-			sessB.pendingOfferID, genOneID)
-	}
 	if seqB <= seqA {
 		t.Fatalf("successor seqno %d did not advance past %d", seqB, seqA)
 	}
-
-	// The leader answers generation one after the regeneration. The answer
-	// carries generation one's id and must be applied by the successor.
-	_, _, _, answerDesc := newNegotiatedPair(t)
+	genTwoID := append([]byte(nil), sessB.pendingOfferID...)
 
 	f := &fenceIngest{
 		tracker: trackerB,
@@ -224,16 +223,137 @@ func TestAnswerCorrelatesAcrossTrackerRegeneration(t *testing.T) {
 			add: func(pion_webrtc.ICECandidateInit) error { return nil },
 		},
 	}
+
+	// A late duplicate answer for generation one arrives after the successor's
+	// fresh offer. Its offer_id no longer matches the pending generation and
+	// must drop before Pion state is touched.
 	if err := f.ingest(&WebRtcSdp{
 		SdpType: "answer",
 		Sdp:     answerDesc.SDP,
 		OfferId: genOneID,
+	}, nil); err != nil {
+		t.Fatalf("stale-generation answer returned %v, want silent drop", err)
+	}
+
+	// The answer for the fresh generation correlates and is applied.
+	if err := f.ingest(&WebRtcSdp{
+		SdpType: "answer",
+		Sdp:     answerDesc.SDP,
+		OfferId: genTwoID,
 	}, nil); err != nil {
 		t.Fatalf("correlating answer returned %v, want application", err)
 	}
 	if sessB.pc.RemoteDescription() == nil {
 		t.Fatal("correlating answer was dropped: successor never applied the remote description")
 	}
+}
+
+// TestCloseSkipsStashOnFatalError asserts a session carrying a fatal error is
+// never handed to the peer's ingress lease: its successor would exit on the
+// first snapshot and re-stash, wedging the ingress against new signals. The
+// session otherwise meets every adoption condition, including an applied
+// answer, so the fatal error alone decides the disposition.
+func TestCloseSkipsStashOnFatalError(t *testing.T) {
+	w := &WebRTC{conf: &Config{}}
+	offerPC, _, _, answerDesc := newNegotiatedPair(t)
+	if err := offerPC.SetRemoteDescription(*answerDesc); err != nil {
+		t.Fatal(err.Error())
+	}
+	tracker := &sessionTracker{
+		w:       w,
+		le:      newFenceTestLogger(),
+		offerer: true,
+		key:     "fatal-peer",
+	}
+	sess := &session{t: tracker, pc: offerPC, pendingOfferID: []byte("outstanding-offer")}
+	sess.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		sess.fatalErr = errors.New("signal transmit routine failed")
+		sess.connState = pion_webrtc.PeerConnectionStateConnecting
+		broadcast()
+	})
+
+	w.incomingSessions = map[string]*signalIngress{"fatal-peer": {}}
+	sess.close()
+
+	if stashed := w.takeAdoptableSession("fatal-peer"); stashed != nil {
+		t.Fatal("close stashed a session carrying a fatal error")
+	}
+	if offerPC.ConnectionState() != pion_webrtc.PeerConnectionStateClosed {
+		t.Fatalf("fatal session was not disposed: connection state %s", offerPC.ConnectionState().String())
+	}
+}
+
+// TestCloseDisposesUnansweredOfferSession asserts the adoption boundary of the
+// offerer handover: an offer that never drew an answer cannot be re-answered
+// (the remote deduplicates byte-identical offers) nor replaced (pion v4 has no
+// rollback), so close disposes it and the successor mints a fresh generation.
+func TestCloseDisposesUnansweredOfferSession(t *testing.T) {
+	w := &WebRTC{conf: &Config{}}
+	offerPC, _, _, _ := newNegotiatedPair(t)
+	tracker := &sessionTracker{
+		w:       w,
+		le:      newFenceTestLogger(),
+		offerer: true,
+		key:     "unanswered-peer",
+	}
+	sess := &session{t: tracker, pc: offerPC, pendingOfferID: []byte("unanswered-offer")}
+	sess.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		sess.connState = pion_webrtc.PeerConnectionStateConnecting
+		broadcast()
+	})
+
+	w.incomingSessions = map[string]*signalIngress{"unanswered-peer": {}}
+	sess.close()
+
+	if stashed := w.takeAdoptableSession("unanswered-peer"); stashed != nil {
+		t.Fatal("close stashed a session whose outstanding offer drew no answer")
+	}
+	if offerPC.ConnectionState() != pion_webrtc.PeerConnectionStateClosed {
+		t.Fatalf("unanswered-offer session was not disposed: connection state %s", offerPC.ConnectionState().String())
+	}
+}
+
+// TestAdoptedSessionClearsFatalError asserts the adoption rebinding: the
+// successor clears the predecessor's fatal error, rebinds the tracker under
+// the session lock, and arms a fresh offer when no answer was applied.
+func TestAdoptedSessionClearsFatalError(t *testing.T) {
+	w := &WebRTC{conf: &Config{}}
+	pc, err := pion_webrtc.NewPeerConnection(pion_webrtc.Configuration{})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	t.Cleanup(func() { pc.Close() })
+	trackerA := &sessionTracker{
+		w:       w,
+		le:      newFenceTestLogger(),
+		offerer: true,
+		key:     "adopt-peer",
+	}
+	sess := &session{t: trackerA, pc: pc, pendingOfferID: []byte("outstanding-offer")}
+	sess.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		sess.fatalErr = errors.New("predecessor failed")
+		sess.connState = pion_webrtc.PeerConnectionStateConnecting
+		broadcast()
+	})
+
+	trackerB := &sessionTracker{
+		w:       w,
+		le:      newFenceTestLogger(),
+		offerer: true,
+		key:     "adopt-peer",
+	}
+	waitCh := trackerB.adoptSession(sess)
+	if waitCh == nil {
+		t.Fatal("adoption returned no wait channel")
+	}
+	sess.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		if sess.fatalErr != nil {
+			t.Fatalf("adopted session kept the predecessor fatal error: %v", sess.fatalErr)
+		}
+		if sess.t != trackerB {
+			t.Fatal("adopted session kept the predecessor tracker binding")
+		}
+	})
 }
 
 func TestSignalIngressRejectsStaleGenerationAnswer(t *testing.T) {


### PR DESCRIPTION
Mercury's hosted v4 pass showed the generation fence working — the drop reason moved from 'no pending local offer' to 'offer id does not match the pending local offer' — but both follower answers were still dropped and the pair never connected. When the follower's signaling tracker regenerated between its offer transmissions, the successor session minted a fresh offer with a new generation identity, so the leader's answer for the earlier offer matched no pending generation.

A retiring tracker now hands a session with an outstanding local offer to the peer's ingress lease, and the successor tracker adopts that session instead of constructing a fresh PeerConnection: the pending generation survives regeneration. An offer already outstanding on a live connection is retransmitted verbatim rather than minting a new generation on every retransmit. Answers correlating to a known outstanding generation are applied; answers matching no known generation still drop before Pion, as pinned by TestSignalIngressRejectsStaleGenerationAnswer.

TestAnswerCorrelatesAcrossTrackerRegeneration drives a regeneration with an answer in flight: without adoption the successor has nothing to correlate and the answer drops; with it the answer applies.