### PR TITLE
fix(web): fail the boot loudly instead of stalling silently

### DIFF
--- a/app/loading/AppLoadingScreen.tsx
+++ b/app/loading/AppLoadingScreen.tsx
@@ -9,6 +9,7 @@ import {
 
 import AnimatedLogo from '@s4wave/app/landing/AnimatedLogo.js'
 import { useBrowserStartupProjection } from '@s4wave/app/loading/status/browser-startup.js'
+import { useBrowserBootWatchdog } from '@s4wave/app/loading/status/browser-boot-watchdog.js'
 import { useBootDownloads } from '@s4wave/app/loading/status/browser-downloads.js'
 import {
   browserStartupStallCopy,
@@ -27,6 +28,7 @@ import { BootLoadingCriticalStyle } from './boot-loading-critical.js'
 // classes) instead of the not-yet-loaded Tailwind app.css.
 export function AppLoadingScreen() {
   const startup = useBrowserStartupProjection()
+  useBrowserBootWatchdog()
   const reducedMotion = useReducedMotion()
   const view = withBrowserStartupErrorActions(startup.view)
   const hasProgress =

--- a/app/loading/status/browser-boot-watchdog.test.ts
+++ b/app/loading/status/browser-boot-watchdog.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  markBrowserStartupBoundary,
+  readBrowserBootStatus,
+  resetBrowserStartupMarksForTest,
+} from '@s4wave/app/prerender/boot-status.js'
+import {
+  armBrowserBootWatchdog,
+  browserBootFrameReadyProgress,
+  defaultBrowserBootWatchdogCeilingMs,
+  evaluateBrowserBootStall,
+  readBrowserBootWatchdogCeilingMs,
+} from './browser-boot-watchdog.js'
+
+describe('browser boot watchdog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    resetBrowserStartupMarksForTest()
+    delete globalThis.__swBootStatus
+    delete globalThis.__swBootWatchdogCeilingMs
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    resetBrowserStartupMarksForTest()
+    delete globalThis.__swBootStatus
+    delete globalThis.__swBootWatchdogCeilingMs
+  })
+
+  it('writes an error status at the ceiling when stuck below the threshold', () => {
+    readBrowserBootStatus()
+    markBrowserStartupBoundary('webview.registered', { source: 'test' })
+    expect(readBrowserBootStatus().state).toBe('loading')
+
+    const cancel = armBrowserBootWatchdog({ ceilingMs: 5000 })
+    vi.advanceTimersByTime(4999)
+    expect(readBrowserBootStatus().state).toBe('loading')
+
+    vi.advanceTimersByTime(1)
+    const status = readBrowserBootStatus()
+    expect(status.state).toBe('error')
+    expect(status.phase).toBe('browser-boot')
+    expect(status.detail).toContain('webview.registered')
+    expect(status.detail).toContain('5s')
+    expect(status.progress).toBeLessThan(browserBootFrameReadyProgress)
+
+    cancel()
+  })
+
+  it('cancels without writing when progress crosses the threshold', () => {
+    markBrowserStartupBoundary('webview.registered', { source: 'test' })
+    const cancel = armBrowserBootWatchdog({ ceilingMs: 5000 })
+
+    vi.advanceTimersByTime(1000)
+    markBrowserStartupBoundary('worker.first-ready', { source: 'test' })
+    expect(evaluateBrowserBootStall(0, Date.now())).toBeUndefined()
+
+    vi.advanceTimersByTime(10000)
+    expect(readBrowserBootStatus().state).toBe('loading')
+    cancel()
+  })
+
+  it('does nothing after the timer is cancelled', () => {
+    markBrowserStartupBoundary('webview.registered', { source: 'test' })
+    const cancel = armBrowserBootWatchdog({ ceilingMs: 5000 })
+    cancel()
+
+    vi.advanceTimersByTime(defaultBrowserBootWatchdogCeilingMs * 2)
+    expect(readBrowserBootStatus().state).toBe('loading')
+  })
+
+  it('does not double-write when boot already failed', () => {
+    globalThis.__swBootStatus = {
+      phase: 'runtime-error',
+      detail: 'runtime channel failed',
+      state: 'error',
+    }
+    const before = readBrowserBootStatus()
+    const cancel = armBrowserBootWatchdog({ ceilingMs: 5000 })
+
+    vi.advanceTimersByTime(defaultBrowserBootWatchdogCeilingMs)
+    const after = readBrowserBootStatus()
+    expect(after).toEqual(before)
+    expect(evaluateBrowserBootStall(0, Date.now())).toBeUndefined()
+    cancel()
+  })
+
+  it('resolves the ceiling from the option, test hook, then default', () => {
+    expect(readBrowserBootWatchdogCeilingMs()).toBe(
+      defaultBrowserBootWatchdogCeilingMs,
+    )
+    globalThis.__swBootWatchdogCeilingMs = 1234
+    expect(readBrowserBootWatchdogCeilingMs()).toBe(1234)
+    expect(readBrowserBootWatchdogCeilingMs(50)).toBe(50)
+    delete globalThis.__swBootWatchdogCeilingMs
+    expect(readBrowserBootWatchdogCeilingMs(-1)).toBe(
+      defaultBrowserBootWatchdogCeilingMs,
+    )
+  })
+})

--- a/app/loading/status/browser-boot-watchdog.ts
+++ b/app/loading/status/browser-boot-watchdog.ts
@@ -1,0 +1,109 @@
+import { useEffect } from 'react'
+
+import { projectBootProgress } from '@aptre/bldr'
+
+import {
+  readBrowserBootStatus,
+  readBrowserStartupMarks,
+  writeBrowserBootStatus,
+  type BrowserBootStatus,
+} from '@s4wave/app/prerender/boot-status.js'
+import { useBrowserStartupProjection } from './browser-startup.js'
+
+// browserBootFrameReadyProgress is the boot ladder position of the
+// worker.first-ready rung (bldr/web/bldr/boot-progress.ts): the first mark
+// proving the app frame opened and its plugins started. The watchdog treats
+// any projection below this rung as not yet past webview.registered.
+export const browserBootFrameReadyProgress = 0.86
+
+// defaultBrowserBootWatchdogCeilingMs is the hard ceiling for a boot that
+// never crosses the app-frame threshold: past it the outer shell fails loudly
+// instead of stalling silently.
+export const defaultBrowserBootWatchdogCeilingMs = 5 * 60 * 1000
+
+declare global {
+  // __swBootWatchdogCeilingMs overrides the watchdog ceiling from tests and
+  // end-to-end harnesses without changing code.
+  var __swBootWatchdogCeilingMs: number | undefined
+}
+
+export interface BrowserBootWatchdogOptions {
+  ceilingMs?: number
+  now?: () => number
+}
+
+// readBrowserBootWatchdogCeilingMs resolves the watchdog ceiling: the explicit
+// option, then the __swBootWatchdogCeilingMs test hook, then the default.
+export function readBrowserBootWatchdogCeilingMs(override?: number): number {
+  if (override !== undefined && override > 0) return override
+  const injected = globalThis.__swBootWatchdogCeilingMs
+  if (typeof injected === 'number' && injected > 0) return injected
+  return defaultBrowserBootWatchdogCeilingMs
+}
+
+// evaluateBrowserBootStall returns the terminal failure status to synthesize
+// when boot stalled below the app-frame threshold since startedAtMs, or
+// undefined when boot already reached a terminal state or crossed the
+// threshold.
+export function evaluateBrowserBootStall(
+  startedAtMs: number,
+  nowMs: number,
+): BrowserBootStatus | undefined {
+  const status = readBrowserBootStatus()
+  if (status.state !== 'loading') return undefined
+  const marks = readBrowserStartupMarks()
+  const step = projectBootProgress(status, marks)
+  if (step.progress >= browserBootFrameReadyProgress) return undefined
+  return {
+    phase: 'browser-boot',
+    detail:
+      `Startup stalled before the app frame after ${formatElapsedMs(nowMs - startedAtMs)}; ` +
+      `last mark ${marks.at(-1)?.label ?? step.label} (${step.label}).`,
+    state: 'error',
+    progress: step.progress,
+  }
+}
+
+// armBrowserBootWatchdog schedules one check after the ceiling and writes the
+// synthesized terminal boot failure when boot remains stuck below the
+// app-frame threshold. The returned function cancels the timer.
+export function armBrowserBootWatchdog(
+  options: BrowserBootWatchdogOptions = {},
+): () => void {
+  const now = options.now ?? Date.now
+  const startedAtMs = now()
+  let cancelled = false
+  const timer = setTimeout(() => {
+    if (cancelled) return
+    const failure = evaluateBrowserBootStall(startedAtMs, now())
+    if (failure) writeBrowserBootStatus(failure)
+  }, readBrowserBootWatchdogCeilingMs(options.ceilingMs))
+  return () => {
+    cancelled = true
+    clearTimeout(timer)
+  }
+}
+
+// useBrowserBootWatchdog arms the outer-shell watchdog while the loading
+// screen projects a non-terminal state below the app-frame threshold. It
+// cancels as soon as the projection crosses the threshold or turns terminal.
+export function useBrowserBootWatchdog(): void {
+  const { view } = useBrowserStartupProjection()
+  const armed =
+    view.state === 'loading' &&
+    (view.progress === undefined ||
+      view.progress < browserBootFrameReadyProgress)
+  useEffect(() => {
+    if (!armed) return
+    return armBrowserBootWatchdog()
+  }, [armed])
+}
+
+// formatElapsedMs renders an elapsed duration as a compact m/s string.
+function formatElapsedMs(elapsedMs: number): string {
+  const seconds = Math.max(0, Math.round(elapsedMs / 1000))
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  const rest = seconds % 60
+  return rest === 0 ? `${minutes}m` : `${minutes}m${rest}s`
+}

--- a/bldr/web/bldr-react/WebView.tsx
+++ b/bldr/web/bldr-react/WebView.tsx
@@ -28,6 +28,15 @@ import { ReactComponentContainer } from './web-view-react.js'
 import { DebugInfo } from './DebugInfo.js'
 import { useLatestRef } from './hooks.js'
 import { markStartupBoundary } from '../bldr/startup-marks.js'
+import {
+  beginBootDownload,
+  failBootDownload,
+} from '../bldr/boot-downloads.js'
+
+// webViewRevealDeadlineMillis bounds how long a startup-critical web view may
+// wait for the plugin's SetRenderMode/SetHtmlLinks calls and component
+// readiness before boot reports a terminal failure instead of stalling.
+const webViewRevealDeadlineMillis = 90_000
 
 // RemoveWebViewFunc is a function to remove a web view.
 type RemoveWebViewFunc = (view: BldrWebView) => void
@@ -542,6 +551,26 @@ export const WebView: React.FC<IWebViewProps> = (props) => {
     webViewState.ready,
     webViewState.refreshNonce,
   ])
+
+  // Boot-ladder deadline: if this startup-critical view never receives a
+  // render mode, html links, or component readiness, the loading screen would
+  // wait forever behind a frozen progress bar. After webViewRevealDeadlineMillis
+  // without progress, surface a terminal boot-download failure instead.
+  useEffect(() => {
+    if (!props.startupProgress || !webViewState.ready || isComponentReady) {
+      return
+    }
+    const timer = setTimeout(() => {
+      if (markedRevealedRef.current || markedComponentReadyRef.current) {
+        return
+      }
+      const message = `web view did not become ready within ${webViewRevealDeadlineMillis / 1000}s (no render mode, html links, or component-ready)`
+      console.error(`WebView ${uuid}: ${message}`)
+      beginBootDownload('webview-frame', 'Interface frame')
+      failBootDownload('webview-frame', message)
+    }, webViewRevealDeadlineMillis)
+    return () => clearTimeout(timer)
+  }, [props.startupProgress, uuid, webViewState.ready, isComponentReady])
 
   const handleComponentReady = useCallback(() => {
     setIsComponentReady(true)

--- a/bldr/web/bldr-react/web-view-module-loader.test.ts
+++ b/bldr/web/bldr-react/web-view-module-loader.test.ts
@@ -8,6 +8,7 @@ import {
   webViewModuleImportErrorEvent,
   webViewRootAssetStatusEvent,
 } from './web-view-module-loader.js'
+import { readBootDownloads } from '../bldr/boot-downloads.js'
 
 function pluginAssetResponse(
   status: number,
@@ -33,6 +34,57 @@ function deferred<T>(): {
   })
   return { promise, resolve, reject }
 }
+
+describe('WebView boot deadlines', () => {
+  it('fails the boot download when the root asset fetch never settles', async () => {
+    const fetchRootAsset = vi.fn(
+      () => new Promise<Response>(() => undefined),
+    )
+    const importModule = vi.fn(async () => ({ default: 'module' }))
+
+    await expect(
+      loadWebViewScriptModule('/b/pa/spacewave-app/v/app/App.mjs', {
+        fetchRootAsset,
+        importModule,
+        fetchDeadlineMillis: 10,
+      }),
+    ).rejects.toThrow('root asset fetch')
+
+    const downloads = readBootDownloads()
+    const failed = downloads.find((download) => download.state === 'error')
+    expect(failed?.error).toContain('timed out')
+    expect(
+      globalThis.__bldrWebViewModuleImportError,
+    ).toBeUndefined()
+  })
+
+  it('fails the boot download when the module import never settles', async () => {
+    const fetchRootAsset = vi.fn(async () =>
+      pluginAssetResponse(200, '', {
+        'X-Bldr-Fetch-Source': 'plugin-assets',
+        'X-Bldr-Plugin-Asset-Fetch-Result': 'live',
+      }),
+    )
+    const importModule = vi.fn(
+      () => new Promise<unknown>(() => undefined),
+    )
+
+    await expect(
+      loadWebViewScriptModule('/b/pa/spacewave-app/v/app/App.mjs', {
+        fetchRootAsset,
+        importModule,
+        importDeadlineMillis: 10,
+      }),
+    ).rejects.toThrow('module import')
+
+    const downloads = readBootDownloads()
+    const failed = downloads.find((download) => download.state === 'error')
+    expect(failed?.error).toContain('timed out')
+    expect(globalThis.__bldrWebViewModuleImportError?.message).toContain(
+      'timed out',
+    )
+  })
+})
 
 describe('WebView root module loader', () => {
   it('skips the root asset probe for non-plugin asset paths', async () => {

--- a/bldr/web/bldr-react/web-view-module-loader.ts
+++ b/bldr/web/bldr-react/web-view-module-loader.ts
@@ -34,7 +34,18 @@ export type WebViewModuleImporter<T> = (scriptPath: string) => Promise<T>
 export interface LoadWebViewScriptModuleOptions<T> {
   fetchRootAsset?: typeof fetch
   importModule?: WebViewModuleImporter<T>
+  // fetchDeadlineMillis overrides the root-asset fetch deadline (tests).
+  fetchDeadlineMillis?: number
+  // importDeadlineMillis overrides the module import deadline (tests).
+  importDeadlineMillis?: number
 }
+
+// Root-asset fetches and dynamic imports have no built-in timeout. When an
+// engine wedges one (the fetch or import promise never settles), the boot
+// ladder would wait forever behind a frozen progress bar. These deadlines
+// convert a wedged load into a terminal boot-download failure instead.
+const rootAssetFetchDeadlineMillis = 45_000
+const moduleImportDeadlineMillis = 45_000
 
 const rootPluginAssetPrefix = '/b/pa/'
 export const webViewRootAssetStatusEvent = 'bldr:webview-root-asset-status'
@@ -190,8 +201,13 @@ export function getWebViewRootAssetLoadError(
 export async function fetchWebViewRootAssetResult(
   scriptPath: string,
   fetchRootAsset: typeof fetch = fetch,
+  fetchDeadlineMillis: number = rootAssetFetchDeadlineMillis,
 ): Promise<WebViewRootAssetResult> {
-  const response = await fetchRootAsset(scriptPath, { cache: 'no-store' })
+  const response = await withDeadline(
+    fetchRootAsset(scriptPath, { cache: 'no-store' }),
+    fetchDeadlineMillis,
+    `root asset fetch ${scriptPath}`,
+  )
   const classification = classifyRootAssetResponse(response)
   const result: WebViewRootAssetResult = {
     scriptPath,
@@ -219,6 +235,27 @@ export async function fetchWebViewRootAssetResult(
 
 async function importWebViewScriptModule<T>(scriptPath: string): Promise<T> {
   return import(/* @vite-ignore */ scriptPath) as Promise<T>
+}
+
+// withDeadline rejects with a timeout error if the wrapped promise does not
+// settle within deadlineMillis. The wrapped promise itself is left running;
+// its eventual result is ignored once the deadline has fired.
+async function withDeadline<T>(
+  promise: Promise<T>,
+  deadlineMillis: number,
+  description: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`${description}: timed out after ${deadlineMillis}ms`))
+    }, deadlineMillis)
+  })
+  try {
+    return await Promise.race([promise, timeout])
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+  }
 }
 
 function buildModuleImportPath(scriptPath: string): string {
@@ -284,9 +321,21 @@ async function loadWebViewScriptModuleUncached<T>(
   if (isRootPluginAsset) {
     beginBootDownload(scriptPath, webViewDownloadLabel(scriptPath))
   }
-  const rootAsset = isRootPluginAsset
-    ? await fetchWebViewRootAssetResult(scriptPath, options.fetchRootAsset)
-    : undefined
+  let rootAsset: WebViewRootAssetResult | undefined
+  if (isRootPluginAsset) {
+    try {
+      rootAsset = await fetchWebViewRootAssetResult(
+        scriptPath,
+        options.fetchRootAsset,
+        options.fetchDeadlineMillis,
+      )
+    } catch (error) {
+      // A wedged or failed fetch never reaches the response classification
+      // below, so report the boot download as failed here.
+      failBootDownload(scriptPath, serializeImportError(error).message)
+      throw error
+    }
+  }
   if (rootAsset && (!rootAsset.ok || rootAsset.classification !== 'live')) {
     if (isRootPluginAsset) {
       failBootDownload(scriptPath, rootAsset.classification)
@@ -296,7 +345,11 @@ async function loadWebViewScriptModuleUncached<T>(
 
   const importModule = options.importModule ?? importWebViewScriptModule<T>
   try {
-    const module = await importModule(moduleImportPath)
+    const module = await withDeadline(
+      importModule(moduleImportPath),
+      options.importDeadlineMillis ?? moduleImportDeadlineMillis,
+      `module import ${moduleImportPath}`,
+    )
     recordModuleImportSuccess(scriptPath)
     if (isRootPluginAsset) {
       completeBootDownload(scriptPath)

--- a/db/volume/controller/controller.go
+++ b/db/volume/controller/controller.go
@@ -3,6 +3,7 @@ package volume_controller
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -18,6 +19,16 @@ import (
 	peer_controller "github.com/s4wave/spacewave/net/peer/controller"
 	"github.com/sirupsen/logrus"
 )
+
+// maxConstructionAttempts caps consecutive failed volume constructions before
+// the failure is treated as permanent. The controllerbus loader restarts a
+// controller whose Execute returned an error with exponential backoff and no
+// elapsed-time ceiling, so without this cap a wedged environment (for example
+// OPFS GetRoot failing with UnknownError) loops forever at the backoff ceiling
+// while boot waits silently. After this many consecutive failures, retrying
+// has stopped being plausible; the controller records a terminal error and
+// stops so GetVolume surfaces it to the boot failure path.
+const maxConstructionAttempts = 5
 
 // Controller implements a common volume controller.
 //
@@ -42,6 +53,10 @@ type Controller struct {
 	// bucketHandles contains open bucket handles
 	// key: bucket id
 	bucketHandles *keyed.KeyedRefCount[string, *bucketHandleTracker]
+
+	// constructionFailures counts consecutive failed volume constructions
+	// across controllerbus restarts of this same controller instance.
+	constructionFailures int
 
 	// terminalMtx guards terminalErr and terminalDone.
 	terminalMtx sync.Mutex
@@ -105,8 +120,19 @@ func (c *Controller) Execute(ctx context.Context) error {
 			c.setTerminal(err)
 			return nil
 		}
+		c.constructionFailures++
+		if c.constructionFailures >= maxConstructionAttempts {
+			err = volume.Permanent(fmt.Errorf(
+				"volume construction failed %d times consecutively: %w",
+				c.constructionFailures, err,
+			))
+			c.le.WithError(err).Error("volume unavailable: retry cap exceeded, not restarting")
+			c.setTerminal(err)
+			return nil
+		}
 		return err
 	}
+	c.constructionFailures = 0
 	defer v.Close()
 
 	// Prepare readiness diagnostics and the volume execution error channel.

--- a/db/volume/controller/permanent-error_test.go
+++ b/db/volume/controller/permanent-error_test.go
@@ -59,3 +59,44 @@ func TestExecuteRetriesTransientError(t *testing.T) {
 		t.Fatalf("getTerminal returned %v, want nil for a transient error", got)
 	}
 }
+
+// TestExecuteStopsAfterConsecutiveTransientFailures proves the consecutive
+// construction-failure cap converts an endlessly retried transient failure
+// (for example "opfs GetRoot: UnknownError") into a terminal error instead of
+// looping forever under the loader's unbounded backoff.
+func TestExecuteStopsAfterConsecutiveTransientFailures(t *testing.T) {
+	le := logrus.NewEntry(logrus.New())
+	transient := errors.New("opfs GetRoot: UnknownError")
+	attempts := 0
+
+	ctrl := NewController(le, &Config{}, nil, nil,
+		func(ctx context.Context, le *logrus.Entry) (volume.Volume, error) {
+			attempts++
+			return nil, transient
+		})
+
+	for i := range maxConstructionAttempts - 1 {
+		if err := ctrl.Execute(context.Background()); !errors.Is(err, transient) {
+			t.Fatalf("attempt %d: Execute returned %v, want the transient error so it retries", i+1, err)
+		}
+	}
+	if err := ctrl.Execute(context.Background()); err != nil {
+		t.Fatalf("Execute returned %v after %d attempts, want nil so controllerbus stops restarting", err, maxConstructionAttempts)
+	}
+	if attempts != maxConstructionAttempts {
+		t.Fatalf("constructor ran %d times, want %d", attempts, maxConstructionAttempts)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	vol, err := ctrl.GetVolume(ctx)
+	if vol != nil {
+		t.Fatalf("GetVolume returned a volume, want nil")
+	}
+	if !errors.Is(err, transient) {
+		t.Fatalf("GetVolume returned %v, want it to wrap %v", err, transient)
+	}
+	if !volume.IsPermanent(err) {
+		t.Fatalf("GetVolume error %v is not classified permanent", err)
+	}
+}


### PR DESCRIPTION
On WebKit, a first-launch boot could sit silently at 'Preparing the app frame' for the entire wait budget: the wasm runtime's storage-volume controller retried opfs GetRoot forever, and nothing in the outer shell ever reported a problem. The same class of silent stall was possible at any pre-webview hop.

Three changes make every such wedge fail loudly within bounded time:

- The storage-volume controller caps consecutive construction failures (5) and then records a terminal error, so GetVolume surfaces it to waiters instead of blocking behind unbounded controllerbus restarts.
- Boot downloads fail when their module load wedges: root-asset fetches and dynamic imports carry 45s deadlines routed through the existing failBootDownload plumbing, with a fetch-wedge catch so a never-settling fetch also fails rather than hanging.
- The web view gets a 90s reveal deadline after mount; if no render mode, html links, or component-ready arrives, the boot fails through the same path. An outer-shell watchdog additionally fails the boot when progress stays below the app-frame threshold past a hard ceiling.

All deadlines are time-without-progress based and engine-neutral: healthy Chromium behavior is unchanged (verified with the bottom-bar-context-menu webframe scenario and the full vitest/typecheck gates), while a wedged WebKit boot now reaches an attributed terminal failure — 'web view did not become ready within 90s (no render mode, html links, or component-ready)' — inside about two minutes of the wedge instead of stalling silently for fifteen.