### PR TITLE
fix(webrtc): correlate answers across tracker regeneration

### DIFF
--- a/net/transport/webrtc/ingress.go
+++ b/net/transport/webrtc/ingress.go
@@ -142,8 +142,14 @@ func (w *WebRTC) takeAdoptableSession(peerID string) *session {
 	return sess
 }
 
-// closeSignalIngress removes a resolver from the peer's ingress lease.
+// closeSignalIngress removes a resolver from the peer's ingress lease. The
+// last resolver out detaches the lease and disposes a session handed over for
+// adoption: take-and-clear of the stash runs under the same hold as the
+// deletion, so a concurrent successor adoption yields exactly one adopter or
+// one disposer, never both. The disposal itself runs outside w.bcast through
+// the non-stashing dispose path.
 func (w *WebRTC) closeSignalIngress(peerID string, resolver *handleSignalPeerResolver) {
+	var orphan *session
 	w.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
 		resolver.closed = true
 		ingress := w.incomingSessions[peerID]
@@ -160,9 +166,14 @@ func (w *WebRTC) closeSignalIngress(peerID string, resolver *handleSignalPeerRes
 				ingress.ref.Release()
 				ingress.ref = nil
 			}
+			orphan = ingress.adoptedSession
+			ingress.adoptedSession = nil
 		}
 		broadcast()
 	})
+	if orphan != nil {
+		orphan.dispose()
+	}
 }
 
 // isGenerationFencedBody reports whether a signal body carries offer

--- a/net/transport/webrtc/session.go
+++ b/net/transport/webrtc/session.go
@@ -364,6 +364,13 @@ type session struct {
 	// whose offer_id does not match it are dropped before Pion.
 	pendingOfferID []byte
 
+	// pendingOfferSDP holds the exact local offer SDP bytes whose digest is
+	// pendingOfferID. Pion augments LocalDescription with gathered ICE
+	// candidates after the initial transmission, so the outstanding-offer
+	// retransmit path replays these bytes to keep the generation identity
+	// stable across retransmissions.
+	pendingOfferSDP string
+
 	// retiredOfferIDs holds the digests of remote offers this session already
 	// applied and replaced with a newer generation. A replayed copy of a
 	// retired offer is dropped before Pion so a stale description can never
@@ -620,23 +627,33 @@ func (s *session) close() {
 		fatalErr = s.fatalErr
 		connState = s.connState
 	})
-	// An outstanding offer survives this tracker: hand the session to the
-	// peer's ingress lease for adoption by a successor instead of disposing
-	// a generation the remote side may already have answered. Only a session
-	// whose offer drew an answer is worth adopting: an unanswered offer can
-	// never be re-answered (the remote deduplicates byte-identical offers) nor
-	// replaced (pion v4 has no rollback), so the successor must mint a fresh
-	// generation on a new connection. A session with a recorded fatal error is
-	// likewise never adoptable: its successor would exit on the first snapshot
-	// and re-stash, wedging the ingress against new signals.
+	// An in-flight negotiation survives this tracker: hand the session to the
+	// peer's ingress lease for adoption by a successor instead of disposing an
+	// outstanding offer. The successor adopts the connection with the same
+	// pending offer id and retransmits the identical offer via the outstanding-
+	// offer path in transmitLocalNegotiation, so an answer already sent or
+	// still in flight correlates instead of dying with the retired generation.
+	// Only a session holding a live outstanding local offer is adoptable; a
+	// session with a recorded fatal error, a finished or unusable connection,
+	// or no outstanding offer cannot continue negotiation and is disposed so
+	// its successor mints a fresh generation on a new connection.
+	localDesc := s.pc.LocalDescription()
 	if fatalErr == nil && s.t != nil && s.t.offerer && len(s.pendingOfferID) > 0 &&
-		s.pc.RemoteDescription() != nil &&
+		localDesc != nil && localDesc.SDP != "" &&
+		s.pc.SignalingState() == webrtc.SignalingStateHaveLocalOffer &&
 		connState != webrtc.PeerConnectionStateConnected &&
 		connState != webrtc.PeerConnectionStateFailed &&
 		connState != webrtc.PeerConnectionStateClosed &&
 		s.t.w.stashAdoptableSession(s.t.key, s) {
 		return
 	}
+	s.dispose()
+}
+
+// dispose releases the session's generation fence state and closes the peer
+// connection exactly once. It never stashes: the ingress-lease cleanup path
+// uses it to dispose a handed-over session outside every w.bcast section.
+func (s *session) dispose() {
 	s.retiredOfferIDs = nil
 	_ = s.pc.Close()
 }
@@ -687,13 +704,19 @@ func (s *sessionTracker) transmitLocalNegotiation(
 			sess.pc.SignalingState() == webrtc.SignalingStateHaveLocalOffer {
 			// An offer is already outstanding on this connection: retransmit
 			// the same bytes and identity instead of minting a new
-			// generation, so an in-flight answer still correlates.
-			localDesc := sess.pc.LocalDescription()
-			if localDesc == nil {
-				return lastLocalSeqno, false, pkgerrors.New("retransmit outstanding offer: no local description")
+			// generation, so an in-flight answer still correlates. The minted
+			// bytes are replayed verbatim: Pion augments LocalDescription
+			// with gathered ICE candidates, which would present the remote
+			// with a byte-different offer that answers under a new identity.
+			if sess.pendingOfferSDP == "" {
+				return lastLocalSeqno, false, pkgerrors.New("retransmit outstanding offer: no pending offer sdp")
 			}
 			le.Debug("signal tx: retransmit outstanding offer")
-			xmitSdp := NewWebRtcSdp(currLocalSeqno, localDesc)
+			xmitSdp := &WebRtcSdp{
+				TxSeqno: currLocalSeqno,
+				SdpType: webrtc.SDPTypeOffer.String(),
+				Sdp:     sess.pendingOfferSDP,
+			}
 			xmitSdp.OfferId = sess.pendingOfferID
 			xmit = &WebRtcSignal{Body: &WebRtcSignal_Sdp{Sdp: xmitSdp}}
 			xmitSignal(xmit)
@@ -708,6 +731,7 @@ func (s *sessionTracker) transmitLocalNegotiation(
 		}
 		offerSum := sha256.Sum256([]byte(localDesc.SDP))
 		sess.pendingOfferID = offerSum[:]
+		sess.pendingOfferSDP = localDesc.SDP
 		xmitSdp := NewWebRtcSdp(currLocalSeqno, &localDesc)
 		xmitSdp.OfferId = offerSum[:]
 		xmit = &WebRtcSignal{Body: &WebRtcSignal_Sdp{Sdp: xmitSdp}}
@@ -1105,9 +1129,26 @@ func isOfferer(a, b string) bool {
 	return strings.Compare(a, b) < 0
 }
 
+// transmitAnswer emits one Sdp signal carrying an answer description tagged
+// with the session's active remote-offer digest. The first answer
+// transmission and the duplicate-offer replay share it; it performs no
+// matching or validation of its own.
+func (s *sessionTracker) transmitAnswer(
+	sess *session,
+	answer *webrtc.SessionDescription,
+	currLocalSeqno uint64,
+	xmitSignal func(*WebRtcSignal),
+) {
+	if answer == nil || answer.SDP == "" || answer.Type != webrtc.SDPTypeAnswer {
+		return
+	}
+	ans := NewWebRtcSdp(currLocalSeqno, answer)
+	ans.OfferId = sess.rxOfferID
+	xmitSignal(&WebRtcSignal{Body: &WebRtcSignal_Sdp{Sdp: ans}})
+}
+
 // ingestRemoteSignal applies one received SDP/candidate signal pair to the
-// session. It is the execute-loop answer/candidate application extracted
-// verbatim; behavior is byte-for-byte unchanged.
+// session.
 func (s *sessionTracker) ingestRemoteSignal(
 	sess *session,
 	currRxSdp *WebRtcSdp,
@@ -1163,7 +1204,19 @@ func (s *sessionTracker) ingestRemoteSignal(
 			// A byte-identical duplicate of the description we already applied.
 			// Ignore it to avoid an unnecessary renegotiation / ICE restart. The
 			// offerer re-sends its offer on every request_offer, so the answerer
-			// routinely sees the same offer twice.
+			// routinely sees the same offer twice. When the retransmitted offer
+			// is the generation this session already answered, the offerer may
+			// have regenerated and lost the original answer in flight: replay
+			// the retained local answer so the outstanding offer still
+			// correlates, without touching Pion state a second time.
+			if !s.offerer &&
+				bytes.Equal(currRxSdp.GetOfferId(), sess.rxOfferID) &&
+				sess.pc.RemoteDescription() != nil {
+				if s.w.GetVerbose() {
+					le.Debug("signal tx: replay retained answer")
+				}
+				s.transmitAnswer(sess, sess.pc.LocalDescription(), currLocalSeqno, xmitSignal)
+			}
 		case s.offerer && sess.pc.SignalingState() != webrtc.SignalingStateHaveLocalOffer:
 			// Drop an answer that arrives with no local offer pending. Applying an
 			// answer while signalingState is already "stable" makes pion fail with
@@ -1213,9 +1266,7 @@ func (s *sessionTracker) ingestRemoteSignal(
 				if err := sess.pc.SetLocalDescription(answer); err != nil {
 					return pkgerrors.Wrap(err, "set local description(answer)")
 				}
-				ans := NewWebRtcSdp(currLocalSeqno, &answer)
-				ans.OfferId = sess.rxOfferID
-				xmitSignal(&WebRtcSignal{Body: &WebRtcSignal_Sdp{Sdp: ans}})
+				s.transmitAnswer(sess, &answer, currLocalSeqno, xmitSignal)
 			}
 		}
 	}

--- a/net/transport/webrtc/signal_hosted_stale_answer_red_test.go
+++ b/net/transport/webrtc/signal_hosted_stale_answer_red_test.go
@@ -1,0 +1,357 @@
+package webrtc
+
+// RED reproduction for the Mercury v5 hosted-join stale-answer drops.
+//
+// Drives the real production boundary end to end: handleSignalPeerResolver
+// delivers through deliverSignal into the ingress lease, the keyed ref-count
+// runs the real sessionTracker.execute with real Pion peer connections, and
+// the remote answerer is a real Pion answer-side PeerConnection. No fence or
+// guard behavior is modified.
+//
+// Sequence under test mirrors the Mercury v5 hosted join: the WebRTC offerer
+// regenerates its tracker generation while its answer is still in flight, and
+// the era-A answers arrive at the successor generation. The target invariant
+// is that a hosted join loses no answers across tracker regeneration. The
+// observed behavior today is two "dropping stale answer: offer id does not
+// match the pending local offer" drops, after which negotiation stalls until
+// ICE fails - exactly the Mercury v5 signature.
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"strings"
+	"testing"
+	"time"
+
+	inmem "github.com/aperturerobotics/controllerbus/bus/inmem"
+	"github.com/aperturerobotics/controllerbus/controller"
+	"github.com/aperturerobotics/controllerbus/directive"
+	directive_controller "github.com/aperturerobotics/controllerbus/directive/controller"
+	cbackoff "github.com/aperturerobotics/util/backoff/cbackoff"
+	"github.com/aperturerobotics/util/keyed"
+	pion_webrtc "github.com/pion/webrtc/v4"
+	"github.com/s4wave/spacewave/net/crypto"
+	"github.com/s4wave/spacewave/net/peer"
+	signaling "github.com/s4wave/spacewave/net/signaling"
+)
+
+// staleAnswerDropPrefix is the consumer fence log line the defect produces.
+const staleAnswerDropPrefix = "dropping stale answer"
+
+// redXmitSession stands in for the outbound signaling session execute opens
+// through ExSignalPeer. Every transmitted signal lands on sendCh.
+type redXmitSession struct {
+	localPeerID  peer.ID
+	remotePeerID peer.ID
+	sendCh       chan []byte
+}
+
+func (s *redXmitSession) GetLocalPeerID() peer.ID  { return s.localPeerID }
+func (s *redXmitSession) GetRemotePeerID() peer.ID { return s.remotePeerID }
+func (s *redXmitSession) Recv(ctx context.Context) ([]byte, error) {
+	<-ctx.Done()
+	return nil, context.Canceled
+}
+
+func (s *redXmitSession) Send(ctx context.Context, msg []byte) error {
+	// Copy before parking: the caller scrubs its buffer once Send returns.
+	cp := make([]byte, len(msg))
+	copy(cp, msg)
+	select {
+	case s.sendCh <- cp:
+		return nil
+	case <-ctx.Done():
+		return context.Canceled
+	}
+}
+
+// redSignalController resolves SignalPeer directives with one shared
+// scripted session, standing in for the signaling relay.
+type redSignalController struct {
+	sess signaling.SignalPeerSession
+}
+
+func (c *redSignalController) HandleDirective(ctx context.Context, di directive.Instance) ([]directive.Resolver, error) {
+	if _, ok := di.GetDirective().(signaling.SignalPeer); ok {
+		resolvers, _ := directive.R(&redSignalResolver{sess: c.sess}, nil)
+		return resolvers, nil
+	}
+	return nil, nil
+}
+func (c *redSignalController) Execute(ctx context.Context) error { return nil }
+func (c *redSignalController) Close() error                      { return nil }
+func (c *redSignalController) GetControllerInfo() *controller.Info {
+	return controller.NewInfo(ControllerID+"/signal-red-test", Version, "test signal peer provider")
+}
+
+type redSignalResolver struct {
+	sess signaling.SignalPeerSession
+}
+
+func (r *redSignalResolver) Resolve(ctx context.Context, handler directive.ResolverHandler) error {
+	handler.ClearValues()
+	if vid, accepted := handler.AddValue(r.sess); accepted {
+		handler.AddValueRemovedCallback(vid, func() {})
+	}
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// redIdentity generates a local and remote identity with both private keys,
+// forcing the local peer to sort before the remote so the local side takes
+// the deterministic offerer role.
+type redIdentity struct {
+	ident        *hostedFlowIdentity
+	localPriv    crypto.PrivKey
+	localPub     crypto.PubKey
+	localPeerID  peer.ID
+	remotePriv   crypto.PrivKey
+	remotePeerID peer.ID
+}
+
+func newRedIdentity(t *testing.T) *redIdentity {
+	t.Helper()
+	for {
+		localPriv, localPub, err := crypto.GenerateEd25519Key(rand.Reader)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		localPeerID, err := peer.IDFromPrivateKey(localPriv)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		remotePriv, _, err := crypto.GenerateEd25519Key(rand.Reader)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		remotePeerID, err := peer.IDFromPrivateKey(remotePriv)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		if strings.Compare(localPeerID.String(), remotePeerID.String()) < 0 {
+			return &redIdentity{
+				ident: &hostedFlowIdentity{
+					localPriv:    localPriv,
+					localPub:     localPub,
+					localPeerID:  localPeerID,
+					remotePeerID: remotePeerID,
+				},
+				localPriv:    localPriv,
+				localPub:     localPub,
+				localPeerID:  localPeerID,
+				remotePriv:   remotePriv,
+				remotePeerID: remotePeerID,
+			}
+		}
+	}
+}
+
+// awaitRedOutboundSignal decodes the next outbound signal of the given body
+// kind, skipping anything else (ICE trickle, end-of-candidates).
+func awaitRedOutboundSignal(
+	t *testing.T,
+	ch <-chan []byte,
+	remotePriv crypto.PrivKey,
+	wantSdpOffer bool,
+) *WebRtcSignal {
+	t.Helper()
+	deadline := time.After(hostedFlowTimeout)
+	for {
+		select {
+		case msg := <-ch:
+			sig, err := DecodeWebRtcSignal(msg, remotePriv)
+			if err != nil {
+				t.Fatalf("decode outbound signal (%d bytes): %v", len(msg), err)
+			}
+			switch b := sig.GetBody().(type) {
+			case *WebRtcSignal_Sdp:
+				if wantSdpOffer && b.Sdp.GetSdpType() == "offer" {
+					return sig
+				}
+			case *WebRtcSignal_Ice:
+				// gathering noise; skip
+			case *WebRtcSignal_RequestOffer:
+				// not expected outbound; skip
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for the expected outbound signal")
+			return nil
+		}
+	}
+}
+
+// startRedResolver drives one inbound signaling session through the
+// production resolver loop with its own lifetime.
+func startRedResolver(
+	ctx context.Context,
+	tpt *WebRTC,
+	signalSession *testSignalPeerSession,
+) (*handleSignalPeerResolver, context.CancelFunc) {
+	resolverCtx, cancel := context.WithCancel(tpt.ctx)
+	resolver := &handleSignalPeerResolver{t: tpt, sess: signalSession}
+	go func() {
+		_ = resolver.Resolve(resolverCtx, nil)
+	}()
+	return resolver, cancel
+}
+
+// buildRedTaggedOffer builds one real, valid offer SDP signal tagged with its
+// own generation digest, encrypted for the local transport.
+func buildRedTaggedOffer(t *testing.T, api *pion_webrtc.API, pub crypto.PubKey) []byte {
+	t.Helper()
+	offerPC, err := api.NewPeerConnection(pion_webrtc.Configuration{})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer offerPC.Close()
+	if _, err := offerPC.CreateDataChannel(dataChannelID, nil); err != nil {
+		t.Fatal(err.Error())
+	}
+	offer, err := offerPC.CreateOffer(nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	msg, err := EncodeWebRtcSignal(&WebRtcSignal{
+		Body: &WebRtcSignal_Sdp{Sdp: &WebRtcSdp{
+			TxSeqno: 1,
+			SdpType: offer.Type.String(),
+			Sdp:     offer.SDP,
+			OfferId: offerDigest(offer.SDP),
+		}},
+	}, pub)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	return msg
+}
+
+// TestHostedJoinKeepsAnswersAcrossTrackerRegeneration pins the hosted-join
+// invariant broken by Mercury v5: when the offerer's tracker generation is
+// retired while its answer is still in flight, the successor generation adopts
+// the outstanding-offer session, retransmits the identical offer, and the
+// era-A answer - plus a redelivered copy of it - correlates instead of being
+// dropped as stale. Today's pre-fix behavior drops both answers and the join
+// stalls until ICE fails.
+func TestHostedJoinKeepsAnswersAcrossTrackerRegeneration(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	ident := newRedIdentity(t)
+	logs := newHostedFlowLogs()
+	tpt := newHostedFlowTransport(ctx, ident.ident, logs)
+
+	// Wire the outbound signaling session through a real bus so
+	// sessionTracker.execute resolves ExSignalPeer exactly as in production.
+	xmit := &redXmitSession{
+		localPeerID:  ident.localPeerID,
+		remotePeerID: ident.remotePeerID,
+		sendCh:       make(chan []byte, 64),
+	}
+	b := inmem.NewBus(directive_controller.NewController(ctx, logs.entry))
+	if _, err := b.AddController(ctx, &redSignalController{sess: xmit}, nil); err != nil {
+		t.Fatal(err.Error())
+	}
+	tpt.b = b
+
+	// Production tracker factory: every generation runs the real execute loop.
+	tpt.sessionTrackers = keyed.NewKeyedRefCount(
+		tpt.newSessionTracker,
+		keyed.WithBackoff[string, *sessionTracker](func(string) cbackoff.BackOff {
+			return new(cbackoff.ZeroBackOff)
+		}),
+	)
+	tpt.sessionTrackers.SetContext(tpt.ctx, true)
+	t.Cleanup(tpt.sessionTrackers.ClearContext)
+
+	// Generation A: establish the lease, let the real execute loop mint and
+	// transmit its offer, then build the matching answer and hold it in
+	// flight, exactly where the regeneration strikes.
+	signalSessionA := newHostedFlowSignalSession(ident.ident, 8)
+	_, cancelA := startRedResolver(ctx, tpt, signalSessionA)
+	defer cancelA()
+
+	signalSessionA.recvCh <- newHostedFlowMarker(t, ident.localPub)
+	offerASig := awaitRedOutboundSignal(t, xmit.sendCh, ident.remotePriv, true)
+	offerA := offerASig.GetBody().(*WebRtcSignal_Sdp).Sdp
+	hA := sha256.Sum256([]byte(offerA.GetSdp()))
+
+	answerPC, err := tpt.webrtcApi.NewPeerConnection(pion_webrtc.Configuration{})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer func() { _ = answerPC.Close() }()
+	if err := answerPC.SetRemoteDescription(pion_webrtc.SessionDescription{
+		Type: pion_webrtc.SDPTypeOffer,
+		SDP:  offerA.GetSdp(),
+	}); err != nil {
+		t.Fatal(err.Error())
+	}
+	answerA, err := answerPC.CreateAnswer(nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	eraAAnswer, err := EncodeWebRtcSignal(&WebRtcSignal{
+		Body: &WebRtcSignal_Sdp{Sdp: &WebRtcSdp{
+			TxSeqno: 0,
+			SdpType: answerA.Type.String(),
+			Sdp:     answerA.SDP,
+			OfferId: hA[:],
+		}},
+	}, ident.localPub)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	// Retire generation A while the era-A answer is still in flight. An SDP
+	// offer arriving at an offerer is a fatal role violation, which returns
+	// from execute without recording a session fatal error - the production
+	// churn shape this fix targets. The signaling session stays alive, so the
+	// ingress lease stays discoverable between generations.
+	signalSessionA.recvCh <- buildRedTaggedOffer(t, tpt.webrtcApi, ident.localPub)
+	if !logs.awaitPrefix(t, "session tracker exited") {
+		t.Fatal("generation A did not retire")
+	}
+
+	// The next delivery rebinds a successor onto the same lease; the successor
+	// adopts the handed-over session and retransmits the identical outstanding
+	// offer instead of minting a new generation.
+	signalSessionA.recvCh <- newHostedFlowMarker(t, ident.localPub)
+	retransSig := awaitRedOutboundSignal(t, xmit.sendCh, ident.remotePriv, true)
+	retrans := retransSig.GetBody().(*WebRtcSignal_Sdp).Sdp
+	if retrans.GetSdp() != offerA.GetSdp() || !bytes.Equal(retrans.GetOfferId(), hA[:]) {
+		t.Fatal("successor did not retransmit the identical outstanding offer generation")
+	}
+
+	// Deliver the held era-A answer, then a redelivered copy the way the hub
+	// replays era material to the peer's second signaling session.
+	pushRedSignal := func() {
+		// Deliver a fresh copy each time: the resolver scrubs the buffer
+		// after decoding, exactly as production hands off decoded signals.
+		cp := make([]byte, len(eraAAnswer))
+		copy(cp, eraAAnswer)
+		signalSessionA.recvCh <- cp
+	}
+	pushRedSignal()
+	pushRedSignal()
+
+	// The invariant: zero stale-answer drops across the whole sequence.
+	drainDeadline := time.After(3 * time.Second)
+	var drops []string
+drain:
+	for {
+		select {
+		case msg := <-logs.ch:
+			if strings.HasPrefix(msg, staleAnswerDropPrefix) {
+				drops = append(drops, msg)
+			}
+		case <-drainDeadline:
+			break drain
+		}
+	}
+	if len(drops) > 0 {
+		t.Fatalf("hosted join dropped %d answers across tracker regeneration:\n%s",
+			len(drops), strings.Join(drops, "\n"))
+	}
+}

--- a/net/transport/webrtc/signal_ingress_red_test.go
+++ b/net/transport/webrtc/signal_ingress_red_test.go
@@ -7,9 +7,12 @@ package webrtc
 // existing fatal role and Pion error paths, stays unchanged.
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	pion_webrtc "github.com/pion/webrtc/v4"
 	"github.com/sirupsen/logrus"
@@ -28,11 +31,16 @@ type fenceIngest struct {
 	lastApplied string
 	pendingICE  []pion_webrtc.ICECandidateInit
 	applier     *remoteICECandidateApplier
+	xmit        func(*WebRtcSignal)
 }
 
 // ingest applies one received SDP/candidate signal pair.
 func (f *fenceIngest) ingest(sdp *WebRtcSdp, ice *WebRtcIce) error {
 	phase := ""
+	xmit := f.xmit
+	if xmit == nil {
+		xmit = func(*WebRtcSignal) {}
+	}
 	return f.tracker.ingestRemoteSignal(
 		f.sess,
 		sdp,
@@ -41,7 +49,7 @@ func (f *fenceIngest) ingest(sdp *WebRtcSdp, ice *WebRtcIce) error {
 		&f.lastApplied,
 		f.applier,
 		&f.pendingICE,
-		func(*WebRtcSignal) {},
+		xmit,
 		newFenceTestLogger(),
 		&phase,
 	)
@@ -141,61 +149,61 @@ func newNegotiatedPair(t *testing.T) (offerPC, answerPC *pion_webrtc.PeerConnect
 // answer whose offer_id does not match the active generation must be dropped
 // before Pion state is touched, leaving the remote description unapplied.
 // TestAnswerCorrelatesAcrossTrackerRegeneration pins the adoption seam across
-// tracker regeneration. The successor adopts the handed-over session, clears
-// any predecessor fatal error, and continues negotiation with a fresh offer;
-// answers from earlier generations stay fenced out.
+// tracker regeneration. The successor adopts the handed-over session with its
+// outstanding local offer, retransmits the identical offer generation, drops
+// an answer for any other generation before Pion state is touched, and
+// applies the answer that matches the outstanding generation.
 func TestAnswerCorrelatesAcrossTrackerRegeneration(t *testing.T) {
 	w := &WebRTC{conf: &Config{}}
 
-	newTrackerSess := func(pc *pion_webrtc.PeerConnection) (*sessionTracker, *session) {
-		tracker := &sessionTracker{
+	newTracker := func() *sessionTracker {
+		return &sessionTracker{
 			w:       w,
 			le:      newFenceTestLogger(),
 			offerer: true,
 			key:     "regen-peer",
 		}
-		return tracker, &session{t: tracker, pc: pc}
 	}
 
-	xmit := func(*WebRtcSignal) {}
+	var xmitted []*WebRtcSdp
+	xmit := func(sig *WebRtcSignal) {
+		xmitted = append(xmitted, sig.GetBody().(*WebRtcSignal_Sdp).Sdp)
+	}
 	le := newFenceTestLogger()
 
-	// Generation one: the first tracker transmits its local offer.
+	// Generation one: the first tracker transmits its local offer and retires
+	// with the offer still outstanding.
 	pcA, err := pion_webrtc.NewPeerConnection(pion_webrtc.Configuration{})
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 	t.Cleanup(func() { pcA.Close() })
-	trackerA, sessA := newTrackerSess(pcA)
+	if _, err := pcA.CreateDataChannel(dataChannelID, nil); err != nil {
+		t.Fatal(err.Error())
+	}
+	trackerA := newTracker()
+	sessA := &session{t: trackerA, pc: pcA}
 	seqA, _, err := trackerA.transmitLocalNegotiation(sessA, le, 1, 0, xmit)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 	genOneID := append([]byte(nil), sessA.pendingOfferID...)
-	if len(genOneID) == 0 {
-		t.Fatal("first generation recorded no pending offer id")
+	offerSDP := xmitted[0].GetSdp()
+	if offerSDP == "" || !strings.Contains(offerSDP, "a=ice-ufrag") {
+		t.Fatalf("first generation transmitted no usable offer: n=%d body=%q type=%q", len(xmitted), offerSDP, xmitted[0].GetSdpType())
+	}
+	if len(genOneID) == 0 || offerSDP == "" {
+		t.Fatal("first generation recorded no outstanding offer")
 	}
 
-	// The remote answered generation one before the tracker retired: the
-	// session carries a live connection worth handing over.
-	_, _, _, answerDesc := newNegotiatedPair(t)
-	if err := pcA.SetRemoteDescription(*answerDesc); err != nil {
-		t.Fatal(err.Error())
-	}
-
-	// The tracker retires: the in-flight session is handed to the peer's
-	// ingress lease for adoption instead of disposed.
+	// The tracker retires mid-handshake: the in-flight negotiation is handed
+	// to the peer's ingress lease for adoption instead of disposed.
 	w.incomingSessions = map[string]*signalIngress{"regen-peer": {}}
 	sessA.close()
 
 	// A successor regenerates on the same peer key and adopts the handed-over
 	// session.
-	trackerB := &sessionTracker{
-		w:       w,
-		le:      le,
-		offerer: true,
-		key:     "regen-peer",
-	}
+	trackerB := newTracker()
 	sessB := w.takeAdoptableSession("regen-peer")
 	if sessB == nil {
 		t.Fatal("successor found no adoptable session after regeneration")
@@ -205,16 +213,23 @@ func TestAnswerCorrelatesAcrossTrackerRegeneration(t *testing.T) {
 		t.Fatal("adopted session lost its peer connection")
 	}
 
-	// Generation two: the successor continues negotiation on the adopted
-	// connection with a fresh offer generation.
-	seqB, _, err := trackerB.transmitLocalNegotiation(sessB, le, seqA+1, 0, xmit)
-	if err != nil {
+	// The successor retransmits the identical outstanding offer instead of
+	// minting a new generation, so an in-flight or replayed answer still
+	// correlates.
+	before := len(xmitted)
+	if _, _, err := trackerB.transmitLocalNegotiation(sessB, le, seqA+1, 0, xmit); err != nil {
 		t.Fatal(err.Error())
 	}
-	if seqB <= seqA {
-		t.Fatalf("successor seqno %d did not advance past %d", seqB, seqA)
+	if len(xmitted) != before+1 {
+		t.Fatalf("successor transmitted %d offers, want exactly one retransmission", len(xmitted)-before)
 	}
-	genTwoID := append([]byte(nil), sessB.pendingOfferID...)
+	retrans := xmitted[len(xmitted)-1]
+	if retrans.GetSdpType() != "offer" || retrans.GetSdp() != offerSDP {
+		t.Fatal("successor did not retransmit the identical outstanding offer")
+	}
+	if !bytes.Equal(retrans.GetOfferId(), genOneID) {
+		t.Fatal("retransmitted offer changed the generation identity")
+	}
 
 	f := &fenceIngest{
 		tracker: trackerB,
@@ -224,22 +239,38 @@ func TestAnswerCorrelatesAcrossTrackerRegeneration(t *testing.T) {
 		},
 	}
 
-	// A late duplicate answer for generation one arrives after the successor's
-	// fresh offer. Its offer_id no longer matches the pending generation and
+	// A late duplicate answer for a retired generation arrives after the
+	// handover. Its offer_id no longer matches the outstanding generation and
 	// must drop before Pion state is touched.
+	staleID := sha256.Sum256([]byte("retired-generation-offer"))
 	if err := f.ingest(&WebRtcSdp{
 		SdpType: "answer",
-		Sdp:     answerDesc.SDP,
-		OfferId: genOneID,
+		Sdp:     "stale-answer-sdp",
+		OfferId: staleID[:],
 	}, nil); err != nil {
 		t.Fatalf("stale-generation answer returned %v, want silent drop", err)
 	}
 
-	// The answer for the fresh generation correlates and is applied.
+	// The answer for the outstanding generation correlates and is applied.
+	answerPC, err := pion_webrtc.NewPeerConnection(pion_webrtc.Configuration{})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	t.Cleanup(func() { answerPC.Close() })
+	if err := answerPC.SetRemoteDescription(pion_webrtc.SessionDescription{
+		Type: pion_webrtc.SDPTypeOffer,
+		SDP:  offerSDP,
+	}); err != nil {
+		t.Fatal(err.Error())
+	}
+	answerDesc, err := answerPC.CreateAnswer(nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
 	if err := f.ingest(&WebRtcSdp{
 		SdpType: "answer",
 		Sdp:     answerDesc.SDP,
-		OfferId: genTwoID,
+		OfferId: genOneID,
 	}, nil); err != nil {
 		t.Fatalf("correlating answer returned %v, want application", err)
 	}
@@ -283,33 +314,148 @@ func TestCloseSkipsStashOnFatalError(t *testing.T) {
 	}
 }
 
-// TestCloseDisposesUnansweredOfferSession asserts the adoption boundary of the
-// offerer handover: an offer that never drew an answer cannot be re-answered
-// (the remote deduplicates byte-identical offers) nor replaced (pion v4 has no
-// rollback), so close disposes it and the successor mints a fresh generation.
-func TestCloseDisposesUnansweredOfferSession(t *testing.T) {
-	w := &WebRTC{conf: &Config{}}
-	offerPC, _, _, _ := newNegotiatedPair(t)
-	tracker := &sessionTracker{
-		w:       w,
-		le:      newFenceTestLogger(),
-		offerer: true,
-		key:     "unanswered-peer",
+// waitForSignalingState bounds the asynchronous application of pion
+// description operations before the test asserts on the signaling state.
+func waitForSignalingState(t *testing.T, pc *pion_webrtc.PeerConnection, want pion_webrtc.SignalingState) {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	for pc.SignalingState() != want {
+		select {
+		case <-deadline:
+			t.Fatalf("signaling state %v, want %v", pc.SignalingState(), want)
+		case <-time.After(time.Millisecond):
+		}
 	}
-	sess := &session{t: tracker, pc: offerPC, pendingOfferID: []byte("unanswered-offer")}
+}
+
+// newOutstandingOfferSession builds an offerer session holding a live
+// outstanding local offer in the have-local-offer signaling state, the shape a
+// tracker hands over when it retires mid-negotiation.
+func newOutstandingOfferSession(t *testing.T, w *WebRTC, key string) (*sessionTracker, *session, *pion_webrtc.PeerConnection) {
+	t.Helper()
+	pc, err := pion_webrtc.NewPeerConnection(pion_webrtc.Configuration{})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	t.Cleanup(func() { pc.Close() })
+	if _, err := pc.CreateDataChannel(dataChannelID, nil); err != nil {
+		t.Fatal(err.Error())
+	}
+	offer, err := pc.CreateOffer(nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if err := pc.SetLocalDescription(offer); err != nil {
+		t.Fatal(err.Error())
+	}
+	tracker := &sessionTracker{w: w, le: newFenceTestLogger(), offerer: true, key: key}
+	sess := &session{
+		t:               tracker,
+		pc:              pc,
+		pendingOfferID:  offerDigest(offer.SDP),
+		pendingOfferSDP: offer.SDP,
+	}
 	sess.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
 		sess.connState = pion_webrtc.PeerConnectionStateConnecting
 		broadcast()
 	})
+	return tracker, sess, pc
+}
 
-	w.incomingSessions = map[string]*signalIngress{"unanswered-peer": {}}
+// TestCloseStashesOutstandingOfferForAdoption asserts the offerer handover:
+// retiring with a live outstanding local offer hands the session to the peer's
+// ingress lease with its connection, description, and generation identity
+// intact, so the successor can retransmit the identical offer.
+func TestCloseStashesOutstandingOfferForAdoption(t *testing.T) {
+	w := &WebRTC{conf: &Config{}}
+	tracker, sess, pc := newOutstandingOfferSession(t, w, "handover-peer")
+	pendingID := append([]byte(nil), sess.pendingOfferID...)
+
+	w.incomingSessions = map[string]*signalIngress{"handover-peer": {}}
 	sess.close()
 
-	if stashed := w.takeAdoptableSession("unanswered-peer"); stashed != nil {
-		t.Fatal("close stashed a session whose outstanding offer drew no answer")
+	stashed := w.takeAdoptableSession("handover-peer")
+	if stashed == nil {
+		t.Fatal("close disposed an outstanding-offer session instead of handing it over")
 	}
-	if offerPC.ConnectionState() != pion_webrtc.PeerConnectionStateClosed {
-		t.Fatalf("unanswered-offer session was not disposed: connection state %s", offerPC.ConnectionState().String())
+	if stashed.pc != pc {
+		t.Fatal("handed-over session lost its peer connection")
+	}
+	if !bytes.Equal(stashed.pendingOfferID, pendingID) {
+		t.Fatal("handed-over session lost its outstanding generation identity")
+	}
+	if state := stashed.pc.SignalingState(); state != pion_webrtc.SignalingStateHaveLocalOffer {
+		t.Fatalf("handed-over session signaling state %v, want have-local-offer", state)
+	}
+	if stashed.pc.ConnectionState() == pion_webrtc.PeerConnectionStateClosed {
+		t.Fatal("handed-over session's peer connection was disposed")
+	}
+	_ = tracker
+}
+
+// TestCloseDisposesNonAdoptableSessions asserts every non-adoptable
+// disposition of the offerer handover: a fatal error, a finished or unusable
+// connection, and sessions without an outstanding local offer are disposed so
+// the successor mints a fresh generation on a new connection.
+func TestCloseDisposesNonAdoptableSessions(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*session)
+	}{
+		{"fatal_error", func(s *session) {
+			s.fatalErr = errors.New("signal transmit routine failed")
+		}},
+		{"connected", func(s *session) {
+			s.connState = pion_webrtc.PeerConnectionStateConnected
+		}},
+		{"failed", func(s *session) {
+			s.connState = pion_webrtc.PeerConnectionStateFailed
+		}},
+		{"closed", func(s *session) {
+			s.connState = pion_webrtc.PeerConnectionStateClosed
+		}},
+		{"no_outstanding_offer", func(s *session) {
+			s.pendingOfferID = nil
+		}},
+		{"already_answered", func(s *session) {
+			answerPC, err := pion_webrtc.NewPeerConnection(pion_webrtc.Configuration{})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			t.Cleanup(func() { answerPC.Close() })
+			if err := answerPC.SetRemoteDescription(pion_webrtc.SessionDescription{
+				Type: pion_webrtc.SDPTypeOffer,
+				SDP:  s.pendingOfferSDP,
+			}); err != nil {
+				t.Fatal(err.Error())
+			}
+			answer, err := answerPC.CreateAnswer(nil)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if err := s.pc.SetRemoteDescription(answer); err != nil {
+				t.Fatal(err.Error())
+			}
+			waitForSignalingState(t, s.pc, pion_webrtc.SignalingStateStable)
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := &WebRTC{conf: &Config{}}
+			tracker, sess, pc := newOutstandingOfferSession(t, w, "dispose-peer")
+			tc.mutate(sess)
+
+			w.incomingSessions = map[string]*signalIngress{"dispose-peer": {}}
+			sess.close()
+
+			if stashed := w.takeAdoptableSession("dispose-peer"); stashed != nil {
+				t.Fatalf("close handed over a non-adoptable session: %s", tc.name)
+			}
+			if pc.ConnectionState() != pion_webrtc.PeerConnectionStateClosed {
+				t.Fatalf("non-adoptable session was not disposed: connection state %s", pc.ConnectionState().String())
+			}
+			_ = tracker
+		})
 	}
 }
 
@@ -487,4 +633,150 @@ func TestSignalIngressMatchingGenerationFatalControls(t *testing.T) {
 			t.Fatalf("matching-generation candidate applied %d times, want exactly 1", applied)
 		}
 	})
+}
+
+// TestAnswererReplaysRetainedAnswerOnDuplicateOffer pins the answerer side of
+// the regeneration handover: when the byte-identical offer this session
+// already answered arrives again, the session replays its retained local
+// answer carrying the same generation identity, and its Pion state stays
+// untouched.
+func TestAnswererReplaysRetainedAnswerOnDuplicateOffer(t *testing.T) {
+	_, answerPC, offerDesc, _ := newNegotiatedPair(t)
+
+	var xmitted []*WebRtcSdp
+	tracker := &sessionTracker{
+		w:       &WebRTC{conf: &Config{}},
+		le:      newFenceTestLogger(),
+		offerer: false,
+	}
+	sess := &session{pc: answerPC}
+	f := &fenceIngest{
+		tracker: tracker,
+		sess:    sess,
+		applier: &remoteICECandidateApplier{
+			add: func(pion_webrtc.ICECandidateInit) error { return nil },
+		},
+		xmit: func(sig *WebRtcSignal) {
+			xmitted = append(xmitted, sig.GetBody().(*WebRtcSignal_Sdp).Sdp)
+		},
+	}
+
+	// First delivery of the offer: apply it and transmit the fresh answer.
+	if err := f.ingest(&WebRtcSdp{
+		SdpType: "offer",
+		Sdp:     offerDesc.SDP,
+		OfferId: offerDigest(offerDesc.SDP),
+	}, nil); err != nil {
+		t.Fatal(err.Error())
+	}
+	if len(xmitted) != 1 || xmitted[0].GetSdpType() != "answer" {
+		t.Fatalf("first offer produced %d answers, want exactly one answer", len(xmitted))
+	}
+	firstAnswer := xmitted[0]
+
+	stateBefore := answerPC.SignalingState()
+	localBefore := answerPC.LocalDescription().SDP
+
+	// Byte-identical redelivery of the same generation: replay the retained
+	// answer instead of re-running SetRemote/CreateAnswer/SetLocal.
+	if err := f.ingest(&WebRtcSdp{
+		SdpType: "offer",
+		Sdp:     offerDesc.SDP,
+		OfferId: offerDigest(offerDesc.SDP),
+	}, nil); err != nil {
+		t.Fatal(err.Error())
+	}
+	if len(xmitted) != 2 {
+		t.Fatalf("duplicate offer produced %d answers, want exactly one replay", len(xmitted))
+	}
+	replayed := xmitted[1]
+	if replayed.GetSdp() != firstAnswer.GetSdp() {
+		t.Fatal("replayed answer changed the local description bytes")
+	}
+	if !bytes.Equal(replayed.GetOfferId(), sess.rxOfferID) {
+		t.Fatal("replayed answer changed the generation identity")
+	}
+	if answerPC.SignalingState() != stateBefore {
+		t.Fatal("replay mutated the signaling state")
+	}
+	if answerPC.LocalDescription().SDP != localBefore {
+		t.Fatal("replay mutated the local description")
+	}
+}
+
+// TestCloseSignalIngressDisposesStashedSessionOnLastResolver pins that the
+// last resolver out detaches the lease and disposes a session handed over for
+// adoption exactly once: the stash is gone and the peer connection is closed.
+func TestCloseSignalIngressDisposesStashedSessionOnLastResolver(t *testing.T) {
+	w := &WebRTC{conf: &Config{}}
+	pc, err := pion_webrtc.NewPeerConnection(pion_webrtc.Configuration{})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	t.Cleanup(func() { pc.Close() })
+	sess := &session{pc: pc, pendingOfferID: []byte("outstanding-offer")}
+	resolver := &handleSignalPeerResolver{t: w}
+	w.incomingSessions = map[string]*signalIngress{"detach-peer": {
+		adoptedSession: sess,
+		resolvers:      map[*handleSignalPeerResolver]struct{}{resolver: {}},
+	}}
+
+	w.closeSignalIngress("detach-peer", resolver)
+
+	if w.incomingSessions["detach-peer"] != nil {
+		t.Fatal("ingress lease survived its last resolver")
+	}
+	if taken := w.takeAdoptableSession("detach-peer"); taken != nil {
+		t.Fatal("stash survived the last-resolver detach")
+	}
+	if pc.ConnectionState() != pion_webrtc.PeerConnectionStateClosed {
+		t.Fatalf("detached stash was not disposed: connection state %s", pc.ConnectionState().String())
+	}
+}
+
+// TestCloseSignalIngressTakeVsDisposeExactlyOnce pins the concurrent handover
+// boundary: a successor taking the stashed session races the last-resolver
+// cleanup, and the take-and-clear under the transport lock yields exactly one
+// adopter or one disposer, never both.
+func TestCloseSignalIngressTakeVsDisposeExactlyOnce(t *testing.T) {
+	for i := range 50 {
+		w := &WebRTC{conf: &Config{}}
+		pc, err := pion_webrtc.NewPeerConnection(pion_webrtc.Configuration{})
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		sess := &session{pc: pc, pendingOfferID: []byte("outstanding-offer")}
+		resolver := &handleSignalPeerResolver{t: w}
+		w.incomingSessions = map[string]*signalIngress{"race-peer": {
+			adoptedSession: sess,
+			resolvers:      map[*handleSignalPeerResolver]struct{}{resolver: {}},
+		}}
+
+		start := make(chan struct{})
+		taken := make(chan *session, 1)
+		go func() {
+			<-start
+			taken <- w.takeAdoptableSession("race-peer")
+		}()
+		go func() {
+			<-start
+			w.closeSignalIngress("race-peer", resolver)
+		}()
+		close(start)
+
+		got := <-taken
+		if got != nil {
+			// The adopter won: the disposer observed an empty stash and left
+			// the connection open for the adopted negotiation.
+			if got.pc != pc {
+				t.Fatal("adopter received a foreign session")
+			}
+			if second := w.takeAdoptableSession("race-peer"); second != nil {
+				t.Fatal("stash was handed over twice")
+			}
+			_ = pc.Close()
+		} else if pc.ConnectionState() != pion_webrtc.PeerConnectionStateClosed {
+			t.Fatalf("iteration %d: disposer won but did not close the connection", i)
+		}
+	}
 }


### PR DESCRIPTION
A hosted join loses its negotiation whenever the offerer's session tracker regenerates while an answer is still in flight. The retired generation's outstanding offer was disposed because adoption demanded an applied remote description, so the successor minted a fresh generation that no longer matched the answer the remote had already produced, and the consumer fence dropped it as stale. Mercury v5 showed exactly two such drops before the join timed out.

close() now hands over any offerer session holding a live outstanding local offer in have-local-offer state; sessions with a fatal error, a finished or unusable connection, or no outstanding offer are still disposed. The retransmit path replays the exact minted offer bytes: pion augments LocalDescription with gathered ICE candidates after the initial transmission, which would otherwise present a byte-different offer that answers under a new identity.

An answerer that receives a byte-identical redelivery of the offer it already answered now replays its retained local answer with the same generation identity instead of silently ignoring the duplicate, giving a regenerated offerer a second chance to correlate. Pion state is not touched a second time.

The ingress lease disposes a handed-over session when its last resolver leaves: take-and-clear of the stash runs under the transport lock next to the lease deletion, so a concurrent successor adoption yields exactly one adopter or one disposer.

The real-boundary regression TestHostedJoinKeepsAnswersAcrossTracker- Regeneration drives resolver delivery, the keyed tracker lifecycle, and real pion sessions through regeneration with the answer in flight; it failed 9/9 with both stale-answer drops before this change and passes count=9 after.