### PR TITLE
fix(unixfs): make FUSE writes synchronous

### DIFF
--- a/db/unixfs/fuse/inode.go
+++ b/db/unixfs/fuse/inode.go
@@ -269,6 +269,10 @@ func (i *Inode) Create(
 	req *fuse.CreateRequest,
 	resp *fuse.CreateResponse,
 ) (fs.Node, fs.Handle, error) {
+	// Require each successful write to reach the World before FUSE reports it.
+	resp.OpenResponse.Flags |= fuse.OpenDirectIO
+	openFlags := req.Flags | fuse.OpenSync
+
 	name := req.Name
 	mode := req.Mode
 
@@ -294,7 +298,7 @@ func (i *Inode) Create(
 		return nil, nil, err
 	}
 
-	return childNode, NewHandle(childNode, req.Flags), nil
+	return childNode, NewHandle(childNode, openFlags), nil
 }
 
 // Rename moves an inode from one location to another.
@@ -433,7 +437,9 @@ func (i *Inode) Open(
 	req *fuse.OpenRequest,
 	resp *fuse.OpenResponse,
 ) (fs.Handle, error) {
-	return NewHandle(i, req.Flags), nil
+	// Bypass the kernel page cache and the Handle's asynchronous write buffer.
+	resp.Flags |= fuse.OpenDirectIO
+	return NewHandle(i, req.Flags|fuse.OpenSync), nil
 }
 
 // Remove removes the entry with the given name from the receiver, which must be

--- a/db/unixfs/fuse/inode.go
+++ b/db/unixfs/fuse/inode.go
@@ -270,7 +270,7 @@ func (i *Inode) Create(
 	resp *fuse.CreateResponse,
 ) (fs.Node, fs.Handle, error) {
 	// Require each successful write to reach the World before FUSE reports it.
-	resp.OpenResponse.Flags |= fuse.OpenDirectIO
+	resp.Flags |= fuse.OpenDirectIO
 	openFlags := req.Flags | fuse.OpenSync
 
 	name := req.Name

--- a/db/unixfs/fuse/inode_test.go
+++ b/db/unixfs/fuse/inode_test.go
@@ -78,7 +78,7 @@ func TestInodeCreateUsesSynchronousDirectIO(t *testing.T) {
 	t.Cleanup(func() {
 		_ = opened.Release(context.Background(), &fuse.ReleaseRequest{})
 	})
-	if response.OpenResponse.Flags&fuse.OpenDirectIO == 0 {
+	if response.Flags&fuse.OpenDirectIO == 0 {
 		t.Fatal("expected OpenDirectIO response flag")
 	}
 	if opened.openFlags&fuse.OpenSync == 0 {

--- a/db/unixfs/fuse/inode_test.go
+++ b/db/unixfs/fuse/inode_test.go
@@ -1,0 +1,98 @@
+//go:build linux
+
+package fuse
+
+import (
+	"context"
+	"testing"
+
+	"bazil.org/fuse"
+	hydra_testbed "github.com/s4wave/spacewave/db/testbed"
+	unixfs_world_testbed "github.com/s4wave/spacewave/db/unixfs/world/testbed"
+	world_testbed "github.com/s4wave/spacewave/db/world/testbed"
+	"github.com/sirupsen/logrus"
+)
+
+// TestInodeOpenUsesSynchronousDirectIO checks the existing-file open path.
+func TestInodeOpenUsesSynchronousDirectIO(t *testing.T) {
+	inode := &Inode{}
+	request := &fuse.OpenRequest{Flags: fuse.OpenReadWrite}
+	response := &fuse.OpenResponse{}
+
+	handle, err := inode.Open(context.Background(), request, response)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opened, ok := handle.(*Handle)
+	if !ok {
+		t.Fatalf("expected *Handle, got %T", handle)
+	}
+	if response.Flags&fuse.OpenDirectIO == 0 {
+		t.Fatal("expected OpenDirectIO response flag")
+	}
+	if opened.openFlags&fuse.OpenSync == 0 {
+		t.Fatal("expected synchronous Spacewave writes")
+	}
+}
+
+// TestInodeCreateUsesSynchronousDirectIO checks the create-and-open path.
+func TestInodeCreateUsesSynchronousDirectIO(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	le := logrus.NewEntry(logrus.New())
+	tb, err := hydra_testbed.NewTestbed(ctx, le)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wtb, err := world_testbed.NewTestbed(tb)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootHandle, err := unixfs_world_testbed.InitTestbed(wtb, "test/fuse-create", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(rootHandle.Release)
+	rootFS := &RootFS{ctx: ctx, ctxCancel: cancel, le: le}
+	inode := NewInode(rootFS, nil, rootHandle)
+	request := &fuse.CreateRequest{
+		Name:  "created.txt",
+		Flags: fuse.OpenReadWrite,
+		Mode:  0o644,
+	}
+	response := &fuse.CreateResponse{}
+
+	created, handle, err := inode.Create(ctx, request, response)
+	if err != nil {
+		t.Fatal(err)
+	}
+	createdInode, ok := created.(*Inode)
+	if !ok {
+		t.Fatalf("expected *Inode, got %T", created)
+	}
+	t.Cleanup(createdInode.h.Release)
+	opened, ok := handle.(*Handle)
+	if !ok {
+		t.Fatalf("expected *Handle, got %T", handle)
+	}
+	t.Cleanup(func() {
+		_ = opened.Release(context.Background(), &fuse.ReleaseRequest{})
+	})
+	if response.OpenResponse.Flags&fuse.OpenDirectIO == 0 {
+		t.Fatal("expected OpenDirectIO response flag")
+	}
+	if opened.openFlags&fuse.OpenSync == 0 {
+		t.Fatal("expected synchronous Spacewave writes")
+	}
+
+	writeResponse := &fuse.WriteResponse{}
+	if err := opened.Write(ctx, &fuse.WriteRequest{Offset: 0, Data: []byte("created synchronously")}, writeResponse); err != nil {
+		t.Fatal(err)
+	}
+	if writeResponse.Size != len("created synchronously") {
+		t.Fatalf("expected synchronous write size %d, got %d", len("created synchronously"), writeResponse.Size)
+	}
+	if err := opened.Release(ctx, &fuse.ReleaseRequest{}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/db/unixfs/world/fs-cursor_test.go
+++ b/db/unixfs/world/fs-cursor_test.go
@@ -1,0 +1,43 @@
+package unixfs_world
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// TestNewFSCursorWithWriterConfirmsObservedRevision checks that a successful
+// writer operation remains fenced on the cursor's observed object revision.
+func TestNewFSCursorWithWriterConfirmsObservedRevision(t *testing.T) {
+	cursor, writer := NewFSCursorWithWriterContext(
+		context.Background(),
+		nil,
+		nil,
+		"test/revision-confirmation",
+		FSType_FSType_FS_NODE,
+		"",
+	)
+	t.Cleanup(cursor.Release)
+	confirm := writer.confirmFn.Load()
+	if confirm == nil {
+		t.Fatal("expected writer revision confirmation")
+	}
+
+	// A target newer than the observed revision must wait for the context.
+	cursor.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		cursor.prevObjRev = 4
+	})
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := (*confirm)(canceled, 5); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected confirmation to wait, got %v", err)
+	}
+
+	// An observed target must return even when the context is already canceled.
+	cursor.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		cursor.prevObjRev = 5
+	})
+	if err := (*confirm)(canceled, 5); err != nil {
+		t.Fatalf("expected observed revision confirmation, got %v", err)
+	}
+}

--- a/db/unixfs/world/testbed/testbed_test.go
+++ b/db/unixfs/world/testbed/testbed_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	billy_util "github.com/go-git/go-billy/v6/util"
+	"github.com/s4wave/spacewave/db/block"
+	block_mock "github.com/s4wave/spacewave/db/block/mock"
 	hydra_testbed "github.com/s4wave/spacewave/db/testbed"
 	"github.com/s4wave/spacewave/db/unixfs"
 	unixfs_billy "github.com/s4wave/spacewave/db/unixfs/billy"
@@ -20,6 +22,120 @@ import (
 )
 
 var objKey = "test/fs"
+
+// TestEngineWorldFilesystemSurvivesConcurrentWriteAndSync checks that a
+// retained filesystem handle and another World writer cannot lose each other's
+// committed values.
+func TestEngineWorldFilesystemSurvivesConcurrentWriteAndSync(t *testing.T) {
+	ctx := context.Background()
+	logger := logrus.New()
+	le := logrus.NewEntry(logger)
+
+	tb, err := hydra_testbed.NewTestbed(ctx, le)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wtb, err := world_testbed.NewTestbed(tb)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Retain a writable filesystem handle after its initialization commit.
+	fsHandle, err := InitTestbed(wtb, objKey, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(fsHandle.Release)
+	ws := world.NewEngineWorldState(wtb.Engine, true)
+	initialSeqno, err := ws.GetSeqno(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Commit an unrelated object through another short transaction.
+	const unrelatedKey = "test/concurrent-object"
+	const unrelatedValue = "concurrent write survives"
+	_, _, err = world.CreateWorldObject(ctx, ws, unrelatedKey, func(bcs *block.Cursor) error {
+		bcs.SetBlock(block_mock.NewExample(unrelatedValue), true)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	concurrentSeqno, err := ws.GetSeqno(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if concurrentSeqno <= initialSeqno {
+		t.Fatalf("expected concurrent write to advance seqno beyond %d, got %d", initialSeqno, concurrentSeqno)
+	}
+
+	// Write through the retained filesystem handle.
+	const fileName = "retained-handle.txt"
+	content := []byte("filesystem write survives")
+	if err := fsHandle.Mknod(ctx, true, []string{fileName}, unixfs.NewFSCursorNodeType_File(), 0o644, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	fileHandle, err := fsHandle.Lookup(ctx, fileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(fileHandle.Release)
+	if err := fileHandle.WriteAt(ctx, 0, content, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	fileHandle.Release()
+	filesystemSeqno, err := ws.GetSeqno(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filesystemSeqno <= concurrentSeqno {
+		t.Fatalf("expected filesystem write to advance seqno beyond %d, got %d", concurrentSeqno, filesystemSeqno)
+	}
+
+	// Release the retained handle before fencing durable storage.
+	fsHandle.Release()
+	if _, err := ws.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reopen from the engine and prove that neither writer lost the other.
+	freshWS := world.NewEngineWorldState(wtb.Engine, false)
+	unrelated, err := world.LookupObjectBody[*block_mock.Example](ctx, freshWS, unrelatedKey, block_mock.NewExampleBlock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unrelated.GetMsg() != unrelatedValue {
+		t.Fatalf("expected unrelated value %q, got %q", unrelatedValue, unrelated.GetMsg())
+	}
+	freshFS, err := unixfs_world.BuildFSFromUnixfsRef(
+		ctx,
+		le,
+		freshWS,
+		"",
+		&unixfs_world.UnixfsRef{ObjectKey: objKey},
+		false,
+		false,
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(freshFS.Release)
+	freshFile, err := freshFS.Lookup(ctx, fileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(freshFile.Release)
+	read := make([]byte, len(content))
+	n, err := freshFile.ReadAt(ctx, 0, read)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != int64(len(content)) || !bytes.Equal(read, content) {
+		t.Fatalf("expected file %q, got %q (%d bytes)", content, read, n)
+	}
+}
 
 // TestFs runs the e2e tests.
 func TestFs(t *testing.T) {


### PR DESCRIPTION
FUSE file opens currently use the kernel page cache, and the Spacewave handle can return while an asynchronous transfer is still pending. Canceling a mount can therefore lose a write that the client believed had completed.

Open and Create now request direct I/O and construct synchronous handles. The World writer continues to wait until its cursor observes the resulting object revision, so callers can release the filesystem and then fence durable storage with WorldState.Sync.

Tests cover both FUSE entry points, the cursor revision fence, and a retained filesystem handle writing alongside another World transaction before release, Sync, and fresh readback.