### PR TITLE
fix(world): register remote identity operations

### DIFF
--- a/core/resource/world/world-state_test.go
+++ b/core/resource/world/world-state_test.go
@@ -4,6 +4,7 @@ package resource_world_test
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"io"
@@ -23,8 +24,12 @@ import (
 	"github.com/s4wave/spacewave/db/bucket"
 	"github.com/s4wave/spacewave/db/world"
 	world_testbed "github.com/s4wave/spacewave/db/world/testbed"
+	"github.com/s4wave/spacewave/identity"
+	identity_world "github.com/s4wave/spacewave/identity/world"
+	spacewave_crypto "github.com/s4wave/spacewave/net/crypto"
 	s4wave_testbed "github.com/s4wave/spacewave/sdk/testbed"
 	s4wave_world "github.com/s4wave/spacewave/sdk/world"
+	sdk_world_engine "github.com/s4wave/spacewave/sdk/world/engine"
 )
 
 // setupWorldTestbed creates a hydra world testbed and returns it.
@@ -80,6 +85,52 @@ func setupWorldResourceClient(ctx context.Context, t *testing.T, tb *world_testb
 	}
 
 	return resClient, engine, cleanup
+}
+
+func TestRemoteWorldPersistsIdentityKeypair(t *testing.T) {
+	ctx := t.Context()
+	tb, cleanup := setupWorldTestbed(ctx, t)
+	defer cleanup()
+	resourceClient, resourceEngine, cleanupClient := setupWorldResourceClient(ctx, t, tb)
+	defer cleanupClient()
+	engineRef := resourceClient.CreateResourceReference(resourceEngine.GetResourceRef().GetResourceID())
+	engine, err := sdk_world_engine.NewSDKEngine(resourceClient, engineRef)
+	if err != nil {
+		engineRef.Release()
+		t.Fatal(err)
+	}
+	defer engine.Release()
+
+	_, publicKey, err := spacewave_crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keypair, err := identity.NewKeypair(publicKey, "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sender, err := keypair.ParsePeerID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := world.ExecTransaction(ctx, engine, true, func(ctx context.Context, ws world.WorldState) error {
+		_, err := identity_world.EnsureKeypairsExist(ctx, ws, sender, []*identity.Keypair{keypair}, false)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := world.ExecTransaction(ctx, engine, false, func(ctx context.Context, ws world.WorldState) error {
+		stored, err := identity_world.LookupKeypairBody(ctx, ws, identity_world.NewKeypairKey(sender.String()))
+		if err != nil {
+			return err
+		}
+		if stored == nil || !stored.EqualVT(keypair) {
+			return errors.New("remote World did not retain the identity keypair")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
 }
 
 type countingTx struct {

--- a/core/space/world/ops/lookup-world-op.go
+++ b/core/space/world/ops/lookup-world-op.go
@@ -7,6 +7,7 @@ import (
 
 	git_world "github.com/s4wave/spacewave/db/git/world"
 	"github.com/s4wave/spacewave/db/world"
+	identity_world "github.com/s4wave/spacewave/identity/world"
 	s4wave_org "github.com/s4wave/spacewave/sdk/org"
 	s4wave_vm "github.com/s4wave/spacewave/sdk/vm"
 )
@@ -15,6 +16,7 @@ import (
 func LookupWorldOp(ctx context.Context, opTypeID string) (world.Operation, error) {
 	return world.LookupOpSlice([]world.LookupOp{
 		git_world.LookupGitOp,
+		identity_world.LookupOp,
 		lookupCoreWorldOp,
 		s4wave_vm.LookupCreateVmV86Op,
 		s4wave_vm.LookupSetV86ConfigOp,

--- a/core/space/world/optypes/lookup_test.go
+++ b/core/space/world/optypes/lookup_test.go
@@ -17,6 +17,7 @@ import (
 	forge_pass_tx "github.com/s4wave/spacewave/forge/pass/tx"
 	forge_task_tx "github.com/s4wave/spacewave/forge/task/tx"
 	forge_worker "github.com/s4wave/spacewave/forge/worker"
+	identity_world "github.com/s4wave/spacewave/identity/world"
 	spacewave_chat "github.com/s4wave/spacewave/sdk/chat"
 	s4wave_device "github.com/s4wave/spacewave/sdk/device"
 	s4wave_kv_world "github.com/s4wave/spacewave/sdk/kv/world"
@@ -137,6 +138,7 @@ func TestBuildSpaceLookupOpResolvesBuiltInWithoutBus(t *testing.T) {
 }
 
 func TestBuildSpaceLookupOpAndLookupWorldOpResolveForgeQuickstartOps(t *testing.T) {
+	requireLookupWorldAndBuildSpaceOp[*identity_world.KeypairUpdateOp](t, identity_world.KeypairUpdateOpId)
 	requireLookupWorldAndBuildSpaceOp[*forge_dashboard.CreateForgeDashboardOp](t, forge_dashboard.CreateForgeDashboardOpId)
 	requireLookupWorldAndBuildSpaceOp[*forge_dashboard.LinkForgeDashboardOp](t, forge_dashboard.LinkForgeDashboardOpId)
 	requireLookupWorldAndBuildSpaceOp[*forge_dashboard.InitForgeQuickstartOp](t, forge_dashboard.InitForgeQuickstartOpId)


### PR DESCRIPTION
Remote World clients can submit identity keypair updates, but the native Space operation registry did not resolve those operations. New GLaDOS sessions therefore failed while saving the execution identity needed by their stored workdir.

This change includes identity operations in the native registry and covers both registry lookup and an actual remote transaction that saves and reads a keypair.