### PR TITLE
fix(runtime): restore cross-runtime state transitions

### DIFF
--- a/core/space/world/ops/lookup-world-op-core.go
+++ b/core/space/world/ops/lookup-world-op-core.go
@@ -12,6 +12,7 @@ import (
 	unixfs_world "github.com/s4wave/spacewave/db/unixfs/world"
 	"github.com/s4wave/spacewave/db/world"
 	forge_world "github.com/s4wave/spacewave/forge/world"
+	identity_world "github.com/s4wave/spacewave/identity/world"
 	spacewave_chat "github.com/s4wave/spacewave/sdk/chat"
 	s4wave_device "github.com/s4wave/spacewave/sdk/device"
 	s4wave_terminal "github.com/s4wave/spacewave/sdk/terminal"
@@ -20,6 +21,7 @@ import (
 func lookupCoreWorldOp(ctx context.Context, opTypeID string) (world.Operation, error) {
 	return world.LookupOpSlice([]world.LookupOp{
 		unixfs_world.LookupFsOp,
+		identity_world.LookupOp,
 		LookupSetSpaceSettingsOp,
 		LookupInitUnixFSOp,
 		LookupInitObjectLayoutOp,

--- a/core/space/world/ops/lookup-world-op.go
+++ b/core/space/world/ops/lookup-world-op.go
@@ -7,7 +7,6 @@ import (
 
 	git_world "github.com/s4wave/spacewave/db/git/world"
 	"github.com/s4wave/spacewave/db/world"
-	identity_world "github.com/s4wave/spacewave/identity/world"
 	s4wave_org "github.com/s4wave/spacewave/sdk/org"
 	s4wave_vm "github.com/s4wave/spacewave/sdk/vm"
 )
@@ -16,7 +15,6 @@ import (
 func LookupWorldOp(ctx context.Context, opTypeID string) (world.Operation, error) {
 	return world.LookupOpSlice([]world.LookupOp{
 		git_world.LookupGitOp,
-		identity_world.LookupOp,
 		lookupCoreWorldOp,
 		s4wave_vm.LookupCreateVmV86Op,
 		s4wave_vm.LookupSetV86ConfigOp,

--- a/forge/cluster/controller/controller.go
+++ b/forge/cluster/controller/controller.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aperturerobotics/controllerbus/controller/loader"
 	"github.com/aperturerobotics/controllerbus/controller/resolver"
 	"github.com/aperturerobotics/controllerbus/directive"
+	"github.com/aperturerobotics/util/backoff"
 	"github.com/aperturerobotics/util/keyed"
 	"github.com/s4wave/spacewave/db/block"
 	"github.com/s4wave/spacewave/db/bucket"
@@ -65,7 +66,11 @@ func NewController(
 		c.objKey,
 		c.ProcessState,
 	)
-	c.jobTrackers = keyed.NewKeyedWithLogger(c.newJobTracker, le)
+	c.jobTrackers = keyed.NewKeyedWithLogger(
+		c.newJobTracker,
+		le,
+		keyed.WithRetry[string, *jobTracker](&backoff.Backoff{}),
+	)
 	return c
 }
 

--- a/forge/cluster/controller/job-tracker_test.go
+++ b/forge/cluster/controller/job-tracker_test.go
@@ -2,10 +2,14 @@ package cluster_controller
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/s4wave/spacewave/db/bucket"
 	"github.com/s4wave/spacewave/db/world"
+	world_control "github.com/s4wave/spacewave/db/world/control"
+	world_testbed "github.com/s4wave/spacewave/db/world/testbed"
 	"github.com/sirupsen/logrus"
 )
 
@@ -27,5 +31,57 @@ func TestSkipUnhandledOperation(t *testing.T) {
 	}
 	if !waitForChanges {
 		t.Fatal("waitForChanges = false, want true")
+	}
+}
+
+func TestJobTrackerRetriesTransientWorldError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	tb, err := world_testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(tb.Release)
+
+	controller := NewController(
+		tb.Logger,
+		tb.Bus,
+		NewConfig(tb.EngineID, "test-cluster", tb.Volume.GetPeerID()),
+	)
+	tracker, _ := controller.jobTrackers.SetKey("test-job", false)
+
+	attempts := make(chan int, 2)
+	attempt := 0
+	tracker.objLoop = world_control.NewWatchLoop(
+		tb.Logger,
+		"",
+		func(
+			context.Context,
+			*logrus.Entry,
+			world.WorldState,
+			world.ObjectState,
+			*bucket.ObjectRef,
+			uint64,
+		) (bool, error) {
+			attempt++
+			attempts <- attempt
+			if attempt == 1 {
+				return false, errors.New("transient world read")
+			}
+			return false, nil
+		},
+	)
+
+	controller.jobTrackers.SetContext(ctx, true)
+	for want := 1; want <= 2; want++ {
+		select {
+		case got := <-attempts:
+			if got != want {
+				t.Fatalf("attempt = %d, want %d", got, want)
+			}
+		case <-ctx.Done():
+			t.Fatalf("job tracker attempt %d did not start: %v", want, ctx.Err())
+		}
 	}
 }

--- a/net/transport/webrtc/session.go
+++ b/net/transport/webrtc/session.go
@@ -359,6 +359,11 @@ type session struct {
 	// the active generation identity for the signal fence.
 	rxOfferID []byte
 
+	// rxOfferAnswerSDP holds the exact local answer SDP bytes transmitted for
+	// rxOfferID. Pion augments LocalDescription with gathered ICE candidates,
+	// so duplicate-offer replay uses these bytes to preserve the generation.
+	rxOfferAnswerSDP string
+
 	// pendingOfferID is the SHA-256 digest of the local offer SDP bytes most
 	// recently transmitted by this session, when we are the offerer. Answers
 	// whose offer_id does not match it are dropped before Pion.
@@ -1129,21 +1134,23 @@ func isOfferer(a, b string) bool {
 	return strings.Compare(a, b) < 0
 }
 
-// transmitAnswer emits one Sdp signal carrying an answer description tagged
-// with the session's active remote-offer digest. The first answer
-// transmission and the duplicate-offer replay share it; it performs no
-// matching or validation of its own.
+// transmitAnswer emits the exact answer SDP bytes retained for the session's
+// active remote-offer generation.
 func (s *sessionTracker) transmitAnswer(
 	sess *session,
-	answer *webrtc.SessionDescription,
+	answerSDP string,
 	currLocalSeqno uint64,
 	xmitSignal func(*WebRtcSignal),
 ) {
-	if answer == nil || answer.SDP == "" || answer.Type != webrtc.SDPTypeAnswer {
+	if answerSDP == "" {
 		return
 	}
-	ans := NewWebRtcSdp(currLocalSeqno, answer)
-	ans.OfferId = sess.rxOfferID
+	ans := &WebRtcSdp{
+		TxSeqno: currLocalSeqno,
+		SdpType: webrtc.SDPTypeAnswer.String(),
+		Sdp:     answerSDP,
+		OfferId: sess.rxOfferID,
+	}
 	xmitSignal(&WebRtcSignal{Body: &WebRtcSignal_Sdp{Sdp: ans}})
 }
 
@@ -1215,7 +1222,7 @@ func (s *sessionTracker) ingestRemoteSignal(
 				if s.w.GetVerbose() {
 					le.Debug("signal tx: replay retained answer")
 				}
-				s.transmitAnswer(sess, sess.pc.LocalDescription(), currLocalSeqno, xmitSignal)
+				s.transmitAnswer(sess, sess.rxOfferAnswerSDP, currLocalSeqno, xmitSignal)
 			}
 		case s.offerer && sess.pc.SignalingState() != webrtc.SignalingStateHaveLocalOffer:
 			// Drop an answer that arrives with no local offer pending. Applying an
@@ -1245,6 +1252,7 @@ func (s *sessionTracker) ingestRemoteSignal(
 					sess.retiredOfferIDs[string(sess.rxOfferID)] = struct{}{}
 				}
 				sess.rxOfferID = offerSum[:]
+				sess.rxOfferAnswerSDP = ""
 			}
 
 			// Flush any candidates that arrived before the remote description.
@@ -1266,7 +1274,8 @@ func (s *sessionTracker) ingestRemoteSignal(
 				if err := sess.pc.SetLocalDescription(answer); err != nil {
 					return pkgerrors.Wrap(err, "set local description(answer)")
 				}
-				s.transmitAnswer(sess, &answer, currLocalSeqno, xmitSignal)
+				sess.rxOfferAnswerSDP = answer.SDP
+				s.transmitAnswer(sess, sess.rxOfferAnswerSDP, currLocalSeqno, xmitSignal)
 			}
 		}
 	}

--- a/net/transport/webrtc/signal_ingress_red_test.go
+++ b/net/transport/webrtc/signal_ingress_red_test.go
@@ -641,7 +641,8 @@ func TestSignalIngressMatchingGenerationFatalControls(t *testing.T) {
 // answer carrying the same generation identity, and its Pion state stays
 // untouched.
 func TestAnswererReplaysRetainedAnswerOnDuplicateOffer(t *testing.T) {
-	_, answerPC, offerDesc, _ := newNegotiatedPair(t)
+	answerPC, offerDesc := newOfferForAnswerer(t)
+	gatherComplete := pion_webrtc.GatheringCompletePromise(answerPC)
 
 	var xmitted []*WebRtcSdp
 	tracker := &sessionTracker{
@@ -674,6 +675,11 @@ func TestAnswererReplaysRetainedAnswerOnDuplicateOffer(t *testing.T) {
 	}
 	firstAnswer := xmitted[0]
 
+	select {
+	case <-gatherComplete:
+	case <-time.After(5 * time.Second):
+		t.Fatal("answer ICE gathering did not complete")
+	}
 	stateBefore := answerPC.SignalingState()
 	localBefore := answerPC.LocalDescription().SDP
 
@@ -691,7 +697,7 @@ func TestAnswererReplaysRetainedAnswerOnDuplicateOffer(t *testing.T) {
 	}
 	replayed := xmitted[1]
 	if replayed.GetSdp() != firstAnswer.GetSdp() {
-		t.Fatal("replayed answer changed the local description bytes")
+		t.Fatal("replayed answer changed the originally transmitted SDP bytes")
 	}
 	if !bytes.Equal(replayed.GetOfferId(), sess.rxOfferID) {
 		t.Fatal("replayed answer changed the generation identity")


### PR DESCRIPTION
The latest master CI run exposed three independent runtime failures.

GoScript could not resolve identity keypair updates because their operation lookup was registered only in the native build. The shared non-TinyGo lookup now registers those operations for native and GoScript clients.

A transient World read failure could permanently stop a Forge job tracker after every task had completed. The existing keyed lifecycle now retries that tracker with cancellation-bound backoff, allowing it to reconcile the job again.

A WebRTC answerer replayed Pion's mutable `LocalDescription` after ICE gathering. The session now retains and retransmits the exact answer bytes originally sent for that offer generation.

Each path has behavioral regression coverage. A source-proven retry gap in the nested Forge task tracker is separate from the observed failure and is tracked in #588.
