### PR TITLE
fix(cli): confirm daemon exit after stream reset

### DIFF
--- a/cmd/spacewave/cli/daemon-stop.go
+++ b/cmd/spacewave/cli/daemon-stop.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aperturerobotics/cli"
 	"github.com/pkg/errors"
 	cli_entrypoint "github.com/s4wave/spacewave/bldr/cli/entrypoint"
+	listener_control "github.com/s4wave/spacewave/core/resource/listener/control"
 )
 
 // newStopCommand builds the daemon stop command.
@@ -37,24 +38,48 @@ func runStop(ctx context.Context, statePath string) error {
 	sockPath := filepath.Join(statePath, socketName)
 	conn, err := connectDaemonDial(ctx, sockPath)
 	if err != nil {
-		if stderrors.Is(err, os.ErrNotExist) {
-			os.Stdout.WriteString("No Spacewave daemon is running.\n")
-			return nil
-		}
-		if stderrors.Is(err, syscall.ECONNREFUSED) {
-			if err := os.Remove(sockPath); err != nil && !os.IsNotExist(err) {
-				return errors.Wrap(err, "remove stale daemon socket")
-			}
-			os.Stdout.WriteString("No Spacewave daemon is running; removed a stale daemon socket.\n")
-			return nil
+		if handled, handleErr := handleUnavailableDaemonSocket(sockPath, err); handled {
+			return handleErr
 		}
 		return errors.Wrapf(err, "connect to %s", sockPath)
 	}
 	defer conn.Close()
 
 	if err := requestDaemonShutdown(ctx, conn); err != nil {
-		return errors.Wrap(err, "stop daemon")
+		var denyErr *listener_control.DenyError
+		if stderrors.As(err, &denyErr) || ctx.Err() != nil {
+			return errors.Wrap(err, "stop daemon")
+		}
+
+		_ = conn.Close()
+		probe, probeErr := connectDaemonDial(ctx, sockPath)
+		if probeErr == nil {
+			_ = probe.Close()
+			return errors.Wrap(err, "stop daemon")
+		}
+		if handled, handleErr := handleUnavailableDaemonSocket(sockPath, probeErr); handled {
+			return handleErr
+		}
+		return errors.Wrapf(err, "stop daemon; verify listener exit: %v", probeErr)
 	}
 	os.Stdout.WriteString("Stopped Spacewave daemon.\n")
 	return nil
+}
+
+// handleUnavailableDaemonSocket reports errors that prove no daemon listener
+// remains. Other dial errors must remain fatal to the stop command.
+func handleUnavailableDaemonSocket(sockPath string, dialErr error) (bool, error) {
+	switch {
+	case stderrors.Is(dialErr, os.ErrNotExist):
+		os.Stdout.WriteString("No Spacewave daemon is running.\n")
+		return true, nil
+	case stderrors.Is(dialErr, syscall.ECONNREFUSED):
+		if err := os.Remove(sockPath); err != nil && !os.IsNotExist(err) {
+			return true, errors.Wrap(err, "remove stale daemon socket")
+		}
+		os.Stdout.WriteString("No Spacewave daemon is running; removed a stale daemon socket.\n")
+		return true, nil
+	default:
+		return false, nil
+	}
 }

--- a/cmd/spacewave/cli/daemon-stop_test.go
+++ b/cmd/spacewave/cli/daemon-stop_test.go
@@ -60,6 +60,70 @@ func TestRunStopRequestsDaemonShutdown(t *testing.T) {
 	}
 }
 
+func TestRunStopConfirmsPeerExitAfterControlStreamReset(t *testing.T) {
+	statePath, wait := startResettingShutdownPeer(t, "stop-reset", true)
+
+	if err := runStop(t.Context(), statePath); err != nil {
+		t.Fatalf("stop after peer exit: %v", err)
+	}
+	wait()
+}
+
+func TestRunStopPreservesResetWhileListenerRemains(t *testing.T) {
+	statePath, wait := startResettingShutdownPeer(t, "stop-live-reset", false)
+
+	if err := runStop(t.Context(), statePath); err == nil {
+		t.Fatal("stop succeeded while the listener remained reachable")
+	}
+	wait()
+}
+
+func startResettingShutdownPeer(t *testing.T, name string, closeListener bool) (string, func()) {
+	t.Helper()
+
+	statePath := makeShortDaemonStopStatePath(t, name)
+	t.Cleanup(func() { _ = os.RemoveAll(statePath) })
+	lis, err := net.Listen("unix", filepath.Join(statePath, socketName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = lis.Close() })
+
+	var accepted net.Conn
+	mux := srpc.NewMux()
+	if err := mux.Register(newDaemonControlHandler(func() {
+		if closeListener {
+			_ = lis.Close()
+		}
+		_ = accepted.Close()
+	})); err != nil {
+		t.Fatal(err)
+	}
+	server := srpc.NewServer(mux)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, err := lis.Accept()
+		if err != nil {
+			return
+		}
+		accepted = conn
+		muxed, err := srpc.NewMuxedConn(conn, false, nil)
+		if err != nil {
+			return
+		}
+		_ = server.AcceptMuxedConn(t.Context(), muxed)
+	}()
+
+	return statePath, func() {
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("resetting control peer did not exit")
+		}
+	}
+}
+
 func TestRunStopWithoutDaemonDoesNotAutostart(t *testing.T) {
 	oldStart := connectDaemonStart
 	connectDaemonStart = func(ctx context.Context, statePath string) (*exec.Cmd, error) {


### PR DESCRIPTION
Master CI exposed an intermittent `spacewave stop` failure when a daemon released its listener and exited before the control stream completed. A second stop then reported `request daemon shutdown: stream reset` even though no daemon remained.

The stop command now handles a non-denial transport failure the same way as the existing takeover path: it performs one fresh dial. An absent or refused socket proves the daemon is gone and keeps stop idempotent. A reachable listener, policy denial, cancellation, or any unknown dial error remains fatal.

The regression uses the real control protocol to force the listener-exit/reset ordering. A companion case proves that the same reset is not accepted while a listener remains reachable.
