### PR TITLE
fix(device): retain established enrollment link

### DIFF
--- a/core/provider/local/p2p-sync.go
+++ b/core/provider/local/p2p-sync.go
@@ -357,9 +357,18 @@ func (a *ProviderAccount) retainP2PPeerOnState(
 	if childBus == nil {
 		return errors.New("session transport child bus is not ready")
 	}
+	// Keep an attached value reference as well as the directive reference.
+	// A directive with no value handler leaves its MountedLink unreferenced, so
+	// controllerbus disposes the link after EstablishLinkWithPeer's grace period.
+	handler := directive.NewTypedCallbackHandler[link.MountedLink](
+		func(directive.TypedAttachedValue[link.MountedLink]) {},
+		nil,
+		nil,
+		nil,
+	)
 	_, ref, err := childBus.AddDirective(
 		link.NewEstablishLinkWithPeer(state.sessionTransport.GetPeerID(), remotePeerID),
-		nil,
+		handler,
 	)
 	if err != nil {
 		return err

--- a/core/provider/local/p2p-sync_test.go
+++ b/core/provider/local/p2p-sync_test.go
@@ -371,7 +371,7 @@ func TestRetainP2PPeerEstablishesLink(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), p2pSyncTestTimeout)
 	defer cancel()
 
-	_, _, accA, sessA, releaseA := setupProviderAndSession(ctx, t)
+	tbA, sessRefA, accA, sessA, releaseA := setupProviderAndSession(ctx, t)
 	defer releaseA()
 	_, _, accB, sessB, releaseB := setupProviderAndSession(ctx, t)
 	defer releaseB()
@@ -403,6 +403,21 @@ func TestRetainP2PPeerEstablishesLink(t *testing.T) {
 		t.Fatal(err)
 	}
 	waitForSyncedRootSeqno(ctx, t, accB, account_settings.BindingPurpose, 0)
+
+	// Unreferenced EstablishLinkWithPeer values are disposed after ten seconds.
+	// Keep the connection past that boundary, then prove new state still crosses.
+	timer := time.NewTimer(11 * time.Second)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	case <-timer.C:
+	}
+	accountIDA := sessRefA.GetProviderResourceRef().GetProviderAccountId()
+	soA, releaseSOA := mountAccountSettingsSO(ctx, t, tbA.Bus, accountIDA)
+	addPairedDeviceAndWait(ctx, t, soA, stB.GetPeerID().String(), "retained peer")
+	releaseSOA()
+	waitForSyncedRootSeqno(ctx, t, accB, account_settings.BindingPurpose, 1)
 }
 
 // TestStartP2PSyncSameTransportRestartAddsDesiredWork proves that a


### PR DESCRIPTION
A retained Device enrollment peer kept its EstablishLinkWithPeer directive but did not attach a handler to the MountedLink value. Controllerbus therefore disposed the unreferenced link after its ten-second grace period. Mac and Forge reconnected every ten seconds, interrupting shared-object synchronization.

Keep an attached value reference for the lifetime of the account-scoped desired-peer directive. The regression crosses the disposal boundary and then proves that a new shared-object operation still reaches the other account.
