### PR TITLE
fix(sobject): reject inaccessible peer snapshots

### DIFF
--- a/core/provider/local/p2p-sync.go
+++ b/core/provider/local/p2p-sync.go
@@ -782,7 +782,26 @@ func (a *ProviderAccount) startSOSync(
 	// Validate inbound snapshots against the local storage identity that holds
 	// the Space grant. The session transport peer routes the stream but is not
 	// necessarily a participant in a local Space.
-	soSync := sobject_sync.NewSOSync(a.le, childBus, soID, localSO.GetPeerID(), localSO.soHost)
+	validateSnapshotAccess := func(ctx context.Context, state *sobject.SOState) error {
+		snapshot := sobject.NewSOStateParticipantHandle(
+			a.le,
+			a.t.p.sfs,
+			soID,
+			state,
+			localSO.localPriv,
+			localSO.localPid,
+		)
+		_, err := snapshot.GetTransformer(ctx)
+		return err
+	}
+	soSync := sobject_sync.NewSOSync(
+		a.le,
+		childBus,
+		soID,
+		localSO.GetPeerID(),
+		localSO.soHost,
+		validateSnapshotAccess,
+	)
 	state.addWorker()
 	go func() {
 		defer state.workerDone()

--- a/core/provider/spacewave/p2p-sync.go
+++ b/core/provider/spacewave/p2p-sync.go
@@ -229,7 +229,26 @@ func (a *ProviderAccount) startSOSync(
 		return errors.New("unexpected session shared object type")
 	}
 
-	soSync := sobject_sync.NewSOSync(a.le, childBus, soID, localPeerID, swSO.GetSOHost())
+	validateSnapshotAccess := func(ctx context.Context, state *sobject.SOState) error {
+		snapshot := sobject.NewSOStateParticipantHandle(
+			a.le,
+			a.p.sfs,
+			soID,
+			state,
+			swSO.privKey,
+			swSO.localPid,
+		)
+		_, err := snapshot.GetTransformer(ctx)
+		return err
+	}
+	soSync := sobject_sync.NewSOSync(
+		a.le,
+		childBus,
+		soID,
+		localPeerID,
+		swSO.GetSOHost(),
+		validateSnapshotAccess,
+	)
 	state.startWorker()
 	go func() {
 		defer state.workerExited()

--- a/core/sobject/sync/sync-gate_test.go
+++ b/core/sobject/sync/sync-gate_test.go
@@ -2,6 +2,7 @@ package sobject_sync
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
 	"testing"
@@ -154,6 +155,50 @@ func TestSnapshotExchangeRejectsExcludedLocalPeer(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected snapshot from config excluding the local peer to be rejected")
+	}
+	if got := ctr.GetValue().GetRoot().GetInnerSeqno(); got != 1 {
+		t.Fatalf("local state advanced to seqno %d; expected rejection to keep seqno 1", got)
+	}
+}
+
+func TestSnapshotExchangeRejectsSnapshotWithoutLocalGrant(t *testing.T) {
+	ctx := context.Background()
+	soID := "gate-object-local-grant"
+	localPriv := mustKeyPair(t)
+	localPeer, err := peer.IDFromPrivateKey(localPriv)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	ownerPeer := mustPeerIDStr(t, mustKeyPair(t))
+	localHost, ctr := newMemHost(soID, &sobject.SOState{
+		Config: &sobject.SharedObjectConfig{},
+		Root:   &sobject.SORoot{InnerSeqno: 1},
+	})
+	validateAccess := func(_ context.Context, state *sobject.SOState) error {
+		for _, grant := range state.GetRootGrants() {
+			if grant.GetPeerId() == localPeer.String() {
+				return nil
+			}
+		}
+		return errors.New("no local root grant")
+	}
+	s := NewSOSync(gateLogger(), nil, soID, localPeer, localHost, validateAccess)
+	peerState := &sobject.SOState{
+		Config: &sobject.SharedObjectConfig{Participants: []*sobject.SOParticipantConfig{
+			participantCfg(ownerPeer, sobject.SOParticipantRole_SOParticipantRole_OWNER),
+			participantCfg(localPeer.String(), sobject.SOParticipantRole_SOParticipantRole_READER),
+		}},
+		Root: &sobject.SORoot{InnerSeqno: 5},
+	}
+	snapData, err := peerState.MarshalVT()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	err = runSnapshotExchange(t, s, ctx, &SOSyncMessage{
+		Body: &SOSyncMessage_Snapshot{Snapshot: &SOSyncSnapshot{SoState: snapData, RootSeqno: 5}},
+	})
+	if err == nil {
+		t.Fatal("expected inaccessible snapshot to be rejected")
 	}
 	if got := ctr.GetValue().GetRoot().GetInnerSeqno(); got != 1 {
 		t.Fatalf("local state advanced to seqno %d; expected rejection to keep seqno 1", got)

--- a/core/sobject/sync/sync.go
+++ b/core/sobject/sync/sync.go
@@ -24,12 +24,17 @@ const maxMessageSize = 10 * 1024 * 1024
 // SOSync manages bidirectional shared object state synchronization
 // over a solicit protocol stream. Each instance syncs one SharedObject
 // with peers connected via the session transport's child bus.
+// SnapshotAccessValidator verifies that the local object identity can decode
+// an inbound snapshot before it replaces durable state.
+type SnapshotAccessValidator func(context.Context, *sobject.SOState) error
+
 type SOSync struct {
-	le                *logrus.Entry
-	b                 bus.Bus
-	soID              string
-	localObjectPeerID peer.ID
-	soHost            *sobject.SOHost
+	le                     *logrus.Entry
+	b                      bus.Bus
+	soID                   string
+	localObjectPeerID      peer.ID
+	soHost                 *sobject.SOHost
+	validateSnapshotAccess SnapshotAccessValidator
 }
 
 // NewSOSync constructs a new SOSync.
@@ -37,13 +42,25 @@ type SOSync struct {
 // localObjectPeerID is the local storage identity checked against inbound
 // state. The transport peer routes the sync stream but need not be a Space
 // participant.
-func NewSOSync(le *logrus.Entry, b bus.Bus, soID string, localObjectPeerID peer.ID, soHost *sobject.SOHost) *SOSync {
+func NewSOSync(
+	le *logrus.Entry,
+	b bus.Bus,
+	soID string,
+	localObjectPeerID peer.ID,
+	soHost *sobject.SOHost,
+	accessValidators ...SnapshotAccessValidator,
+) *SOSync {
+	var validateSnapshotAccess SnapshotAccessValidator
+	if len(accessValidators) != 0 {
+		validateSnapshotAccess = accessValidators[0]
+	}
 	return &SOSync{
-		le:                le.WithField("so-sync", soID),
-		b:                 b,
-		soID:              soID,
-		localObjectPeerID: localObjectPeerID,
-		soHost:            soHost,
+		le:                     le.WithField("so-sync", soID),
+		b:                      b,
+		soID:                   soID,
+		localObjectPeerID:      localObjectPeerID,
+		soHost:                 soHost,
+		validateSnapshotAccess: validateSnapshotAccess,
 	}
 }
 
@@ -159,6 +176,12 @@ func (s *SOSync) exchangeSnapshots(ctx context.Context, le *logrus.Entry, sess *
 		if err := s.validateSnapshotElements(peerState); err != nil {
 			le.WithError(err).Warn("rejected peer snapshot failing element validation")
 			return errors.Wrap(err, "invalid peer snapshot")
+		}
+		if s.validateSnapshotAccess != nil {
+			if err := s.validateSnapshotAccess(ctx, peerState); err != nil {
+				le.WithError(err).Warn("rejected peer snapshot inaccessible to local object identity")
+				return errors.Wrap(err, "inaccessible peer snapshot")
+			}
 		}
 
 		if err := s.soHost.UpdateSOState(ctx, func(state *sobject.SOState) error {


### PR DESCRIPTION
A peer can advertise a newer full snapshot whose participant list includes the local object identity but whose root grants cannot be decrypted by that identity. The sync path accepted that snapshot and replaced readable local state, leaving the Space inaccessible.

Validate inbound snapshots through the provider's real object identity and transform factories before updating durable state. Local and cloud providers supply their mounted object keys. A regression keeps the prior state when an inbound snapshot omits the local root grant.