### PR TITLE
test(alpha): wait for transport state changes

### DIFF
--- a/core/provider/local/session-standalone-signaling_test.go
+++ b/core/provider/local/session-standalone-signaling_test.go
@@ -71,29 +71,31 @@ func newSignalingServer() *signalingServer {
 	return s
 }
 
-// awaitSessionTransport waits for the account's running session transport.
-func awaitSessionTransport(ctx context.Context, t *testing.T, acc *provider_local.ProviderAccount) *transport.SessionTransport {
+// awaitReadySessionTransport follows account transport replacements until the
+// current transport becomes ready.
+func awaitReadySessionTransport(ctx context.Context, t *testing.T, acc *provider_local.ProviderAccount) *transport.SessionTransport {
 	t.Helper()
 	for {
-		if st := acc.GetSessionTransport(); st != nil {
-			return st
-		}
 		_, waitCh := acc.GetTransportSnapshotWithWait()
+		st := acc.GetSessionTransport()
+		if st == nil {
+			select {
+			case <-ctx.Done():
+				t.Fatalf("session transport did not start: %v", ctx.Err())
+			case <-waitCh:
+			}
+			continue
+		}
 		select {
 		case <-ctx.Done():
-			t.Fatalf("session transport did not start: %v", ctx.Err())
+			t.Fatalf("session transport did not become ready: %v", ctx.Err())
 		case <-waitCh:
+			continue
+		case <-st.Ready():
+			if acc.GetSessionTransport() == st {
+				return st
+			}
 		}
-	}
-}
-
-// awaitTransportReady waits for the transport to become ready.
-func awaitTransportReady(ctx context.Context, t *testing.T, st *transport.SessionTransport) {
-	t.Helper()
-	select {
-	case <-st.Ready():
-	case <-ctx.Done():
-		t.Fatalf("session transport did not become ready: %v", ctx.Err())
 	}
 }
 
@@ -120,8 +122,7 @@ func TestStandaloneSessionSignaling(t *testing.T) {
 		_, _, acc, _, release := setupProviderAndSession(ctx, t, "")
 		defer release()
 
-		st := awaitSessionTransport(ctx, t, acc)
-		awaitTransportReady(ctx, t, st)
+		st := awaitReadySessionTransport(ctx, t, acc)
 		if got := st.GetStartupStage(); got != "ready" {
 			t.Fatalf("startup stage = %q, want ready", got)
 		}
@@ -138,8 +139,7 @@ func TestStandaloneSessionSignaling(t *testing.T) {
 	_, _, acc, sess, release := setupProviderAndSession(ctx, t, sig.server.URL)
 	defer release()
 
-	st := awaitSessionTransport(ctx, t, acc)
-	awaitTransportReady(ctx, t, st)
+	awaitReadySessionTransport(ctx, t, acc)
 	if n := sig.tickets.Load(); n == 0 {
 		t.Fatal("standalone session did not request a signal ticket")
 	}

--- a/core/transport/transport_test.go
+++ b/core/transport/transport_test.go
@@ -424,8 +424,8 @@ func TestSessionTransportRepeatedWaitersObserveReady(t *testing.T) {
 }
 
 type establishLinkSpy struct {
-	count   atomic.Int32
-	bridged atomic.Int32
+	count      atomic.Int32
+	bridgedSig chan struct{}
 }
 
 func (s *establishLinkSpy) HandleDirective(_ context.Context, di directive.Instance) ([]directive.Resolver, error) {
@@ -433,7 +433,10 @@ func (s *establishLinkSpy) HandleDirective(_ context.Context, di directive.Insta
 	case link.EstablishLinkWithPeer:
 		s.count.Add(1)
 	case link_solicit.SolicitProtocol:
-		s.bridged.Add(1)
+		select {
+		case s.bridgedSig <- struct{}{}:
+		default:
+		}
 	}
 	return nil, nil
 }
@@ -452,14 +455,14 @@ func (*establishLinkSpy) Close() error { return nil }
 // TestSessionTransportKeepsEstablishLinkOnChildBus prevents one desired peer
 // from starting duplicate WebRTC offers on both the session and parent buses.
 func TestSessionTransportKeepsEstablishLinkOnChildBus(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 	tb, err := testbed.Default(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer tb.Release()
-	spy := &establishLinkSpy{}
+	spy := &establishLinkSpy{bridgedSig: make(chan struct{}, 1)}
 	if _, err := tb.Bus.AddController(ctx, spy, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -492,7 +495,7 @@ func TestSessionTransportKeepsEstablishLinkOnChildBus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ref.Release()
+	defer ref.Release()
 	_, bridgeRef, err := st.GetChildBus().AddDirective(
 		link_solicit.NewSolicitProtocol(protocol.ID("test/bridge"), nil, "", 0),
 		nil,
@@ -500,9 +503,11 @@ func TestSessionTransportKeepsEstablishLinkOnChildBus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	bridgeRef.Release()
-	if got := spy.bridged.Load(); got == 0 {
-		t.Fatal("parent bus did not observe bridged protocol directive")
+	defer bridgeRef.Release()
+	select {
+	case <-spy.bridgedSig:
+	case <-ctx.Done():
+		t.Fatalf("parent bus did not observe bridged protocol directive: %v", ctx.Err())
 	}
 	if got := spy.count.Load(); got != 0 {
 		t.Fatalf("parent bus observed %d EstablishLinkWithPeer directives", got)


### PR DESCRIPTION
Two Alpha tests sampled asynchronous transport state before the responsible component reported its transition. The bridge test released its child directive before the resolver reached the parent bus. The standalone signaling helper could wait on a transport that the account replaced during startup.

The bridge test now keeps both requests alive until the parent observes the allowed protocol directive. The signaling helper subscribes to the account transport broadcast before reading the current transport, then follows replacements until that current transport is ready.

The focused tests pass 100 times. Both pass 20 times under the race detector, and the complete `core/transport` and `core/provider/local` package tests pass.
