### PR TITLE
test(local): build valid shared Space fixture

### DIFF
--- a/core/provider/local/auto-start-p2p-sync_test.go
+++ b/core/provider/local/auto-start-p2p-sync_test.go
@@ -82,9 +82,20 @@ func TestAutoStartP2PSyncIfNeededWithSharedSpace(t *testing.T) {
 
 	_, _, acc, sess, release := setupProviderAndSession(ctx, t)
 	defer release()
-	acc.GetSOListCtr().SetValue(&sobject.SharedObjectList{
-		SharedObjects: []*sobject.SharedObjectListEntry{{Source: "shared"}},
-	})
+
+	spaceRef, err := acc.CreateSharedObject(ctx, "auto-start-shared-space", &sobject.SharedObjectMeta{
+		BodyType: "space",
+	}, "", "")
+	if err != nil {
+		t.Fatalf("CreateSharedObject: %v", err)
+	}
+	soList := acc.GetSOListCtr().GetValue().CloneVT()
+	for _, entry := range soList.GetSharedObjects() {
+		if entry.GetRef().GetProviderResourceRef().GetId() == spaceRef.GetProviderResourceRef().GetId() {
+			entry.Source = "shared"
+		}
+	}
+	acc.GetSOListCtr().SetValue(soList)
 
 	if err := acc.CreateSessionTransport(ctx, sess.GetPrivKey(), ""); err != nil {
 		t.Fatalf("CreateSessionTransport: %v", err)


### PR DESCRIPTION
The GoScript provider-local test constructed a shared-object list entry with only `source: "shared"`. It had no provider resource or block-store reference. P2P startup therefore reached SO synchronization with an empty resource ID and canceled, while native goroutine scheduling hid the invalid fixture.

Create the Space through the local provider before marking its complete list entry as invite-shared. The test now uses the same reference shape that invite enrollment persists and still proves that a joined Space starts synchronization without a paired-device record.