### PR TITLE
fix(resource): protect daemon socket before serving

### DIFF
--- a/cmd/spacewave/cli/serve.go
+++ b/cmd/spacewave/cli/serve.go
@@ -4,7 +4,6 @@ package spacewave_cli
 
 import (
 	"context"
-	"net"
 	"os"
 	"path/filepath"
 	"sync"
@@ -22,6 +21,7 @@ import (
 	plugin_host_default "github.com/s4wave/spacewave/bldr/plugin/host/default"
 	resource "github.com/s4wave/spacewave/bldr/resource"
 	device_policy "github.com/s4wave/spacewave/core/device/policy"
+	resource_listener "github.com/s4wave/spacewave/core/resource/listener"
 	yield_policy "github.com/s4wave/spacewave/core/resource/listener/yieldpolicy"
 	resource_root_controller "github.com/s4wave/spacewave/core/resource/root/controller"
 	terminal_remoteshell "github.com/s4wave/spacewave/core/terminal/remoteshell"
@@ -190,15 +190,13 @@ func runServeCommand(
 	releaseDeviceRemoteShell := terminal_remoteshell.StartHandler(serveCtx, le, cliBus.GetBus(), devicePolicy)
 	defer releaseDeviceRemoteShell()
 
-	lis, err := net.ListenUnix("unix", &net.UnixAddr{Name: sockPath, Net: "unix"})
+	_, explicitSocket := lineageFlagSet(c, "socket-path")
+	// Protect and bind the Resource socket before publishing daemon readiness.
+	lis, err := resource_listener.ListenProtectedUnix(sockPath, !explicitSocket)
 	if err != nil {
-		return errors.Wrapf(err, "listen on daemon socket %s; use --takeover only if you intend to ask another runtime to yield", sockPath)
+		return errors.Wrapf(err, "listen on daemon socket %s", sockPath)
 	}
 	defer lis.Close()
-
-	if err := os.Chmod(sockPath, 0o600); err != nil {
-		le.WithError(err).Warn("failed to chmod socket")
-	}
 
 	le.Infof("listening on %s", sockPath)
 	idleTracker := newDaemonIdleTracker(idleTimeout, func() {

--- a/core/resource/listener/config.go
+++ b/core/resource/listener/config.go
@@ -40,6 +40,16 @@ func (c *Config) DetermineSocketPath() (string, error) {
 	return filepath.Join(storageRoot, projectID+".sock"), nil
 }
 
+// SocketPathManaged reports whether the configured socket uses the managed
+// state/storage parent rather than an explicitly selected path.
+func (c *Config) SocketPathManaged() bool {
+	if c.GetListenerSocketPath() != "" {
+		return false
+	}
+	return c.GetStorageProjectId() != "" &&
+		os.Getenv(storagepath.SocketPathEnvVar(c.GetStorageProjectId())) == ""
+}
+
 // GetConfigID returns the unique string for this configuration type.
 func (c *Config) GetConfigID() string {
 	return ConfigID

--- a/core/resource/listener/config_test.go
+++ b/core/resource/listener/config_test.go
@@ -111,7 +111,7 @@ func TestDetermineSocketPathUsesStatePath(t *testing.T) {
 	statePath := filepath.Join(t.TempDir(), "state")
 	t.Setenv("HOME", home)
 	t.Setenv("SPACEWAVE_DATA_DIR", "")
-	t.Setenv("SPACEWAVE_SOCKET_PATH", "")
+	t.Setenv(storagepath.SocketPathEnvVar("spacewave"), "")
 	t.Setenv("SPACEWAVE_STATE_PATH", statePath)
 
 	got, err := (&Config{StorageProjectId: "spacewave"}).DetermineSocketPath()
@@ -139,5 +139,23 @@ func TestDetermineSocketPathUsesExplicitSocketPath(t *testing.T) {
 	}
 	if got != explicit {
 		t.Fatalf("socket path: got %q, want %q", got, explicit)
+	}
+}
+
+func TestSocketPathManaged(t *testing.T) {
+	t.Setenv(storagepath.SocketPathEnvVar("spacewave"), "")
+	if !(&Config{StorageProjectId: "spacewave"}).SocketPathManaged() {
+		t.Fatal("state-derived socket path must use its managed parent")
+	}
+	if (&Config{
+		ListenerSocketPath: "/tmp/explicit.sock",
+		StorageProjectId:   "spacewave",
+	}).SocketPathManaged() {
+		t.Fatal("configured socket path parent must not be managed")
+	}
+
+	t.Setenv(storagepath.SocketPathEnvVar("spacewave"), "/tmp/environment.sock")
+	if (&Config{StorageProjectId: "spacewave"}).SocketPathManaged() {
+		t.Fatal("environment socket path parent must not be managed")
 	}
 }

--- a/core/resource/listener/execute.go
+++ b/core/resource/listener/execute.go
@@ -111,7 +111,16 @@ func (c *Controller) Execute(ctx context.Context) error {
 		}
 
 		// Serve until shutdown, takeover, or context cancellation.
-		yielded, err := c.serveOnce(ctx, le, invokers[0], absPath, broker, status, allowTakeover)
+		yielded, err := c.serveOnce(
+			ctx,
+			le,
+			invokers[0],
+			absPath,
+			broker,
+			status,
+			c.GetConfig().SocketPathManaged(),
+			allowTakeover,
+		)
 		if err != nil {
 			if listener_control.IsSocketInUse(err) {
 				// Another live daemon holds the socket. Retrying under the
@@ -161,6 +170,7 @@ func (c *Controller) serveOnce(
 	absPath string,
 	broker *yield_policy.Broker,
 	status *StatusBroker,
+	managed bool,
 	allowTakeover bool,
 ) (bool, error) {
 	// Choose the socket preparation policy for this serve attempt.
@@ -171,12 +181,8 @@ func (c *Controller) serveOnce(
 	if err := prepare(parentCtx, le, absPath); err != nil {
 		return false, errors.Wrap(err, "prepare socket")
 	}
-	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
-		return false, err
-	}
-
-	// Bind the Unix socket and classify bind races.
-	lis, err := net.ListenUnix("unix", &net.UnixAddr{Name: absPath, Net: "unix"})
+	// Bind only after the socket parent has been made private.
+	lis, err := ListenProtectedUnix(absPath, managed)
 	if err != nil {
 		if stderrors.Is(err, syscall.EADDRINUSE) {
 			// Two daemons can both pass the availability check before
@@ -188,10 +194,6 @@ func (c *Controller) serveOnce(
 		return false, err
 	}
 	defer lis.Close()
-
-	if err := os.Chmod(absPath, 0o600); err != nil {
-		le.WithError(err).Warn("failed to chmod socket")
-	}
 
 	// Publish listening status and register RPC handlers.
 	le.Infof("resource listener listening on %s", absPath)

--- a/core/resource/listener/execute_test.go
+++ b/core/resource/listener/execute_test.go
@@ -113,6 +113,7 @@ func TestServeOnceRefusesConnectableSocket(t *testing.T) {
 		sock,
 		yield_policy.NewBroker(),
 		NewStatusBroker(),
+		true,
 		false,
 	)
 	if err == nil {
@@ -243,6 +244,7 @@ func TestServeOnceReleasesSocketBeforeDrainingConcurrentClients(t *testing.T) {
 			sock,
 			broker,
 			status,
+			true,
 			false,
 		)
 		serveResultCh <- serveResult{yielded: yielded, err: err}

--- a/core/resource/listener/socket_unix.go
+++ b/core/resource/listener/socket_unix.go
@@ -1,0 +1,61 @@
+//go:build !windows && !js
+
+package resource_listener
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+// ListenProtectedUnix restricts the socket parent and socket before returning
+// a listener. Managed parents are tightened to 0700. Explicit parents must
+// already be 0700, except that a missing parent is created with that mode.
+func ListenProtectedUnix(path string, managed bool) (*net.UnixListener, error) {
+	return listenProtectedUnix(path, managed, os.Chmod)
+}
+
+func listenProtectedUnix(path string, managed bool, chmodSocket func(string, os.FileMode) error) (*net.UnixListener, error) {
+	// Create a missing parent with owner-only access.
+	parent := filepath.Dir(path)
+	info, err := os.Stat(parent)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, errors.Wrap(err, "inspect socket parent")
+		}
+		if err := os.MkdirAll(parent, 0o700); err != nil {
+			return nil, errors.Wrap(err, "create private socket parent")
+		}
+		info, err = os.Stat(parent)
+		if err != nil {
+			return nil, errors.Wrap(err, "inspect created socket parent")
+		}
+	}
+
+	// Require or establish the parent policy before binding.
+	if !info.IsDir() {
+		return nil, errors.Errorf("socket parent %s is not a directory", parent)
+	}
+	if managed {
+		if err := os.Chmod(parent, 0o700); err != nil {
+			return nil, errors.Wrap(err, "protect socket parent")
+		}
+	} else if info.Mode().Perm() != 0o700 {
+		return nil, errors.Errorf("socket parent %s is not private (mode %04o); choose a private directory (0700) for the explicit socket path", parent, info.Mode().Perm())
+	}
+
+	// Bind only after the parent blocks group and other traversal.
+	lis, err := net.ListenUnix("unix", &net.UnixAddr{Name: path, Net: "unix"})
+	if err != nil {
+		return nil, err
+	}
+
+	// Restrict the socket before returning it to an RPC server.
+	if err := chmodSocket(path, 0o600); err != nil {
+		_ = lis.Close()
+		return nil, errors.Wrap(err, "protect Unix socket")
+	}
+	return lis, nil
+}

--- a/core/resource/listener/socket_unix_test.go
+++ b/core/resource/listener/socket_unix_test.go
@@ -1,0 +1,95 @@
+//go:build !windows && !js
+
+package resource_listener
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestListenProtectedUnixProtectsParentAndSocket(t *testing.T) {
+	if err := os.MkdirAll(".tmp", 0o700); err != nil {
+		t.Fatal(err)
+	}
+	root, err := os.MkdirTemp(".tmp", "sock-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(root) })
+	parent := filepath.Join(root, "state")
+	sock := filepath.Join(parent, "daemon.sock")
+	lis, err := ListenProtectedUnix(sock, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lis.Close()
+	parentInfo, err := os.Stat(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := parentInfo.Mode().Perm(); got != 0o700 {
+		t.Fatalf("parent mode = %04o", got)
+	}
+	socketInfo, err := os.Stat(sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := socketInfo.Mode().Perm(); got != 0o600 {
+		t.Fatalf("socket mode = %04o", got)
+	}
+}
+
+func TestListenProtectedUnixRefusesLooseExplicitParent(t *testing.T) {
+	if err := os.MkdirAll(".tmp", 0o700); err != nil {
+		t.Fatal(err)
+	}
+	root, err := os.MkdirTemp(".tmp", "sock-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(root) })
+	parent := filepath.Join(root, "shared")
+	if err := os.Mkdir(parent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sock := filepath.Join(parent, "daemon.sock")
+	if _, err := ListenProtectedUnix(sock, false); err == nil {
+		t.Fatal("expected loose parent refusal")
+	}
+	info, err := os.Stat(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o755 {
+		t.Fatalf("parent changed to %04o", got)
+	}
+}
+
+func TestListenProtectedUnixClosesOnSocketProtectionFailure(t *testing.T) {
+	if err := os.MkdirAll(".tmp", 0o700); err != nil {
+		t.Fatal(err)
+	}
+	root, err := os.MkdirTemp(".tmp", "sock-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(root) })
+	parent := filepath.Join(root, "state")
+	sock := filepath.Join(parent, "daemon.sock")
+	lis, err := listenProtectedUnix(sock, true, func(string, os.FileMode) error {
+		return os.ErrPermission
+	})
+	if err == nil {
+		if lis != nil {
+			lis.Close()
+		}
+		t.Fatal("expected socket protection failure")
+	}
+	if lis != nil {
+		t.Fatal("returned listener after protection failure")
+	}
+	if _, statErr := os.Stat(sock); !os.IsNotExist(statErr) {
+		t.Fatalf("socket remains after protection failure: %v", statErr)
+	}
+}

--- a/core/resource/listener/socket_windows.go
+++ b/core/resource/listener/socket_windows.go
@@ -1,0 +1,29 @@
+//go:build windows && !js
+
+package resource_listener
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+// ListenProtectedUnix preserves Windows Unix-socket behavior. Windows does
+// not use Unix mode bits as filesystem authority; callers must not treat the
+// requested modes as an access-control boundary.
+func ListenProtectedUnix(path string, managed bool) (*net.UnixListener, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, errors.Wrap(err, "create socket parent")
+	}
+	lis, err := net.ListenUnix("unix", &net.UnixAddr{Name: path, Net: "unix"})
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		_ = lis.Close()
+		return nil, errors.Wrap(err, "protect Unix socket")
+	}
+	return lis, nil
+}


### PR DESCRIPTION
The native Resource RPC listeners bound their Unix sockets before restricting the socket mode. A permissive umask could therefore let another local account connect during that interval, and a failed chmod left the unauthenticated listener available for the daemon lifetime.

This change establishes a private parent directory before binding. Spacewave-managed socket directories are tightened to 0700. Explicit socket paths must already use a private parent, so Spacewave does not change an unrelated directory. The listener is closed and startup fails if the socket cannot be restricted to 0600.

The default socket path and client interface are unchanged. Windows keeps its existing Unix-socket behavior because Unix mode bits are not its access-control boundary.
