### PR TITLE
fix(gc): replay exact edge lookup on stale snapshot

### DIFF
--- a/db/block/gc/refgraph.go
+++ b/db/block/gc/refgraph.go
@@ -429,6 +429,18 @@ func (rg *RefGraph) filterExistingRemoves(
 // reads the complete object-predicate-subject posting key rather than scanning
 // keys that share its unpadded base62 prefix.
 func (rg *RefGraph) hasRef(ctx context.Context, subject, object string) (bool, error) {
+	var found bool
+	err := kvtx.RunOperation(ctx, func(ctx context.Context) error {
+		var err error
+		found, err = rg.hasRefAttempt(ctx, subject, object)
+		return err
+	})
+	return found, err
+}
+
+// hasRefAttempt reads one exact edge without external effects so hasRef can
+// replay the full lookup when one of its storage snapshots becomes invalid.
+func (rg *RefGraph) hasRefAttempt(ctx context.Context, subject, object string) (bool, error) {
 	qs, ok := graph.Unwrap(rg.handle.QuadStore).(*cayley_kv.QuadStore)
 	if !ok {
 		return rg.hasRefGeneric(ctx, subject, object)

--- a/db/block/gc/refgraph_test.go
+++ b/db/block/gc/refgraph_test.go
@@ -1292,3 +1292,70 @@ func TestApplyRefBatchIgnoresAbsentStagingRemoval(t *testing.T) {
 		t.Fatalf("target lost its owner but was not marked orphaned: %v", unreferenced)
 	}
 }
+
+func TestRegisterEntityChainRetriesInvalidSnapshot(t *testing.T) {
+	ctx := context.Background()
+	store := &invalidSnapshotOnceStore{Store: store_kvtx_inmem.NewStore()}
+	rg, err := NewRefGraph(ctx, store, []byte("gc/"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rg.Close()
+
+	if err := rg.AddRef(ctx, NodeGCRoot, "provider:local"); err != nil {
+		t.Fatal(err)
+	}
+	store.failNextRead.Store(true)
+
+	if err := RegisterEntityChain(
+		ctx,
+		rg,
+		NodeGCRoot,
+		"provider:local",
+		"bucket:account-settings",
+	); err != nil {
+		t.Fatal(err)
+	}
+	if !store.failed.Load() {
+		t.Fatal("test store did not inject an invalid snapshot")
+	}
+	found, err := rg.hasRef(ctx, "provider:local", "bucket:account-settings")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("entity chain stopped after its duplicate root edge")
+	}
+}
+
+type invalidSnapshotOnceStore struct {
+	kvtx.Store
+	failNextRead atomic.Bool
+	failed       atomic.Bool
+}
+
+func (s *invalidSnapshotOnceStore) NewTransaction(ctx context.Context, write bool) (kvtx.Tx, error) {
+	tx, err := s.Store.NewTransaction(ctx, write)
+	if err != nil {
+		return nil, err
+	}
+	if write || !s.failNextRead.Load() {
+		return tx, nil
+	}
+	return &invalidSnapshotOnceTx{Tx: tx, store: s}, nil
+}
+
+type invalidSnapshotOnceTx struct {
+	kvtx.Tx
+	store *invalidSnapshotOnceStore
+	reads int
+}
+
+func (t *invalidSnapshotOnceTx) Get(ctx context.Context, key []byte) ([]byte, bool, error) {
+	t.reads++
+	if t.reads == 2 && t.store.failNextRead.CompareAndSwap(true, false) {
+		t.store.failed.Store(true)
+		return nil, false, kvtx.ErrInvalidSnapshot
+	}
+	return t.Tx.Get(ctx, key)
+}

--- a/db/kvtx/transaction.go
+++ b/db/kvtx/transaction.go
@@ -25,14 +25,60 @@ func RetryInvalidSnapshot(err error) bool {
 	return errors.Is(err, ErrInvalidSnapshot)
 }
 
+// RunOperation executes a complete logical operation again when its storage
+// snapshot becomes invalid. The body must be safe to replay.
+func RunOperation(ctx context.Context, body func(context.Context) error) error {
+	return RunOperationWithRetry(ctx, body, RetryInvalidSnapshot)
+}
+
+// RunOperationWithRetry executes a complete logical operation with the
+// supplied typed retry policy. The body must not perform non-idempotent external
+// effects. Per-attempt mutable state must be created or reset inside the body;
+// immutable inputs may be captured from outside it.
+func RunOperationWithRetry(
+	ctx context.Context,
+	body func(context.Context) error,
+	retry RetryPredicate,
+) error {
+	return runOperationWithRetry(
+		ctx,
+		body,
+		retry,
+		"kvtx operation attempt limit exhausted",
+	)
+}
+
+func runOperationWithRetry(
+	ctx context.Context,
+	body func(context.Context) error,
+	retry RetryPredicate,
+	exhaustedError string,
+) error {
+	for range transactionAttemptLimit {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		err := body(ctx)
+		if err == nil {
+			return nil
+		}
+		if !retry(err) {
+			return err
+		}
+	}
+
+	return errors.New(exhaustedError)
+}
+
 // RunTransaction executes body against a fresh transaction for each retryable
 // failure and retries only ErrInvalidSnapshot. A successful read body is
 // discarded without committing; a successful write body is committed before
 // the attempt is discarded.
 //
 // The body must be safe to replay. It may use the transaction and perform
-// deterministic local computation, but external effects and mutable
-// accumulators that span attempts belong outside the body.
+// deterministic local computation, but it must not perform non-idempotent
+// external effects. Per-attempt mutable state must be reset inside the body.
 func RunTransaction[T TransactionLifecycle](
 	ctx context.Context,
 	write bool,
@@ -52,23 +98,14 @@ func RunTransactionWithRetry[T TransactionLifecycle](
 	body func(context.Context, T) error,
 	retry RetryPredicate,
 ) error {
-	for range transactionAttemptLimit {
-		// Cancellation between attempts must win before another transaction opens.
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-
-		// Run one transaction attempt and classify its retryability.
-		err := runTransactionAttempt(ctx, write, open, body)
-		if err == nil {
-			return nil
-		}
-		if !retry(err) {
-			return err
-		}
-	}
-
-	return errors.New("kvtx transaction attempt limit exhausted")
+	return runOperationWithRetry(
+		ctx,
+		func(ctx context.Context) error {
+			return runTransactionAttempt(ctx, write, open, body)
+		},
+		retry,
+		"kvtx transaction attempt limit exhausted",
+	)
 }
 
 func runTransactionAttempt[T TransactionLifecycle](

--- a/db/kvtx/transaction_test.go
+++ b/db/kvtx/transaction_test.go
@@ -140,6 +140,24 @@ func TestRunTransactionDiscardsBodyErrorWithoutCommit(t *testing.T) {
 	}
 }
 
+func TestRunOperationReturnsOperationExhaustionError(t *testing.T) {
+	attempts := 0
+	err := RunOperationWithRetry(
+		context.Background(),
+		func(context.Context) error {
+			attempts++
+			return ErrInvalidSnapshot
+		},
+		RetryInvalidSnapshot,
+	)
+	if err == nil || err.Error() != "kvtx operation attempt limit exhausted" {
+		t.Fatalf("error = %v, want operation attempt limit exhaustion", err)
+	}
+	if attempts != transactionAttemptLimit {
+		t.Fatalf("attempts = %d, want %d", attempts, transactionAttemptLimit)
+	}
+}
+
 func TestRunTransactionReturnsExhaustionErrorAtAttemptBound(t *testing.T) {
 	var events []string
 	var opened int


### PR DESCRIPTION
Local account setup registers an existing GC root edge before adding its new provider bucket. The exact-edge lookup spans Cayley ID resolution and direct index reads, which use separate storage transactions. An OPFS metadata commit between those reads could invalidate the snapshot and stop account creation.

This adds a bounded operation-level retry that shares the typed snapshot policy and cancellation behavior with transaction retries. The complete read-only edge lookup restarts, so every nested transaction observes current metadata before registration continues.

The deterministic regression injects `kvtx.ErrInvalidSnapshot` on the second read while registering the same root/provider/bucket chain. It fails against the parent implementation and passes after the fix. The focused browser `TestNoCloudPairingDirect` scenario also passes.