### PR TITLE
fix(e2e): serve selected Notes release

### DIFF
--- a/bldr.star
+++ b/bldr.star
@@ -614,6 +614,8 @@ BROWSER_RELEASE_LAZY_PLUGIN_FIXTURE_LOAD_PLUGINS = BROWSER_RELEASE_LOAD_PLUGINS 
 # sql plugin cold-builds under the e2e release without a populated Release World.
 def browser_e2e_embed_manifests(go_platform_id):
     return browser_release_embed_manifests(go_platform_id) + [
+        {"manifestId": "spacewave-notes",
+         "platformId": "js"},
         {"manifestId": "spacewave-sql",
          "platformId": "js"},
     ]
@@ -672,7 +674,7 @@ build("release-web-e2e",
 build("release-web-e2e-assets",
     manifests=[
         "spacewave-launcher",
-        "spacewave-core", "spacewave-web", "spacewave-app", "spacewave-sql", "spacewave-cli-plugin", "web",
+        "spacewave-core", "spacewave-web", "spacewave-app", "spacewave-notes", "spacewave-sql", "spacewave-cli-plugin", "web",
     ],
     targets=["browser"],
     manifestOverrides={

--- a/bldr/project/starlark/evaluate_test.go
+++ b/bldr/project/starlark/evaluate_test.go
@@ -589,12 +589,12 @@ func TestEvaluateRootDesktopReleaseBuildsJsEmbeds(t *testing.T) {
 		"release-web-e2e",
 		e2eDistConf,
 		"web/js/wasm",
+		distEmbedManifestWant{manifestID: "spacewave-notes", platformID: "js"},
 		distEmbedManifestWant{manifestID: "spacewave-sql", platformID: "js"},
 	)
 
 	for _, unexpected := range []string{
 		`"embeddedManifestOverrides"`,
-		`"spacewave-notes"`,
 		`"spacewave-v86"`,
 		"https://spacewave.app/api/release/config",
 	} {
@@ -607,7 +607,7 @@ func TestEvaluateRootDesktopReleaseBuildsJsEmbeds(t *testing.T) {
 	if e2eAssetBuild == nil {
 		t.Fatal("build target 'release-web-e2e-assets' not found")
 	}
-	for _, want := range []string{"spacewave-launcher", "spacewave-core", "spacewave-web", "spacewave-app", "spacewave-cli-plugin", "web"} {
+	for _, want := range []string{"spacewave-launcher", "spacewave-core", "spacewave-web", "spacewave-app", "spacewave-notes", "spacewave-cli-plugin", "web"} {
 		if !slices.Contains(e2eAssetBuild.GetManifests(), want) {
 			t.Fatalf("release-web-e2e-assets manifests missing %s: %v", want, e2eAssetBuild.GetManifests())
 		}
@@ -655,6 +655,7 @@ func TestEvaluateRootDesktopReleaseBuildsJsEmbeds(t *testing.T) {
 		"release-web-e2e-dist",
 		e2eDistOnlyConf,
 		"web/js/wasm",
+		distEmbedManifestWant{manifestID: "spacewave-notes", platformID: "js"},
 		distEmbedManifestWant{manifestID: "spacewave-sql", platformID: "js"},
 	)
 
@@ -783,6 +784,7 @@ func TestEvaluateRootDesktopStatusProjectorPlatformBoundary(t *testing.T) {
 		"release-web-e2e-tinygo",
 		tinygoE2EDistConf,
 		"web/js/wasm",
+		distEmbedManifestWant{manifestID: "spacewave-notes", platformID: "js"},
 		distEmbedManifestWant{manifestID: "spacewave-sql", platformID: "js"},
 	)
 
@@ -820,6 +822,7 @@ func TestEvaluateRootDesktopStatusProjectorPlatformBoundary(t *testing.T) {
 		"release-web-e2e-goscript",
 		goscriptE2EDistConf,
 		"js",
+		distEmbedManifestWant{manifestID: "spacewave-notes", platformID: "js"},
 		distEmbedManifestWant{manifestID: "spacewave-sql", platformID: "js"},
 	)
 


### PR DESCRIPTION
PR #601 built Notes, but the browser E2E still published two platform manifests while serving only the js asset set. After both manifests arrived, the runtime selected the web/js/wasm entrypoint and received HTTP 404.

Embed the js Notes manifest in the E2E distribution and include Notes in the split asset build. The selected Notes entrypoint and the files served by CI now use the same platform.

The focused `TestBlogCoexistenceScenario` browser run passes with this configuration.