### PR TITLE
fix(provider): remove private transport replacement deadline

### DIFF
--- a/core/provider/local/account-transport.go
+++ b/core/provider/local/account-transport.go
@@ -89,8 +89,20 @@ var (
 	errSessionTransportSuperseded = errors.New("session transport request superseded by newer configuration")
 )
 
+// sessionTransportReplacementContext lets mandatory old-transport cleanup
+// outlive caller cancellation without shortening a caller-supplied deadline.
 func sessionTransportReplacementContext(ctx context.Context) (context.Context, context.CancelFunc) {
-	return sessionTransportCleanupContext(ctx)
+	if ctx == nil {
+		return sessionTransportCleanupContext(nil)
+	}
+	replacementCtx := context.WithoutCancel(ctx)
+	if deadline, ok := ctx.Deadline(); ok {
+		if time.Until(deadline) <= 0 {
+			return sessionTransportCleanupContext(ctx)
+		}
+		return context.WithDeadline(replacementCtx, deadline)
+	}
+	return context.WithCancel(replacementCtx)
 }
 
 func sessionTransportCleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {

--- a/core/provider/local/session-lock-low-cost_test.go
+++ b/core/provider/local/session-lock-low-cost_test.go
@@ -148,6 +148,27 @@ func TestEnsureSessionTransportReleasesAccountLockWhileWaitingReady(t *testing.T
 	}
 }
 
+func TestSessionTransportReplacementContextDoesNotInventDeadline(t *testing.T) {
+	callerCtx, callerCancel := context.WithCancel(t.Context())
+	replacementCtx, replacementCancel := sessionTransportReplacementContext(callerCtx)
+
+	if deadline, ok := replacementCtx.Deadline(); ok {
+		t.Fatalf("replacement context added private deadline %v", deadline)
+	}
+	callerCancel()
+	select {
+	case <-replacementCtx.Done():
+		t.Fatal("caller cancellation interrupted mandatory transport cleanup")
+	default:
+	}
+	replacementCancel()
+	select {
+	case <-replacementCtx.Done():
+	default:
+		t.Fatal("replacement cleanup context did not cancel")
+	}
+}
+
 func TestSessionTransportReadyErrorCleanupHonorsCallerDeadline(t *testing.T) {
 	ctx, ctxCancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer ctxCancel()


### PR DESCRIPTION
Session transport replacement waits for the previous routine to exit before publishing a new transport. The replacement context silently capped that mandatory cleanup at the provider retry backoff maximum. On a loaded runner, pairing failed after exactly 1.8 seconds even though its caller remained active.

This keeps cancellation detached while the old transport shuts down, preserves a caller-supplied deadline, and stops inventing a deadline when none exists. Explicit best-effort stop and readiness-error cleanup retain their existing bounded contexts.

The deterministic regression finds the private 1.8-second deadline against the parent implementation. The replacement lifecycle tests, reported pairing test, full local-provider package, race checks, and vet pass after the change.