### PR TITLE
fix(provider): bound local invite enrollment

### DIFF
--- a/core/provider/local/invite-join.go
+++ b/core/provider/local/invite-join.go
@@ -60,15 +60,22 @@ func (a *ProviderAccount) JoinViaInvite(
 	if childBus == nil {
 		return nil, errors.New("session transport child bus not available")
 	}
-	if inviteMsg.GetProviderId() == "spacewave" {
-		if err := a.waitDirectInviteOwnerOnline(ctx, childBus, st.GetPeerID(), inviteMsg.GetOwnerPeerId()); err != nil {
-			return nil, err
-		}
+	joinCtx, joinCancel := context.WithTimeout(ctx, directInviteOwnerWaitTimeout)
+	defer joinCancel()
+	if err := a.waitDirectInviteOwnerOnline(
+		joinCtx,
+		childBus,
+		st.GetPeerID(),
+		inviteMsg.GetOwnerPeerId(),
+	); err != nil {
+		return nil, err
 	}
 
-	// Execute the invite handshake over SRPC.
+	// Execute the invite handshake over SRPC while the verified owner remains
+	// reachable. A signaling or link failure must not hold the enrollment RPC
+	// forever.
 	result, err := sobject_invite.JoinViaInvite(
-		ctx,
+		joinCtx,
 		childBus,
 		st.GetPeerID(),
 		sessionKey,
@@ -84,7 +91,7 @@ func (a *ProviderAccount) JoinViaInvite(
 	}
 
 	// Start P2P sync so SolicitSync delivers state from the owner.
-	if err := a.StartP2PSync(context.WithoutCancel(ctx), st); err != nil {
+	if err := a.StartP2PSync(joinCtx, st); err != nil {
 		a.le.WithError(err).Warn("failed to start P2P sync after invite join")
 	}
 

--- a/core/resource/provider/local.go
+++ b/core/resource/provider/local.go
@@ -15,6 +15,8 @@ import (
 )
 
 // LocalProviderResource implements the LocalProviderResourceService.
+const localSpaceLinkNetworkTimeout = 10 * time.Second
+
 type LocalProviderResource struct {
 	*ProviderResource
 	le       *logrus.Entry
@@ -129,15 +131,17 @@ func (s *LocalProviderResource) CompleteSpaceLinkEnrollment(
 	if !ok {
 		return nil, errors.New("unexpected provider account type")
 	}
+	networkCtx, networkCancel := context.WithTimeout(ctx, localSpaceLinkNetworkTimeout)
+	defer networkCancel()
 	if !localAccountHasSharedObject(localAcc, invite.GetSharedObjectId()) {
-		if _, err := localAcc.JoinViaInvite(ctx, sessionKey, invite, ""); err != nil {
+		if _, err := localAcc.JoinViaInvite(networkCtx, sessionKey, invite, ""); err != nil {
 			return nil, errors.Wrap(err, "join space via invite")
 		}
 	} else {
-		if err := localAcc.EnsureConfiguredSessionTransport(ctx, sessionKey); err != nil {
+		if err := localAcc.EnsureConfiguredSessionTransport(networkCtx, sessionKey); err != nil {
 			return nil, errors.Wrap(err, "start session transport")
 		}
-		if err := localAcc.StartP2PSync(context.WithoutCancel(ctx), localAcc.GetSessionTransport()); err != nil {
+		if err := localAcc.StartP2PSync(networkCtx, localAcc.GetSessionTransport()); err != nil {
 			return nil, errors.Wrap(err, "start P2P sync")
 		}
 	}
@@ -145,7 +149,7 @@ func (s *LocalProviderResource) CompleteSpaceLinkEnrollment(
 	if err != nil {
 		return nil, errors.Wrap(err, "parse invite owner peer id")
 	}
-	if err := localAcc.RetainP2PPeer(ctx, ownerPeerID); err != nil {
+	if err := localAcc.RetainP2PPeer(networkCtx, ownerPeerID); err != nil {
 		return nil, errors.Wrap(err, "retain invite owner link")
 	}
 

--- a/net/link/establish-link-ex.go
+++ b/net/link/establish-link-ex.go
@@ -28,7 +28,9 @@ func EstablishLinkWithPeerEx(
 		return nil, nil, err
 	}
 	if estl == nil {
-		ref.Release()
+		if ref != nil {
+			ref.Release()
+		}
 		return nil, nil, nil
 	}
 

--- a/net/link/establish-link-ex_test.go
+++ b/net/link/establish-link-ex_test.go
@@ -1,0 +1,25 @@
+package link_test
+
+import (
+	"testing"
+
+	"github.com/s4wave/spacewave/net/link"
+	"github.com/s4wave/spacewave/net/testbed"
+	"github.com/sirupsen/logrus"
+)
+
+func TestEstablishLinkWithPeerExIdleHasNoReference(t *testing.T) {
+	tb, err := testbed.NewTestbed(t.Context(), logrus.NewEntry(logrus.New()), testbed.TestbedOpts{NoPeer: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tb.Release()
+
+	value, release, err := link.EstablishLinkWithPeerEx(t.Context(), tb.Bus, "local", "remote", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value != nil || release != nil {
+		t.Fatal("idle directive returned a value or release function")
+	}
+}


### PR DESCRIPTION
A local Device enrollment waited forever when the Space owner was unavailable through signaling. The local invite path skipped the owner-reachability check that already bounded cloud invite setup, then passed the unbounded RPC context into the invite handshake.

Use one five-second context for owner reachability and the invite handshake for every provider. This keeps enrollment retryable and prevents a failed signaling path from holding the CLI indefinitely.