### PR TITLE
fix(debug): protect RPC sockets before serving

### DIFF
--- a/bldr/util/pipesock/listen-unix.go
+++ b/bldr/util/pipesock/listen-unix.go
@@ -17,6 +17,51 @@ import (
 
 const maxSocketPathLength = 90
 
+// ListenProtectedUnix binds a Unix socket only after its parent is private and
+// restricts the socket before returning it. The parent is created or tightened
+// to 0700.
+func ListenProtectedUnix(path string) (*net.UnixListener, error) {
+	return listenProtectedUnix(path, os.Chmod)
+}
+
+func listenProtectedUnix(path string, chmodSocket func(string, os.FileMode) error) (*net.UnixListener, error) {
+	// Establish owner-only traversal before creating the socket.
+	parent := filepath.Dir(path)
+	info, err := os.Stat(parent)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, errors.Wrap(err, "inspect socket parent")
+		}
+		if err := os.MkdirAll(parent, 0o700); err != nil {
+			return nil, errors.Wrap(err, "create private socket parent")
+		}
+		info, err = os.Stat(parent)
+		if err != nil {
+			return nil, errors.Wrap(err, "inspect created socket parent")
+		}
+	}
+
+	// Restrict the parent before binding the socket.
+	if !info.IsDir() {
+		return nil, errors.Errorf("socket parent %s is not a directory", parent)
+	}
+	if err := os.Chmod(parent, 0o700); err != nil {
+		return nil, errors.Wrap(err, "protect socket parent")
+	}
+
+	// Bind only after the parent blocks group and other traversal.
+	lis, err := net.ListenUnix("unix", &net.UnixAddr{Name: path, Net: "unix"})
+	if err != nil {
+		return nil, err
+	}
+	// Restrict the socket before returning it to the RPC server.
+	if err := chmodSocket(path, 0o600); err != nil {
+		_ = lis.Close()
+		return nil, errors.Wrap(err, "protect Unix socket")
+	}
+	return lis, nil
+}
+
 // Listen creates a short, private Unix socket owned by the returned listener.
 func Listen(le *logrus.Entry, ownerDir, pipeUuid string) (*PipeListener, error) {
 	ownerDir, err := filepath.Abs(ownerDir)

--- a/bldr/util/pipesock/listen-unix_test.go
+++ b/bldr/util/pipesock/listen-unix_test.go
@@ -1,0 +1,69 @@
+//go:build !windows
+
+package pipesock
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestListenProtectedUnixProtectsParentAndSocket(t *testing.T) {
+	if err := os.MkdirAll(".tmp", 0o700); err != nil {
+		t.Fatal(err)
+	}
+	root, err := os.MkdirTemp(".tmp", "sock-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+	parent := filepath.Join(root, "state")
+	sock := filepath.Join(parent, "debug.sock")
+	lis, err := ListenProtectedUnix(sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lis.Close()
+	parentInfo, err := os.Stat(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := parentInfo.Mode().Perm(); got != 0o700 {
+		t.Fatalf("parent mode = %04o, want 0700", got)
+	}
+	socketInfo, err := os.Stat(sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := socketInfo.Mode().Perm(); got != 0o600 {
+		t.Fatalf("socket mode = %04o, want 0600", got)
+	}
+}
+
+func TestListenProtectedUnixClosesOnProtectionFailure(t *testing.T) {
+	if err := os.MkdirAll(".tmp", 0o700); err != nil {
+		t.Fatal(err)
+	}
+	root, err := os.MkdirTemp(".tmp", "sock-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+	parent := filepath.Join(root, "state")
+	sock := filepath.Join(parent, "debug.sock")
+	lis, err := listenProtectedUnix(sock, func(string, os.FileMode) error {
+		return os.ErrPermission
+	})
+	if err == nil {
+		if lis != nil {
+			_ = lis.Close()
+		}
+		t.Fatal("expected socket protection failure")
+	}
+	if lis != nil {
+		t.Fatal("returned listener after protection failure")
+	}
+	if _, statErr := os.Stat(sock); !os.IsNotExist(statErr) {
+		t.Fatalf("socket remains after protection failure: %v", statErr)
+	}
+}

--- a/bldr/util/pipesock/listen-windows.go
+++ b/bldr/util/pipesock/listen-windows.go
@@ -5,10 +5,34 @@ package pipesock
 import (
 	"context"
 	"net"
+	"os"
+	"path/filepath"
 
 	util_pipesock "github.com/aperturerobotics/util/pipesock"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
+
+// ListenProtectedUnix preserves Windows Unix-socket behavior. Windows does
+// not use Unix mode bits as filesystem authority, but protection failures still
+// fail closed before the listener is returned.
+func ListenProtectedUnix(path string) (*net.UnixListener, error) {
+	// Preserve the existing Windows parent and Unix-socket construction.
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, errors.Wrap(err, "create socket parent")
+	}
+
+	// Fail before returning when the platform rejects socket protection.
+	lis, err := net.ListenUnix("unix", &net.UnixAddr{Name: path, Net: "unix"})
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		_ = lis.Close()
+		return nil, errors.Wrap(err, "protect Unix socket")
+	}
+	return lis, nil
+}
 
 // Listen creates a Windows named pipe owned by the returned listener.
 func Listen(le *logrus.Entry, ownerDir, pipeUuid string) (*PipeListener, error) {

--- a/bldr/web/plugin/saucer/debug-bridge.go
+++ b/bldr/web/plugin/saucer/debug-bridge.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/binary"
 	"io"
-	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/aperturerobotics/starpc/srpc"
 	"github.com/pkg/errors"
+	bldr_pipesock "github.com/s4wave/spacewave/bldr/util/pipesock"
 	singleton_muxed_conn "github.com/s4wave/spacewave/bldr/util/singleton-muxed-conn"
 	"github.com/sirupsen/logrus"
 )
@@ -175,26 +175,19 @@ func runDebugSocket(ctx context.Context, le *logrus.Entry, mc *singleton_muxed_c
 	}
 
 	sockDir := filepath.Join(workdir, ".bldr")
-	if err := os.MkdirAll(sockDir, 0o755); err != nil {
-		return errors.Wrap(err, "create .bldr dir")
-	}
 	sockPath := filepath.Join(sockDir, debugSocketName)
 
 	// Remove stale socket.
 	_ = os.Remove(sockPath)
 
-	lis, err := net.Listen("unix", sockPath)
+	lis, err := bldr_pipesock.ListenProtectedUnix(sockPath)
 	if err != nil {
-		return errors.Wrap(err, "listen unix")
+		return errors.Wrap(err, "listen protected unix")
 	}
 	defer func() {
 		lis.Close()
 		_ = os.Remove(sockPath)
 	}()
-
-	if err := os.Chmod(sockPath, 0o600); err != nil {
-		le.WithError(err).Warn("failed to chmod socket")
-	}
 
 	le.Infof("debug bridge listening on %s", sockPath)
 

--- a/core/debug/bridge/controller.go
+++ b/core/debug/bridge/controller.go
@@ -2,7 +2,6 @@ package debug_bridge
 
 import (
 	"context"
-	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -13,6 +12,7 @@ import (
 	"github.com/aperturerobotics/controllerbus/controller"
 	"github.com/aperturerobotics/controllerbus/directive"
 	"github.com/aperturerobotics/starpc/srpc"
+	bldr_pipesock "github.com/s4wave/spacewave/bldr/util/pipesock"
 	web_view "github.com/s4wave/spacewave/bldr/web/view"
 	debug_projectroot "github.com/s4wave/spacewave/core/debug/projectroot"
 	bifrost_http "github.com/s4wave/spacewave/net/http"
@@ -125,12 +125,7 @@ func (c *Controller) Execute(ctx context.Context) error {
 	// Remove stale socket.
 	_ = os.Remove(absPath)
 
-	// Ensure parent directory exists.
-	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
-		return err
-	}
-
-	lis, err := net.Listen("unix", absPath)
+	lis, err := bldr_pipesock.ListenProtectedUnix(absPath)
 	if err != nil {
 		return err
 	}
@@ -138,11 +133,6 @@ func (c *Controller) Execute(ctx context.Context) error {
 		lis.Close()
 		_ = os.Remove(absPath)
 	}()
-
-	// Restrict socket permissions to owner only.
-	if err := os.Chmod(absPath, 0o600); err != nil {
-		le.WithError(err).Warn("failed to chmod socket")
-	}
 
 	le.Infof("debug bridge listening on %s", absPath)
 


### PR DESCRIPTION
The project and Saucer debug RPC bridges bound Unix sockets in traversable directories before restricting their modes. A permissive umask could let another local account connect during that interval, and either bridge continued serving if chmod failed.

This change moves protected Unix socket construction into the shared build pipesock package. It creates or tightens the parent to 0700 before binding, restricts the socket to 0600 before returning it, and closes the listener if protection fails. Both debug bridges now start their RPC accept loops only after that constructor succeeds.

Windows keeps its existing Unix-socket construction because Windows ACLs, not Unix mode bits, define its authority boundary. Protection errors still fail startup.
