### PR TITLE
fix(daemon): keep local sessions mounted

### DIFF
--- a/.protoc-manifest.json
+++ b/.protoc-manifest.json
@@ -1306,7 +1306,7 @@
       ]
     },
     "github.com/s4wave/spacewave/core/sobject/invite": {
-      "hash": "980d8b2b717748577bc604f6c0134a25c618244c60da8e63aff850192525b14a",
+      "hash": "798f7dcda8e84c46e6d3bf51f6adbb9cff7bccc453be4852ae468a6728a830da",
       "generatedFiles": [
         "core/sobject/invite/invite.pb.go",
         "core/sobject/invite/invite.pb.ts",

--- a/cmd/spacewave/cli/device-capacity-observe.go
+++ b/cmd/spacewave/cli/device-capacity-observe.go
@@ -77,45 +77,102 @@ func runDeviceCapacityObserver(
 		return errors.Wrap(err, "generate claim id")
 	}
 
+	type policyUpdate struct {
+		policy *device_policy.DevicePolicy
+		err    error
+	}
+	watchCtx, stopWatch := context.WithCancel(ctx)
+	updates := make(chan policyUpdate, 1)
+	watchDone := make(chan struct{})
+	go func() {
+		defer close(watchDone)
+		var last *device_policy.DevicePolicy
+		for {
+			policy, err := store.WaitChange(watchCtx, last)
+			select {
+			case updates <- policyUpdate{policy: policy, err: err}:
+			case <-watchCtx.Done():
+				return
+			}
+			if err != nil {
+				return
+			}
+			last = policy
+		}
+	}()
+	defer func() {
+		stopWatch()
+		<-watchDone
+	}()
+
 	var admission *forge_runtime.WorldRuntimeAdmission
 	var ref forge_runtime.WorkerClaimRef
 	var cleanup func()
-	defer func() {
+	closeAdmission := func() {
 		if cleanup != nil {
 			cleanup()
 		}
-	}()
+		admission = nil
+		ref = forge_runtime.WorkerClaimRef{}
+		cleanup = nil
+	}
+	defer closeAdmission()
 
-	var last *device_policy.DevicePolicy
+	var current *device_policy.DevicePolicy
+	var havePolicy bool
+	var applyNeeded bool
+	ticker := time.NewTicker(capacityRenewPeriod)
+	defer ticker.Stop()
 	for {
-		policy, err := store.WaitChange(ctx, last)
-		if err != nil {
-			if ctx.Err() != nil {
-				return nil
-			}
-			return err
-		}
-		if admission == nil {
-			admission, ref, cleanup, err = openDeviceCapacityAdmission(ctx, statePath, client, claimID)
-			if err != nil {
-				le.WithError(err).Warn("failed to open declared capacity target")
-				last = policy
-				continue
-			}
+		if applyNeeded && havePolicy {
+			applyNeeded = false
 			if admission == nil {
-				last = policy
+				admission, ref, cleanup, err = openDeviceCapacityAdmission(ctx, statePath, client, claimID)
+				if err != nil {
+					le.WithError(err).Warn("failed to open declared capacity target")
+					closeAdmission()
+				} else if admission == nil {
+					closeAdmission()
+				}
+			}
+			if admission != nil {
+				var declared *device_policy.ForgeWorkerPolicy
+				if current != nil {
+					declared = current.GetForgeWorker()
+				}
+				if err := applyDeclaredCapacity(ctx, le, admission, ref, declared); err != nil {
+					le.WithError(err).Warn("failed to observe declared capacity")
+					closeAdmission()
+				}
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case update := <-updates:
+			if update.err != nil {
+				if ctx.Err() != nil {
+					return nil
+				}
+				return update.err
+			}
+			current = update.policy
+			havePolicy = true
+			applyNeeded = true
+		case <-ticker.C:
+			if admission == nil {
+				applyNeeded = true
 				continue
 			}
-			go renewOwnedCapacityLoop(ctx, le, admission, ref)
+			if err := renewOwnedCapacityOnceWithAdmission(ctx, admission, ref.DeviceObjectKey, ref); err != nil {
+				if ctx.Err() == nil {
+					le.WithError(err).Warn("capacity claim renewal failed")
+				}
+				closeAdmission()
+				applyNeeded = true
+			}
 		}
-		var declared *device_policy.ForgeWorkerPolicy
-		if policy != nil && ctx.Err() == nil {
-			declared = policy.GetForgeWorker()
-		}
-		if err := applyDeclaredCapacity(ctx, le, admission, ref, declared); err != nil {
-			le.WithError(err).Warn("failed to observe declared capacity")
-		}
-		last = policy
 	}
 }
 
@@ -239,34 +296,6 @@ func applyDeclaredCapacity(
 	_, err = admission.ObserveWorker(ctx, declaredKey, ref, capacity.OwnerEpoch,
 		declared.GetMilliCpu(), declared.GetMemoryBytes(), declared.GetBackends())
 	return err
-}
-
-// renewOwnedCapacityLoop extends the claim on every owned record at a bounded
-// fraction of the owner lease. An expired lease falls back to reclaim with an
-// epoch bump inside RenewWorkerClaim, so turnover stays safe.
-func renewOwnedCapacityLoop(
-	ctx context.Context,
-	le *logrus.Entry,
-	admission *forge_runtime.WorldRuntimeAdmission,
-	ref forge_runtime.WorkerClaimRef,
-) {
-	ticker := time.NewTicker(capacityRenewPeriod)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			if err := renewOwnedCapacityOnceWithAdmission(
-				ctx,
-				admission,
-				ref.DeviceObjectKey,
-				ref,
-			); err != nil && ctx.Err() == nil {
-				le.WithError(err).Warn("capacity claim renewal failed")
-			}
-		}
-	}
 }
 
 // renewOwnedCapacityOnceWithAdmission renews every record the Device owns

--- a/cmd/spacewave/cli/device-capacity-observe.go
+++ b/cmd/spacewave/cli/device-capacity-observe.go
@@ -255,7 +255,7 @@ func applyDeclaredCapacity(
 ) error {
 	owned, err := admission.ScanOwnedCapacity(ctx, ref.DeviceObjectKey)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "scan owned capacity")
 	}
 	declaredKey := ""
 	if declared != nil {
@@ -267,12 +267,12 @@ func applyDeclaredCapacity(
 		handled[key] = true
 		capacity, err := admission.ClaimWorkerCapacity(ctx, key, ref)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "claim owned worker capacity")
 		}
 		if key == declaredKey {
 			if _, err := admission.ObserveWorker(ctx, key, ref, capacity.OwnerEpoch,
 				declared.GetMilliCpu(), declared.GetMemoryBytes(), declared.GetBackends()); err != nil {
-				return err
+				return errors.Wrap(err, "observe declared worker capacity")
 			}
 			continue
 		}
@@ -280,7 +280,7 @@ func applyDeclaredCapacity(
 		// when terminal. Completion failure means reservations are still
 		// live; the next cycle retries.
 		if _, err := admission.BeginDrainCapacity(ctx, key, ref, capacity.OwnerEpoch); err != nil {
-			return err
+			return errors.Wrap(err, "begin stale capacity drain")
 		}
 		if err := admission.CompleteDrainCapacity(ctx, key, ref, capacity.OwnerEpoch); err != nil {
 			le.WithError(err).Debug("drained capacity retains live reservations")
@@ -291,11 +291,11 @@ func applyDeclaredCapacity(
 	}
 	capacity, err := admission.ClaimWorkerCapacity(ctx, declaredKey, ref)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "claim declared worker capacity")
 	}
 	_, err = admission.ObserveWorker(ctx, declaredKey, ref, capacity.OwnerEpoch,
 		declared.GetMilliCpu(), declared.GetMemoryBytes(), declared.GetBackends())
-	return err
+	return errors.Wrap(err, "observe declared worker capacity")
 }
 
 // renewOwnedCapacityOnceWithAdmission renews every record the Device owns

--- a/cmd/spacewave/cli/device-capacity-observe.go
+++ b/cmd/spacewave/cli/device-capacity-observe.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aperturerobotics/starpc/srpc"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
@@ -34,14 +33,14 @@ func startDeviceCapacityObserver(
 	ctx context.Context,
 	le *logrus.Entry,
 	statePath string,
-	invoker srpc.Invoker,
+	sockPath string,
 	store *device_policy.PolicyStore,
 ) {
-	if invoker == nil || store == nil {
+	if sockPath == "" || store == nil {
 		return
 	}
 	go func() {
-		client, err := buildSDKClientFromInvoker(ctx, invoker)
+		client, err := connectDaemonAtSocket(ctx, sockPath)
 		if err != nil {
 			if ctx.Err() == nil {
 				le.WithError(err).Warn("device capacity observer unavailable")

--- a/cmd/spacewave/cli/local-session-keeper.go
+++ b/cmd/spacewave/cli/local-session-keeper.go
@@ -1,0 +1,106 @@
+//go:build !js
+
+package spacewave_cli
+
+import (
+	"context"
+
+	"github.com/aperturerobotics/starpc/srpc"
+	"github.com/sirupsen/logrus"
+
+	core_session "github.com/s4wave/spacewave/core/session"
+)
+
+type localSessionMount interface {
+	Release()
+}
+
+// startLocalSessionKeeper keeps configured local sessions mounted while the
+// daemon serves requests. Their session transports and P2P controllers must
+// remain available after a short CLI request releases its own resource.
+func startLocalSessionKeeper(
+	ctx context.Context,
+	le *logrus.Entry,
+	invoker srpc.Invoker,
+) {
+	if invoker == nil {
+		return
+	}
+	go func() {
+		client, err := buildSDKClientFromInvoker(ctx, invoker)
+		if err != nil {
+			if ctx.Err() == nil {
+				le.WithError(err).Warn("local session keeper unavailable")
+			}
+			return
+		}
+		defer client.close()
+
+		watch, err := client.root.WatchSessions(ctx)
+		if err != nil {
+			if ctx.Err() == nil {
+				le.WithError(err).Warn("local session keeper could not watch sessions")
+			}
+			return
+		}
+		defer watch.Close()
+
+		mounted := make(map[uint32]localSessionMount)
+		defer func() {
+			for _, sess := range mounted {
+				sess.Release()
+			}
+		}()
+		for {
+			resp, err := watch.Recv()
+			if err != nil {
+				if ctx.Err() == nil {
+					le.WithError(err).Warn("local session keeper stopped")
+				}
+				return
+			}
+			reconcileLocalSessionMounts(
+				le,
+				resp.GetSessions(),
+				mounted,
+				func(index uint32) (localSessionMount, error) {
+					return client.mountSession(ctx, index)
+				},
+			)
+		}
+	}()
+}
+
+func reconcileLocalSessionMounts(
+	le *logrus.Entry,
+	entries []*core_session.SessionListEntry,
+	mounted map[uint32]localSessionMount,
+	mount func(uint32) (localSessionMount, error),
+) {
+	present := make(map[uint32]struct{})
+	for _, entry := range entries {
+		ref := entry.GetSessionRef()
+		if ref.GetProviderResourceRef().GetProviderId() != "local" {
+			continue
+		}
+		index := entry.GetSessionIndex()
+		present[index] = struct{}{}
+		if _, ok := mounted[index]; ok {
+			continue
+		}
+		sess, err := mount(index)
+		if err != nil {
+			le.WithError(err).WithField("session-index", index).
+				Warn("local session keeper could not mount session")
+			continue
+		}
+		mounted[index] = sess
+	}
+	for index, sess := range mounted {
+		if _, ok := present[index]; ok {
+			continue
+		}
+		sess.Release()
+		delete(mounted, index)
+	}
+}

--- a/cmd/spacewave/cli/local-session-keeper_test.go
+++ b/cmd/spacewave/cli/local-session-keeper_test.go
@@ -1,0 +1,50 @@
+//go:build !js
+
+package spacewave_cli
+
+import (
+	"testing"
+
+	provider "github.com/s4wave/spacewave/core/provider"
+	session "github.com/s4wave/spacewave/core/session"
+	"github.com/sirupsen/logrus"
+)
+
+type testLocalSessionMount struct {
+	released bool
+}
+
+func (m *testLocalSessionMount) Release() {
+	m.released = true
+}
+
+func TestReconcileLocalSessionMountsRetainsConfiguredSession(t *testing.T) {
+	entry := &session.SessionListEntry{
+		SessionIndex: 1,
+		SessionRef: &session.SessionRef{ProviderResourceRef: &provider.ProviderResourceRef{
+			ProviderId: "local",
+		}},
+	}
+	mount := &testLocalSessionMount{}
+	mounted := make(map[uint32]localSessionMount)
+	mountCalls := 0
+	mountFunc := func(index uint32) (localSessionMount, error) {
+		mountCalls++
+		if index != 1 {
+			t.Fatalf("mount index = %d, want 1", index)
+		}
+		return mount, nil
+	}
+	le := logrus.NewEntry(logrus.New())
+
+	reconcileLocalSessionMounts(le, []*session.SessionListEntry{entry}, mounted, mountFunc)
+	reconcileLocalSessionMounts(le, []*session.SessionListEntry{entry}, mounted, mountFunc)
+	if mountCalls != 1 || mount.released {
+		t.Fatalf("configured session calls=%d released=%v", mountCalls, mount.released)
+	}
+
+	reconcileLocalSessionMounts(le, nil, mounted, mountFunc)
+	if !mount.released || len(mounted) != 0 {
+		t.Fatalf("removed session released=%v mounted=%d", mount.released, len(mounted))
+	}
+}

--- a/cmd/spacewave/cli/serve.go
+++ b/cmd/spacewave/cli/serve.go
@@ -184,6 +184,7 @@ func runServeCommand(
 	if err != nil {
 		return err
 	}
+	startLocalSessionKeeper(serveCtx, le, invoker)
 	startDeviceLauncherUpdateProjection(serveCtx, le, resolved, cliBus.GetBus(), invoker)
 	startDevicePolicyCapabilityProjection(serveCtx, le, resolved, cliBus.GetBus(), invoker, devicePolicy)
 	startDeviceCapacityObserver(serveCtx, le, resolved, invoker, devicePolicy)

--- a/cmd/spacewave/cli/serve.go
+++ b/cmd/spacewave/cli/serve.go
@@ -187,7 +187,6 @@ func runServeCommand(
 	startLocalSessionKeeper(serveCtx, le, invoker)
 	startDeviceLauncherUpdateProjection(serveCtx, le, resolved, cliBus.GetBus(), invoker)
 	startDevicePolicyCapabilityProjection(serveCtx, le, resolved, cliBus.GetBus(), invoker, devicePolicy)
-	startDeviceCapacityObserver(serveCtx, le, resolved, invoker, devicePolicy)
 	releaseDeviceRemoteShell := terminal_remoteshell.StartHandler(serveCtx, le, cliBus.GetBus(), devicePolicy)
 	defer releaseDeviceRemoteShell()
 
@@ -240,6 +239,7 @@ func runServeCommand(
 	}
 
 	srv := srpc.NewServer(mux)
+	startDeviceCapacityObserver(serveCtx, le, resolved, sockPath, devicePolicy)
 	if err := startupNotifier.reportReady(); err != nil {
 		return err
 	}

--- a/core/provider/local/auto-start-p2p-sync.go
+++ b/core/provider/local/auto-start-p2p-sync.go
@@ -8,6 +8,7 @@ import (
 	account_settings "github.com/s4wave/spacewave/core/account/settings"
 	sobject "github.com/s4wave/spacewave/core/sobject"
 	"github.com/s4wave/spacewave/core/transport"
+	"github.com/s4wave/spacewave/net/peer"
 	"github.com/sirupsen/logrus"
 )
 
@@ -51,6 +52,15 @@ func (a *ProviderAccount) AutoStartP2PSyncIfNeeded(
 	}).Debug("auto-starting P2P sync")
 	if err := a.StartP2PSync(ctx, st); err != nil {
 		return errors.Wrap(err, "auto-start P2P sync")
+	}
+	for _, device := range devices {
+		remotePeerID, _, err := peer.ParsePeerIDWithPubKey(device.GetPeerId())
+		if err != nil {
+			return errors.Wrap(err, "parse paired Device peer id")
+		}
+		if err := a.RetainP2PPeer(ctx, remotePeerID); err != nil {
+			return errors.Wrap(err, "retain paired Device peer")
+		}
 	}
 	return nil
 }

--- a/core/provider/local/auto-start-p2p-sync_test.go
+++ b/core/provider/local/auto-start-p2p-sync_test.go
@@ -44,31 +44,30 @@ func TestAutoStartP2PSyncIfNeededWithDevice(t *testing.T) {
 
 	tb, sessRef, acc, sess, release := setupProviderAndSession(ctx, t)
 	defer release()
+	_, _, _, remoteSess, releaseRemote := setupProviderAndSession(ctx, t)
+	defer releaseRemote()
 
-	const devicePeerID = "12D3KooWAutoStartPaired"
-	if err := acc.RecordPairedDevice(ctx, devicePeerID, "Auto-Start Test Device"); err != nil {
+	remotePeerID := remoteSess.GetPeerId().String()
+	if err := acc.RecordPairedDevice(ctx, remotePeerID, "Auto-Start Test Device"); err != nil {
 		t.Fatalf("RecordPairedDevice: %v", err)
 	}
 	accountID := sessRef.GetProviderResourceRef().GetProviderAccountId()
 	so, soRelease := mountAccountSettingsSO(ctx, t, tb.Bus, accountID)
-	waitPairedDevice(ctx, t, so, devicePeerID)
+	waitPairedDevice(ctx, t, so, remotePeerID)
 	soRelease()
 
 	if err := acc.CreateSessionTransport(ctx, sess.GetPrivKey(), ""); err != nil {
 		t.Fatalf("CreateSessionTransport: %v", err)
 	}
 	defer acc.StopSessionTransport()
-
 	st := acc.GetSessionTransport()
 	if st == nil {
 		t.Fatal("expected non-nil session transport")
 	}
-
 	if err := acc.AutoStartP2PSyncIfNeeded(ctx, st); err != nil {
 		t.Fatalf("AutoStartP2PSyncIfNeeded: %v", err)
 	}
 	defer acc.StopP2PSync()
-
 	if !acc.IsP2PSyncRunning() {
 		t.Fatal("expected P2P sync to be running after auto-start with paired device present")
 	}

--- a/core/provider/local/invite-join.go
+++ b/core/provider/local/invite-join.go
@@ -90,8 +90,9 @@ func (a *ProviderAccount) JoinViaInvite(
 		return nil, errors.Wrap(err, "mount invited shared object")
 	}
 
-	// Start P2P sync so SolicitSync delivers state from the owner.
-	if err := a.StartP2PSync(joinCtx, st); err != nil {
+	// The bounded join context ends with this call. P2P sync belongs to the
+	// account and stops with the account, not with the enrollment request.
+	if err := a.StartP2PSync(context.WithoutCancel(ctx), st); err != nil {
 		a.le.WithError(err).Warn("failed to start P2P sync after invite join")
 	}
 

--- a/core/provider/local/invite-join.go
+++ b/core/provider/local/invite-join.go
@@ -143,6 +143,9 @@ func (a *ProviderAccount) mountInvitedSO(
 	if result.Grant == nil {
 		return errors.New("invite result has no grant")
 	}
+	if result.OwnerGrant == nil {
+		return errors.New("invite result has no owner grant")
+	}
 
 	soID := result.SharedObjectID
 	if soID == "" {
@@ -208,6 +211,13 @@ func (a *ProviderAccount) mountInvitedSO(
 		addParticipant(signerPeerID.String(), sobject.SOParticipantRole_SOParticipantRole_OWNER)
 		addParticipant(grantPeerID, role)
 		state.RootGrants = append(state.RootGrants, result.Grant)
+		ownerGrantPeerID := result.OwnerGrant.GetPeerId()
+		for _, g := range state.GetRootGrants() {
+			if g.GetPeerId() == ownerGrantPeerID {
+				return nil
+			}
+		}
+		state.RootGrants = append(state.RootGrants, result.OwnerGrant)
 		return nil
 	}); err != nil {
 		return errors.Wrap(err, "store grant")

--- a/core/resource/provider/local.go
+++ b/core/resource/provider/local.go
@@ -141,7 +141,7 @@ func (s *LocalProviderResource) CompleteSpaceLinkEnrollment(
 		if err := localAcc.EnsureConfiguredSessionTransport(networkCtx, sessionKey); err != nil {
 			return nil, errors.Wrap(err, "start session transport")
 		}
-		if err := localAcc.StartP2PSync(networkCtx, localAcc.GetSessionTransport()); err != nil {
+		if err := localAcc.StartP2PSync(context.WithoutCancel(ctx), localAcc.GetSessionTransport()); err != nil {
 			return nil, errors.Wrap(err, "start P2P sync")
 		}
 	}

--- a/core/resource/session/local-spacelink-e2e_test.go
+++ b/core/resource/session/local-spacelink-e2e_test.go
@@ -277,6 +277,13 @@ func TestLocalSpaceLinkDeviceEnrollmentEndToEnd(t *testing.T) {
 	if deviceSessRef.GetProviderResourceRef().GetProviderId() != "local" {
 		t.Fatal("device session is not a local session")
 	}
+	if _, err := deviceEnv.sessCtrl.RegisterSession(ctx, deviceSessRef, &core_session.SessionMetadata{
+		ProviderDisplayName: "Local",
+		ProviderId:          "local",
+		ProviderAccountId:   deviceSessRef.GetProviderResourceRef().GetProviderAccountId(),
+	}); err != nil {
+		t.Fatal(err)
+	}
 	deviceAccIface, relDeviceAcc, err := deviceEnv.prov.AccessProviderAccount(
 		ctx,
 		deviceSessRef.GetProviderResourceRef().GetProviderAccountId(),
@@ -329,6 +336,30 @@ func TestLocalSpaceLinkDeviceEnrollmentEndToEnd(t *testing.T) {
 	}
 	if err := deviceAcc.RetainP2PPeer(ctx, ownerTransport.GetPeerID()); err != nil {
 		t.Fatalf("enrollment request released P2P sync: %v", err)
+	}
+
+	// Reopening an already-joined enrollment follows a separate path. Its
+	// request lifetime must not become the P2P lifetime either.
+	deviceAcc.StopP2PSync()
+	reopenCtx, cancelReopen := context.WithCancel(ctx)
+	_, err = deviceProvRes.CompleteSpaceLinkEnrollment(reopenCtx, &s4wave_provider_local.CompleteSpaceLinkEnrollmentRequest{
+		SessionPemPrivateKey: devicePEM,
+		SessionPeerId:        devicePeerID.String(),
+		Invite:               invite,
+	})
+	cancelReopen()
+	if err != nil {
+		t.Fatal(err)
+	}
+	reopenRelease := time.NewTimer(250 * time.Millisecond)
+	defer reopenRelease.Stop()
+	select {
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	case <-reopenRelease.C:
+	}
+	if err := deviceAcc.RetainP2PPeer(ctx, ownerTransport.GetPeerID()); err != nil {
+		t.Fatalf("reopened enrollment request released P2P sync: %v", err)
 	}
 	if joinResult.SharedObjectID != spaceID {
 		t.Fatalf("unexpected joined shared object %q", joinResult.SharedObjectID)

--- a/core/resource/session/local-spacelink-e2e_test.go
+++ b/core/resource/session/local-spacelink-e2e_test.go
@@ -327,6 +327,12 @@ func TestLocalSpaceLinkDeviceEnrollmentEndToEnd(t *testing.T) {
 	if joinResult == nil || joinResult.Grant == nil {
 		t.Fatal("invite join returned no grant")
 	}
+	if joinResult.OwnerGrant == nil {
+		t.Fatal("invite join returned no owner grant")
+	}
+	if _, err := joinResult.OwnerGrant.DecryptInnerData(ownerMountedSO.GetPrivKey(), spaceID); err != nil {
+		t.Fatalf("originating owner cannot decrypt joined state: %v", err)
+	}
 	joinRelease := time.NewTimer(250 * time.Millisecond)
 	defer joinRelease.Stop()
 	select {

--- a/core/resource/session/local-spacelink-e2e_test.go
+++ b/core/resource/session/local-spacelink-e2e_test.go
@@ -311,12 +311,24 @@ func TestLocalSpaceLinkDeviceEnrollmentEndToEnd(t *testing.T) {
 	defer deviceAcc.StopSessionTransport()
 	connectSessionTransportsForTest(ctx, t, deviceAcc.GetSessionTransport(), ownerTransport)
 
-	joinResult, err := deviceAcc.JoinViaInvite(ctx, devicePriv, invite, "")
+	joinCtx, cancelJoin := context.WithCancel(ctx)
+	joinResult, err := deviceAcc.JoinViaInvite(joinCtx, devicePriv, invite, "")
+	cancelJoin()
 	if err != nil {
 		t.Fatal(err)
 	}
 	if joinResult == nil || joinResult.Grant == nil {
 		t.Fatal("invite join returned no grant")
+	}
+	joinRelease := time.NewTimer(250 * time.Millisecond)
+	defer joinRelease.Stop()
+	select {
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	case <-joinRelease.C:
+	}
+	if err := deviceAcc.RetainP2PPeer(ctx, ownerTransport.GetPeerID()); err != nil {
+		t.Fatalf("enrollment request released P2P sync: %v", err)
 	}
 	if joinResult.SharedObjectID != spaceID {
 		t.Fatalf("unexpected joined shared object %q", joinResult.SharedObjectID)

--- a/core/resource/world/world-state.go
+++ b/core/resource/world/world-state.go
@@ -231,7 +231,9 @@ func (r *WorldStateResource) IterateObjects(ctx context.Context, req *s4wave_wor
 		return nil, err
 	}
 
-	iter := r.ws.IterateObjects(ctx, req.GetPrefix(), req.GetReversed())
+	// The iterator outlives this unary RPC. Resource release closes it, while
+	// each iterator method supplies its own request context.
+	iter := r.ws.IterateObjects(context.WithoutCancel(ctx), req.GetPrefix(), req.GetReversed())
 	iterResource := NewObjectIteratorResource(r.le, r.b, iter)
 	id, err := resourceCtx.AddResource(iterResource.GetMux(), func() {
 		iter.Close()

--- a/core/sobject/invite/client.go
+++ b/core/sobject/invite/client.go
@@ -20,6 +20,8 @@ type JoinResult struct {
 	Grant *sobject.SOGrant
 	// SharedObjectID is the ID of the shared object.
 	SharedObjectID string
+	// OwnerGrant keeps the originating owner's root access on the joined copy.
+	OwnerGrant *sobject.SOGrant
 }
 
 // JoinViaInvite executes the invitee side of the invite handshake.
@@ -74,6 +76,7 @@ func JoinViaInvite(
 	return &JoinResult{
 		Grant:          resp.GetGrant(),
 		SharedObjectID: resp.GetSharedObjectId(),
+		OwnerGrant:     resp.GetOwnerGrant(),
 	}, nil
 }
 

--- a/core/sobject/invite/invite.pb.go
+++ b/core/sobject/invite/invite.pb.go
@@ -53,6 +53,9 @@ type AcceptInviteResponse struct {
 	Grant *sobject.SOGrant `protobuf:"bytes,1,opt,name=grant,proto3" json:"grant,omitempty"`
 	// SharedObjectId is the ID of the shared object the invitee was enrolled in.
 	SharedObjectId string `protobuf:"bytes,2,opt,name=shared_object_id,json=sharedObjectId,proto3" json:"sharedObjectId,omitempty"`
+	// OwnerGrant is the owner's existing root grant. The invitee preserves it so
+	// the owner can read later state written by the joined copy.
+	OwnerGrant *sobject.SOGrant `protobuf:"bytes,3,opt,name=owner_grant,json=ownerGrant,proto3" json:"ownerGrant,omitempty"`
 }
 
 func (x *AcceptInviteResponse) Reset() {
@@ -73,6 +76,13 @@ func (x *AcceptInviteResponse) GetSharedObjectId() string {
 		return x.SharedObjectId
 	}
 	return ""
+}
+
+func (x *AcceptInviteResponse) GetOwnerGrant() *sobject.SOGrant {
+	if x != nil {
+		return x.OwnerGrant
+	}
+	return nil
 }
 
 func (m *AcceptInviteRequest) CloneVT() *AcceptInviteRequest {
@@ -99,6 +109,7 @@ func (m *AcceptInviteResponse) CloneVT() *AcceptInviteResponse {
 	r := new(AcceptInviteResponse)
 	r.SharedObjectId = m.SharedObjectId
 	r.Grant = protobuf_go_lite.CloneVTValue(m.Grant)
+	r.OwnerGrant = protobuf_go_lite.CloneVTValue(m.OwnerGrant)
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = slices.Clone(m.unknownFields)
 	}
@@ -142,6 +153,9 @@ func (this *AcceptInviteResponse) EqualVT(that *AcceptInviteResponse) bool {
 		return false
 	}
 	if this.SharedObjectId != that.SharedObjectId {
+		return false
+	}
+	if !protobuf_go_lite.IsEqualVT(this.OwnerGrant, that.OwnerGrant) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -227,6 +241,11 @@ func (x *AcceptInviteResponse) MarshalProtoJSON(s *json.MarshalState) {
 		s.WriteObjectField("sharedObjectId")
 		s.WriteString(x.SharedObjectId)
 	}
+	if x.OwnerGrant != nil || s.HasField("ownerGrant") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("ownerGrant")
+		x.OwnerGrant.MarshalProtoJSON(s.WithField("ownerGrant"))
+	}
 	s.WriteObjectEnd()
 }
 
@@ -254,6 +273,13 @@ func (x *AcceptInviteResponse) UnmarshalProtoJSON(s *json.UnmarshalState) {
 		case "shared_object_id", "sharedObjectId":
 			s.AddField("shared_object_id")
 			x.SharedObjectId = s.ReadString()
+		case "owner_grant", "ownerGrant":
+			if s.ReadNil() {
+				x.OwnerGrant = nil
+				return
+			}
+			x.OwnerGrant = &sobject.SOGrant{}
+			x.OwnerGrant.UnmarshalProtoJSON(s.WithField("owner_grant", true))
 		}
 	})
 }
@@ -339,6 +365,16 @@ func (m *AcceptInviteResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) 
 	if m.unknownFields != nil {
 		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
 	}
+	if m.OwnerGrant != nil {
+		size, err := m.OwnerGrant.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
+	}
 	if len(m.SharedObjectId) > 0 {
 		i = protobuf_go_lite.EncodeString(dAtA, i, m.SharedObjectId)
 		i--
@@ -383,6 +419,10 @@ func (m *AcceptInviteResponse) SizeVT() (n int) {
 		n += protobuf_go_lite.SizeMessage(1, l)
 	}
 	n += protobuf_go_lite.SizeStringNonEmpty(1, m.SharedObjectId)
+	if m.OwnerGrant != nil {
+		l = m.OwnerGrant.SizeVT()
+		n += protobuf_go_lite.SizeMessage(1, l)
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -415,6 +455,10 @@ func (x *AcceptInviteResponse) MarshalProtoText() string {
 	if x.SharedObjectId != "" {
 		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "shared_object_id")
 		protobuf_go_lite.TextWriteString(&sb, x.SharedObjectId)
+	}
+	if x.OwnerGrant != nil {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "owner_grant")
+		protobuf_go_lite.TextWriteTextMarshaler(&sb, x.OwnerGrant)
 	}
 	return protobuf_go_lite.TextFinishMessage(&sb)
 }
@@ -534,6 +578,21 @@ func (m *AcceptInviteResponse) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			m.SharedObjectId = v
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field OwnerGrant", wireType)
+			}
+			msgStart, postIndex, err := protobuf_go_lite.DecodeLengthDelimited(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			if m.OwnerGrant == nil {
+				m.OwnerGrant = &sobject.SOGrant{}
+			}
+			if err := m.OwnerGrant.UnmarshalVT(dAtA[msgStart:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])

--- a/core/sobject/invite/invite.pb.ts
+++ b/core/sobject/invite/invite.pb.ts
@@ -66,6 +66,13 @@ export interface AcceptInviteResponse {
    * @generated from field: string shared_object_id = 2;
    */
   sharedObjectId?: string
+  /**
+   * OwnerGrant is the owner's existing root grant. The invitee preserves it so
+   * the owner can read later state written by the joined copy.
+   *
+   * @generated from field: sobject.SOGrant owner_grant = 3;
+   */
+  ownerGrant?: SOGrant
 }
 
 export const AcceptInviteResponse: MessageType<AcceptInviteResponse> =
@@ -74,6 +81,7 @@ export const AcceptInviteResponse: MessageType<AcceptInviteResponse> =
     fields: [
       { no: 1, name: 'grant', kind: 'message', T: () => SOGrant },
       { no: 2, name: 'shared_object_id', kind: 'scalar', T: ScalarType.STRING },
+      { no: 3, name: 'owner_grant', kind: 'message', T: () => SOGrant },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,
   })

--- a/core/sobject/invite/invite.proto
+++ b/core/sobject/invite/invite.proto
@@ -26,4 +26,7 @@ message AcceptInviteResponse {
   .sobject.SOGrant grant = 1;
   // SharedObjectId is the ID of the shared object the invitee was enrolled in.
   string shared_object_id = 2;
+  // OwnerGrant is the owner's existing root grant. The invitee preserves it so
+  // the owner can read later state written by the joined copy.
+  .sobject.SOGrant owner_grant = 3;
 }

--- a/core/sobject/invite/server.go
+++ b/core/sobject/invite/server.go
@@ -142,6 +142,27 @@ func (s *Server) AcceptInvite(ctx context.Context, req *AcceptInviteRequest) (*A
 		return nil, errors.Wrap(err, "enroll participant")
 	}
 
+	// Preserve the owner's root grant on the joined copy. Without it, state
+	// written by the invitee can no longer be decoded by the originating owner.
+	ownerPeerID, err := peer.IDFromPrivateKey(result.OwnerPrivKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "derive owner peer ID")
+	}
+	ownerState, err := result.Host.GetHostState(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "read owner shared object state")
+	}
+	var ownerGrant *sobject.SOGrant
+	for _, candidate := range ownerState.GetRootGrants() {
+		if candidate.GetPeerId() == ownerPeerID.String() {
+			ownerGrant = candidate.CloneVT()
+			break
+		}
+	}
+	if ownerGrant == nil {
+		return nil, errors.New("owner root grant not found")
+	}
+
 	// Enrollment succeeded. Increment invite uses.
 	inviteMutator := result.InviteMutator
 	if inviteMutator == nil {
@@ -154,6 +175,7 @@ func (s *Server) AcceptInvite(ctx context.Context, req *AcceptInviteRequest) (*A
 	return &AcceptInviteResponse{
 		Grant:          grant,
 		SharedObjectId: result.SharedObjectID,
+		OwnerGrant:     ownerGrant,
 	}, nil
 }
 

--- a/sdk/world/engine/engine_test.go
+++ b/sdk/world/engine/engine_test.go
@@ -5,6 +5,7 @@ package sdk_world_engine_test
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 	"time"
 
@@ -956,21 +957,59 @@ func TestSDKEngine_ObjectState(t *testing.T) {
 	}
 }
 
-// TestSDKEngine_IterateObjects tests the object iterator.
-//
-// Note: the server-side IterateObjects RPC handler passes the RPC request
-// context to the hydra iterator. That context is canceled when the unary
-// RPC completes, so subsequent Next()/Seek() calls on the iterator may
-// encounter context.Canceled. This is a known server-side design limitation
-// where lazy iterator initialization uses a stale context.
+// TestSDKEngine_IterateObjects exercises the lazy iterator after the unary
+// IterateObjects request has returned. The iterator resource, not that request,
+// controls its lifetime.
 func TestSDKEngine_IterateObjects(t *testing.T) {
-	t.Skip("server-side IterateObjects passes RPC request context to hydra iterator; context is canceled after unary RPC response, causing subsequent Next()/Seek() to fail")
-}
+	ctx := context.Background()
+	engine, cleanup := setupSDKEngine(ctx, t)
+	defer cleanup()
 
-// TestSDKEngine_IteratorSeek tests the Seek method on the object iterator.
-// See TestSDKEngine_IterateObjects for the known server-side limitation.
-func TestSDKEngine_IteratorSeek(t *testing.T) {
-	t.Skip("server-side IterateObjects passes RPC request context to hydra iterator; context is canceled after unary RPC response, causing subsequent Next()/Seek() to fail")
+	writeTx, err := engine.NewTransaction(ctx, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"iterator/a", "iterator/b", "other/c"} {
+		if _, err := writeTx.CreateObject(ctx, key, nil); err != nil {
+			writeTx.Discard()
+			t.Fatal(err)
+		}
+	}
+	if err := writeTx.Commit(ctx); err != nil {
+		writeTx.Discard()
+		t.Fatal(err)
+	}
+	writeTx.Discard()
+
+	readTx, err := engine.NewTransaction(ctx, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer readTx.Discard()
+	iter := readTx.IterateObjects(ctx, "iterator/", false)
+	defer iter.Close()
+	var keys []string
+	for iter.Next() {
+		if !iter.Valid() {
+			break
+		}
+		keys = append(keys, iter.Key())
+	}
+	if err := iter.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(keys, []string{"iterator/a", "iterator/b"}) {
+		t.Fatalf("unexpected iterator keys %v", keys)
+	}
+
+	seek := readTx.IterateObjects(ctx, "iterator/", false)
+	defer seek.Close()
+	if err := seek.Seek("iterator/b"); err != nil {
+		t.Fatal(err)
+	}
+	if !seek.Valid() || seek.Key() != "iterator/b" {
+		t.Fatalf("seek returned valid=%v key=%q", seek.Valid(), seek.Key())
+	}
 }
 
 // TestSDKEngine_GraphQuadOperations tests graph quad set, lookup, and delete.


### PR DESCRIPTION
The daemon released its only local Session resource after each short CLI request. That stopped the session transport and invite service immediately after Device approval, so the Forge Device could exchange WebRTC signaling but could not complete the invite handshake.

Watch the configured session list for the daemon lifetime. Keep each local Session resource mounted until it is removed or the daemon exits. This uses the existing Session resource lifetime instead of adding another transport or readiness mechanism.