### PR TITLE
test(webrtc): join ingress disposer before assertion

### DIFF
--- a/net/transport/webrtc/signal_ingress_red_test.go
+++ b/net/transport/webrtc/signal_ingress_red_test.go
@@ -760,17 +760,20 @@ func TestCloseSignalIngressTakeVsDisposeExactlyOnce(t *testing.T) {
 
 		start := make(chan struct{})
 		taken := make(chan *session, 1)
+		closeDone := make(chan struct{})
 		go func() {
 			<-start
 			taken <- w.takeAdoptableSession("race-peer")
 		}()
 		go func() {
+			defer close(closeDone)
 			<-start
 			w.closeSignalIngress("race-peer", resolver)
 		}()
 		close(start)
 
 		got := <-taken
+		<-closeDone
 		if got != nil {
 			// The adopter won: the disposer observed an empty stash and left
 			// the connection open for the adopted negotiation.


### PR DESCRIPTION
The ingress take-versus-dispose regression waited only for the competing take goroutine. If disposal won the transport lock, the take could return `nil` while the disposer was paused between releasing that lock and closing the peer connection. The test then reported a false exactly-once failure.

This joins both contenders before inspecting the result. Product code already selects exactly one adopter or disposer under `w.bcast`, and `closeSignalIngress` returns only after disposal completes. Keeping disposal outside the transport lock preserves the existing callback and lock boundary.

The focused race test fails repeatedly against the parent and passes 100 times with this change. It also passes 1,000 times normally. The complete WebRTC package passes normally and under the race detector, and vet passes.