### PR TITLE
test(e2e): build Notes only for JavaScript

### DIFF
--- a/bldr.star
+++ b/bldr.star
@@ -571,7 +571,7 @@ BROWSER_RELEASE_MANIFESTS = [
 ]
 BROWSER_RELEASE_E2E_MANIFESTS = [
     "spacewave-launcher",
-    "spacewave-core", "spacewave-web", "spacewave-app", "spacewave-notes", "spacewave-sql", "spacewave-cli-plugin", "web",
+    "spacewave-core", "spacewave-web", "spacewave-app", "spacewave-sql", "spacewave-cli-plugin", "web",
     "spacewave-browser",
 ]
 DESKTOP_RELEASE_MANIFESTS = [
@@ -674,7 +674,7 @@ build("release-web-e2e",
 build("release-web-e2e-assets",
     manifests=[
         "spacewave-launcher",
-        "spacewave-core", "spacewave-web", "spacewave-app", "spacewave-notes", "spacewave-sql", "spacewave-cli-plugin", "web",
+        "spacewave-core", "spacewave-web", "spacewave-app", "spacewave-sql", "spacewave-cli-plugin", "web",
     ],
     targets=["browser"],
     manifestOverrides={

--- a/bldr/project/starlark/evaluate_test.go
+++ b/bldr/project/starlark/evaluate_test.go
@@ -534,7 +534,10 @@ func TestEvaluateRootDesktopReleaseBuildsJsEmbeds(t *testing.T) {
 	if e2eBrowserRelease == nil {
 		t.Fatal("build target 'release-web-e2e' not found")
 	}
-	for _, want := range []string{"spacewave-launcher", "spacewave-core", "spacewave-web", "spacewave-app", "spacewave-notes", "spacewave-cli-plugin", "web", "spacewave-browser"} {
+	if slices.Contains(e2eBrowserRelease.GetManifests(), "spacewave-notes") {
+		t.Fatalf("release-web-e2e should build Notes only through the js embed: %v", e2eBrowserRelease.GetManifests())
+	}
+	for _, want := range []string{"spacewave-launcher", "spacewave-core", "spacewave-web", "spacewave-app", "spacewave-cli-plugin", "web", "spacewave-browser"} {
 		if !slices.Contains(e2eBrowserRelease.GetManifests(), want) {
 			t.Fatalf("release-web-e2e manifests missing %s: %v", want, e2eBrowserRelease.GetManifests())
 		}
@@ -607,12 +610,12 @@ func TestEvaluateRootDesktopReleaseBuildsJsEmbeds(t *testing.T) {
 	if e2eAssetBuild == nil {
 		t.Fatal("build target 'release-web-e2e-assets' not found")
 	}
-	for _, want := range []string{"spacewave-launcher", "spacewave-core", "spacewave-web", "spacewave-app", "spacewave-notes", "spacewave-cli-plugin", "web"} {
+	for _, want := range []string{"spacewave-launcher", "spacewave-core", "spacewave-web", "spacewave-app", "spacewave-cli-plugin", "web"} {
 		if !slices.Contains(e2eAssetBuild.GetManifests(), want) {
 			t.Fatalf("release-web-e2e-assets manifests missing %s: %v", want, e2eAssetBuild.GetManifests())
 		}
 	}
-	for _, unexpected := range []string{"spacewave-browser", "spacewave-dist"} {
+	for _, unexpected := range []string{"spacewave-browser", "spacewave-dist", "spacewave-notes"} {
 		if slices.Contains(e2eAssetBuild.GetManifests(), unexpected) {
 			t.Fatalf("release-web-e2e-assets should not build %s: %v", unexpected, e2eAssetBuild.GetManifests())
 		}


### PR DESCRIPTION
The release E2E build published both JavaScript and WebAssembly Notes manifests while only the JavaScript plugin distribution was served. Runtime manifest selection could therefore choose the unavailable WebAssembly plugin and receive a 404.

Build Notes only through the explicit `spacewave-notes@js` embed. The broad browser manifest and asset builds no longer publish an unserved second platform. The release browser still receives Notes lazily through its embedded world.