### PR TITLE
fix(e2e): embed every selectable Notes platform

### DIFF
--- a/bldr.star
+++ b/bldr.star
@@ -610,12 +610,14 @@ BROWSER_RELEASE_LAZY_PLUGIN_FIXTURE_LOAD_PLUGINS = BROWSER_RELEASE_LOAD_PLUGINS 
     "spacewave-cli-plugin",
 ]
 
-# Browser e2e embeds the startup closure plus the spacewave-sql plugin so the
-# sql plugin cold-builds under the e2e release without a populated Release World.
+# Browser e2e embeds the startup closure, every Notes platform the browser can
+# select, and the spacewave-sql fixture without a populated Release World.
 def browser_e2e_embed_manifests(go_platform_id):
     return browser_release_embed_manifests(go_platform_id) + [
         {"manifestId": "spacewave-notes",
          "platformId": "js"},
+        {"manifestId": "spacewave-notes",
+         "platformId": "web/js/wasm"},
         {"manifestId": "spacewave-sql",
          "platformId": "js"},
     ]

--- a/bldr/project/starlark/evaluate_test.go
+++ b/bldr/project/starlark/evaluate_test.go
@@ -593,6 +593,7 @@ func TestEvaluateRootDesktopReleaseBuildsJsEmbeds(t *testing.T) {
 		e2eDistConf,
 		"web/js/wasm",
 		distEmbedManifestWant{manifestID: "spacewave-notes", platformID: "js"},
+		distEmbedManifestWant{manifestID: "spacewave-notes", platformID: "web/js/wasm"},
 		distEmbedManifestWant{manifestID: "spacewave-sql", platformID: "js"},
 	)
 
@@ -659,6 +660,7 @@ func TestEvaluateRootDesktopReleaseBuildsJsEmbeds(t *testing.T) {
 		e2eDistOnlyConf,
 		"web/js/wasm",
 		distEmbedManifestWant{manifestID: "spacewave-notes", platformID: "js"},
+		distEmbedManifestWant{manifestID: "spacewave-notes", platformID: "web/js/wasm"},
 		distEmbedManifestWant{manifestID: "spacewave-sql", platformID: "js"},
 	)
 
@@ -788,6 +790,7 @@ func TestEvaluateRootDesktopStatusProjectorPlatformBoundary(t *testing.T) {
 		tinygoE2EDistConf,
 		"web/js/wasm",
 		distEmbedManifestWant{manifestID: "spacewave-notes", platformID: "js"},
+		distEmbedManifestWant{manifestID: "spacewave-notes", platformID: "web/js/wasm"},
 		distEmbedManifestWant{manifestID: "spacewave-sql", platformID: "js"},
 	)
 
@@ -826,6 +829,7 @@ func TestEvaluateRootDesktopStatusProjectorPlatformBoundary(t *testing.T) {
 		goscriptE2EDistConf,
 		"js",
 		distEmbedManifestWant{manifestID: "spacewave-notes", platformID: "js"},
+		distEmbedManifestWant{manifestID: "spacewave-notes", platformID: "web/js/wasm"},
 		distEmbedManifestWant{manifestID: "spacewave-sql", platformID: "js"},
 	)
 
@@ -854,15 +858,17 @@ func assertDistEmbedPlatform(
 	wantPlatformID string,
 ) {
 	t.Helper()
+	var gotPlatformIDs []string
 	for _, embed := range conf.GetEmbedManifests() {
-		if embed.GetManifestId() == manifestID {
-			if got := embed.GetPlatformId(); got != wantPlatformID {
-				t.Fatalf("%s embeds %s platform: got %q, want %q", label, manifestID, got, wantPlatformID)
-			}
+		if embed.GetManifestId() != manifestID {
+			continue
+		}
+		gotPlatformIDs = append(gotPlatformIDs, embed.GetPlatformId())
+		if embed.GetPlatformId() == wantPlatformID {
 			return
 		}
 	}
-	t.Fatalf("%s embed manifests missing %s: %v", label, manifestID, conf.GetEmbedManifests())
+	t.Fatalf("%s embeds %s platforms %v, missing %q", label, manifestID, gotPlatformIDs, wantPlatformID)
 }
 
 type distEmbedManifestWant struct {


### PR DESCRIPTION
The release browser asks for both the JavaScript and WebAssembly Notes manifests. The static E2E distribution embedded only the JavaScript manifest, so a clean build could select the later WebAssembly result and then return 404 for its plugin module. BlogCoexistence timed out after that missing module.

Embed both exact Notes platform tuples in every release E2E distribution. Keep Notes out of the broad browser build lists, and continue loading it lazily. The distribution now contains every Notes platform the runtime can select.