### PR TITLE
feat(secret): add a provider credential kind

### DIFF
--- a/.protoc-manifest.json
+++ b/.protoc-manifest.json
@@ -3653,7 +3653,7 @@
       ]
     },
     "github.com/s4wave/spacewave/sdk/secret": {
-      "hash": "0017714fe83010bd9a944bf6213dd1623ed4f55e29ca02e9463a0c0d09c75777",
+      "hash": "363ea6b55aafdd8c0f794fb482e485b1b52e981575a6dfa5e04c34769e79e80f",
       "generatedFiles": [
         "sdk/secret/secret.pb.go",
         "sdk/secret/secret.pb.ts",

--- a/core/resource/space/secret_test.go
+++ b/core/resource/space/secret_test.go
@@ -40,11 +40,11 @@ func TestSpaceResourceCreateSecretCreatesGrantedSecret(t *testing.T) {
 	}
 
 	resp, err := resource.CreateSecret(ctx, &s4wave_space.CreateSecretRequest{
-		ObjectKey:          "secrets/matrix/access-token",
-		DisplayName:        "Matrix access token",
-		Kind:               s4wave_secret.SecretKindMatrixAccessToken,
-		ContentType:        s4wave_secret.MatrixAccessTokenContentType,
-		Value:              []byte("matrix-token"),
+		ObjectKey:          "secrets/provider/access-token",
+		DisplayName:        "Provider credential",
+		Kind:               s4wave_secret.SecretKindProviderCredential,
+		ContentType:        s4wave_secret.ProviderCredentialContentType,
+		Value:              []byte(`{"api_key":"opencode-go"}`),
 		ReaderPublicKeyPem: readerPubPEM,
 	})
 	if err != nil {
@@ -54,10 +54,10 @@ func TestSpaceResourceCreateSecretCreatesGrantedSecret(t *testing.T) {
 		t.Fatal("expected nested SharedObjectRef")
 	}
 
-	secretResource := s4wave_secret.NewSecretResource(tb.Logger, tb.Bus, tb.WorldState, "secrets/matrix/access-token")
+	secretResource := s4wave_secret.NewSecretResource(tb.Logger, tb.Bus, tb.WorldState, "secrets/provider/access-token")
 	begin, err := secretResource.BeginReadPayload(ctx, &s4wave_secret.BeginReadPayloadRequest{
 		ReaderPeerId: readerPeerID.String(),
-		ExpectedKind: s4wave_secret.SecretKindMatrixAccessToken,
+		ExpectedKind: s4wave_secret.SecretKindProviderCredential,
 	})
 	if err != nil {
 		t.Fatalf("BeginReadPayload: %v", err)
@@ -79,7 +79,7 @@ func TestSpaceResourceCreateSecretCreatesGrantedSecret(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadPayload: %v", err)
 	}
-	if got := string(read.GetPayload().GetValue()); got != "matrix-token" {
+	if got := string(read.GetPayload().GetValue()); got != `{"api_key":"opencode-go"}` {
 		t.Fatalf("payload mismatch: %q", got)
 	}
 }
@@ -98,31 +98,31 @@ func TestSpaceResourceReadSecretPayloadUsesMountedSessionGrant(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := resource.CreateSecret(ctx, &s4wave_space.CreateSecretRequest{
-		ObjectKey:          "secrets/matrix/session-token",
-		DisplayName:        "Matrix access token",
-		Kind:               s4wave_secret.SecretKindMatrixAccessToken,
-		ContentType:        s4wave_secret.MatrixAccessTokenContentType,
-		Value:              []byte("session-matrix-token"),
+		ObjectKey:          "secrets/provider/session-token",
+		DisplayName:        "Provider credential",
+		Kind:               s4wave_secret.SecretKindProviderCredential,
+		ContentType:        s4wave_secret.ProviderCredentialContentType,
+		Value:              []byte(`{"api_key":"session-token"}`),
 		ReaderPublicKeyPem: readerPubPEM,
 	}); err != nil {
 		t.Fatalf("CreateSecret: %v", err)
 	}
 
 	read, err := resource.ReadSecretPayload(ctx, &s4wave_space.ReadSecretPayloadRequest{
-		ObjectKey:    "secrets/matrix/session-token",
-		ExpectedKind: s4wave_secret.SecretKindMatrixAccessToken,
+		ObjectKey:    "secrets/provider/session-token",
+		ExpectedKind: s4wave_secret.SecretKindProviderCredential,
 	})
 	if err != nil {
 		t.Fatalf("ReadSecretPayload: %v", err)
 	}
-	if read.GetSecret().GetKind() != s4wave_secret.SecretKindMatrixAccessToken {
+	if read.GetSecret().GetKind() != s4wave_secret.SecretKindProviderCredential {
 		t.Fatalf("secret kind: got %q", read.GetSecret().GetKind())
 	}
-	if got := string(read.GetPayload().GetValue()); got != "session-matrix-token" {
+	if got := string(read.GetPayload().GetValue()); got != `{"api_key":"session-token"}` {
 		t.Fatalf("payload mismatch: %q", got)
 	}
 	if _, err := resource.ReadSecretPayload(ctx, &s4wave_space.ReadSecretPayloadRequest{
-		ObjectKey:    "secrets/matrix/session-token",
+		ObjectKey:    "secrets/provider/session-token",
 		ExpectedKind: "other",
 	}); !errors.Is(err, s4wave_secret.ErrSecretKindMismatch) {
 		t.Fatalf("expected kind mismatch, got %v", err)
@@ -138,8 +138,8 @@ func TestSpaceResourceReadSecretPayloadUsesMountedSessionGrant(t *testing.T) {
 	}
 	resource.sessionPeerID = otherPeerID.String()
 	if _, err := resource.ReadSecretPayload(ctx, &s4wave_space.ReadSecretPayloadRequest{
-		ObjectKey:    "secrets/matrix/session-token",
-		ExpectedKind: s4wave_secret.SecretKindMatrixAccessToken,
+		ObjectKey:    "secrets/provider/session-token",
+		ExpectedKind: s4wave_secret.SecretKindProviderCredential,
 	}); !errors.Is(err, s4wave_secret.ErrPayloadAccessDenied) {
 		t.Fatalf("expected payload access denied, got %v", err)
 	}

--- a/sdk/secret/secret.go
+++ b/sdk/secret/secret.go
@@ -26,16 +26,17 @@ const (
 	SecretTypeID = "spacewave/secret"
 	// SecretBodyType is the nested SharedObject body type for Secret payloads.
 	SecretBodyType = "secret"
-	// SecretKindMatrixAccessToken is the kind for Matrix access tokens.
-	SecretKindMatrixAccessToken = "matrix_access_token" // #nosec G101 -- this identifies a secret kind, not a credential value.
+	// SecretKindProviderCredential is the kind for provider credential blobs
+	// such as an auth.json document for an LLM provider.
+	SecretKindProviderCredential = "provider_credential" // #nosec G101 -- this identifies a secret kind, not a credential value.
+	// ProviderCredentialContentType is the content type for provider credential payloads.
+	ProviderCredentialContentType = "application/json"
 	// SecretKindSSHPrivateKey is the kind for SSH private-key credentials.
 	SecretKindSSHPrivateKey = "ssh_private_key" // #nosec G101 -- this identifies a secret kind, not a credential value.
 	// SecretKindSSHPassword is the kind for SSH password credentials.
 	SecretKindSSHPassword = "ssh_password" // #nosec G101 -- this identifies a secret kind, not a credential value.
 	// SecretKindSSHPassphrase is the kind for SSH private-key passphrases.
 	SecretKindSSHPassphrase = "ssh_passphrase" // #nosec G101 -- this identifies a secret kind, not a credential value.
-	// MatrixAccessTokenContentType is the content type for Matrix access tokens.
-	MatrixAccessTokenContentType = "text/plain; charset=utf-8" // #nosec G101 -- this is a MIME content type, not a credential value.
 	// SSHPrivateKeyContentType is the content type for SSH private-key payloads.
 	SSHPrivateKeyContentType = "application/x-pem-file"
 	// SSHTextCredentialContentType is the content type for text SSH credentials.
@@ -119,9 +120,9 @@ func NewSharedObjectMeta() *sobject.SharedObjectMeta {
 	}
 }
 
-// NewMatrixAccessTokenPayload constructs a Matrix access token payload.
-func NewMatrixAccessTokenPayload(token string, ts time.Time) *SecretPayload {
-	return newSecretPayload([]byte(token), MatrixAccessTokenContentType, ts)
+// NewProviderCredentialPayload constructs a provider credential payload.
+func NewProviderCredentialPayload(credential []byte, ts time.Time) *SecretPayload {
+	return newSecretPayload(credential, ProviderCredentialContentType, ts)
 }
 
 // NewSSHPrivateKeyPayload constructs an SSH private-key payload.
@@ -313,13 +314,16 @@ func ReadSecretPayloadFromSnapshot(ctx context.Context, snap sobject.SharedObjec
 	return payload, nil
 }
 
-// ReadMatrixAccessToken reads a Matrix access token Secret payload.
-func ReadMatrixAccessToken(ctx context.Context, b bus.Bus, secret *Secret) (string, error) {
+// ReadProviderCredentialPayload reads a provider credential Secret payload after checking its kind.
+func ReadProviderCredentialPayload(ctx context.Context, b bus.Bus, secret *Secret) ([]byte, error) {
+	if secret == nil || secret.GetKind() != SecretKindProviderCredential {
+		return nil, ErrSecretKindMismatch
+	}
 	payload, err := ReadSecretPayload(ctx, b, secret)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return string(payload.GetValue()), nil
+	return append([]byte(nil), payload.GetValue()...), nil
 }
 
 // ReadSSHCredentialPayload reads an SSH Secret payload after checking its kind.

--- a/sdk/secret/secret.pb.go
+++ b/sdk/secret/secret.pb.go
@@ -21,14 +21,12 @@ type Secret struct {
 	unknownFields []byte
 	// DisplayName is the user-visible secret label.
 	DisplayName string `protobuf:"bytes,1,opt,name=display_name,json=displayName,proto3" json:"displayName,omitempty"`
-	// Kind identifies the secret use, such as matrix_access_token.
+	// Kind identifies the secret use, such as provider_credential or ssh_private_key.
 	Kind string `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
 	// NestedSharedObjectId is the SharedObject id that stores the payload.
 	NestedSharedObjectId string `protobuf:"bytes,3,opt,name=nested_shared_object_id,json=nestedSharedObjectId,proto3" json:"nestedSharedObjectId,omitempty"`
 	// Ref points at the nested SharedObject security domain.
 	Ref *sobject.SharedObjectRef `protobuf:"bytes,4,opt,name=ref,proto3" json:"ref,omitempty"`
-	// ValueHash is an optional redacted integrity hint.
-	ValueHash string `protobuf:"bytes,5,opt,name=value_hash,json=valueHash,proto3" json:"valueHash,omitempty"`
 	// CreatedAt is when the Secret object was created.
 	CreatedAt *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=created_at,json=createdAt,proto3" json:"createdAt,omitempty"`
 	// UpdatedAt is when the Secret metadata was last updated.
@@ -67,13 +65,6 @@ func (x *Secret) GetRef() *sobject.SharedObjectRef {
 		return x.Ref
 	}
 	return nil
-}
-
-func (x *Secret) GetValueHash() string {
-	if x != nil {
-		return x.ValueHash
-	}
-	return ""
 }
 
 func (x *Secret) GetCreatedAt() *timestamppb.Timestamp {
@@ -478,7 +469,6 @@ func (m *Secret) CloneVT() *Secret {
 	r.DisplayName = m.DisplayName
 	r.Kind = m.Kind
 	r.NestedSharedObjectId = m.NestedSharedObjectId
-	r.ValueHash = m.ValueHash
 	r.Ref = protobuf_go_lite.CloneVTValue(m.Ref)
 	r.CreatedAt = protobuf_go_lite.CloneVTValue(m.CreatedAt)
 	r.UpdatedAt = protobuf_go_lite.CloneVTValue(m.UpdatedAt)
@@ -688,9 +678,6 @@ func (this *Secret) EqualVT(that *Secret) bool {
 		return false
 	}
 	if !protobuf_go_lite.IsEqualVT(this.Ref, that.Ref) {
-		return false
-	}
-	if this.ValueHash != that.ValueHash {
 		return false
 	}
 	if !protobuf_go_lite.IsEqualVT(this.CreatedAt, that.CreatedAt) {
@@ -998,11 +985,6 @@ func (x *Secret) MarshalProtoJSON(s *json.MarshalState) {
 		s.WriteObjectField("ref")
 		x.Ref.MarshalProtoJSON(s.WithField("ref"))
 	}
-	if x.ValueHash != "" || s.HasField("valueHash") {
-		s.WriteMoreIf(&wroteField)
-		s.WriteObjectField("valueHash")
-		s.WriteString(x.ValueHash)
-	}
 	if x.CreatedAt != nil || s.HasField("createdAt") {
 		s.WriteMoreIf(&wroteField)
 		s.WriteObjectField("createdAt")
@@ -1046,9 +1028,6 @@ func (x *Secret) UnmarshalProtoJSON(s *json.UnmarshalState) {
 			}
 			x.Ref = &sobject.SharedObjectRef{}
 			x.Ref.UnmarshalProtoJSON(s.WithField("ref", true))
-		case "value_hash", "valueHash":
-			s.AddField("value_hash")
-			x.ValueHash = s.ReadString()
 		case "created_at", "createdAt":
 			if s.ReadNil() {
 				x.CreatedAt = nil
@@ -1737,11 +1716,6 @@ func (m *Secret) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i--
 		dAtA[i] = 0x32
 	}
-	if len(m.ValueHash) > 0 {
-		i = protobuf_go_lite.EncodeString(dAtA, i, m.ValueHash)
-		i--
-		dAtA[i] = 0x2a
-	}
 	if m.Ref != nil {
 		size, err := m.Ref.MarshalToSizedBufferVT(dAtA[:i])
 		if err != nil {
@@ -2303,7 +2277,6 @@ func (m *Secret) SizeVT() (n int) {
 		l = m.Ref.SizeVT()
 		n += protobuf_go_lite.SizeMessage(1, l)
 	}
-	n += protobuf_go_lite.SizeStringNonEmpty(1, m.ValueHash)
 	if m.CreatedAt != nil {
 		l = m.CreatedAt.SizeVT()
 		n += protobuf_go_lite.SizeMessage(1, l)
@@ -2494,10 +2467,6 @@ func (x *Secret) MarshalProtoText() string {
 	if x.Ref != nil {
 		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "ref")
 		protobuf_go_lite.TextWriteTextMarshaler(&sb, x.Ref)
-	}
-	if x.ValueHash != "" {
-		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "value_hash")
-		protobuf_go_lite.TextWriteString(&sb, x.ValueHash)
 	}
 	if x.CreatedAt != nil {
 		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "created_at")
@@ -2799,16 +2768,6 @@ func (m *Secret) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 5:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ValueHash", wireType)
-			}
-			var v string
-			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
-			if err != nil {
-				return err
-			}
-			m.ValueHash = v
 		case 6:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field CreatedAt", wireType)

--- a/sdk/secret/secret.pb.ts
+++ b/sdk/secret/secret.pb.ts
@@ -33,7 +33,7 @@ export interface Secret {
    */
   displayName?: string
   /**
-   * Kind identifies the secret use, such as matrix_access_token.
+   * Kind identifies the secret use, such as provider_credential or ssh_private_key.
    *
    * @generated from field: string kind = 2;
    */
@@ -50,12 +50,6 @@ export interface Secret {
    * @generated from field: sobject.SharedObjectRef ref = 4;
    */
   ref?: SharedObjectRef
-  /**
-   * ValueHash is an optional redacted integrity hint.
-   *
-   * @generated from field: string value_hash = 5;
-   */
-  valueHash?: string
   /**
    * CreatedAt is when the Secret object was created.
    *
@@ -82,7 +76,6 @@ export const Secret: MessageType<Secret> = /* @__PURE__ */ createMessageType({
       T: ScalarType.STRING,
     },
     { no: 4, name: 'ref', kind: 'message', T: () => SharedObjectRef },
-    { no: 5, name: 'value_hash', kind: 'scalar', T: ScalarType.STRING },
     { no: 6, name: 'created_at', kind: 'message', T: () => Timestamp },
     { no: 7, name: 'updated_at', kind: 'message', T: () => Timestamp },
   ] satisfies readonly PartialFieldInfo[],

--- a/sdk/secret/secret.proto
+++ b/sdk/secret/secret.proto
@@ -17,14 +17,14 @@ service SecretResourceService {
 message Secret {
   // DisplayName is the user-visible secret label.
   string display_name = 1;
-  // Kind identifies the secret use, such as matrix_access_token.
+  // Kind identifies the secret use, such as provider_credential or ssh_private_key.
   string kind = 2;
   // NestedSharedObjectId is the SharedObject id that stores the payload.
   string nested_shared_object_id = 3;
   // Ref points at the nested SharedObject security domain.
   .sobject.SharedObjectRef ref = 4;
-  // ValueHash is an optional redacted integrity hint.
-  string value_hash = 5;
+  // Reserved 5 for a removed optional value_hash integrity hint.
+  reserved 5;
   // CreatedAt is when the Secret object was created.
   .google.protobuf.Timestamp created_at = 6;
   // UpdatedAt is when the Secret metadata was last updated.

--- a/sdk/secret/secret_test.go
+++ b/sdk/secret/secret_test.go
@@ -27,12 +27,12 @@ func TestCreateSecretStoresPayloadOnlyInNestedSharedObject(t *testing.T) {
 	tb, soProvider, release := setupSecretTest(ctx, t)
 	defer release()
 
-	token := "matrix-token-secret-value"
+	token := "provider-credential-secret-value"
 	secret, err := s4wave_secret.CreateSecret(ctx, tb.Bus, soProvider, tb.BusEngine, s4wave_secret.CreateSecretOptions{
-		ObjectKey:   "secrets/matrix",
-		DisplayName: "Matrix token",
-		Kind:        s4wave_secret.SecretKindMatrixAccessToken,
-		ContentType: s4wave_secret.MatrixAccessTokenContentType,
+		ObjectKey:   "secrets/provider/opencode-go",
+		DisplayName: "OpenCode Go credential",
+		Kind:        s4wave_secret.SecretKindProviderCredential,
+		ContentType: s4wave_secret.ProviderCredentialContentType,
 		Value:       []byte(token),
 		Timestamp:   time.Unix(100, 0),
 	})
@@ -46,11 +46,11 @@ func TestCreateSecretStoresPayloadOnlyInNestedSharedObject(t *testing.T) {
 		t.Fatal("expected nested SharedObject id")
 	}
 
-	if err := world_types.CheckObjectType(ctx, tb.WorldState, "secrets/matrix", s4wave_secret.SecretTypeID); err != nil {
+	if err := world_types.CheckObjectType(ctx, tb.WorldState, "secrets/provider/opencode-go", s4wave_secret.SecretTypeID); err != nil {
 		t.Fatalf("CheckObjectType: %v", err)
 	}
 
-	parent := readParentSecret(ctx, t, tb.WorldState, "secrets/matrix")
+	parent := readParentSecret(ctx, t, tb.WorldState, "secrets/provider/opencode-go")
 	parentData, err := parent.MarshalVT()
 	if err != nil {
 		t.Fatalf("marshal parent: %v", err)
@@ -66,12 +66,12 @@ func TestCreateSecretStoresPayloadOnlyInNestedSharedObject(t *testing.T) {
 	if got := string(payload.GetValue()); got != token {
 		t.Fatalf("payload value mismatch: %q", got)
 	}
-	readToken, err := s4wave_secret.ReadMatrixAccessToken(ctx, tb.Bus, secret)
+	readCredential, err := s4wave_secret.ReadProviderCredentialPayload(ctx, tb.Bus, secret)
 	if err != nil {
-		t.Fatalf("ReadMatrixAccessToken: %v", err)
+		t.Fatalf("ReadProviderCredentialPayload: %v", err)
 	}
-	if readToken != token {
-		t.Fatalf("matrix token mismatch: %q", readToken)
+	if string(readCredential) != token {
+		t.Fatalf("provider credential mismatch: %q", readCredential)
 	}
 }
 

--- a/sdk/sshhost/release_regression_test.go
+++ b/sdk/sshhost/release_regression_test.go
@@ -45,7 +45,7 @@ func TestValidateSshHostCredentialSecretsReleasesLookedUpStates(t *testing.T) {
 	defer tb.Release()
 
 	createSecretParent(ctx, t, tb.WorldState, "secrets/ssh/key", s4wave_secret.SecretKindSSHPrivateKey)
-	createSecretParent(ctx, t, tb.WorldState, "secrets/ssh/wrong", s4wave_secret.SecretKindMatrixAccessToken)
+	createSecretParent(ctx, t, tb.WorldState, "secrets/ssh/wrong", s4wave_secret.SecretKindProviderCredential)
 
 	var released int
 	ws := &countingWorldState{WorldState: tb.WorldState, released: &released}

--- a/sdk/sshhost/secret_refs_test.go
+++ b/sdk/sshhost/secret_refs_test.go
@@ -26,7 +26,7 @@ func TestValidateSshHostCredentialSecretsChecksSecretKinds(t *testing.T) {
 	createSecretParent(ctx, t, tb.WorldState, "secrets/ssh/key", s4wave_secret.SecretKindSSHPrivateKey)
 	createSecretParent(ctx, t, tb.WorldState, "secrets/ssh/password", s4wave_secret.SecretKindSSHPassword)
 	createSecretParent(ctx, t, tb.WorldState, "secrets/ssh/passphrase", s4wave_secret.SecretKindSSHPassphrase)
-	createSecretParent(ctx, t, tb.WorldState, "secrets/ssh/wrong", s4wave_secret.SecretKindMatrixAccessToken)
+	createSecretParent(ctx, t, tb.WorldState, "secrets/ssh/wrong", s4wave_secret.SecretKindProviderCredential)
 
 	refs := &SshHostCredentialRefs{
 		PrivateKeySecretObjectKey: "secrets/ssh/key",


### PR DESCRIPTION
## Summary

GLaDOS will source LLM provider credentials from a Secret in the World instead of a RuntimeHome auth.json file. This gives the Secret feature the payload shape that needs: a provider_credential kind carrying a JSON credential document, with a typed read helper that rejects kind mismatches the way the SSH readers do.

Remove the matrix_access_token kind and its reader. It has no consumer in the tree and the feature has no production data to migrate. Remove the never-read value_hash field from the Secret parent proto and reserve its field number; redaction is enforced by keeping SecretPayload inside the encrypted SharedObject state, not by hashing into the parent.

The SecretViewer, SSH host credential references, and the space migration handler keep their behavior; tests now exercise the provider credential kind.

## Test plan

- go test ./sdk/secret/ ./sdk/sshhost/ ./core/resource/space/ ./sdk/terminal/
- bun run gen (regenerated Go, TS, and manifest output reviewed)
- bun run lint
