### PR TITLE
fix(secret): grant reader before storing payload

### DIFF
--- a/core/resource/space/secret.go
+++ b/core/resource/space/secret.go
@@ -71,27 +71,16 @@ func (r *SpaceResource) CreateSecret(
 		return nil, err
 	}
 	secret, err := s4wave_secret.CreateSecret(ctx, r.b, soProvider, r.space.GetWorldEngine(), s4wave_secret.CreateSecretOptions{
-		ObjectKey:   req.GetObjectKey(),
-		DisplayName: req.GetDisplayName(),
-		Kind:        req.GetKind(),
-		ContentType: req.GetContentType(),
-		Value:       req.GetValue(),
+		ObjectKey:       req.GetObjectKey(),
+		DisplayName:     req.GetDisplayName(),
+		Kind:            req.GetKind(),
+		ContentType:     req.GetContentType(),
+		Value:           req.GetValue(),
+		ReaderPeerID:    readerPeerID,
+		ReaderPublicKey: readerPub,
 	})
 	if err != nil {
 		return nil, err
-	}
-	if readerPeerID != "" {
-		if _, err := s4wave_secret.AddSecretParticipant(
-			ctx,
-			r.b,
-			secret,
-			readerPeerID,
-			readerPub,
-			sobject.SOParticipantRole_SOParticipantRole_READER,
-			"",
-		); err != nil {
-			return nil, errors.Wrap(err, "grant reader")
-		}
 	}
 	return &s4wave_space.CreateSecretResponse{Secret: secret}, nil
 }

--- a/sdk/secret/secret.go
+++ b/sdk/secret/secret.go
@@ -71,6 +71,10 @@ type CreateSecretOptions struct {
 	Timestamp time.Time
 	// NestedSharedObjectId optionally fixes the nested SharedObject id.
 	NestedSharedObjectId string
+	// ReaderPeerID identifies the peer granted payload access before storage.
+	ReaderPeerID string
+	// ReaderPublicKey verifies the reader grant.
+	ReaderPublicKey crypto.PubKey
 }
 
 type secretPayloadStoreOperation struct {
@@ -209,6 +213,25 @@ func CreateSecret(
 	if err != nil {
 		return nil, errors.Wrap(err, "create nested shared object")
 	}
+	secret := &Secret{
+		DisplayName:          opts.DisplayName,
+		Kind:                 opts.Kind,
+		NestedSharedObjectId: nestedRef.GetProviderResourceRef().GetId(),
+		Ref:                  nestedRef.CloneVT(),
+		CreatedAt:            timestamppb.New(opts.Timestamp),
+		UpdatedAt:            timestamppb.New(opts.Timestamp),
+	}
+	if opts.ReaderPeerID != "" {
+		if opts.ReaderPublicKey == nil {
+			return nil, errors.New("reader public key is missing")
+		}
+		if _, err := AddSecretParticipant(
+			ctx, b, secret, opts.ReaderPeerID, opts.ReaderPublicKey,
+			sobject.SOParticipantRole_SOParticipantRole_READER, "",
+		); err != nil {
+			return nil, errors.Wrap(err, "grant reader")
+		}
+	}
 	payload := &SecretPayload{
 		Value:       append([]byte(nil), opts.Value...),
 		ContentType: opts.ContentType,
@@ -217,15 +240,6 @@ func CreateSecret(
 	}
 	if err := StoreSecretPayload(ctx, b, nestedRef, payload); err != nil {
 		return nil, errors.Wrap(err, "store secret payload")
-	}
-
-	secret := &Secret{
-		DisplayName:          opts.DisplayName,
-		Kind:                 opts.Kind,
-		NestedSharedObjectId: nestedRef.GetProviderResourceRef().GetId(),
-		Ref:                  nestedRef.CloneVT(),
-		CreatedAt:            timestamppb.New(opts.Timestamp),
-		UpdatedAt:            timestamppb.New(opts.Timestamp),
 	}
 
 	wtx, err := engine.NewTransaction(ctx, true)

--- a/sdk/secret/secret_test.go
+++ b/sdk/secret/secret_test.go
@@ -75,6 +75,55 @@ func TestCreateSecretStoresPayloadOnlyInNestedSharedObject(t *testing.T) {
 	}
 }
 
+func TestCreateSecretGrantsReaderBeforePayloadStoreCompletes(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	tb, soProvider, release := setupSecretTest(ctx, t)
+	defer release()
+
+	readerPriv, readerPub, readerPeerID := makePeer(t)
+	secret, err := s4wave_secret.CreateSecret(ctx, tb.Bus, soProvider, tb.BusEngine, s4wave_secret.CreateSecretOptions{
+		ObjectKey:       "secrets/preauthorized-reader",
+		Kind:            "api_key",
+		Value:           []byte("reader-authorized-payload"),
+		Timestamp:       time.Unix(125, 0),
+		ReaderPeerID:    readerPeerID.String(),
+		ReaderPublicKey: readerPub,
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	so, soRef, err := sobject.ExMountSharedObject(ctx, tb.Bus, secret.GetRef(), false, nil)
+	if err != nil {
+		t.Fatalf("mount nested shared object: %v", err)
+	}
+	defer soRef.Release()
+	inviteHost, ok := so.(sobject.InviteHost)
+	if !ok {
+		t.Fatal("nested shared object does not expose its grants")
+	}
+	state, err := inviteHost.GetSOHost().GetHostState(ctx)
+	if err != nil {
+		t.Fatalf("GetHostState: %v", err)
+	}
+	readerSnapshot := sobject.NewSOStateParticipantHandle(
+		tb.Logger,
+		tb.StepFactorySet,
+		so.GetSharedObjectID(),
+		state,
+		readerPriv,
+		readerPeerID,
+	)
+	payload, err := s4wave_secret.ReadSecretPayloadFromSnapshot(ctx, readerSnapshot)
+	if err != nil {
+		t.Fatalf("reader payload: %v", err)
+	}
+	if got := string(payload.GetValue()); got != "reader-authorized-payload" {
+		t.Fatalf("payload = %q", got)
+	}
+}
+
 func TestSSHSecretContractStoresCredentialPayloadOnlyInNestedSharedObject(t *testing.T) {
 	ctx := t.Context()
 	tb, soProvider, release := setupSecretTest(ctx, t)


### PR DESCRIPTION
CreateSecret waited for payload storage to become readable before its caller installed the requested reader grant. A mounted session that was not the genesis peer could therefore wait forever, and the parent World object never committed.

This change passes reader authority into secret creation and installs the SharedObject reader grant before queueing the payload. Payload access remains limited to granted peers. A local-provider regression test covers creation, grant visibility, payload storage completion, and reader decryption.