### PR TITLE
fix(web): recover signed-out browser boot

### DIFF
--- a/bldr/web/entrypoint/browser/bundle/boot_reset_fixture_test.go
+++ b/bldr/web/entrypoint/browser/bundle/boot_reset_fixture_test.go
@@ -18,6 +18,10 @@ func TestStableBootGateRunsOnceBeforeEntrypointImport(t *testing.T) {
 	runStableBootFixture(t, stableBootImportOrderFixtureScript)
 }
 
+func TestStableBootRecoversSignedOutSession(t *testing.T) {
+	runStableBootFixture(t, stableBootSignedOutRecoveryFixtureScript)
+}
+
 func TestStableBootEntrypointStreamProgress(t *testing.T) {
 	runStableBootFixture(t, stableBootEntrypointStreamProgressFixtureScript)
 }
@@ -207,6 +211,128 @@ assert(!indexedDBDeleteCalled, 'boot must not delete IndexedDB')
 assert(!opfsDirectoryRequested, 'boot must not request OPFS root')
 
 console.log('boot-reset-fixture=passed')
+`
+
+const stableBootSignedOutRecoveryFixtureScript = `
+const bootPath = process.argv[2]
+if (!bootPath) throw new Error('missing boot asset path')
+const script = await Bun.file(bootPath).text()
+
+class StorageFixture {
+  constructor(entries) { this.map = new Map(Object.entries(entries)) }
+  get length() { return this.map.size }
+  getItem(key) { return this.map.has(key) ? this.map.get(key) : null }
+  setItem(key, value) { this.map.set(key, String(value)) }
+  removeItem(key) { this.map.delete(key) }
+  key(index) { return Array.from(this.map.keys())[index] ?? null }
+}
+
+async function runScenario(gatedPath) {
+  const localStorage = new StorageFixture({
+    'spacewave-browser-app-state-version': '1000000',
+    'presentation-preference': 'compact',
+    'selected-map': 'moon',
+    'map-draft-session': '{"moves":[1,2]}',
+  })
+  const sessionStorage = new StorageFixture({
+    'spacewave-browser-tab-state-version': '1000000',
+  })
+  const events = []
+  let redirectedTo
+  let redirectResolve
+  const redirectPromise = new Promise((resolve) => { redirectResolve = resolve })
+  const opfsEntries = new Map([['runtime-cache', {}], ['session-shell', {}]])
+
+  globalThis.localStorage = localStorage
+  globalThis.sessionStorage = sessionStorage
+  globalThis.CustomEvent = class CustomEvent {
+    constructor(type, init) { this.type = type; this.detail = init?.detail }
+  }
+  globalThis.performance = { mark() {} }
+  globalThis.window = {
+    location: {
+      href: 'https://spacewave.test/',
+      origin: 'https://spacewave.test',
+      hash: '',
+      replace(path) {
+        events.push('redirect')
+        redirectedTo = path
+        redirectResolve()
+      },
+    },
+    history: { state: null, replaceState() {} },
+    dispatchEvent() {},
+    addEventListener() {},
+    removeEventListener() {},
+    setTimeout,
+    clearTimeout,
+  }
+  globalThis.document = {
+    readyState: 'complete',
+    documentElement: { setAttribute() {} },
+    querySelector() { return null },
+    getElementById() { return null },
+    addEventListener() {},
+    removeEventListener() {},
+  }
+  globalThis.navigator = {
+    serviceWorker: {
+      async getRegistrations() {
+        return [{ async unregister() { events.push('unregister') } }]
+      },
+    },
+    storage: {
+      async getDirectory() {
+        return {
+          async *entries() { for (const entry of opfsEntries) yield entry },
+          async removeEntry(name, options) {
+            if (!options?.recursive) throw new Error('OPFS cleanup must be recursive')
+            opfsEntries.delete(name)
+            events.push('opfs:' + name)
+          },
+        }
+      },
+    },
+  }
+  globalThis.caches = {
+    async keys() { return ['shell-cache'] },
+    async delete(name) { events.push('cache:' + name); return true },
+  }
+  globalThis.fetch = async (path) => {
+    if (gatedPath === 'release' || path === '/entrypoint.mjs') {
+      return new Response(JSON.stringify({
+        error: { code: 'login_required', message: 'Login is required.' },
+      }), { status: 401, headers: { 'content-type': 'application/json' } })
+    }
+    return new Response(JSON.stringify({
+      generationId: 'fixture',
+      autoStart: true,
+      shellAssets: { entrypoint: '/entrypoint.mjs', serviceWorker: '/sw.mjs' },
+    }), { status: 200, headers: { 'content-type': 'application/json' } })
+  }
+
+  new Function(script)()
+  await Promise.race([
+    redirectPromise,
+    new Promise((_, reject) => setTimeout(() => reject(new Error('timeout waiting for login redirect')), 2000)),
+  ])
+
+  function assert(condition, message) {
+    if (!condition) throw new Error(gatedPath + ': ' + message)
+  }
+  assert(redirectedTo === '/login', 'boot did not use the origin-relative login path')
+  assert(events.includes('unregister'), 'boot did not unregister its service worker')
+  assert(events.includes('cache:shell-cache'), 'boot did not clear Cache Storage')
+  assert(opfsEntries.size === 0, 'boot did not clear shell OPFS state')
+  assert(events.at(-1) === 'redirect', 'boot redirected before cleanup settled')
+  assert(localStorage.getItem('presentation-preference') === 'compact', 'boot removed presentation preference')
+  assert(localStorage.getItem('selected-map') === 'moon', 'boot removed selected map')
+  assert(localStorage.getItem('map-draft-session') === '{"moves":[1,2]}', 'boot removed map draft')
+}
+
+await runScenario('release')
+await runScenario('entrypoint')
+console.log('boot-signed-out-recovery-fixture=passed')
 `
 
 const stableBootImportOrderFixtureScript = `

--- a/bldr/web/entrypoint/browser/bundle/bundle.go
+++ b/bldr/web/entrypoint/browser/bundle/bundle.go
@@ -347,6 +347,30 @@ async function clearCachesForBootReset(){
   const cacheNames=await g.caches.keys();
   await Promise.all(cacheNames.map(function(cacheName){return g.caches.delete(cacheName)}));
 }
+async function clearOpfsForSignedOutRecovery(){
+  if(!navigator.storage||typeof navigator.storage.getDirectory!=='function')return;
+  const root=await navigator.storage.getDirectory();
+  const names=[];
+  for await(const entry of root.entries())names.push(entry[0]);
+  await Promise.all(names.map(function(name){return root.removeEntry(name,{recursive:true})}));
+}
+async function isLoginRequiredResponse(response){
+  if(response.status!==401)return false;
+  try{
+    const body=await response.clone().json();
+    return body&&body.error&&body.error.code==='login_required';
+  }catch(_){return false}
+}
+async function recoverSignedOutSession(response){
+  if(!await isLoginRequiredResponse(response))return false;
+  await Promise.allSettled([
+    unregisterServiceWorkersForBootReset(),
+    clearCachesForBootReset(),
+    clearOpfsForSignedOutRecovery()
+  ]);
+  window.location.replace('/login');
+  return true;
+}
 function clearBootResetReloadParam(){
   try{
     if(!window.history||typeof window.history.replaceState!=='function')return;
@@ -546,6 +570,7 @@ function loadRelease(){
   if(releasePromise)return releasePromise;
   setBootStatus('manifest','Loading browser release...');
   releasePromise=fetch(releasePath,{cache:'no-cache'}).then(async function(resp){
+    if(await recoverSignedOutSession(resp))return new Promise(function(){});
     if(!resp.ok)throw new Error('failed to load browser release manifest: '+resp.status);
     const release=await resp.json();
     const shellAssets=release.shellAssets||{};
@@ -577,6 +602,7 @@ function primeRelease(){
 let entrypointStreamPromise;
 async function streamEntrypointModule(release){
   const response=await fetch(release.entrypoint,{credentials:'same-origin'});
+  if(await recoverSignedOutSession(response))return new Promise(function(){});
   if(!response.ok)throw new Error('failed to load entrypoint bundle: '+response.status);
   const total=release.entrypointDecompressedSize||parsePositiveByteLength(response.headers&&response.headers.get?response.headers.get('content-length'):undefined);
   // The app shell bundle download is part of the connect phase (entrypoint),


### PR DESCRIPTION
A cached browser shell can outlive its authenticated session. When the release manifest or application entrypoint is protected, the boot bundle currently leaves the loading screen active after the server returns `401 login_required`.

Treat that response as a terminal signed-out state. The browser boot now unregisters its service workers, clears Cache Storage and OPFS runtime state, preserves localStorage, and replaces the current location with `/login`. Other HTTP failures keep the existing visible boot error.

The executable boot fixture covers both protected fetches and verifies that cleanup settles before navigation without removing embedder data.