### PR TITLE
fix(coord): preserve key prefix in inmem watch replay

### DIFF
--- a/db/coord/inmem/state.go
+++ b/db/coord/inmem/state.go
@@ -22,8 +22,12 @@ func newScopeKey(scope coord.Scope) scopeKey {
 type scopeState struct {
 	generation uint64
 	root       *bucket.ObjectRef
-	locked     bool
-	watchers   map[uint64]*watch
+	// lastKeyPrefix is the key prefix invalidated by the most recent publish
+	// that carried one. Replayed events carry it so a watcher that missed the
+	// live publish still observes the outstanding invalidation.
+	lastKeyPrefix []byte
+	locked        bool
+	watchers      map[uint64]*watch
 }
 
 func newScopeState() *scopeState {
@@ -43,10 +47,11 @@ func (s *scopeState) snapshot(scope coord.Scope) *coord.Snapshot {
 
 func (s *scopeState) snapshotEvent(scope coord.Scope) coord.Event {
 	return coord.Event{
-		VolumeID:      scope.VolumeID,
-		ObjectStoreID: scope.ObjectStoreID,
-		Generation:    s.generation,
-		RootChanged:   s.root.Clone(),
+		VolumeID:         scope.VolumeID,
+		ObjectStoreID:    scope.ObjectStoreID,
+		Generation:       s.generation,
+		RootChanged:      s.root.Clone(),
+		KeyPrefixChanged: append([]byte(nil), s.lastKeyPrefix...),
 	}
 }
 
@@ -54,6 +59,7 @@ func (s *scopeState) publishLocked(event coord.Event) {
 	event.RootChanged = event.RootChanged.Clone()
 	if event.KeyPrefixChanged != nil {
 		event.KeyPrefixChanged = append([]byte(nil), event.KeyPrefixChanged...)
+		s.lastKeyPrefix = append([]byte(nil), event.KeyPrefixChanged...)
 	}
 	for _, watch := range s.watchers {
 		watch.sendLocked(event)


### PR DESCRIPTION
Spacewave master's `CI (db / tests)` job failed intermittently with:

    conformance.go:56: live event prefix = "", want world-head/

Root cause: the RPC proxy volume registers the server-side coordinator
watcher asynchronously. A publish can land between the moment the client's
`Watch` call returns and the moment the inner in-memory watcher is actually
registered. When that happens, the watcher receives the in-memory replay
event instead of the live publish event. The replay carried only the
generation and root, dropping `KeyPrefixChanged` entirely, so the
missed-event recovery conformance check saw an empty prefix.

The fix: track the last changed key prefix in the in-memory scope state and
include it in the replayed event. The in-memory coordinator is the one
component that owns the replay invariant, and this covers every wrapper that
delegates replay to it: the bbolt coordinator, the OPFS coordinator, and the
RPC proxy volume. The live publish path is unchanged. Events already
delivered live keep their exact prefix.

Verification: the focused regression passes repeatedly with the race
detector, including 50 runs of the full `TestRPCVolume`. The complete
`db/volume/rpc`, `db/coord`, and `db/volume/common/kvtx` packages pass under
the race detector. `go build ./...` succeeds.