### PR TITLE
fix(bldr): restore native and browser release builds

### DIFF
--- a/bldr/cli/compiler/analyze-cli-imports.go
+++ b/bldr/cli/compiler/analyze-cli-imports.go
@@ -1,0 +1,52 @@
+//go:build !js
+
+package bldr_cli_compiler
+
+import (
+	"context"
+	"go/types"
+	"path"
+
+	"github.com/pkg/errors"
+	plugin_compiler_go "github.com/s4wave/spacewave/bldr/plugin/compiler/go"
+	"github.com/sirupsen/logrus"
+)
+
+// AnalyzeCliImports discovers command builder signatures for a target platform.
+func AnalyzeCliImports(ctx context.Context, le *logrus.Entry, sourcePath string, cliPkgs []string, goos, goarch string) (map[string]CliImport, error) {
+	cliImports := make(map[string]CliImport)
+	if len(cliPkgs) != 0 {
+		cliAnalysis, err := plugin_compiler_go.AnalyzePackages(
+			ctx, le, sourcePath, cliPkgs, nil, goos, goarch, false,
+		)
+		if err != nil {
+			return nil, err
+		}
+		loadedPkgs := cliAnalysis.GetLoadedPackages()
+		for _, cliPkg := range cliPkgs {
+			pkgPath := cliPkg
+			if resolved, ok := cliAnalysis.GetPackagePathMappings()[cliPkg]; ok {
+				pkgPath = resolved
+			}
+			pkg := loadedPkgs[pkgPath]
+			if pkg == nil || pkg.Types == nil {
+				return nil, errors.Errorf("failed to analyze cli package %s", cliPkg)
+			}
+			cmdObj := pkg.Types.Scope().Lookup("NewCliCommands")
+			if cmdObj == nil {
+				return nil, errors.Errorf("cli package %s does not export NewCliCommands", pkgPath)
+			}
+			sig, ok := cmdObj.Type().(*types.Signature)
+			if !ok {
+				return nil, errors.Errorf("cli package %s NewCliCommands is not a function", pkgPath)
+			}
+			takesBroker, err := cliCommandsNeedsYieldBroker(pkgPath, sig)
+			if err != nil {
+				return nil, err
+			}
+			cliImports[cliPkg] = CliImport{Alias: path.Base(cliPkg), TakesYieldBroker: takesBroker}
+		}
+	}
+
+	return cliImports, nil
+}

--- a/bldr/cli/compiler/cli-import.go
+++ b/bldr/cli/compiler/cli-import.go
@@ -1,0 +1,33 @@
+//go:build !js
+
+package bldr_cli_compiler
+
+import "strconv"
+
+// CliImport describes a discovered NewCliCommands in a Go package.
+type CliImport struct {
+	// Alias is the import alias for the package.
+	Alias string
+	// TakesYieldBroker is true when NewCliCommands declares a second yield
+	// broker parameter. Generated wrappers pass the process-shared broker
+	// and guard the first bus access with a handoff.
+	TakesYieldBroker bool
+}
+
+// CommandBuilder formats a command builder using the composition root's broker.
+func (c CliImport) CommandBuilder(appName, broker string) string {
+	if !c.TakesYieldBroker {
+		return c.Alias + ".NewCliCommands"
+	}
+	return `func(getBus func() cli_entrypoint.CliBus) []*aperture_cli.Command {
+	handedOff := false
+	protectedGetBus := func() cli_entrypoint.CliBus {
+		if !handedOff {
+			` + broker + `.BeginHandoff(` + strconv.Quote(appName+" CLI") + `, "")
+			handedOff = true
+		}
+		return getBus()
+	}
+	return ` + c.Alias + `.NewCliCommands(protectedGetBus, ` + broker + `)
+}`
+}

--- a/bldr/cli/compiler/codegen.go
+++ b/bldr/cli/compiler/codegen.go
@@ -4,7 +4,6 @@ package bldr_cli_compiler
 
 import (
 	"bytes"
-	"fmt"
 	gast "go/ast"
 	"go/format"
 	"go/parser"
@@ -26,16 +25,6 @@ type FactoryImport struct {
 	// PassBus is true when NewFactory takes a single bus.Bus argument.
 	// When false, NewFactory takes no arguments.
 	PassBus bool
-}
-
-// CliImport describes a discovered NewCliCommands in a Go package.
-type CliImport struct {
-	// Alias is the import alias for the package.
-	Alias string
-	// TakesYieldBroker is true when NewCliCommands declares a second yield
-	// broker parameter. Generated wrappers pass the process-shared broker
-	// and guard the first bus access with a handoff.
-	TakesYieldBroker bool
 }
 
 // brokerConsumerFactories maps factory import paths whose controller
@@ -495,30 +484,17 @@ func buildFactoriesDecl(factoryElts []gast.Expr) gast.Decl {
 // with a handoff so a command process never displaces the foreground serve
 // process on the listener socket.
 func buildCliCommandsDecl(appName string, cliImports map[string]CliImport) (gast.Decl, error) {
-	aliases := make([]string, 0, len(cliImports))
+	imports := make([]CliImport, 0, len(cliImports))
 	for _, ci := range cliImports {
-		if ci.TakesYieldBroker {
-			aliases = append(aliases, ci.Alias)
-		}
+		imports = append(imports, ci)
 	}
-	slices.Sort(aliases)
+	slices.SortFunc(imports, func(a, b CliImport) int { return strings.Compare(a.Alias, b.Alias) })
 
 	var cliElts []gast.Expr
-	for _, alias := range aliases {
-		wrapperSrc := fmt.Sprintf(`func(getBus func() cli_entrypoint.CliBus) []*aperture_cli.Command {
-	handedOff := false
-	protectedGetBus := func() cli_entrypoint.CliBus {
-		if !handedOff {
-			brokers.yield.BeginHandoff(%q, "")
-			handedOff = true
-		}
-		return getBus()
-	}
-	return %s.NewCliCommands(protectedGetBus, brokers.yield)
-}`, appName+" CLI", alias)
-		wrapperExpr, err := parser.ParseExpr(wrapperSrc)
+	for _, ci := range imports {
+		wrapperExpr, err := parser.ParseExpr(ci.CommandBuilder(appName, "brokers.yield"))
 		if err != nil {
-			return nil, errors.Wrapf(err, "parse generated cli command wrapper for %s", alias)
+			return nil, errors.Wrapf(err, "parse generated cli command wrapper for %s", ci.Alias)
 		}
 		cliElts = append(cliElts, wrapperExpr)
 	}

--- a/bldr/cli/compiler/codegen_test.go
+++ b/bldr/cli/compiler/codegen_test.go
@@ -305,3 +305,21 @@ func TestFormatCliEntrypointBrokerWiring(t *testing.T) {
 		t.Fatalf("generated entrypoint mismatch:\n%s", dmp.DiffPrettyText(dmp.DiffMain(expected, output, false)))
 	}
 }
+
+func TestFormatCliEntrypointMixedCommandSignatures(t *testing.T) {
+	src, err := FormatCliEntrypoint("example", "example", nil, map[string]CliImport{
+		"example.com/simple": {Alias: "simple_cli"},
+		"example.com/broker": {Alias: "broker_cli", TakesYieldBroker: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"simple_cli.NewCliCommands",
+		"broker_cli.NewCliCommands(protectedGetBus, brokers.yield)",
+	} {
+		if !strings.Contains(string(src), want) {
+			t.Fatalf("generated CLI omits %s:\n%s", want, src)
+		}
+	}
+}

--- a/bldr/cli/compiler/compiler.go
+++ b/bldr/cli/compiler/compiler.go
@@ -7,7 +7,6 @@ import (
 	"encoding/binary"
 	"go/types"
 	"os"
-	"path"
 	"path/filepath"
 	"slices"
 
@@ -185,38 +184,9 @@ func (c *Controller) BuildManifest(
 	cliPkgs, _ := plugin_compiler_go.UpdateRelativeGoPackagePaths(
 		conf.GetCliPkgs(), rootModule,
 	)
-	cliImports := make(map[string]CliImport)
-	if len(cliPkgs) != 0 {
-		cliAnalysis, err := plugin_compiler_go.AnalyzePackages(
-			ctx, le, sourcePath, cliPkgs, nil, analyzeGOOS, analyzeGOARCH, false,
-		)
-		if err != nil {
-			return nil, err
-		}
-		loadedPkgs := cliAnalysis.GetLoadedPackages()
-		for _, cliPkg := range cliPkgs {
-			pkgPath := cliPkg
-			if resolved, ok := cliAnalysis.GetPackagePathMappings()[cliPkg]; ok {
-				pkgPath = resolved
-			}
-			pkg := loadedPkgs[pkgPath]
-			if pkg == nil || pkg.Types == nil {
-				return nil, errors.Errorf("failed to analyze cli package %s", cliPkg)
-			}
-			cmdObj := pkg.Types.Scope().Lookup("NewCliCommands")
-			if cmdObj == nil {
-				return nil, errors.Errorf("cli package %s does not export NewCliCommands", pkgPath)
-			}
-			sig, ok := cmdObj.Type().(*types.Signature)
-			if !ok {
-				return nil, errors.Errorf("cli package %s NewCliCommands is not a function", pkgPath)
-			}
-			takesBroker, err := cliCommandsNeedsYieldBroker(pkgPath, sig)
-			if err != nil {
-				return nil, err
-			}
-			cliImports[cliPkg] = CliImport{Alias: path.Base(cliPkg), TakesYieldBroker: takesBroker}
-		}
+	cliImports, err := AnalyzeCliImports(ctx, le, sourcePath, cliPkgs, analyzeGOOS, analyzeGOARCH)
+	if err != nil {
+		return nil, err
 	}
 
 	// serialize config set

--- a/bldr/dist/compiler/bundle.go
+++ b/bldr/dist/compiler/bundle.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aperturerobotics/util/fsutil"
 	"github.com/pkg/errors"
 	spacewave "github.com/s4wave/spacewave"
+	bldr_cli_compiler "github.com/s4wave/spacewave/bldr/cli/compiler"
 	bldr_dist "github.com/s4wave/spacewave/bldr/dist"
 	dist_compiler_bundle "github.com/s4wave/spacewave/bldr/dist/compiler/bundle"
 	bldr_manifest "github.com/s4wave/spacewave/bldr/manifest"
@@ -82,7 +83,7 @@ func BuildDistBundle(
 	buildPlatform bldr_platform.Platform,
 	hostConfigSet map[string]*configset_proto.ControllerConfig,
 	initEmbeddedWorld func(ctx context.Context, embedEngine world.Engine, embedOpPeerID peer.ID) error,
-	cliImports map[string]string,
+	cliImports map[string]bldr_cli_compiler.CliImport,
 	enableCgoOpt enabled.Enabled,
 	goCompilerOpt plugin_compiler_go.GoCompiler,
 	enableCompressionOpt enabled.Enabled,

--- a/bldr/dist/compiler/compiler.go
+++ b/bldr/dist/compiler/compiler.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"os"
-	"path"
 	"path/filepath"
 	"slices"
 	"sync"
@@ -18,6 +17,7 @@ import (
 	timestamp "github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
 	"github.com/aperturerobotics/util/fsutil"
 	pkgerrors "github.com/pkg/errors"
+	bldr_cli_compiler "github.com/s4wave/spacewave/bldr/cli/compiler"
 	bldr_dist "github.com/s4wave/spacewave/bldr/dist"
 	bldr_manifest "github.com/s4wave/spacewave/bldr/manifest"
 	bldr_manifest_builder "github.com/s4wave/spacewave/bldr/manifest/builder"
@@ -394,17 +394,19 @@ func (c *Controller) BuildManifest(
 		return nil, err
 	}
 
-	var cliImports map[string]string
+	var cliImports map[string]bldr_cli_compiler.CliImport
 	if !bldr_platform.IsWebPlatform(buildPlatform) {
 		cliPkgs, _ := plugin_compiler_go.UpdateRelativeGoPackagePaths(
 			conf.GetCliPkgs(),
 			rootModule,
 		)
-		if len(cliPkgs) != 0 {
-			cliImports = make(map[string]string, len(cliPkgs))
-			for _, pkg := range cliPkgs {
-				cliImports[pkg] = path.Base(pkg)
-			}
+		var goos, goarch string
+		if native, ok := buildPlatform.(*bldr_platform.NativePlatform); ok {
+			goos, goarch = native.GetGOOS(), native.GetGOARCH()
+		}
+		cliImports, err = bldr_cli_compiler.AnalyzeCliImports(ctx, le, sourcePath, cliPkgs, goos, goarch)
+		if err != nil {
+			return nil, err
 		}
 	}
 

--- a/bldr/dist/compiler/entrypoint.go
+++ b/bldr/dist/compiler/entrypoint.go
@@ -1,3 +1,5 @@
+//go:build !js
+
 package bldr_dist_compiler
 
 import (
@@ -6,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	bldr_cli_compiler "github.com/s4wave/spacewave/bldr/cli/compiler"
 	bldr_dist "github.com/s4wave/spacewave/bldr/dist"
 )
 
@@ -41,7 +44,7 @@ func main() {
 func FormatDistEntrypoint(
 	meta *bldr_dist.DistMeta,
 	embedAssetsFS []string,
-	cliImports map[string]string,
+	cliImports map[string]bldr_cli_compiler.CliImport,
 	nativeBuild bool,
 ) string {
 	var goEmbedLine string
@@ -64,27 +67,34 @@ func FormatDistEntrypoint(
 		slices.Sort(importPkgs)
 		for _, pkg := range importPkgs {
 			importLines.WriteString("\t")
-			importLines.WriteString(cliImports[pkg])
+			importLines.WriteString(cliImports[pkg].Alias)
 			importLines.WriteString(" ")
 			importLines.WriteString(strconv.Quote(pkg))
 			importLines.WriteString("\n")
 		}
 
-		aliases := make([]string, 0, len(cliImports))
-		for _, alias := range cliImports {
-			aliases = append(aliases, alias)
+		imports := make([]bldr_cli_compiler.CliImport, 0, len(cliImports))
+		var needsBroker bool
+		for _, ci := range cliImports {
+			imports = append(imports, ci)
+			needsBroker = needsBroker || ci.TakesYieldBroker
 		}
-		slices.Sort(aliases)
-		builders := make([]string, 0, len(aliases))
-		for _, alias := range aliases {
-			builders = append(builders, alias+".NewCliCommands")
+		slices.SortFunc(imports, func(a, b bldr_cli_compiler.CliImport) int { return strings.Compare(a.Alias, b.Alias) })
+		builders := make([]string, 0, len(imports))
+		for _, ci := range imports {
+			builders = append(builders, ci.CommandBuilder(meta.GetProjectId(), "yieldBroker"))
 		}
-		cliCommandsDecl = "// cliCommands are the native CLI command builders.\n" +
+		if needsBroker {
+			importLines.WriteString("\taperture_cli \"github.com/aperturerobotics/cli\"\n")
+			importLines.WriteString("\tyield_policy \"github.com/s4wave/spacewave/core/resource/listener/yieldpolicy\"\n")
+			cliCommandsDecl = "var yieldBroker = yield_policy.NewBroker()\n\n"
+		}
+		cliCommandsDecl += "// cliCommands are the native CLI command builders.\n" +
 			"var cliCommands = []cli_entrypoint.BuildCommandsFunc{" +
 			strings.Join(builders, ", ") + "}\n"
 	}
 	if nativeBuild && len(cliImports) == 0 {
-		cliCommandsDecl = "// cliCommands are the native CLI command builders.\n" +
+		cliCommandsDecl += "// cliCommands are the native CLI command builders.\n" +
 			"var cliCommands []cli_entrypoint.BuildCommandsFunc\n"
 	}
 

--- a/bldr/dist/compiler/entrypoint_test.go
+++ b/bldr/dist/compiler/entrypoint_test.go
@@ -1,3 +1,5 @@
+//go:build !js
+
 package bldr_dist_compiler
 
 import (
@@ -5,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	bldr_cli_compiler "github.com/s4wave/spacewave/bldr/cli/compiler"
 	bldr_dist "github.com/s4wave/spacewave/bldr/dist"
 	bldr_manifest "github.com/s4wave/spacewave/bldr/manifest"
 	bldr_platform "github.com/s4wave/spacewave/bldr/platform"
@@ -17,8 +20,8 @@ func TestFormatDistEntrypointNativeCLI(t *testing.T) {
 	src := FormatDistEntrypoint(
 		meta,
 		[]string{"assets.kvfile", "config-set.bin"},
-		map[string]string{
-			"github.com/s4wave/spacewave/cmd/spacewave/cli": "spacewave_cli",
+		map[string]bldr_cli_compiler.CliImport{
+			"github.com/s4wave/spacewave/cmd/spacewave/cli": {Alias: "spacewave_cli", TakesYieldBroker: true},
 		},
 		true,
 	)
@@ -29,7 +32,7 @@ func TestFormatDistEntrypointNativeCLI(t *testing.T) {
 	if !strings.Contains(src, `spacewave_cli "github.com/s4wave/spacewave/cmd/spacewave/cli"`) {
 		t.Fatalf("expected CLI package import, got:\n%s", src)
 	}
-	if !strings.Contains(src, `var cliCommands = []cli_entrypoint.BuildCommandsFunc{spacewave_cli.NewCliCommands}`) {
+	if !strings.Contains(src, `spacewave_cli.NewCliCommands(protectedGetBus, yieldBroker)`) {
 		t.Fatalf("expected cliCommands declaration, got:\n%s", src)
 	}
 	if !strings.Contains(src, `dist_entrypoint.Main(DistMeta, LogLevel, AssetsFS, cliCommands)`) {

--- a/bldr/plugin/host/wazero-quickjs/quickjs/polyfill-symbol.ts
+++ b/bldr/plugin/host/wazero-quickjs/quickjs/polyfill-symbol.ts
@@ -1,26 +1,10 @@
+import '../../../../sdk/dispose-symbol.js'
+
 // createSymbolPolyfills adds missing Symbol properties if they don't exist.
 export function createSymbolPolyfills(): void {
   if (!Symbol.asyncIterator) {
     Object.defineProperty(Symbol, 'asyncIterator', {
       value: Symbol('Symbol.asyncIterator'),
-      writable: false,
-      enumerable: false,
-      configurable: false,
-    })
-  }
-
-  if (!Symbol.dispose) {
-    Object.defineProperty(Symbol, 'dispose', {
-      value: Symbol('Symbol.dispose'),
-      writable: false,
-      enumerable: false,
-      configurable: false,
-    })
-  }
-
-  if (!Symbol.asyncDispose) {
-    Object.defineProperty(Symbol, 'asyncDispose', {
-      value: Symbol('Symbol.asyncDispose'),
       writable: false,
       enumerable: false,
       configurable: false,

--- a/bldr/sdk/defer.ts
+++ b/bldr/sdk/defer.ts
@@ -1,3 +1,5 @@
+import './dispose-symbol.js'
+
 /**
  * DisposableStack manages synchronous disposable resources, mimicking Go's defer behavior.
  * Functions added via `defer` are executed in LIFO order when the stack is disposed.

--- a/bldr/sdk/dispose-symbol.ts
+++ b/bldr/sdk/dispose-symbol.ts
@@ -1,0 +1,9 @@
+// Install disposal symbols before classes declare their computed methods. The
+// registry keys agree with the fallback used by lowered `using` declarations.
+for (const name of ['dispose', 'asyncDispose'] as const) {
+  if (!Symbol[name]) {
+    Object.defineProperty(Symbol, name, {
+      value: Symbol.for(`Symbol.${name}`),
+    })
+  }
+}

--- a/bldr/sdk/resource/client.test.ts
+++ b/bldr/sdk/resource/client.test.ts
@@ -613,9 +613,12 @@ describe('ResourceClient', () => {
     })
 
     const client = new Client(service, new AbortController().signal)
+    const generations: number[] = []
+    client.onConnectionLost(() => generations.push(client.connectionGeneration))
     const first = await client.accessRootResource()
 
     expect(first.resourceId).toBe(1)
+    expect(client.connectionGeneration).toBe(0)
 
     if (!firstStream.close) {
       throw new Error('expected first ResourceClient stream close callback')
@@ -624,6 +627,7 @@ describe('ResourceClient', () => {
     await vi.advanceTimersByTimeAsync(0)
 
     expect(first.released).toBe(true)
+    expect(generations).toEqual([1])
     expect(Reflect.get(client, 'initState')).toBe(null)
     expect(Reflect.get(client, 'initPromise')).toBeInstanceOf(Promise)
 
@@ -632,6 +636,7 @@ describe('ResourceClient', () => {
     const second = await secondPromise
 
     expect(second.resourceId).toBe(2)
+    expect(client.connectionGeneration).toBe(1)
     expect(calls).toBe(2)
 
     client.dispose()

--- a/bldr/sdk/resource/client.ts
+++ b/bldr/sdk/resource/client.ts
@@ -1,3 +1,5 @@
+import '../dispose-symbol.js'
+
 import { createAbortController, retryWithAbort } from '@aptre/bldr'
 import type { ResourceService } from './resource_srpc.pb.js'
 import type {
@@ -909,7 +911,7 @@ export class Client {
         const session: ResourceClientSession = {
           controller: attemptController,
           outgoing,
-          generation: ++this._connectionGeneration,
+          generation: this._connectionGeneration,
           initialized: false,
           closed: false,
           nextControlId: 0,
@@ -1180,6 +1182,7 @@ export class Client {
    * Used when connection is lost and resources are no longer valid.
    */
   private releaseAllResources(reason: ResourceReleaseReason): void {
+    this._connectionGeneration++
     this.clearAttachSession()
     for (const [resourceId, refs] of this.resources.entries()) {
       refs.forEach((ref) => ref._markReleased())

--- a/bldr/sdk/resource/resource.ts
+++ b/bldr/sdk/resource/resource.ts
@@ -1,3 +1,5 @@
+import '../dispose-symbol.js'
+
 import { ItState } from '@aptre/bldr'
 
 import type { ClientResourceRef } from './client.js'

--- a/bldr/sdk/resource/server/tracked-client.ts
+++ b/bldr/sdk/resource/server/tracked-client.ts
@@ -1,3 +1,5 @@
+import '../../dispose-symbol.js'
+
 import type { Mux, Client as SRPCClient } from 'starpc'
 import type { ClientResourceRef, ReleasedResourceClient } from '../client.js'
 import type { ResourceClientResponse } from '../resource.pb.js'

--- a/bldr/sdk/resource/unix-client.ts
+++ b/bldr/sdk/resource/unix-client.ts
@@ -1,3 +1,5 @@
+import '../dispose-symbol.js'
+
 import net from 'node:net'
 
 import { StreamConn, castToError } from 'starpc'

--- a/bldr/util/gocompiler/gocompiler.go
+++ b/bldr/util/gocompiler/gocompiler.go
@@ -111,7 +111,7 @@ func GetWasmExecPath(ctx context.Context, le *logrus.Entry, useTinygo bool) (str
 	if err := uexec.ExecCmd(le, goc); err != nil {
 		return "", errors.Wrap(err, "cannot determine GOROOT")
 	}
-	goRootDir := strings.SplitN(gocBuf.String(), "\n", 2)[0]
+	goRootDir, _, _ := strings.Cut(gocBuf.String(), "\n")
 
 	var wasmExecFile string
 	if useTinygo {

--- a/bldr/util/gocompiler/goscript.go
+++ b/bldr/util/gocompiler/goscript.go
@@ -90,7 +90,7 @@ func isGoScriptBldrStateRootName(name string) bool {
 // GoScriptBindingRoots returns dependency module roots containing protobuf
 // TypeScript siblings. The main module is covered by GoScript's source root.
 func GoScriptBindingRoots(ctx context.Context, workDir string, env ...string) ([]string, error) {
-	cmd := exec.CommandContext(ctx, "go", "list", "-m", "-f", "{{if not .Main}}{{.Dir}}{{end}}", "all")
+	cmd := exec.CommandContext(ctx, "go", "list", "-mod=readonly", "-m", "-f", "{{if not .Main}}{{.Dir}}{{end}}", "all")
 	cmd.Env = append(os.Environ(), GetDefaultEnv()...)
 	cmd.Env = append(cmd.Env, env...)
 	cmd.Dir = workDir

--- a/bldr/util/gocompiler/goscript_test.go
+++ b/bldr/util/gocompiler/goscript_test.go
@@ -246,7 +246,7 @@ replace example.com/without-pb => ./without-pb
 	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	got, err := GoScriptBindingRoots(context.Background(), dir)
+	got, err := GoScriptBindingRoots(context.Background(), dir, "GOFLAGS=-mod=vendor")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Native release builds fail when a CLI package accepts the yield broker, and browser builds fail when Go module discovery inherits vendor mode. Share CLI signature discovery and command wrappers with dist, retain both supported callback signatures, and resolve GoScript dependency bindings explicitly in readonly module mode.

Initialize disposal symbols before SDK methods are defined so WebKit can use disposable resources. Advance the ResourceClient generation when a connection is lost, preserving the initial session generation.

Validation: actual macOS arm64 and browser release builds passed; focused CLI/dist/compiler tests, 87 SDK/client/server/QuickJS tests, Go lint and TypeScript lint passed. Checks on the integrated master revision are also running.
