### PR TITLE
fix(bldr): package native assets outside Go archives

### DIFF
--- a/bldr/dist/README.md
+++ b/bldr/dist/README.md
@@ -1,0 +1,23 @@
+# Distribution resources
+
+A native distribution directory contains the executable and `assets.kvfile`.
+Distribute and install the directory together. The executable resolves the
+volume beside its actual executable path, including when launched through a
+symlink or from another working directory. Application bundles should keep the
+volume beside their contained executable.
+
+The volume holds the distribution's World and plugin manifests. It stays out
+of Go package archives, so editing assets does not make the Go compiler cache
+another copy of the payload. Small bootstrap configuration remains embedded.
+The existing block reader opens the volume lazily and checks that the expected
+root exists. A missing or mismatched volume fails startup.
+
+Web distributions continue to serve their volume separately through the browser
+range reader. Both packers include reachable blocks only; unrelated blocks left
+in a build store do not become distribution assets.
+
+Set `SOURCE_DATE_EPOCH` to a fixed Unix timestamp for reproducible manifest
+construction and distribution copying. Without it, the builder uses the current
+time. Reproducibility also requires identical source manifests, configuration,
+and toolchain inputs. Existing installed binaries keep their original embedded
+resources; this layout applies to newly built native distributions.

--- a/bldr/dist/compiler/bundle.go
+++ b/bldr/dist/compiler/bundle.go
@@ -41,7 +41,6 @@ import (
 	bucket_setup "github.com/s4wave/spacewave/db/bucket/setup"
 	node_controller "github.com/s4wave/spacewave/db/node/controller"
 	store_kvkey "github.com/s4wave/spacewave/db/store/kvkey"
-	common_kvtx "github.com/s4wave/spacewave/db/volume/common/kvtx"
 	volume_controller "github.com/s4wave/spacewave/db/volume/controller"
 	"github.com/s4wave/spacewave/db/world"
 	world_block "github.com/s4wave/spacewave/db/world/block"
@@ -225,13 +224,8 @@ func BuildDistBundle(
 	if err != nil {
 		return err
 	}
-	boltVol, ok := workingVol.(common_kvtx.KvtxVolume)
-	if !ok {
-		return errors.New("unexpected type for volume")
-	}
 
-	// workingVol will be embedded in the dist binary and available to the
-	// application. It will contain the embedded manifests.
+	// The packaged volume contains the distribution manifests.
 
 	// Create the embedded manifests world.
 	embedWorldID := bldr_dist.DistWorldEngineID
@@ -299,6 +293,9 @@ func BuildDistBundle(
 	le.Debug("packing embedded volume to assets.kvfile")
 	embeddedVolumeFilename := "assets.kvfile"
 	embeddedVolumePath := filepath.Join(entrypointBuildDir, embeddedVolumeFilename)
+	if !isWebPlatform {
+		embeddedVolumePath = filepath.Join(outputPath, embeddedVolumeFilename)
+	}
 	embeddedVolFile, err := os.OpenFile(embeddedVolumePath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
 	if err != nil {
 		return err
@@ -320,10 +317,6 @@ func BuildDistBundle(
 	kvfileKvkey := store_kvkey.NewDefaultKVKey()
 	kvfileBlockPrefix := kvfileKvkey.GetBlockFullPrefix()
 
-	// Access the workingVol kvtx.
-	kvtxVolStore := boltVol.GetKvtxStore()
-	kvtxVolBlockPrefix := boltVol.GetKvKey().GetBlockFullPrefix()
-
 	// Write the kvfile.
 	// NOTE: We don't use compression here since the content is already compressed / not compressible.
 	err = dist_compiler_bundle.BundleManifestsKvfile(
@@ -332,8 +325,6 @@ func BuildDistBundle(
 		kvfileWriter,
 		kvfileBlockPrefix,
 		embedBlockEngine,
-		kvtxVolStore,
-		kvtxVolBlockPrefix,
 	)
 	if err != nil {
 		_ = kvfileWriter.Close()
@@ -533,8 +524,7 @@ func BuildDistBundle(
 			return err
 		}
 	} else {
-		// Otherwise we go:embed it.
-		embedAssetsFS = append(embedAssetsFS, embeddedVolumeFilename)
+		// Native distributions keep the volume beside the executable.
 		outBinPath = filepath.Join(outputPath, outBinName)
 		if err := writeDistEntrypoint(true); err != nil {
 			return err

--- a/bldr/dist/compiler/bundle/bundle.go
+++ b/bldr/dist/compiler/bundle/bundle.go
@@ -3,134 +3,75 @@ package dist_compiler_bundle
 import (
 	"bytes"
 	"context"
-	"sync"
 
 	"github.com/aperturerobotics/go-kvfile"
 	"github.com/pkg/errors"
 	bldr_manifest "github.com/s4wave/spacewave/bldr/manifest"
 	bldr_manifest_world "github.com/s4wave/spacewave/bldr/manifest/world"
 	"github.com/s4wave/spacewave/db/block"
-	"github.com/s4wave/spacewave/db/block/blob"
 	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
-	"github.com/s4wave/spacewave/db/kvtx"
 	"github.com/s4wave/spacewave/db/world"
 	world_block "github.com/s4wave/spacewave/db/world/block"
 	world_types "github.com/s4wave/spacewave/db/world/types"
 	"github.com/sirupsen/logrus"
 )
 
-// BundleManifestsKvfile copies the blocks to the kvfile in the order that they
-// are read after first traversing the world state blocks followed by the blocks
-// for each manifest.
-//
-// Ideally this will cover all of the blocks in the storage, however, if there
-// are any remaining blocks not found after this process, those are copied last.
+// BundleManifestsKvfile packs the world and its manifests in traversal order
+// for read locality. Only reachable blocks are included; prior build history
+// in the backing store does not affect the result.
 func BundleManifestsKvfile(
 	ctx context.Context,
 	le *logrus.Entry,
 	kvfileWriter *kvfile.Writer,
 	kvfileBlockPrefix []byte,
 	blkEng *world_block.Engine,
-	kvtxVolStore kvtx.Store,
-	kvtxVolBlockPrefix []byte,
 ) error {
 	nextRootRef := blkEng.GetRootRef()
-	// nextRootRefStr := nextRootRef.MarshalString()
-
-	// Ensure we do not process duplicate blocks by tracking which blocks were seen.
-	// use a sync.Map since this is the exact situation it is meant for
-	// key: string (BlockRef)
-	// value: bool (seen)
-	var seenBlocks sync.Map
-
-	// TODO: track parents for debugging. not necessary, remove eventually.
-	parents := make(map[string]*bucket_lookup.WalkObjectBlocksEntry)
-
-	walkWriteBlocks := func(bls *bucket_lookup.Cursor, rootEnt *bucket_lookup.WalkObjectBlocksEntry) error {
+	seen := make(map[string]struct{})
+	walkWriteBlocks := func(bls *bucket_lookup.Cursor, ref *block.BlockRef, ctor block.Ctor) error {
 		return bucket_lookup.WalkObjectBlocks(
 			ctx,
-			rootEnt,
-			func(ent *bucket_lookup.WalkObjectBlocksEntry) (cntu bool, err error) {
-				err = ent.Err
-				if err == nil && !ent.Found && !ent.IsSubBlock && !ent.Ref.GetEmpty() {
-					err = errors.Wrap(block.ErrNotFound, ent.Ref.MarshalString())
+			bucket_lookup.NewWalkObjectBlocksWithRef(ref, ctor),
+			func(ent *bucket_lookup.WalkObjectBlocksEntry) (bool, error) {
+				if ent.Err != nil {
+					return false, ent.Err
 				}
-				cntu = err == nil
-
-				if err != nil || ent.IsSubBlock || !ent.Found || ent.Ref.GetEmpty() || len(ent.Data) == 0 {
-					// skip this block since it is not found or a sub-block or empty
-					return
+				if ent.IsSubBlock || ent.Ref.GetEmpty() {
+					return true, nil
 				}
-
-				// skip copying if we already saw this block
-				refStr := ent.Ref.MarshalString()
-				_, seen := seenBlocks.LoadOrStore(refStr, true)
-				if seen {
-					return
+				if !ent.Found {
+					return false, errors.Wrap(block.ErrNotFound, ent.Ref.MarshalString())
 				}
-
-				// TODO
-				parent := parents[refStr]
-				// le.Debugf("COPY BLOCK: %s: len(%d): %#v", refStr, len(ent.Data), ent.Blk)
-				if blb, blbOk := ent.Blk.(*blob.Blob); blbOk && blb.GetTotalSize() < 100 {
-					le.Debugf("COPY SMALL BLOCK: %s: parent(%v) len(%d): %#v", refStr, parent, len(ent.Data), ent.Blk)
+				key := ent.Ref.MarshalString()
+				if _, ok := seen[key]; ok {
+					return true, nil
 				}
-				if withRefs, withRefsOk := ent.Blk.(block.BlockWithRefs); withRefsOk {
-					outRefs, err := withRefs.GetBlockRefs()
-					if err != nil {
-						return false, err
-					}
-					for _, outRef := range outRefs {
-						parents[outRef.MarshalString()] = ent
-					}
-				}
-
-				// copy to the kvfile
-				key := bytes.Join([][]byte{kvfileBlockPrefix, []byte(refStr)}, nil)
-				err = kvfileWriter.WriteValue(key, bytes.NewReader(ent.Data))
-				cntu = err == nil
-				return
+				seen[key] = struct{}{}
+				outKey := append(bytes.Clone(kvfileBlockPrefix), key...)
+				return true, kvfileWriter.WriteValue(outKey, bytes.NewReader(ent.Data))
 			},
 			bls.GetBucket(),
 			bls.GetTransformer(),
-			1, // 1 concurrency to get correct order
+			1, // Serial callbacks preserve traversal order and writer ownership.
 			false,
 		)
 	}
 
-	// TODO: Replace the Walk functions here with analyzing the GC graph.
-
-	// The only values we will be using in this kvfile are blocks for the world engine & manifests.
-	// Walk the world block store and manifests and store the blocks in that order.
-	// This optimizes the order of the values in the file to the order they will be accessed.
-	// This means that grabbing a 1MB chunk of the file is more likely to have related data.
-	// This is a significant optimization over key-sorted-order values.
 	return blkEng.AccessWorldState(ctx, nextRootRef, func(bls *bucket_lookup.Cursor) error {
-		_, bcs := bls.BuildTransaction(nil)
-		worldRoot, err := world_block.UnmarshalWorld(ctx, bcs)
-		if err != nil {
+		if err := walkWriteBlocks(bls, nextRootRef.GetRootRef(), world_block.NewWorldBlock); err != nil {
 			return err
 		}
-
-		// Write the blocks for the world k/v store
-		if err := walkWriteBlocks(bls, bucket_lookup.NewWalkObjectBlocksWithBlock(worldRoot)); err != nil {
-			return err
-		}
-
-		// Access the world contents
 		wtx, err := blkEng.NewTransaction(ctx, false)
 		if err != nil {
 			return err
 		}
 		defer wtx.Discard()
 
-		// Lookup the list of manifests and write them to the store.
-		err = world_types.IterateObjectsWithType(ctx, wtx, bldr_manifest_world.ManifestTypeID, func(objKey string) (bool, error) {
+		return world_types.IterateObjectsWithType(ctx, wtx, bldr_manifest_world.ManifestTypeID, func(objKey string) (bool, error) {
 			obj, err := world.MustGetObject(ctx, wtx, objKey)
 			if err != nil {
 				return false, err
 			}
-
 			rootRef, _, err := obj.GetRootRef(ctx)
 			if err != nil {
 				return false, err
@@ -138,72 +79,13 @@ func BundleManifestsKvfile(
 			if rootRef.GetEmpty() {
 				return true, nil
 			}
-
-			// copy the manifest
 			rootBls, err := bls.FollowRef(ctx, rootRef)
 			if err != nil {
 				return false, err
 			}
 			defer rootBls.Release()
-
-			_, bcs := rootBls.BuildTransaction(nil)
-			manifest, err := bldr_manifest.UnmarshalManifest(ctx, bcs)
-			if err != nil {
-				return false, err
-			}
-
-			if err := walkWriteBlocks(rootBls, bucket_lookup.NewWalkObjectBlocksWithBlock(manifest)); err != nil {
-				return false, err
-			}
-
-			return true, nil
+			err = walkWriteBlocks(rootBls, rootRef.GetRootRef(), bldr_manifest.NewManifestBlock)
+			return err == nil, err
 		})
-		if err != nil {
-			return err
-		}
-
-		wtx.Discard()
-
-		// Finally, copy (& log) any blocks that we missed above.
-		// Retry classification: external to RunTransaction. This scan mutates
-		// seenBlocks and writes the release bundle through kvfileWriter.
-		kvtxTx, err := kvtxVolStore.NewTransaction(ctx, false)
-		if err != nil {
-			return err
-		}
-		defer kvtxTx.Discard()
-
-		if err := kvtxTx.ScanPrefix(ctx, kvtxVolBlockPrefix, func(key, value []byte) error {
-			blockKey := key[len(kvtxVolBlockPrefix):]
-			ref, err := block.UnmarshalBlockRefB58(string(blockKey))
-			if err != nil {
-				return errors.Wrapf(err, "invalid block ref key: %v", blockKey)
-			}
-			if ref.GetEmpty() {
-				return nil
-			}
-
-			refStr := ref.MarshalString()
-			_, seen := seenBlocks.LoadOrStore(refStr, true)
-			if seen {
-				return nil
-			}
-
-			// write the block to the store
-			le.Debugf("copying block that was not part of the world state or any manifest: %v", refStr)
-			kvfileBlockKey := bytes.Join([][]byte{kvfileBlockPrefix, []byte(refStr)}, nil)
-			return kvfileWriter.WriteValue(kvfileBlockKey, bytes.NewReader(value))
-		}); err != nil {
-			return err
-		}
-		rootRef := nextRootRef.GetRootRef()
-		if rootRef == nil || rootRef.GetEmpty() {
-			return nil
-		}
-		rootRefStr := rootRef.MarshalString()
-		if _, seen := seenBlocks.Load(rootRefStr); !seen {
-			return errors.Wrap(block.ErrNotFound, rootRefStr)
-		}
-		return nil
 	})
 }

--- a/bldr/dist/compiler/bundle/bundle_test.go
+++ b/bldr/dist/compiler/bundle/bundle_test.go
@@ -3,18 +3,30 @@ package dist_compiler_bundle_test
 import (
 	"bytes"
 	"errors"
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aperturerobotics/go-kvfile"
+	timestamp "github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
+	"github.com/go-git/go-billy/v6/osfs"
 	dist_compiler_bundle "github.com/s4wave/spacewave/bldr/dist/compiler/bundle"
+	bldr_manifest "github.com/s4wave/spacewave/bldr/manifest"
+	bldr_manifest_world "github.com/s4wave/spacewave/bldr/manifest/world"
 	"github.com/s4wave/spacewave/db/block"
+	block_store_kvfile "github.com/s4wave/spacewave/db/block/store/kvfile"
 	"github.com/s4wave/spacewave/db/bucket"
 	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
+	store_kvkey "github.com/s4wave/spacewave/db/store/kvkey"
 	"github.com/s4wave/spacewave/db/testbed"
+	unixfs_block "github.com/s4wave/spacewave/db/unixfs/block"
 	volume_kvtx "github.com/s4wave/spacewave/db/volume/common/kvtx"
 	world_block "github.com/s4wave/spacewave/db/world/block"
 	world_mock "github.com/s4wave/spacewave/db/world/mock"
+	world_types "github.com/s4wave/spacewave/db/world/types"
 	"github.com/sirupsen/logrus"
 )
 
@@ -56,6 +68,23 @@ func TestBundleManifestsKvfileWorldRootLifetime(t *testing.T) {
 		}
 	})
 
+	assetData := bytes.Repeat([]byte("packaged asset contents"), 16*1024)
+	assetDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(assetDir, "asset.bin"), assetData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	btx, bcs := ocs.BuildTransactionAtRef(nil, nil)
+	_, err = bldr_manifest.CreateManifestWithBilly(ctx, bcs, bldr_manifest.NewManifestMeta("fixture", bldr_manifest.BuildType_DEV, "js", 1), "", nil, osfs.New(assetDir), timestamp.New(time.Unix(1700000000, 0)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestRoot, _, err := btx.Write(ctx, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestRef := ocs.GetRef().Clone()
+	manifestRef.RootRef = manifestRoot
+
 	wtx, err := eng.NewTransaction(ctx, true)
 	if err != nil {
 		t.Fatal(err.Error())
@@ -63,6 +92,12 @@ func TestBundleManifestsKvfileWorldRootLifetime(t *testing.T) {
 	if _, err := wtx.CreateObject(ctx, "bundle-root-closure-object", &bucket.ObjectRef{BucketId: tb.BucketId}); err != nil {
 		wtx.Discard()
 		t.Fatal(err.Error())
+	}
+	if _, err := wtx.CreateObject(ctx, "manifest-fixture", manifestRef); err != nil {
+		t.Fatal(err)
+	}
+	if err := world_types.SetObjectType(ctx, wtx, "manifest-fixture", bldr_manifest_world.ManifestTypeID); err != nil {
+		t.Fatal(err)
 	}
 	if err := wtx.Commit(ctx); err != nil {
 		t.Fatal(err.Error())
@@ -85,10 +120,8 @@ func TestBundleManifestsKvfileWorldRootLifetime(t *testing.T) {
 			ctx,
 			le,
 			kvfileWriter,
-			[]byte("kvfile-block/"),
+			store_kvkey.NewDefaultKVKey().GetBlockFullPrefix(),
 			eng,
-			kvtxVol.GetKvtxStore(),
-			kvtxVol.GetKvKey().GetBlockFullPrefix(),
 		)
 		if err != nil {
 			t.Fatal(err.Error())
@@ -99,9 +132,74 @@ func TestBundleManifestsKvfileWorldRootLifetime(t *testing.T) {
 		if buf.Len() == 0 {
 			t.Fatal("BundleManifestsKvfile wrote an empty kvfile")
 		}
+
+		// Reopen the asset using only the packed bytes, without the source store.
+		rdr, err := kvfile.BuildReader(bytes.NewReader(buf.Bytes()), uint64(buf.Len()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		store := block_store_kvfile.NewKvfileBlock(ctx, store_kvkey.NewDefaultKVKey(), rdr)
+		_, packedCursor := block.NewTransaction(store, nil, manifestRoot, nil)
+		manifest, err := bldr_manifest.UnmarshalManifest(ctx, packedCursor)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tree, err := unixfs_block.NewFSTree(ctx, manifest.FollowAssetsFsRef(packedCursor), unixfs_block.NodeType_NodeType_DIRECTORY)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assetTree, _, err := tree.FollowDirent(0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		handle, err := assetTree.BuildFileHandle(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer handle.Close()
+		got, err := io.ReadAll(handle)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, assetData) {
+			t.Fatal("packaged asset differs from input")
+		}
+
+		// Unreachable blocks from earlier builds must not affect this snapshot.
+		orphan := []byte("unreachable earlier build")
+		orphanRef, err := block.BuildBlockRef(orphan, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tx, err := kvtxVol.GetKvtxStore().NewTransaction(ctx, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer tx.Discard()
+		orphanKey := append(bytes.Clone(kvtxVol.GetKvKey().GetBlockFullPrefix()), []byte(orphanRef.MarshalString())...)
+		if err := tx.Set(ctx, orphanKey, orphan); err != nil {
+			t.Fatal(err)
+		}
+		if err := tx.Commit(ctx); err != nil {
+			t.Fatal(err)
+		}
+		var repeated bytes.Buffer
+		repeatedWriter := kvfile.NewWriter(&repeated)
+		if err := dist_compiler_bundle.BundleManifestsKvfile(ctx, le, repeatedWriter, store_kvkey.NewDefaultKVKey().GetBlockFullPrefix(), eng); err != nil {
+			t.Fatal(err)
+		}
+		if err := repeatedWriter.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(buf.Bytes(), repeated.Bytes()) {
+			t.Fatalf("unchanged snapshot changed after unrelated history: %d -> %d bytes", buf.Len(), repeated.Len())
+		}
 	})
 
 	t.Run("missing world root", func(t *testing.T) {
+		if err := ocs.GetBucket().RmBlock(ctx, rootRef); err != nil {
+			t.Fatal(err)
+		}
 		var buf bytes.Buffer
 		kvfileWriter := kvfile.NewWriter(&buf)
 		t.Cleanup(func() { _ = kvfileWriter.Close() })
@@ -110,10 +208,8 @@ func TestBundleManifestsKvfileWorldRootLifetime(t *testing.T) {
 			ctx,
 			le,
 			kvfileWriter,
-			[]byte("kvfile-block/"),
+			store_kvkey.NewDefaultKVKey().GetBlockFullPrefix(),
 			eng,
-			kvtxVol.GetKvtxStore(),
-			[]byte("prefix-that-does-not-contain-blocks/"),
 		)
 		if !errors.Is(err, block.ErrNotFound) {
 			t.Fatalf("BundleManifestsKvfile error = %v, want block.ErrNotFound", err)

--- a/bldr/dist/compiler/compiler.go
+++ b/bldr/dist/compiler/compiler.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aperturerobotics/controllerbus/controller"
 	configset_proto "github.com/aperturerobotics/controllerbus/controller/configset/proto"
 	"github.com/aperturerobotics/controllerbus/directive"
-	timestamp "github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
 	"github.com/aperturerobotics/util/fsutil"
 	pkgerrors "github.com/pkg/errors"
 	bldr_cli_compiler "github.com/s4wave/spacewave/bldr/cli/compiler"
@@ -130,7 +129,7 @@ func (c *Controller) BuildManifest(
 	platformID := meta.GetPlatformId()
 	manifestID := meta.GetManifestId()
 	buildType := bldr_manifest.ToBuildType(meta.GetBuildType())
-	buildTimestamp := timestamp.Now()
+	buildTimestamp := bldr_manifest_builder.ManifestCommitTimestamp(ctx)
 
 	le := c.GetLogger().
 		WithField("manifest-id", manifestID).

--- a/bldr/dist/compiler/native-bundle_test.go
+++ b/bldr/dist/compiler/native-bundle_test.go
@@ -1,0 +1,78 @@
+//go:build !js
+
+package bldr_dist_compiler
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	bldr_dist "github.com/s4wave/spacewave/bldr/dist"
+	bldr_manifest "github.com/s4wave/spacewave/bldr/manifest"
+	bldr_manifest_world "github.com/s4wave/spacewave/bldr/manifest/world"
+	bldr_platform "github.com/s4wave/spacewave/bldr/platform"
+	"github.com/s4wave/spacewave/db/world"
+	"github.com/s4wave/spacewave/net/peer"
+	"github.com/sirupsen/logrus"
+)
+
+func TestNativeBundleResources(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds a complete native distribution")
+	}
+	root, err := filepath.Abs("../../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	scratch := filepath.Join(root, ".tmp")
+	if err := os.MkdirAll(scratch, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	work, err := os.MkdirTemp(scratch, "native-bundle-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(work) })
+	out := filepath.Join(work, "dist")
+	if err := os.MkdirAll(out, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	platformID := "desktop/" + runtime.GOOS + "/" + runtime.GOARCH
+	platform, err := bldr_platform.ParsePlatform(platformID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initWorld := func(ctx context.Context, engine world.Engine, _ peer.ID) error {
+		_, err := bldr_manifest_world.CreateManifestStoreInEngine(ctx, engine, "manifests")
+		return err
+	}
+	var previous []byte
+	for range 2 {
+		meta := bldr_dist.NewDistMeta("resource-fixture", platformID, nil, nil, "dist")
+		err := BuildDistBundle(t.Context(), logrus.NewEntry(logrus.New()), root, root, "", work, out, "app", meta, bldr_manifest.BuildType_DEV, nil, platform, nil, initWorld, nil, 0, 0, 0, nil, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		volume, err := os.ReadFile(filepath.Join(out, "assets.kvfile"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(volume) == 0 {
+			t.Fatal("empty packaged volume")
+		}
+		if previous != nil && !bytes.Equal(previous, volume) {
+			t.Fatalf("repeated bundle changed: %d -> %d bytes", len(previous), len(volume))
+		}
+		previous = volume
+		if _, err := os.Stat(filepath.Join(out, "app")); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Stat(filepath.Join(work, "entrypoint", "assets.kvfile")); !os.IsNotExist(err) {
+			t.Fatalf("volume entered Go compilation directory: %v", err)
+		}
+	}
+	t.Logf("complete native bundle repeats with %d volume bytes", len(previous))
+}

--- a/bldr/dist/compiler/native-cache_test.go
+++ b/bldr/dist/compiler/native-cache_test.go
@@ -1,0 +1,68 @@
+//go:build !js
+
+package bldr_dist_compiler
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	bldr_dist "github.com/s4wave/spacewave/bldr/dist"
+)
+
+// TestNativeAssetPackageCache measures the real Go package archive generated
+// from the native entrypoint, using the configured shared build cache.
+func TestNativeAssetPackageCache(t *testing.T) {
+	if testing.Short() {
+		t.Skip("compiles a native entrypoint")
+	}
+	if err := os.MkdirAll(".tmp", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dir, err := os.MkdirTemp(".tmp", "native-cache-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	meta := bldr_dist.NewDistMeta("cache-fixture", "desktop/darwin/arm64", nil, nil, "dist")
+	if err := os.WriteFile(filepath.Join(dir, "config-set.bin"), []byte("config"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	asset := bytes.Repeat([]byte("large-asset-data!"), 512*1024)
+	measure := func(embed bool) (string, int64) {
+		t.Helper()
+		files := []string{"config-set.bin"}
+		if embed {
+			files = append(files, "assets.kvfile")
+		}
+		if err := os.WriteFile(filepath.Join(dir, "assets.kvfile"), asset, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(FormatDistEntrypoint(meta, files, nil, true)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		cmd := exec.CommandContext(t.Context(), "go", "list", "-mod=mod", "-export", "-f", "{{.Export}}", ".")
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("compile native entrypoint: %v\n%s", err, out)
+		}
+		archive := strings.TrimSpace(string(out))
+		info, err := os.Stat(archive)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return archive, info.Size()
+	}
+	_, before := measure(true)
+	first, after := measure(false)
+	asset[0]++
+	second, changed := measure(false)
+	if before < int64(len(asset)) || after >= 1024*1024 || changed != after || first != second {
+		t.Fatalf("archive bytes: embedded=%d external=%d changed=%d; external cache reused=%v", before, after, changed, first == second)
+	}
+	t.Logf("asset=%d bytes; embedded archive=%d; external archive=%d; asset-only edit reuses archive", len(asset), before, after)
+}

--- a/bldr/dist/entrypoint/native-assets.go
+++ b/bldr/dist/entrypoint/native-assets.go
@@ -1,0 +1,33 @@
+//go:build !js
+
+package dist_entrypoint
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// nativeAssetsFS keeps configuration embedded and reads the distribution volume
+// beside the executable. The caller owns each returned file's lifetime.
+type nativeAssetsFS struct {
+	fs.FS
+	executable func() (string, error)
+}
+
+// Open resolves the volume relative to the actual executable, including when
+// launched through a symlink. Other assets retain their embedded filesystem.
+func (f nativeAssetsFS) Open(name string) (fs.File, error) {
+	if name != "assets.kvfile" {
+		return f.FS.Open(name)
+	}
+	executable, err := f.executable()
+	if err != nil {
+		return nil, err
+	}
+	executable, err = filepath.EvalSymlinks(executable)
+	if err != nil {
+		return nil, err
+	}
+	return os.Open(filepath.Join(filepath.Dir(executable), name))
+}

--- a/bldr/dist/entrypoint/native-assets_test.go
+++ b/bldr/dist/entrypoint/native-assets_test.go
@@ -1,0 +1,86 @@
+//go:build !js
+
+package dist_entrypoint
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/aperturerobotics/go-kvfile"
+	"github.com/s4wave/spacewave/db/block"
+	store_kvkey "github.com/s4wave/spacewave/db/store/kvkey"
+)
+
+func TestNativeAssetsResource(t *testing.T) {
+	dir := t.TempDir()
+	executable := filepath.Join(dir, "app")
+	if err := os.WriteFile(executable, nil, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(t.TempDir(), "app-link")
+	if err := os.Symlink(executable, link); err != nil {
+		t.Fatal(err)
+	}
+	assets := nativeAssetsFS{
+		FS:         fstest.MapFS{"config-set.bin": {Data: []byte("config")}},
+		executable: func() (string, error) { return link, nil },
+	}
+	t.Chdir(t.TempDir())
+	if _, err := assets.Open("assets.kvfile"); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("missing volume error = %v", err)
+	}
+	data := []byte("root block")
+	ref, err := block.BuildBlockRef(data, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := ref.MarshalKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var volume bytes.Buffer
+	writer := kvfile.NewWriter(&volume)
+	if err := writer.WriteValue(store_kvkey.NewDefaultKVKey().GetBlockKey(key), bytes.NewReader(data)); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "assets.kvfile"), volume.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	file, err := assets.Open("assets.kvfile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := file.(io.ReaderAt); !ok {
+		t.Fatal("volume must retain random-access reads")
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	config, err := fs.ReadFile(assets, "config-set.bin")
+	if err != nil || string(config) != "config" {
+		t.Fatalf("embedded config = %q, error = %v", config, err)
+	}
+	resolve := newStaticBlockStoreReaderBuilder(nil, assets, false, ref)
+	_, closeReader, err := resolve(t.Context(), func() {})
+	if err != nil {
+		t.Fatal(err)
+	}
+	closeReader()
+	otherRef, err := block.BuildBlockRef([]byte("other root"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = newStaticBlockStoreReaderBuilder(nil, assets, false, otherRef)(t.Context(), func() {})
+	if !errors.Is(err, block.ErrNotFound) {
+		t.Fatalf("mismatched volume error = %v", err)
+	}
+}

--- a/bldr/dist/entrypoint/native.go
+++ b/bldr/dist/entrypoint/native.go
@@ -30,6 +30,8 @@ func Main(
 	assetsFS fs.FS,
 	commandBuilders []cli_entrypoint.BuildCommandsFunc,
 ) {
+	assetsFS = nativeAssetsFS{FS: assetsFS, executable: os.Executable}
+
 	if len(commandBuilders) != 0 && len(os.Args) > 1 {
 		if err := func() error {
 			distMeta, err := bldr_dist.UnmarshalDistMetaB58(distMetaB58)

--- a/bldr/manifest/builder/commit-content-addressing_test.go
+++ b/bldr/manifest/builder/commit-content-addressing_test.go
@@ -11,6 +11,7 @@ import (
 
 	timestamp "github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
 	bldr_manifest "github.com/s4wave/spacewave/bldr/manifest"
+	bldr_manifest_world "github.com/s4wave/spacewave/bldr/manifest/world"
 	"github.com/s4wave/spacewave/bldr/testbed"
 	"github.com/s4wave/spacewave/db/bucket"
 	"github.com/sirupsen/logrus"
@@ -47,6 +48,23 @@ func TestCommitManifestUsesContentAddressing(t *testing.T) {
 	}
 	if !secondManifest.GetAssetsFsRef().EqualVT(firstManifest.GetAssetsFsRef()) {
 		t.Fatal("identical build produced a different assets filesystem ref")
+	}
+
+	// Dist copying uses this same timestamp policy and preserves content identity.
+	var copiedRoot *bucket.ObjectRef
+	for _, target := range []*testbed.Testbed{firstWorld, secondWorld} {
+		_, copied, err := bldr_manifest_world.DeepCopyManifest(
+			ctx, target.GetLogger(), firstWorld.GetWorldState().AccessWorldState,
+			firstRef, nil, target.GetWorldState(), target.GetWorldState().AccessWorldState,
+			"copied-manifest", nil, target.GetVolume().GetPeerID(), ManifestCommitTimestamp(ctx),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if copiedRoot != nil && !copied.GetRootRef().EqualVT(copiedRoot.GetRootRef()) {
+			t.Fatal("fixed-time dist copying changed manifest content identity")
+		}
+		copiedRoot = copied
 	}
 
 	writeCommitTestFile(t, distPath, "plugin-HASH.mjs", "export const value = 2;\n")

--- a/bldr/manifest/builder/config.go
+++ b/bldr/manifest/builder/config.go
@@ -82,7 +82,7 @@ func (c *BuilderConfig) CommitManifest(
 	if err != nil {
 		return nil, nil, err
 	}
-	ts := manifestCommitTimestamp(ctx)
+	ts := ManifestCommitTimestamp(ctx)
 
 	var manifestValue *manifest.Manifest
 	manifestRef, err := world.AccessObject(ctx, ws.AccessWorldState, nil, func(bcs *block.Cursor) error {
@@ -174,7 +174,9 @@ func (c *BuilderConfig) CheckoutManifest(
 	)
 }
 
-func manifestCommitTimestamp(ctx context.Context) *timestamp.Timestamp {
+// ManifestCommitTimestamp returns the lifecycle's fixed build time when set,
+// otherwise the current time. Callers capture it once per build.
+func ManifestCommitTimestamp(ctx context.Context) *timestamp.Timestamp {
 	ts, ok := ctx.Value(manifestCommitTimestampContextKey{}).(*timestamp.Timestamp)
 	if ok && ts != nil {
 		return ts.CloneVT()

--- a/bldr/manifest/builder/timestamp_test.go
+++ b/bldr/manifest/builder/timestamp_test.go
@@ -14,7 +14,7 @@ func TestManifestCommitTimestampFromSourceDateEpoch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ts := manifestCommitTimestamp(ctx)
+	ts := ManifestCommitTimestamp(ctx)
 	if ts.GetSeconds() != 1700000000 || ts.GetNanos() != 0 {
 		t.Fatalf("manifest timestamp = %d.%09d, want 1700000000.000000000", ts.GetSeconds(), ts.GetNanos())
 	}


### PR DESCRIPTION
Native distributions put the entire asset volume in a generated Go package archive, so asset changes retain another asset-sized entry in the Go build cache. Package `assets.kvfile` beside the executable and keep only bootstrap configuration embedded. The native reader finds the resource relative to the actual executable, including symlink launches, and retains lazy reads and root validation.

Distribute the executable and `assets.kvfile` together. Existing binaries remain unchanged. Distribution copying now honors the existing `SOURCE_DATE_EPOCH` policy, and volume packing includes only reachable blocks instead of historical backing-store contents.

Validation: an 8,912,896-byte asset produced a 9,584,018-byte archive before the change and a 670,856-byte archive afterward; an asset-only edit reused the exact new archive. Two complete native builds in the same directory produced identical volume bytes. Tests cover reopening a multi-block asset from the packed volume, historical-block exclusion, missing or mismatched resources, and executable-relative lookup. Race checks passed for all four changed owner packages; the entrypoint also cross-compiled for Windows amd64. Windows execution and a full large-application rebuild were not exercised.
