### PR TITLE
fix(packfile): bound delta chunks by encoded file size

### DIFF
--- a/core/provider/spacewave/packfile/delta/chunks.go
+++ b/core/provider/spacewave/packfile/delta/chunks.go
@@ -3,40 +3,32 @@ package delta
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"time"
 
+	"github.com/aperturerobotics/go-kvfile"
 	"github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
 	"github.com/pkg/errors"
-	"github.com/s4wave/spacewave/net/hash"
-
 	packfile "github.com/s4wave/spacewave/core/provider/spacewave/packfile"
 	"github.com/s4wave/spacewave/core/provider/spacewave/packfile/identity"
 	"github.com/s4wave/spacewave/core/provider/spacewave/packfile/writer"
+	"github.com/s4wave/spacewave/net/hash"
 )
 
-// DefaultMaxChunkBytes is the default byte ceiling a single delta chunk may
-// occupy before =EmitDeltaChunks= rolls the iterator into a new chunk. 63 MiB
-// leaves headroom under the Worker =sync/push= 64 MiB body cap.
+// DefaultMaxChunkBytes is the encoded byte ceiling for a delta chunk.
+// The default leaves headroom under the Worker sync/push body cap.
 const DefaultMaxChunkBytes int64 = writer.DefaultMaxPackBytes
 
-// ChunkEmitter receives one kvfile chunk at a time, in emission order. =idx=
-// counts up from zero. =entry= is the =PackfileEntry= proto constructed from
-// the chunk, with =id=, =bloom_filter=, =block_count=, =size_bytes=, and
-// =created_at= populated. =data= is the raw kvfile bytes.
-//
-// The callback may persist, upload, or drop the bytes. Returning an error
-// aborts =EmitDeltaChunks= immediately (matches the =OQ-25= "abort without
-// posting root" semantics in scope).
+// ChunkEmitter receives complete KVFiles in emission order. Returning an error
+// stops emission immediately; previously emitted chunks remain the caller's
+// responsibility.
 type ChunkEmitter func(ctx context.Context, idx int, entry *packfile.PackfileEntry, data []byte) error
 
-// EmitDeltaChunks drives =writer.PackBlocks= one chunk at a time, reading from
-// =iter= until it is exhausted. A chunk is closed as soon as appending the next
-// block would push the running byte total past =maxBytes=; if =maxBytes= is
-// non-positive, =DefaultMaxChunkBytes= is used. Each closed chunk is emitted
-// via =emit= with a v1 pack id and =created_at=timestamppb.Now()=.
-//
-// Returns the emitted =PackfileEntry= list in chunk order (same order as
-// =emit= was called).
+// EmitDeltaChunks packs iterator blocks in order, bounded by maxBytes including
+// the KVFile index and footer. A non-positive limit uses DefaultMaxChunkBytes.
+// A single block that cannot fit returns an error without emitting that block.
+// On success, entries correspond to callbacks in emission order. Errors return
+// no entries, even if earlier callbacks succeeded.
 func EmitDeltaChunks(
 	ctx context.Context,
 	resourceID string,
@@ -44,6 +36,7 @@ func EmitDeltaChunks(
 	maxBytes int64,
 	emit ChunkEmitter,
 ) ([]*packfile.PackfileEntry, error) {
+	// Validate the stream and resolve the packing limits.
 	if iter == nil {
 		return nil, errors.New("iter is nil")
 	}
@@ -55,6 +48,7 @@ func EmitDeltaChunks(
 	}
 	maxBlocks := int(writer.DefaultPolicy().MaxBlocksPerPack)
 
+	// Carry one lookahead block between chunks without advancing past it.
 	var emitted []*packfile.PackfileEntry
 	chunkIdx := 0
 
@@ -63,9 +57,12 @@ func EmitDeltaChunks(
 	var pendingHash *hash.Hash
 	var pendingData []byte
 
+	// Encode and publish each complete chunk before consuming the next.
 	for {
 		var chunkBuf bytes.Buffer
 		var chunkBytes int64
+		indexBytes := int64(8) // KVFile trailing index-entry count.
+		var sizeBuf [binary.MaxVarintLen64]byte
 		var chunkBlocks int
 		chunkClosed := false
 
@@ -74,10 +71,13 @@ func EmitDeltaChunks(
 				return nil, nil, nil
 			}
 
+			// Consume the lookahead before advancing the source iterator.
+			if err := ctx.Err(); err != nil {
+				return nil, nil, err
+			}
 			h, data, err := pendingHash, pendingData, error(nil)
-			if h != nil {
-				pendingHash, pendingData = nil, nil
-			} else {
+			pendingHash, pendingData = nil, nil
+			if h == nil {
 				h, data, err = iter()
 				if err != nil {
 					return nil, nil, err
@@ -87,22 +87,31 @@ func EmitDeltaChunks(
 				}
 			}
 
-			if chunkBytes > 0 && chunkBytes+int64(len(data)) > maxBytes {
+			// Include the generated entry, its size varint, and its fixed-width
+			// index position before accepting the block into this chunk.
+			entry := kvfile.IndexEntry{
+				Key:    []byte(h.MarshalString()),
+				Offset: uint64(chunkBytes),
+				Size:   uint64(len(data)),
+			}
+			entrySize := entry.SizeVT()
+			entryBytes := int64(entrySize + binary.PutUvarint(sizeBuf[:], uint64(entrySize)) + 8)
+			remaining := maxBytes - chunkBytes - indexBytes - entryBytes
+			if int64(len(data)) > remaining || (maxBlocks > 0 && chunkBlocks >= maxBlocks) {
+				if chunkBlocks == 0 {
+					return nil, nil, errors.Errorf("block %s cannot fit in a %d-byte encoded pack", h.MarshalString(), maxBytes)
+				}
 				pendingHash, pendingData = h, data
 				chunkClosed = true
 				return nil, nil, nil
 			}
-			if maxBlocks > 0 && chunkBlocks >= maxBlocks {
-				pendingHash, pendingData = h, data
-				chunkClosed = true
-				return nil, nil, nil
-			}
-
 			chunkBytes += int64(len(data))
+			indexBytes += entryBytes
 			chunkBlocks++
 			return h, data, nil
 		}
 
+		// Finalize the KVFile and derive its content-addressed identity.
 		res, err := writer.PackBlocks(&chunkBuf, chunkIter)
 		if err != nil {
 			return nil, errors.Wrap(err, "pack delta chunk")
@@ -115,6 +124,7 @@ func EmitDeltaChunks(
 			return nil, errors.Wrap(err, "build delta pack id")
 		}
 
+		// Transfer the complete pack to the caller before advancing.
 		entry := &packfile.PackfileEntry{
 			Id:                 packID,
 			BloomFilter:        res.BloomFilter,

--- a/core/provider/spacewave/packfile/delta/chunks_test.go
+++ b/core/provider/spacewave/packfile/delta/chunks_test.go
@@ -1,0 +1,78 @@
+package delta
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/aperturerobotics/go-kvfile"
+	packfile "github.com/s4wave/spacewave/core/provider/spacewave/packfile"
+)
+
+// TestEmitDeltaChunksEncodedLimit exercises index-heavy packs at the complete
+// file limit and verifies every block remains readable after splitting.
+func TestEmitDeltaChunksEncodedLimit(t *testing.T) {
+	// Small values make index overhead dominate the payload-only accounting.
+	ctx := t.Context()
+	specs, reader := buildTestKvfile(t, "encoded", 200, 32)
+	iter, err := DiffBlockStores(ctx, reader, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Reopen each emitted file and collect the original values exactly once.
+	const limit = 1024
+	seen := make(map[string][]byte)
+	_, err = EmitDeltaChunks(ctx, "encoded-limit", iter, limit, func(_ context.Context, _ int, entry *packfile.PackfileEntry, data []byte) error {
+		if len(data) > limit || entry.GetSizeBytes() != uint64(len(data)) {
+			t.Fatalf("encoded size = %d, metadata = %d, limit = %d", len(data), entry.GetSizeBytes(), limit)
+		}
+		packed, err := kvfile.BuildReader(bytes.NewReader(data), uint64(len(data)))
+		if err != nil {
+			return err
+		}
+		return packed.ScanPrefixEntries(nil, func(entry *kvfile.IndexEntry, _ int) error {
+			key := string(entry.GetKey())
+			if _, exists := seen[key]; exists {
+				t.Fatalf("duplicate block %s", key)
+			}
+			value, found, err := packed.Get(entry.GetKey())
+			if err != nil {
+				return err
+			}
+			if !found {
+				t.Fatalf("missing block %s", key)
+			}
+			seen[key] = bytes.Clone(value)
+			return nil
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, spec := range specs {
+		if !bytes.Equal(seen[spec.key], spec.data) {
+			t.Fatalf("block %s did not round trip", spec.key)
+		}
+	}
+}
+
+// TestEmitDeltaChunksRejectsOversizeBlock prevents a single payload from
+// bypassing the encoded byte ceiling or reaching the publication callback.
+func TestEmitDeltaChunksRejectsOversizeBlock(t *testing.T) {
+	// The payload alone fits exactly, but its index cannot fit beside it.
+	_, reader := buildTestKvfile(t, "oversize", 1, 1024)
+	iter, err := DiffBlockStores(t.Context(), reader, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Reject before publishing the oversized file.
+	_, err = EmitDeltaChunks(t.Context(), "oversize", iter, 1024, func(context.Context, int, *packfile.PackfileEntry, []byte) error {
+		t.Fatal("oversized block reached emitter")
+		return nil
+	})
+	if err == nil {
+		t.Fatal("oversized block accepted")
+	}
+}


### PR DESCRIPTION
Count the KVFile index and footer when splitting delta packs so complete files stay within the configured upload limit. Reject a single block that cannot fit before invoking the publication callback. Block order and the storage format remain unchanged.

Focused pack writer and delta tests pass with the race detector, including index-heavy round trips and oversized-block rejection.