### PR TITLE
fix(release): disable interactive Windows signing credentials

### DIFF
--- a/bldr/util/gocompiler/sign-windows.go
+++ b/bldr/util/gocompiler/sign-windows.go
@@ -39,6 +39,7 @@ const WindowsSignDescriptionEnv = "BLDR_WINDOWS_SIGN_DESCRIPTION"
 // when WindowsSignDescriptionEnv is unset.
 const defaultWindowsSignDescription = "Spacewave"
 
+// signWindowsMu serializes access to the module's shared metadata file.
 var signWindowsMu sync.Mutex
 
 // signWindowsScript is the PowerShell script driving the signing call.
@@ -52,19 +53,27 @@ Invoke-TrustedSigning ` +
 	`-Description $env:BLDR_SIGN_DESCRIPTION ` +
 	`-FileDigest SHA256 ` +
 	`-TimestampRfc3161 'http://timestamp.acs.microsoft.com' ` +
-	`-TimestampDigest SHA256`
+	`-TimestampDigest SHA256 ` +
+	`-ExcludeManagedIdentityCredential ` +
+	`-ExcludeSharedTokenCacheCredential ` +
+	`-ExcludeVisualStudioCredential ` +
+	`-ExcludeVisualStudioCodeCredential ` +
+	`-ExcludeAzurePowerShellCredential ` +
+	`-ExcludeAzureDeveloperCliCredential ` +
+	`-ExcludeInteractiveBrowserCredential`
 
 // SignWindows signs a PE binary via Azure Trusted Signing using the
 // Invoke-TrustedSigning cmdlet from the TrustedSigning PowerShell module.
 //
 // The TrustedSigning module must be installed on the host
 // (Install-Module -Name TrustedSigning). Authentication uses
-// DefaultAzureCredential, so a prior `az login` (or azure/login@v3 in CI)
-// is required.
+// environment, workload identity, or a prior az login (azure/login@v3 in CI).
+// Developer-tool and interactive credentials are excluded for unattended builds.
 //
 // No-op when BLDR_WINDOWS_SIGN_PROFILE is unset. Caller is responsible
 // for gating on GOOS=windows.
 func SignWindows(ctx context.Context, le *logrus.Entry, binPath string) error {
+	// Resolve the optional signing configuration before starting PowerShell.
 	profile := os.Getenv(WindowsSignProfileEnv)
 	if profile == "" {
 		return nil
@@ -81,6 +90,8 @@ func SignWindows(ctx context.Context, le *logrus.Entry, binPath string) error {
 	if description == "" {
 		description = defaultWindowsSignDescription
 	}
+
+	// Keep values out of command syntax and disable interactive credentials.
 	cmd := uexec.NewCmd(ctx, "pwsh", "-NoProfile", "-NonInteractive", "-Command", signWindowsScript)
 	cmd.Env = append(os.Environ(),
 		"BLDR_SIGN_ENDPOINT="+endpoint,
@@ -89,6 +100,8 @@ func SignWindows(ctx context.Context, le *logrus.Entry, binPath string) error {
 		"BLDR_SIGN_FILE="+binPath,
 		"BLDR_SIGN_DESCRIPTION="+description,
 	)
+
+	// The PowerShell module writes one shared metadata file for every binary.
 	signWindowsMu.Lock()
 	defer signWindowsMu.Unlock()
 	if err := uexec.ExecCmd(le, cmd); err != nil {

--- a/scripts/release/build-helper.sh
+++ b/scripts/release/build-helper.sh
@@ -180,7 +180,7 @@ sign_windows_helper() {
     BLDR_SIGN_FILE="$exe" \
     BLDR_SIGN_DESCRIPTION="Spacewave Helper" \
     pwsh -NoProfile -NonInteractive -Command \
-      "Invoke-TrustedSigning -Endpoint \$env:BLDR_SIGN_ENDPOINT -CodeSigningAccountName \$env:BLDR_SIGN_ACCOUNT -CertificateProfileName \$env:BLDR_SIGN_PROFILE -Files \$env:BLDR_SIGN_FILE -Description \$env:BLDR_SIGN_DESCRIPTION -FileDigest SHA256 -TimestampRfc3161 'http://timestamp.acs.microsoft.com' -TimestampDigest SHA256"
+      "Invoke-TrustedSigning -Endpoint \$env:BLDR_SIGN_ENDPOINT -CodeSigningAccountName \$env:BLDR_SIGN_ACCOUNT -CertificateProfileName \$env:BLDR_SIGN_PROFILE -Files \$env:BLDR_SIGN_FILE -Description \$env:BLDR_SIGN_DESCRIPTION -FileDigest SHA256 -TimestampRfc3161 'http://timestamp.acs.microsoft.com' -TimestampDigest SHA256 -ExcludeManagedIdentityCredential -ExcludeSharedTokenCacheCredential -ExcludeVisualStudioCredential -ExcludeVisualStudioCodeCredential -ExcludeAzurePowerShellCredential -ExcludeAzureDeveloperCliCredential -ExcludeInteractiveBrowserCredential"
 }
 
 # Per-platform output is namespaced under <goos>-<goarch>/ so darwin, linux,

--- a/scripts/release/build-msix.sh
+++ b/scripts/release/build-msix.sh
@@ -177,6 +177,6 @@ BLDR_SIGN_ENDPOINT="$SIGN_ENDPOINT" \
   BLDR_SIGN_FILE="$MSIX" \
   BLDR_SIGN_DESCRIPTION="Spacewave" \
   pwsh -NoProfile -NonInteractive -Command \
-    "Invoke-TrustedSigning -Endpoint \$env:BLDR_SIGN_ENDPOINT -CodeSigningAccountName \$env:BLDR_SIGN_ACCOUNT -CertificateProfileName \$env:BLDR_SIGN_PROFILE -Files \$env:BLDR_SIGN_FILE -Description \$env:BLDR_SIGN_DESCRIPTION -FileDigest SHA256 -TimestampRfc3161 'http://timestamp.acs.microsoft.com' -TimestampDigest SHA256"
+    "Invoke-TrustedSigning -Endpoint \$env:BLDR_SIGN_ENDPOINT -CodeSigningAccountName \$env:BLDR_SIGN_ACCOUNT -CertificateProfileName \$env:BLDR_SIGN_PROFILE -Files \$env:BLDR_SIGN_FILE -Description \$env:BLDR_SIGN_DESCRIPTION -FileDigest SHA256 -TimestampRfc3161 'http://timestamp.acs.microsoft.com' -TimestampDigest SHA256 -ExcludeManagedIdentityCredential -ExcludeSharedTokenCacheCredential -ExcludeVisualStudioCredential -ExcludeVisualStudioCodeCredential -ExcludeAzurePowerShellCredential -ExcludeAzureDeveloperCliCredential -ExcludeInteractiveBrowserCredential"
 
 echo "Built and signed: $MSIX"


### PR DESCRIPTION
Exclude browser and developer-tool credentials from the native binary, helper, and MSIX signing calls. Unattended builds continue to use environment credentials, workload identity, or the authenticated Azure CLI session instead of opening a browser when signing authentication falls through.

The signing configuration tests and shell syntax checks pass. The next signed Windows plugin build provides live authentication validation.