### PR TITLE
fix(release): skip plugin handoff after producer failure

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -535,7 +535,8 @@ jobs:
       - native-macos
       - native-windows
       - native-linux
-    if: always() && needs.prep.result == 'success'
+    # Unselected surfaces may be skipped; failed producers cannot form a handoff.
+    if: ${{ !cancelled() && !failure() && needs.prep.result == 'success' }}
     runs-on: ubuntu-latest
     environment: ${{ needs.prep.outputs.environment_name }}
     timeout-minutes: 30


### PR DESCRIPTION
Only assemble the plugin handoff when all selected producers succeed. Unselected surfaces may remain skipped. A failed or canceled producer now leaves the run terminal instead of waiting for an environment approval before discovering missing artifacts.