### PR TITLE
fix(release): reject canceled plugin producer results

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -536,7 +536,10 @@ jobs:
       - native-windows
       - native-linux
     # Unselected surfaces may be skipped; failed producers cannot form a handoff.
-    if: ${{ !cancelled() && !failure() && needs.prep.result == 'success' }}
+    if: >-
+      ${{ !cancelled() && needs.prep.result == 'success' &&
+          !contains(needs.*.result, 'failure') &&
+          !contains(needs.*.result, 'cancelled') }}
     runs-on: ubuntu-latest
     environment: ${{ needs.prep.outputs.environment_name }}
     timeout-minutes: 30


### PR DESCRIPTION
Check each producer result explicitly before assembling a plugin handoff. A timed-out producer may be canceled while the overall workflow remains active, so checking workflow cancellation alone does not establish a complete artifact set. Skipped unselected surfaces remain valid.