### PR TITLE
fix(release): cache signing tokens before OIDC assertions expire

### DIFF
--- a/.github/workflows/entrypoint-release.yml
+++ b/.github/workflows/entrypoint-release.yml
@@ -453,6 +453,15 @@ jobs:
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
+      # Exchange the short-lived GitHub assertion before compilation; signing uses
+      # the cached Azure resource token after the assertion has expired.
+      - name: Cache Azure code-signing access token
+        if: ${{ inputs.sign_artifacts && steps.windows_handoff_cache.outputs.cache-hit != 'true' }}
+        shell: pwsh
+        run: |
+          az account get-access-token --resource https://codesigning.azure.net --output none
+          if ($LASTEXITCODE -ne 0) { throw "Failed to acquire the code-signing access token" }
+
       - name: Resolve TrustedSigning module path
         if: ${{ inputs.sign_artifacts && steps.windows_handoff_cache.outputs.cache-hit != 'true' }}
         id: trusted_signing_paths

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -329,6 +329,14 @@ jobs:
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
+      # Exchange the short-lived GitHub assertion before compilation; signing uses
+      # the cached Azure resource token after the assertion has expired.
+      - name: Cache Azure code-signing access token
+        shell: pwsh
+        run: |
+          az account get-access-token --resource https://codesigning.azure.net --output none
+          if ($LASTEXITCODE -ne 0) { throw "Failed to acquire the code-signing access token" }
+
       - name: Resolve TrustedSigning module path
         id: trusted_signing_paths
         shell: pwsh


### PR DESCRIPTION
Windows signing first requested its Azure resource token after compilation, when GitHub's five-minute OIDC assertion had already expired. Azure login had cached a management token, which does not authenticate code signing.

Acquire the code-signing resource token immediately after OIDC login in both release workflows. Suppress token output and stop immediately if acquisition fails. The signing library then uses Azure CLI's cached resource token during the build. YAML formatting and diff checks pass; live Windows verification follows.
