### PR TITLE
fix(provider): accept same-origin signaling URLs

### DIFF
--- a/core/provider/local/config.go
+++ b/core/provider/local/config.go
@@ -24,8 +24,8 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-// ParseSignalingURL parses the signaling_url field. Empty disables WebRTC
-// signaling for standalone local sessions.
+// ParseSignalingURL accepts an absolute HTTP(S) URL or an origin-relative path
+// for browser signaling. Empty disables signaling for standalone local sessions.
 func (c *Config) ParseSignalingURL() (*url.URL, error) {
 	raw := strings.TrimSpace(c.GetSignalingUrl())
 	if raw == "" {
@@ -35,13 +35,16 @@ func (c *Config) ParseSignalingURL() (*url.URL, error) {
 	if err != nil {
 		return nil, err
 	}
+	if u.Scheme == "" && u.Host == "" && strings.HasPrefix(raw, "/") && !strings.HasPrefix(raw, "//") {
+		return u, nil
+	}
 	switch u.Scheme {
 	case "http", "https":
 	default:
-		return nil, errors.Errorf("must be an absolute http or https URL, got %q", raw)
+		return nil, errors.Errorf("must be an absolute http or https URL or an origin-relative path, got %q", raw)
 	}
 	if u.Host == "" {
-		return nil, errors.Errorf("must be an absolute http or https URL, got %q", raw)
+		return nil, errors.Errorf("must be an absolute http or https URL or an origin-relative path, got %q", raw)
 	}
 	return u, nil
 }
@@ -62,5 +65,5 @@ func (c *Config) ParsePeerID() (peer.ID, error) {
 	return confparse.ParsePeerID(c.GetPeerId())
 }
 
-// _ is a type assertion
+// _ is a type assertion.
 var _ config.Config = (*Config)(nil)

--- a/core/provider/local/config_test.go
+++ b/core/provider/local/config_test.go
@@ -1,0 +1,24 @@
+package provider_local
+
+import "testing"
+
+// TestConfigSignalingURL covers the browser's same-origin signaling configuration
+// and the absolute endpoints used by native runtimes.
+func TestConfigSignalingURL(t *testing.T) {
+	for _, raw := range []string{"", "/", "/cloud", "https://spacewave.app", "http://localhost:8080"} {
+		t.Run(raw, func(t *testing.T) {
+			conf := &Config{SignalingUrl: raw}
+			if err := conf.Validate(); err != nil {
+				t.Fatalf("valid signaling URL %q rejected: %v", raw, err)
+			}
+		})
+	}
+	for _, raw := range []string{"cloud", "//other.example", "///other.example", "https:/cloud", "ftp://cloud.example", "/%zz"} {
+		t.Run(raw, func(t *testing.T) {
+			conf := &Config{SignalingUrl: raw}
+			if err := conf.Validate(); err == nil {
+				t.Fatalf("invalid signaling URL %q accepted", raw)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Browser manifests configure local signaling with `/`, but local provider validation rejected that URL and prevented Quickstart from opening the local provider. Accept origin-relative paths alongside absolute HTTP(S) endpoints, matching the signaling transport's existing ticket and WebSocket contract.

Validated with local-provider configuration cases and the existing signaling URL tests. Repository commit checks passed.
