### PR TITLE
fix(iavl): preserve subtree minimums during deletion

### DIFF
--- a/db/kvtx/block/iavl/delete-separator_test.go
+++ b/db/kvtx/block/iavl/delete-separator_test.go
@@ -1,0 +1,45 @@
+package kvtx_block_iavl
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+)
+
+// TestDeletePreservesRemainingKeys checks lookup and iteration after each
+// deletion from a persisted tree, including deletion of subtree minima.
+func TestDeletePreservesRemainingKeys(t *testing.T) {
+	ctx := context.Background()
+	tree := buildBenchTree(t, 128)
+	tx := newBenchReadTx(t, ctx, tree)
+	defer tx.Discard()
+	removed := make(map[string]bool)
+	for _, index := range rand.New(rand.NewSource(4)).Perm(len(tree.keys)) {
+		key := tree.keys[index]
+		if err := tx.Delete(ctx, key); err != nil {
+			t.Fatal(err)
+		}
+		removed[string(key)] = true
+		for _, candidate := range tree.keys {
+			_, found, err := tx.Get(ctx, candidate)
+			if err != nil || found == removed[string(candidate)] {
+				t.Fatalf("after deleting %q, lookup %q: found=%v removed=%v error=%v", key, candidate, found, removed[string(candidate)], err)
+			}
+		}
+		iter := tx.Iterate(ctx, nil, true, false)
+		count := 0
+		for iter.Next() {
+			if removed[string(iter.Key())] {
+				t.Fatalf("deleted key still iterates: %q", iter.Key())
+			}
+			count++
+		}
+		if err := iter.Err(); err != nil {
+			t.Fatal(err)
+		}
+		iter.Close()
+		if count != len(tree.keys)-len(removed) {
+			t.Fatalf("iteration count=%d", count)
+		}
+	}
+}

--- a/db/kvtx/block/iavl/tx.go
+++ b/db/kvtx/block/iavl/tx.go
@@ -693,15 +693,14 @@ func (t *Tx) removeFromNode(
 		return nil, nil, nil, nil, err
 	}
 	if ncs == nil {
-		// node was deleted
-		// clear ref to child
-		// set parent ref (left or right) to other link, deleting this node
+		// Promote the surviving child. The separator is the right subtree's
+		// minimum, even when that child is an internal node.
 		if left {
-			lnod, lcs, err = nod.FollowRight(ctx, bcs)
-		} else {
-			lnod, lcs, err = nod.FollowLeft(ctx, bcs)
+			_, lcs, err = nod.FollowRight(ctx, bcs)
+			return lcs, nod.GetKey(), removedCursor, removedNode, err
 		}
-		return lcs, lnod.GetKey(), removedCursor, removedNode, err
+		_, lcs, err = nod.FollowLeft(ctx, bcs)
+		return lcs, nil, removedCursor, removedNode, err
 	}
 
 	// Set the left or right node to new child.
@@ -713,12 +712,14 @@ func (t *Tx) removeFromNode(
 			nod.Key = nkey
 			bcs.SetBlock(nod, true)
 		}
+		// A changed right minimum updates this separator, not its ancestors.
+		nkey = nil
 	}
 	err = t.calcNodeHeightAndSize(ctx, nod, bcs)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-	return bcs, nil, removedCursor, removedNode, nil
+	return bcs, nkey, removedCursor, removedNode, nil
 }
 
 // calcNodeHeightAndSize calculates a node's height and size.


### PR DESCRIPTION
Deleting a leaf could replace an ancestor separator with an internal routing key and lose changes to a subtree's minimum. Later lookups then missed surviving keys even though iteration still returned them.

Propagate a changed minimum through left ancestors and use it only to update the first right separator. When promoting a right child, retain the parent's separator as that subtree's minimum.

A regression deletes persisted keys in shuffled order and checks lookup and iteration after every deletion. It fails before the fix; the IAVL package tests pass afterward.
