### PR TITLE
fix(release): configure staging browser plugin signing

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -31,6 +31,7 @@ permissions:
   attestations: write
 
 env:
+  SPACEWAVE_RELEASE_ENV: ${{ inputs.environment }}
   TINYGO_VERSION: 0.41.1
 
 jobs:

--- a/.protoc-manifest.json
+++ b/.protoc-manifest.json
@@ -1099,7 +1099,7 @@
       ]
     },
     "github.com/s4wave/spacewave/core/provider/local": {
-      "hash": "66021b7c7ec82f24059043454aca5fb8953867818a0452f294cc5be6add739da",
+      "hash": "7f4ab24d7fee80d116c9fc79d3411bee7cd3ab1d2e079091d0ada5ab064f3c91",
       "generatedFiles": [
         "core/provider/local/local.pb.go",
         "core/provider/local/local.pb.ts"

--- a/bldr.star
+++ b/bldr.star
@@ -63,7 +63,8 @@ E2E_RELEASE_WASM_DIST_PEER_ID = "12D3KooWJPNip1SbsUG7SjteoegGjfq22D4WThuctPvCwJz
 def core_config_set(
         include_export=True,
         cloud_api_endpoint=PRODUCTION_CLOUD_API_ENDPOINT,
-        account_endpoint=PRODUCTION_ACCOUNT_ENDPOINT):
+        account_endpoint=PRODUCTION_ACCOUNT_ENDPOINT,
+        signing_env_prefix="spacewave"):
     configs = {
         "store-peer": config_entry("object/peer", 1, {
             "objectStoreId": "s4wave-peer",
@@ -71,13 +72,14 @@ def core_config_set(
         }),
         "root-resource": config_entry("resource/root", 1),
         "session-list": config_entry("session", 1),
-        "provider-local": config_entry("provider/local", 1, {
+        "provider-local": config_entry("provider/local", 2, {
             "signalingUrl": cloud_api_endpoint,
+            "signalingEnvPrefix": signing_env_prefix,
         }),
         "provider-spacewave": config_entry("provider/spacewave", 2, {
             "endpoint": cloud_api_endpoint,
             "accountEndpoint": account_endpoint,
-            "signingEnvPrefix": "spacewave",
+            "signingEnvPrefix": signing_env_prefix,
         }),
         "space-sobject": config_entry("space/sobject", 1, {"verbose": False}),
         "space-world-ops": config_entry("space/world/ops", 1),
@@ -765,8 +767,16 @@ build("cli",         manifests=["spacewave"])
 PLUGIN_RELEASE_BROWSER_MANIFEST_OVERRIDES = {
     "spacewave-core": browser_spacewave_core_config("GO_COMPILER_GOSCRIPT"),
 }
-def plugin_release_browser_manifest_overrides(manifest_id):
+def plugin_release_browser_manifest_overrides(manifest_id, release_environment="production"):
     if manifest_id == "spacewave-core":
+        if release_environment == "staging":
+            core = browser_spacewave_core_config("GO_COMPILER_GOSCRIPT")
+            core["configSet"] = core_config_set(
+                cloud_api_endpoint=BROWSER_RELEASE_CLOUD_API_ENDPOINT,
+                account_endpoint="https://account-staging.spacewave.app",
+                signing_env_prefix="spacewave-staging",
+            )
+            return {"spacewave-core": core}
         return PLUGIN_RELEASE_BROWSER_MANIFEST_OVERRIDES
     return {}
 

--- a/bldr/project/starlark/release-signaling_test.go
+++ b/bldr/project/starlark/release-signaling_test.go
@@ -1,0 +1,42 @@
+//go:build !js
+
+package bldr_project_starlark
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestBrowserPluginReleaseEnvironment verifies the compiler receives matching
+// cloud and standalone signing namespaces for each browser release environment.
+func TestBrowserPluginReleaseEnvironment(t *testing.T) {
+	source, err := os.ReadFile("../../../bldr.star")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, env := range []string{"production", "staging"} {
+		t.Run(env, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "bldr.star")
+			build := "\n" + `build("release-env-test", manifests=["spacewave-core"], platform_ids=["js"], manifestOverrides=plugin_release_browser_manifest_overrides("spacewave-core", "` + env + `"))`
+			if err := os.WriteFile(path, append(source, []byte(build)...), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			result, err := Evaluate(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			config := string(result.Config.GetBuild()["release-env-test"].GetManifestOverrides()["spacewave-core"].GetConfig())
+			prefix, account := "spacewave", "https://account.spacewave.app"
+			if env == "staging" {
+				prefix, account = "spacewave-staging", "https://account-staging.spacewave.app"
+			}
+			for _, want := range []string{`"signalingEnvPrefix":"` + prefix + `"`, `"signingEnvPrefix":"` + prefix + `"`, `"accountEndpoint":"` + account + `"`, `"signalingUrl":"/"`} {
+				if !strings.Contains(config, want) {
+					t.Fatalf("missing %s in %s", want, config)
+				}
+			}
+		})
+	}
+}

--- a/core/provider/local/account-transport.go
+++ b/core/provider/local/account-transport.go
@@ -497,7 +497,10 @@ func (a *ProviderAccount) stopSessionTransportStateLocked(ctx context.Context, s
 // local sessions have no linked cloud account, so the persisted provider
 // signaling URL is their only rendezvous. Empty keeps them without signaling.
 func (a *ProviderAccount) fallbackSignalingEndpoint() cloudRelayEndpoint {
-	return cloudRelayEndpoint{url: a.t.p.signalingURL}
+	return cloudRelayEndpoint{
+		url:              a.t.p.signalingURL,
+		signingEnvPrefix: a.t.p.signalingEnvPrefix,
+	}
 }
 
 // lookupCloudRelayEndpoint resolves the cloud relay endpoint and signing

--- a/core/provider/local/factory.go
+++ b/core/provider/local/factory.go
@@ -77,6 +77,7 @@ func (t *Factory) Construct(
 				t.bus,
 				cc.GetStorageId(),
 				cc.GetSignalingUrl(),
+				cc.GetSignalingEnvPrefix(),
 				info,
 				peer,
 				handler,

--- a/core/provider/local/local.pb.go
+++ b/core/provider/local/local.pb.go
@@ -33,6 +33,9 @@ type Config struct {
 	// cloud account or provider credential is involved. Empty disables WebRTC
 	// signaling for standalone sessions.
 	SignalingUrl string `protobuf:"bytes,4,opt,name=signaling_url,json=signalingUrl,proto3" json:"signalingUrl,omitempty"`
+	// SignalingEnvPrefix is the request-signing namespace of the signaling server.
+	// Empty uses the production namespace.
+	SignalingEnvPrefix string `protobuf:"bytes,5,opt,name=signaling_env_prefix,json=signalingEnvPrefix,proto3" json:"signalingEnvPrefix,omitempty"`
 }
 
 func (x *Config) Reset() {
@@ -65,6 +68,13 @@ func (x *Config) GetStorageId() string {
 func (x *Config) GetSignalingUrl() string {
 	if x != nil {
 		return x.SignalingUrl
+	}
+	return ""
+}
+
+func (x *Config) GetSignalingEnvPrefix() string {
+	if x != nil {
+		return x.SignalingEnvPrefix
 	}
 	return ""
 }
@@ -167,6 +177,7 @@ func (m *Config) CloneVT() *Config {
 	r.PeerId = m.PeerId
 	r.StorageId = m.StorageId
 	r.SignalingUrl = m.SignalingUrl
+	r.SignalingEnvPrefix = m.SignalingEnvPrefix
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = slices.Clone(m.unknownFields)
 	}
@@ -244,6 +255,9 @@ func (this *Config) EqualVT(that *Config) bool {
 		return false
 	}
 	if this.SignalingUrl != that.SignalingUrl {
+		return false
+	}
+	if this.SignalingEnvPrefix != that.SignalingEnvPrefix {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -354,6 +368,11 @@ func (x *Config) MarshalProtoJSON(s *json.MarshalState) {
 		s.WriteObjectField("signalingUrl")
 		s.WriteString(x.SignalingUrl)
 	}
+	if x.SignalingEnvPrefix != "" || s.HasField("signalingEnvPrefix") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("signalingEnvPrefix")
+		s.WriteString(x.SignalingEnvPrefix)
+	}
 	s.WriteObjectEnd()
 }
 
@@ -383,6 +402,9 @@ func (x *Config) UnmarshalProtoJSON(s *json.UnmarshalState) {
 		case "signaling_url", "signalingUrl":
 			s.AddField("signaling_url")
 			x.SignalingUrl = s.ReadString()
+		case "signaling_env_prefix", "signalingEnvPrefix":
+			s.AddField("signaling_env_prefix")
+			x.SignalingEnvPrefix = s.ReadString()
 		}
 	})
 }
@@ -596,6 +618,11 @@ func (m *Config) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
 	}
+	if len(m.SignalingEnvPrefix) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.SignalingEnvPrefix)
+		i--
+		dAtA[i] = 0x2a
+	}
 	if len(m.SignalingUrl) > 0 {
 		i = protobuf_go_lite.EncodeString(dAtA, i, m.SignalingUrl)
 		i--
@@ -767,6 +794,7 @@ func (m *Config) SizeVT() (n int) {
 	n += protobuf_go_lite.SizeStringNonEmpty(1, m.PeerId)
 	n += protobuf_go_lite.SizeStringNonEmpty(1, m.StorageId)
 	n += protobuf_go_lite.SizeStringNonEmpty(1, m.SignalingUrl)
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.SignalingEnvPrefix)
 	n += len(m.unknownFields)
 	return n
 }
@@ -831,6 +859,10 @@ func (x *Config) MarshalProtoText() string {
 	if x.SignalingUrl != "" {
 		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "signaling_url")
 		protobuf_go_lite.TextWriteString(&sb, x.SignalingUrl)
+	}
+	if x.SignalingEnvPrefix != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "signaling_env_prefix")
+		protobuf_go_lite.TextWriteString(&sb, x.SignalingEnvPrefix)
 	}
 	return protobuf_go_lite.TextFinishMessage(&sb)
 }
@@ -961,6 +993,16 @@ func (m *Config) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			m.SignalingUrl = v
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SignalingEnvPrefix", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.SignalingEnvPrefix = v
 		default:
 			iNdEx = preIndex
 			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])

--- a/core/provider/local/local.pb.ts
+++ b/core/provider/local/local.pb.ts
@@ -51,6 +51,13 @@ export interface Config {
    * @generated from field: string signaling_url = 4;
    */
   signalingUrl?: string
+  /**
+   * SignalingEnvPrefix is the request-signing namespace of the signaling server.
+   * Empty uses the production namespace.
+   *
+   * @generated from field: string signaling_env_prefix = 5;
+   */
+  signalingEnvPrefix?: string
 }
 
 export const Config: MessageType<Config> = /* @__PURE__ */ createMessageType({
@@ -60,6 +67,12 @@ export const Config: MessageType<Config> = /* @__PURE__ */ createMessageType({
     { no: 2, name: 'peer_id', kind: 'scalar', T: ScalarType.STRING },
     { no: 3, name: 'storage_id', kind: 'scalar', T: ScalarType.STRING },
     { no: 4, name: 'signaling_url', kind: 'scalar', T: ScalarType.STRING },
+    {
+      no: 5,
+      name: 'signaling_env_prefix',
+      kind: 'scalar',
+      T: ScalarType.STRING,
+    },
   ] satisfies readonly PartialFieldInfo[],
   packedByDefault: true,
 })

--- a/core/provider/local/local.proto
+++ b/core/provider/local/local.proto
@@ -21,6 +21,9 @@ message Config {
   // cloud account or provider credential is involved. Empty disables WebRTC
   // signaling for standalone sessions.
   string signaling_url = 4;
+  // SignalingEnvPrefix is the request-signing namespace of the signaling server.
+  // Empty uses the production namespace.
+  string signaling_env_prefix = 5;
 }
 
 // LocalSOState contains the local state for a shared object.

--- a/core/provider/local/provider-session_test.go
+++ b/core/provider/local/provider-session_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 // setupProviderAndSession creates a testbed with a local provider, account, and session.
-// An optional trailing signalingURL sets the provider's standalone signaling URL.
+// Optional trailing arguments set the standalone signaling URL and signing namespace.
 func setupProviderAndSession(ctx context.Context, t *testing.T, signalingURL ...string) (
 	*testbed.Testbed,
 	*session.SessionRef,
@@ -41,6 +41,9 @@ func setupProviderAndSession(ctx context.Context, t *testing.T, signalingURL ...
 	}
 	if len(signalingURL) != 0 {
 		provCfg.SignalingUrl = signalingURL[0]
+	}
+	if len(signalingURL) > 1 {
+		provCfg.SignalingEnvPrefix = signalingURL[1]
 	}
 	tb.StaticResolver.AddFactory(provider_local.NewFactory(tb.Bus))
 	_, provCtrlRef, err := tb.Bus.AddDirective(resolver.NewLoadControllerWithConfig(provCfg), nil)

--- a/core/provider/local/provider.go
+++ b/core/provider/local/provider.go
@@ -33,6 +33,8 @@ type Provider struct {
 	// signalingURL is the trusted cloud signaling base URL from the
 	// provider configuration. Empty disables standalone-session signaling.
 	signalingURL string
+	// signalingEnvPrefix selects the trusted signaling server signing namespace.
+	signalingEnvPrefix string
 	// info is the provider info
 	info *provider.ProviderInfo
 	// sfs is the step factory set for block transforms
@@ -80,6 +82,7 @@ func NewProvider(
 	b bus.Bus,
 	storageID string,
 	signalingURL string,
+	signalingEnvPrefix string,
 	info *provider.ProviderInfo,
 	peer peer.Peer,
 	handler provider.ProviderHandler,
@@ -89,14 +92,15 @@ func NewProvider(
 	sfs.AddStepFactory(transform_blockenc.NewStepFactory())
 
 	p := &Provider{
-		le:           le,
-		b:            b,
-		storageID:    storageID,
-		signalingURL: signalingURL,
-		info:         info,
-		peer:         peer,
-		handler:      handler,
-		sfs:          sfs,
+		le:                 le,
+		b:                  b,
+		storageID:          storageID,
+		signalingURL:       signalingURL,
+		signalingEnvPrefix: signalingEnvPrefix,
+		info:               info,
+		peer:               peer,
+		handler:            handler,
+		sfs:                sfs,
 	}
 	p.linkedCloudAccountLoader = defaultLinkedCloudAccountLoader
 	p.accountRc = keyed.NewKeyedRefCountWithLogger(

--- a/core/provider/local/session-standalone-signaling_test.go
+++ b/core/provider/local/session-standalone-signaling_test.go
@@ -103,7 +103,7 @@ func awaitReadySessionTransport(ctx context.Context, t *testing.T, acc *provider
 // standalone local session signaling. A standalone local session (no linked
 // cloud account) uses the trusted signaling URL persisted in the provider
 // configuration: with a URL it signs its own ticket request with the session
-// keypair under the default signing environment and connects the WebRTC
+// keypair under the configured signing environment and connects the WebRTC
 // signaling WebSocket without any cloud account credential; with an empty
 // URL it stays without signaling. A daemon restart re-runs the same mount
 // path, so a configured URL reconnects after restart.
@@ -111,74 +111,82 @@ func TestStandaloneSessionSignaling(t *testing.T) {
 	if runtime.GOOS == "js" {
 		t.Skip("standalone signaling test requires native HTTP server and WebSocket support")
 	}
-	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
-	defer cancel()
+	for _, prefix := range []string{"", "spacewave-staging"} {
+		t.Run("prefix="+prefix, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+			defer cancel()
 
-	// Empty signaling URL keeps the session without WebRTC signaling.
-	{
-		sig := newSignalingServer()
-		defer sig.server.Close()
+			// Empty signaling URL keeps the session without WebRTC signaling.
+			{
+				sig := newSignalingServer()
+				defer sig.server.Close()
 
-		_, _, acc, _, release := setupProviderAndSession(ctx, t, "")
-		defer release()
+				_, _, acc, _, release := setupProviderAndSession(ctx, t, "")
+				defer release()
 
-		st := awaitReadySessionTransport(ctx, t, acc)
-		if got := st.GetStartupStage(); got != "ready" {
-			t.Fatalf("startup stage = %q, want ready", got)
-		}
-		if n := sig.tickets.Load(); n != 0 {
-			t.Fatalf("empty signaling URL requested %d tickets, want 0", n)
-		}
-	}
+				st := awaitReadySessionTransport(ctx, t, acc)
+				if got := st.GetStartupStage(); got != "ready" {
+					t.Fatalf("startup stage = %q, want ready", got)
+				}
+				if n := sig.tickets.Load(); n != 0 {
+					t.Fatalf("empty signaling URL requested %d tickets, want 0", n)
+				}
+			}
 
-	// A configured signaling URL drives ticket signing and the signaling
-	// WebSocket through the existing WebRTC transport.
-	sig := newSignalingServer()
-	defer sig.server.Close()
+			// A configured signaling URL drives ticket signing and the signaling
+			// WebSocket through the existing WebRTC transport.
+			sig := newSignalingServer()
+			defer sig.server.Close()
 
-	_, _, acc, sess, release := setupProviderAndSession(ctx, t, sig.server.URL)
-	defer release()
+			_, _, acc, sess, release := setupProviderAndSession(ctx, t, sig.server.URL, prefix)
+			defer release()
 
-	awaitReadySessionTransport(ctx, t, acc)
-	if n := sig.tickets.Load(); n == 0 {
-		t.Fatal("standalone session did not request a signal ticket")
-	}
+			awaitReadySessionTransport(ctx, t, acc)
+			if n := sig.tickets.Load(); n == 0 {
+				t.Fatal("standalone session did not request a signal ticket")
+			}
 
-	req := sig.first.Load()
-	if want := sess.GetPeerId().String(); req.peerID != want {
-		t.Fatalf("ticket request peer ID = %q, want session peer %s", req.peerID, want)
-	}
-	timestampMs, err := strconv.ParseInt(req.timestamp, 10, 64)
-	if err != nil {
-		t.Fatalf("parse ticket timestamp %q: %v", req.timestamp, err)
-	}
-	payload, err := (&api.SigningPayload{
-		EnvPrefix:     "spacewave",
-		Method:        http.MethodPost,
-		Path:          "/api/signal/ticket",
-		TimestampMs:   timestampMs,
-		ContentLength: 0,
-		BodyHashHex:   req.bodyHash,
-	}).MarshalVT()
-	if err != nil {
-		t.Fatalf("marshal signing payload: %v", err)
-	}
-	pub, err := sess.GetPeerId().ExtractPublicKey()
-	if err != nil {
-		t.Fatalf("extract session public key: %v", err)
-	}
-	signature, err := base64.StdEncoding.DecodeString(req.signature)
-	if err != nil {
-		t.Fatalf("decode ticket signature: %v", err)
-	}
-	valid, err := pub.Verify(payload, signature)
-	if err != nil || !valid {
-		t.Fatalf("ticket signature not signed by the session keypair: valid=%v err=%v", valid, err)
-	}
+			req := sig.first.Load()
+			if want := sess.GetPeerId().String(); req.peerID != want {
+				t.Fatalf("ticket request peer ID = %q, want session peer %s", req.peerID, want)
+			}
+			timestampMs, err := strconv.ParseInt(req.timestamp, 10, 64)
+			if err != nil {
+				t.Fatalf("parse ticket timestamp %q: %v", req.timestamp, err)
+			}
+			wantPrefix := prefix
+			if wantPrefix == "" {
+				wantPrefix = "spacewave"
+			}
+			payload, err := (&api.SigningPayload{
+				EnvPrefix:     wantPrefix,
+				Method:        http.MethodPost,
+				Path:          "/api/signal/ticket",
+				TimestampMs:   timestampMs,
+				ContentLength: 0,
+				BodyHashHex:   req.bodyHash,
+			}).MarshalVT()
+			if err != nil {
+				t.Fatalf("marshal signing payload: %v", err)
+			}
+			pub, err := sess.GetPeerId().ExtractPublicKey()
+			if err != nil {
+				t.Fatalf("extract session public key: %v", err)
+			}
+			signature, err := base64.StdEncoding.DecodeString(req.signature)
+			if err != nil {
+				t.Fatalf("decode ticket signature: %v", err)
+			}
+			valid, err := pub.Verify(payload, signature)
+			if err != nil || !valid {
+				t.Fatalf("ticket signature not signed by the session keypair: valid=%v err=%v", valid, err)
+			}
 
-	select {
-	case <-sig.wsAccepted:
-	case <-ctx.Done():
-		t.Fatal("session transport did not connect to the signaling WebSocket")
+			select {
+			case <-sig.wsAccepted:
+			case <-ctx.Done():
+				t.Fatal("session transport did not connect to the signaling WebSocket")
+			}
+		})
 	}
 }

--- a/scripts/release/build-browser-plugin.sh
+++ b/scripts/release/build-browser-plugin.sh
@@ -15,6 +15,12 @@ case "${plugin}" in
     ;;
 esac
 
+release_environment="${SPACEWAVE_RELEASE_ENV:-production}"
+case "${release_environment}" in
+  staging|production) ;;
+  *) echo "unknown release environment: ${release_environment}" >&2; exit 64 ;;
+esac
+
 target="plugin-release-browser-${plugin}"
 backup="$(mktemp)"
 cp bldr.star "${backup}"
@@ -30,7 +36,7 @@ cat >> bldr.star <<EOF
 build("${target}",
     manifests=["${plugin}"],
     platform_ids=plugin_release_browser_manifest_platform_ids("${plugin}"),
-    manifestOverrides=plugin_release_browser_manifest_overrides("${plugin}"),
+    manifestOverrides=plugin_release_browser_manifest_overrides("${plugin}", "${release_environment}"),
 )
 EOF
 


### PR DESCRIPTION
Staging browser plugins embedded production signing defaults. Standalone Drive sessions consequently received HTTP 401 when requesting their signaling ticket.

Add the local provider's signing namespace to its configuration and carry it into session transport. Select matching staging cloud and local signing settings, plus the staging account URL, in staging browser plugin builds. Production defaults remain valid for existing configurations.

Generation and commit checks pass. The session integration test verifies real ticket signatures under both namespaces, and the Starlark test verifies the compiler configuration for both release environments.
