### PR TITLE
fix(storage): buffer sequential segment iteration

### DIFF
--- a/db/volume/js/opfs/segment/iterator.go
+++ b/db/volume/js/opfs/segment/iterator.go
@@ -1,6 +1,7 @@
 package segment
 
 import (
+	"bufio"
 	"encoding/binary"
 	"io"
 
@@ -8,31 +9,31 @@ import (
 )
 
 // EntryIterator streams entries from an SSTable data block in key order.
+// Its bounded read buffer keeps scans sequential even when a shared cache is full.
 type EntryIterator struct {
-	r          io.ReaderAt
-	dataOffset int64
-	off        uint32
-	limit      uint32
-	remaining  uint32
+	r         io.Reader
+	off       uint32
+	limit     uint32
+	remaining uint32
 }
 
 // NewEntryIterator returns an iterator over the entries described by metadata.
 func NewEntryIterator(r io.ReaderAt, meta *LookupMeta) *EntryIterator {
+	reader := io.NewSectionReader(r, int64(meta.Header.DataOffset), int64(meta.Header.DataSize))
 	return &EntryIterator{
-		r:          r,
-		dataOffset: int64(meta.Header.DataOffset),
-		limit:      meta.Header.DataSize,
-		remaining:  meta.Header.EntryCount,
+		r:         bufio.NewReaderSize(reader, 64*1024),
+		limit:     meta.Header.DataSize,
+		remaining: meta.Header.EntryCount,
 	}
 }
 
 // Entries returns a streaming iterator over the reader's data block.
 func (rd *Reader) Entries() *EntryIterator {
+	reader := io.NewSectionReader(rd.r, int64(rd.header.DataOffset), int64(rd.header.DataSize))
 	return &EntryIterator{
-		r:          rd.r,
-		dataOffset: int64(rd.header.DataOffset),
-		limit:      rd.header.DataSize,
-		remaining:  rd.header.EntryCount,
+		r:         bufio.NewReaderSize(reader, 64*1024),
+		limit:     rd.header.DataSize,
+		remaining: rd.header.EntryCount,
 	}
 }
 
@@ -93,7 +94,7 @@ func (it *EntryIterator) read(buf []byte) error {
 	if uint64(it.limit-it.off) < uint64(len(buf)) {
 		return io.ErrUnexpectedEOF
 	}
-	if _, err := it.r.ReadAt(buf, it.dataOffset+int64(it.off)); err != nil {
+	if _, err := io.ReadFull(it.r, buf); err != nil {
 		return err
 	}
 	it.off += uint32(len(buf))

--- a/db/volume/js/opfs/segment/segment_test.go
+++ b/db/volume/js/opfs/segment/segment_test.go
@@ -283,6 +283,38 @@ func TestEntryIterator(t *testing.T) {
 	}
 }
 
+func TestEntryIteratorBuffersSequentialReads(t *testing.T) {
+	w := NewWriter()
+	value := bytes.Repeat([]byte("v"), 512)
+	const count = 4096
+	for i := range count {
+		w.Add([]byte("key-"+zeroPad(i, 6)), value)
+	}
+	var encoded bytes.Buffer
+	if _, err := w.Build(&encoded); err != nil {
+		t.Fatal(err)
+	}
+	data := encoded.Bytes()
+	meta, err := LoadLookupMeta(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := &countingReaderAt{data: data}
+	iterator := NewEntryIterator(source, meta)
+	for i := range count {
+		entry, ok, err := iterator.Next()
+		if err != nil || !ok || string(entry.Key) != "key-"+zeroPad(i, 6) || !bytes.Equal(entry.Value, value) {
+			t.Fatalf("entry %d: ok=%v err=%v", i, ok, err)
+		}
+	}
+	if _, ok, err := iterator.Next(); ok || err != nil {
+		t.Fatalf("exhaustion: ok=%v err=%v", ok, err)
+	}
+	if source.reads > 40 {
+		t.Fatalf("sequential scan used %d storage reads, want at most 40", source.reads)
+	}
+}
+
 func TestEntryIteratorRejectsTruncatedValueBeforeAlloc(t *testing.T) {
 	w := NewWriter()
 	w.Add([]byte("key"), []byte("value"))


### PR DESCRIPTION
Buffer sequential SSTable iteration within the data section. Compaction holds input cache leases throughout a merge, so four pinned spans can prevent further cache admission and turn every small entry read into another storage range read. The iterator now keeps a bounded 64 KiB buffer independently of shared cache admission.

A 4,096-entry regression required 16,384 storage reads before this change and now passes a 40-read maximum. The full segment test package passes. Existing truncation checks and the stored representation are unchanged.
