### PR TITLE
fix(bldr): exclude generated modules from startup inputs

### DIFF
--- a/bldr/plugin/compiler/go/compiler.go
+++ b/bldr/plugin/compiler/go/compiler.go
@@ -1264,7 +1264,7 @@ func (c *Controller) BuildPlugin(
 			return nil, err
 		}
 	}
-	webRuntimeSrcFiles = filterPathsUnderBase(sourcePath, webRuntimeSrcFiles)
+	webRuntimeSrcFiles = filterPathsUnderBase(sourcePath, webRuntimeSrcFiles, workingPath)
 	if len(webRuntimeSrcFiles) != 0 {
 		err = fsutil.ConvertPathsToRelative(sourcePath, webRuntimeSrcFiles)
 		if err != nil {
@@ -1394,12 +1394,20 @@ func appendInputManifestFiles(
 	return nil
 }
 
-// filterPathsUnderBase drops empty paths and paths that fall outside basePath.
-func filterPathsUnderBase(basePath string, paths []string) []string {
+// filterPathsUnderBase retains source files outside generated build roots.
+// Generated inputs are covered by their source and compiler inputs, and must
+// not make startup validation depend on disposable build output.
+func filterPathsUnderBase(basePath string, paths []string, generatedRoots ...string) []string {
 	if len(paths) == 0 {
 		return nil
 	}
+	for _, root := range slices.Clone(generatedRoots) {
+		if resolved, err := filepath.EvalSymlinks(root); err == nil && resolved != root {
+			generatedRoots = append(generatedRoots, resolved)
+		}
+	}
 	filtered := paths[:0]
+nextInput:
 	for _, filePath := range paths {
 		if filePath == "" {
 			continue
@@ -1410,6 +1418,12 @@ func filterPathsUnderBase(basePath string, paths []string) []string {
 		}
 		if relPath == "." || relPath == ".." || strings.HasPrefix(relPath, ".."+string(filepath.Separator)) {
 			continue
+		}
+		for _, root := range generatedRoots {
+			rel, err := filepath.Rel(root, filePath)
+			if err == nil && filepath.IsLocal(rel) {
+				continue nextInput
+			}
 		}
 		filtered = append(filtered, filePath)
 	}

--- a/bldr/plugin/compiler/go/generated-inputs_test.go
+++ b/bldr/plugin/compiler/go/generated-inputs_test.go
@@ -1,0 +1,29 @@
+//go:build !js
+
+package bldr_plugin_compiler_go
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+// TestStartupInputsExcludeGeneratedTree preserves real runtime dependencies
+// while allowing generated modules to disappear after bundling.
+func TestStartupInputsExcludeGeneratedTree(t *testing.T) {
+	root := t.TempDir()
+	generated := filepath.Join(root, ".bldr-dist", "build", "js", "launcher")
+	if err := os.MkdirAll(generated, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	source := filepath.Join(root, "bldr", "web", "runtime.ts")
+	override := filepath.Join(root, "gs", "encoding", "binary", "index.ts")
+	sibling := generated + "-source.ts"
+	inputs := []string{source, filepath.Join(generated, "dist", "@goscript", "encoding", "binary", "index.ts"), filepath.Join(generated, "codegen", "entrypoint.ts"), override, sibling}
+	got := filterPathsUnderBase(root, inputs, generated)
+	want := []string{source, override, sibling}
+	if !slices.Equal(got, want) {
+		t.Fatalf("startup inputs = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
GoScript plugin bundles were recording generated TypeScript and wrapper files as startup source inputs. A build could then fail while capturing an identity for an intermediate module that was no longer present.

Exclude the plugin build workspace from runtime source inputs. Go sources, module selection, overrides, and compiler configuration continue to control invalidation; real runtime sources remain tracked.

Validation: the Go plugin compiler package tests pass, including generated-tree exclusion and source retention.
