### PR TITLE
feat(app): simplify the browser startup screen

### DIFF
--- a/app/loading/AppLoadingScreen.test.tsx
+++ b/app/loading/AppLoadingScreen.test.tsx
@@ -3,7 +3,6 @@ import { act, cleanup, render, screen } from '@testing-library/react'
 import {
   advanceBootDownload,
   beginBootDownload,
-  bootProgressStallDelayMs,
   completeBootDownload,
   failBootDownload,
   resetBootDownloadsForTest,
@@ -64,15 +63,6 @@ const mockProjection = vi.hoisted<{
   }
 })
 
-vi.mock('@s4wave/app/landing/AnimatedLogo.js', () => ({
-  default: ({ reduceMotion }: { reduceMotion?: boolean }) => (
-    <div
-      data-testid="animated-logo"
-      data-reduce-motion={reduceMotion ? 'true' : undefined}
-    />
-  ),
-}))
-
 vi.mock('@s4wave/app/loading/status/browser-startup.js', () => ({
   useBrowserStartupProjection: () => mockProjection.current,
 }))
@@ -86,204 +76,24 @@ afterEach(() => {
   vi.unstubAllGlobals()
 })
 
-// stepState reads the rendered per-phase state marker (data-state on the <li>)
-// and whether that step shows the active spinner rather than a static dot.
-function stepState(container: HTMLElement, label: string) {
-  const rail = container.querySelector('[aria-label="Startup phases"]')
-  const li = Array.from(rail?.querySelectorAll('.swb-step') ?? []).find(
-    (el) => el.querySelector('.swb-step-label')?.textContent === label,
-  )
-  return {
-    state: li?.getAttribute('data-state'),
-    spinner: !!li?.querySelector('.swb-spinner'),
-    dot: !!li?.querySelector('.swb-dot'),
-  }
-}
-
 describe('AppLoadingScreen', () => {
-  it('renders the branded startup composition from the shared loading view', () => {
+  it('keeps phase percentages out of the default screen and exposes diagnostics on demand', () => {
     const { container } = render(<AppLoadingScreen />)
-
-    expect(screen.getByText('Starting the Spacewave runtime')).toBeDefined()
+    expect(screen.getByText('Opening Spacewave')).toBeDefined()
+    expect(screen.getByText('Starting the app')).toBeDefined()
     expect(
-      screen.getByText(
-        'Runtime initialization: Connecting the Spacewave runtime.',
-      ),
+      screen.getByRole('progressbar').getAttribute('aria-valuenow'),
+    ).toBeNull()
+    expect(screen.queryByText('58%')).toBeNull()
+    expect(screen.queryByLabelText('Startup phases')).toBeNull()
+    const details = container.querySelector('details')
+    expect(details?.open).toBe(false)
+    expect(details?.textContent).toContain(
+      'Runtime initialization: Connecting the Spacewave runtime.',
+    )
+    expect(
+      screen.getByText('Downloaded files are saved on this device.'),
     ).toBeDefined()
-    expect(screen.getByLabelText('Startup phases')).toBeDefined()
-    expect(screen.getByText('Prepare')).toBeDefined()
-    expect(screen.getByText('Connect')).toBeDefined()
-    expect(screen.getByText('Runtime')).toBeDefined()
-    expect(screen.getByText('App')).toBeDefined()
-    expect(screen.getByText('Done')).toBeDefined()
-    // The first-run hint tells new users the initial download can be slow.
-    expect(
-      screen.getByText(/first launch downloads the full app bundle/i),
-    ).toBeDefined()
-    // The surface is self-styled from the inlined boot critical stylesheet so it
-    // paints branded before the Tailwind app.css loads.
-    expect(container.querySelector('.swb-canvas')).not.toBeNull()
-  })
-
-  it('marks each phase with its state: complete dot, current spinner, pending muted', () => {
-    const { container } = render(<AppLoadingScreen />)
-
-    expect(stepState(container, 'Prepare')).toMatchObject({
-      state: 'complete',
-      dot: true,
-      spinner: false,
-    })
-    expect(stepState(container, 'Runtime')).toMatchObject({
-      state: 'current',
-      spinner: true,
-      dot: false,
-    })
-    expect(stepState(container, 'Done')).toMatchObject({
-      state: 'pending',
-      dot: true,
-      spinner: false,
-    })
-  })
-
-  it('renders app bundle progress as determinate frame progress', () => {
-    mockProjection.current = {
-      ...mockProjection.current,
-      view: {
-        state: 'loading',
-        title: 'Loading the app',
-        detail: 'Current app download: Opening the application.',
-        progress: 0.42,
-      },
-      phase: {
-        id: 'frame',
-        label: 'App',
-      },
-      phases: mockProjection.current.phases.map((phase) => ({
-        ...phase,
-        state:
-          phase.id === 'done'
-            ? 'pending'
-            : phase.id === 'frame'
-              ? 'current'
-              : 'complete',
-      })),
-      evidence: {
-        ...mockProjection.current.evidence,
-        status: {
-          phase: 'app',
-          detail: 'Downloading app bundle...',
-          state: 'loading',
-          progress: 0.42,
-        },
-      },
-    }
-
-    const { container } = render(<AppLoadingScreen />)
-
-    expect(screen.getByText('Current download')).toBeDefined()
-    expect(screen.getByText('42%')).toBeDefined()
-    expect(screen.queryByText('84%')).toBeNull()
-    expect(container.querySelector('.swb-bar-fill--indeterminate')).toBeNull()
-    expect(stepState(container, 'App')).toMatchObject({
-      state: 'current',
-      spinner: true,
-    })
-  })
-
-  it('shimmers only after a markless gap and returns to determinate progress on the next mark', () => {
-    vi.useFakeTimers()
-    const { container, rerender } = render(<AppLoadingScreen />)
-    const progress = screen.getByRole('progressbar')
-
-    act(() => {
-      vi.advanceTimersByTime(bootProgressStallDelayMs - 1)
-    })
-    expect(container.querySelector('.swb-bar-fill--stalled')).toBeNull()
-
-    act(() => {
-      vi.advanceTimersByTime(1)
-    })
-    const stalled = container.querySelector('.swb-bar-fill--stalled')
-    if (!(stalled instanceof HTMLElement)) {
-      throw new Error(
-        'Expected the stalled progress bar fill to be an HTMLElement',
-      )
-    }
-    expect(stalled.style.width).toBe('58%')
-    expect(progress.getAttribute('aria-valuenow')).toBe('58')
-    expect(screen.getByText('58%')).toBeDefined()
-    expect(container.querySelector('.swb-bar-fill--indeterminate')).toBeNull()
-    expect(
-      screen.getByText(
-        'The runtime is still starting. First launch may take longer.',
-      ),
-    ).toBeDefined()
-
-    mockProjection.current = {
-      ...mockProjection.current,
-      view: {
-        ...mockProjection.current.view,
-        detail: 'Runtime initialization: Runtime channel connected.',
-        progress: 0.64,
-      },
-      evidence: {
-        ...mockProjection.current.evidence,
-        marks: [
-          {
-            name: 'spacewave.startup.runtime.client-channel-acked',
-            label: 'runtime.client-channel-acked',
-            sequence: 1,
-            detail: {
-              label: 'runtime.client-channel-acked',
-              sequence: 1,
-            },
-          },
-        ],
-      },
-    }
-    rerender(<AppLoadingScreen />)
-
-    expect(container.querySelector('.swb-bar-fill--stalled')).toBeNull()
-    expect(progress.getAttribute('aria-valuenow')).toBe('64')
-    expect(screen.getByText('64%')).toBeDefined()
-    act(() => {
-      vi.advanceTimersByTime(bootProgressStallDelayMs - 1)
-    })
-    expect(container.querySelector('.swb-bar-fill--stalled')).toBeNull()
-    act(() => {
-      vi.advanceTimersByTime(1)
-    })
-    expect(container.querySelector('.swb-bar-fill--stalled')).not.toBeNull()
-  })
-
-  it('clears a stalled shimmer on error and never restarts it in a terminal state', () => {
-    vi.useFakeTimers()
-    const loading = render(<AppLoadingScreen />)
-    act(() => {
-      vi.advanceTimersByTime(bootProgressStallDelayMs)
-    })
-    expect(
-      loading.container.querySelector('.swb-bar-fill--stalled'),
-    ).not.toBeNull()
-
-    mockProjection.current = {
-      ...mockProjection.current,
-      view: {
-        state: 'error',
-        title: 'Starting the Spacewave runtime',
-        detail: 'Runtime initialization: Connecting the Spacewave runtime.',
-        progress: 0.31,
-        error:
-          'Startup did not finish. Check the browser console or startup marks for details.',
-      },
-    }
-    loading.rerender(<AppLoadingScreen />)
-
-    expect(loading.container.querySelector('.swb-bar-fill--stalled')).toBeNull()
-    act(() => {
-      vi.advanceTimersByTime(bootProgressStallDelayMs)
-    })
-    expect(loading.container.querySelector('.swb-bar-fill--stalled')).toBeNull()
   })
 
   it('retires a download when it completes while active and failed rows remain', () => {
@@ -311,7 +121,9 @@ describe('AppLoadingScreen', () => {
     expect(
       container.querySelector('[data-sw-startup-download="styles"]'),
     ).not.toBeNull()
-    expect(screen.getByText('network error')).toBeDefined()
+    expect(screen.getByRole('alert').textContent).toBe('network error')
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeDefined()
+    expect(container.querySelector('.swb-activity')).toBeNull()
   })
 
   it('renders retry and back affordances for startup errors', () => {
@@ -349,14 +161,11 @@ describe('AppLoadingScreen', () => {
         'Startup did not finish. Check the browser console or startup marks for details.',
       ),
     ).toBeDefined()
-    expect(stepState(container, 'Connect')).toMatchObject({
-      state: 'error',
-      dot: true,
-      spinner: false,
-    })
+    expect(screen.getByRole('alert')).toBeDefined()
+    expect(container.querySelector('.swb-activity')).toBeNull()
   })
 
-  it('keeps startup status, phases, and progress readable with reduced motion', () => {
+  it('retains startup diagnostics with reduced motion', () => {
     vi.stubGlobal('matchMedia', (query: string) => ({
       matches: query === '(prefers-reduced-motion: reduce)',
       media: query,
@@ -371,15 +180,13 @@ describe('AppLoadingScreen', () => {
         .querySelector('[data-sw-startup-reduced-motion]')
         ?.getAttribute('data-sw-startup-reduced-motion'),
     ).toBe('true')
-    expect(screen.getByTestId('animated-logo').dataset.reduceMotion).toBe(
-      'true',
-    )
     expect(
       screen.getByText(
         'Runtime initialization: Connecting the Spacewave runtime.',
       ),
     ).toBeDefined()
-    expect(screen.getByLabelText('Startup phases')).toBeDefined()
-    expect(screen.getByText('58%')).toBeDefined()
+    expect(
+      screen.getByRole('progressbar').getAttribute('aria-valuenow'),
+    ).toBeNull()
   })
 })

--- a/app/loading/AppLoadingScreen.tsx
+++ b/app/loading/AppLoadingScreen.tsx
@@ -1,38 +1,34 @@
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 
-import {
-  bootDownloadFraction,
-  bootProgressStallDelayMs,
-  formatBytes,
-  type BootDownload,
-} from '@aptre/bldr'
-
-import AnimatedLogo from '@s4wave/app/landing/AnimatedLogo.js'
 import { useBrowserStartupProjection } from '@s4wave/app/loading/status/browser-startup.js'
 import { useBrowserBootWatchdog } from '@s4wave/app/loading/status/browser-boot-watchdog.js'
-import { useBootDownloads } from '@s4wave/app/loading/status/browser-downloads.js'
-import {
-  browserStartupStallCopy,
-  type BrowserStartupPhaseView,
-} from '@s4wave/app/loading/status/browser-startup-model.js'
 import { markBrowserStartupBoundary } from '@s4wave/app/prerender/boot-status.js'
+import spacewaveIcon from '@s4wave/web/images/spacewave-icon.png'
 import { useReducedMotion } from '@s4wave/web/ui/loading/index.js'
-import type { LoadingView } from '@s4wave/web/ui/loading/types.js'
-import { cn } from '@s4wave/web/style/utils.js'
 
 import { BootLoadingCriticalStyle } from './boot-loading-critical.js'
+import { BrowserStartupDownloadList } from './BrowserStartupDownloadList.js'
+import { useBootDownloads } from './status/browser-downloads.js'
 
-// AppLoadingScreen renders the full-screen browser boot state. It is the node
-// the root WebView shows while the plugin bundle and its stylesheets download,
-// so it is styled entirely from the inlined boot critical CSS (semantic .swb-*
-// classes) instead of the not-yet-loaded Tailwind app.css.
+// AppLoadingScreen presents startup activity before the application stylesheet
+// arrives. Readiness and download evidence stay in the startup projection.
 export function AppLoadingScreen() {
   const startup = useBrowserStartupProjection()
   useBrowserBootWatchdog()
   const reducedMotion = useReducedMotion()
-  const view = withBrowserStartupErrorActions(startup.view)
-  const hasProgress =
-    view.progress !== undefined || view.progressIndeterminate === true
+  const view = startup.view
+  const downloads = useBootDownloads()
+  const failedDownload = downloads.find(
+    (download) => download.state === 'error',
+  )
+  const failed = view.state === 'error' || failedDownload !== undefined
+  const error =
+    view.error ??
+    failedDownload?.error ??
+    (failedDownload
+      ? `${failedDownload.label} could not be loaded.`
+      : undefined)
+
   return (
     <BrowserStartupRevealProbe>
       <BootLoadingCriticalStyle />
@@ -41,73 +37,67 @@ export function AppLoadingScreen() {
         data-sw-startup-reduced-motion={reducedMotion ? 'true' : undefined}
       >
         <div className="swb-col">
-          <div className="swb-logo">
-            <AnimatedLogo
-              followMouse={false}
-              fixedSize="5rem"
-              reduceMotion={reducedMotion}
-            />
-          </div>
-
+          <img
+            className="swb-logo"
+            src={spacewaveIcon}
+            alt=""
+            width={120}
+            height={120}
+          />
           <div className="swb-head" aria-live="polite">
-            <h1 className="swb-title">{view.title}</h1>
-            {view.detail ? <p className="swb-detail">{view.detail}</p> : null}
-            {hasProgress ? (
-              <BrowserStartupProgress
-                value={
-                  view.progress === undefined ? undefined : view.progress * 100
-                }
-                indeterminate={view.progressIndeterminate}
-                active={view.state === 'loading'}
-                activitySequence={startup.evidence.marks.at(-1)?.sequence}
-                stallMessage={browserStartupStallCopy[startup.phase.id]}
-              />
-            ) : null}
-            {view.error ? <p className="swb-error">{view.error}</p> : null}
-            {view.onRetry || view.onCancel ? (
-              <div className="swb-actions">
-                {view.onRetry ? (
-                  <button
-                    type="button"
-                    className="swb-btn swb-btn--primary"
-                    onClick={view.onRetry}
-                  >
-                    Retry
-                  </button>
-                ) : null}
-                {view.onCancel ? (
-                  <button
-                    type="button"
-                    className="swb-btn swb-btn--ghost"
-                    onClick={view.onCancel}
-                  >
-                    Back
-                  </button>
-                ) : null}
-              </div>
-            ) : null}
+            <h1 className="swb-title">
+              {failed ? 'Unable to open Spacewave' : 'Opening Spacewave'}
+            </h1>
+            {!failed ? <p className="swb-detail">Starting the app</p> : null}
           </div>
-          <BrowserStartupDownloadList />
-          <BrowserStartupPhaseRail phases={startup.phases} />
-          {!hasProgress ? (
-            <p className="swb-hint">
-              The first launch downloads the full app bundle and can take a
-              while. It is cached for instant loads afterward.
+          {!failed ? (
+            <>
+              <div
+                className="swb-activity swb-bar"
+                role="progressbar"
+                aria-label="Opening Spacewave"
+              >
+                <div className="swb-bar-fill swb-bar-fill--indeterminate" />
+              </div>
+              <p className="swb-hint">
+                Downloaded files are saved on this device.
+              </p>
+            </>
+          ) : null}
+          {error ? (
+            <p className="swb-error" role="alert">
+              {error}
             </p>
           ) : null}
+          {failed ? (
+            <div className="swb-actions">
+              <button
+                type="button"
+                className="swb-btn swb-btn--primary"
+                onClick={retryBrowserStartup}
+              >
+                Retry
+              </button>
+              <button
+                type="button"
+                className="swb-btn swb-btn--ghost"
+                onClick={leaveBrowserStartup}
+              >
+                Back
+              </button>
+            </div>
+          ) : null}
+          <details className="swb-disclosure">
+            <summary>Show details</summary>
+            <div className="swb-diagnostics">
+              <p className="swb-status">{view.detail ?? startup.phase.label}</p>
+              <BrowserStartupDownloadList downloads={downloads} />
+            </div>
+          </details>
         </div>
       </div>
     </BrowserStartupRevealProbe>
   )
-}
-
-function withBrowserStartupErrorActions(view: LoadingView): LoadingView {
-  if (view.state !== 'error') return view
-  return {
-    ...view,
-    onRetry: retryBrowserStartup,
-    onCancel: leaveBrowserStartup,
-  }
 }
 
 function retryBrowserStartup() {
@@ -146,206 +136,4 @@ function BrowserStartupRevealProbe({
   }, [])
 
   return children
-}
-
-// BrowserStartupProgress renders the determinate boot progress bar with a mono
-// percent readout, or a sweeping indeterminate bar while byte totals are
-// unknown. A determinate bar keeps its accumulated value but starts shimmering
-// after the startup mark stream has been quiet for two seconds.
-function BrowserStartupProgress({
-  value,
-  indeterminate,
-  active,
-  activitySequence,
-  stallMessage,
-}: {
-  value?: number
-  indeterminate?: boolean
-  active?: boolean
-  activitySequence?: number
-  stallMessage: string
-}) {
-  const pct =
-    value === undefined ? 0 : Math.max(0, Math.min(100, Math.round(value)))
-  const activityKey = `${value ?? 'unknown'}:${activitySequence ?? 0}`
-  const [stalledActivity, setStalledActivity] = useState<string>()
-
-  useEffect(() => {
-    if (!active || indeterminate || pct >= 100) return
-    const timer = window.setTimeout(
-      () => setStalledActivity(activityKey),
-      bootProgressStallDelayMs,
-    )
-    return () => window.clearTimeout(timer)
-  }, [active, activityKey, indeterminate, pct])
-
-  const stalled =
-    active && !indeterminate && pct < 100 && stalledActivity === activityKey
-  return (
-    <div className="swb-progress-block">
-      <div className="swb-progress-context">Current download</div>
-      <div className="swb-progress-wrap">
-        <div
-          className="swb-bar"
-          role="progressbar"
-          aria-valuemin={0}
-          aria-valuemax={100}
-          aria-valuenow={indeterminate ? undefined : pct}
-        >
-          {indeterminate ? (
-            <div className="swb-bar-fill swb-bar-fill--indeterminate" />
-          ) : (
-            <div
-              className={cn('swb-bar-fill', stalled && 'swb-bar-fill--stalled')}
-              style={{ width: `${pct}%` }}
-            />
-          )}
-        </div>
-        {indeterminate ? null : (
-          <span className="swb-mono swb-progress-label">{pct}%</span>
-        )}
-      </div>
-      {stalled ? <p className="swb-stall">{stallMessage}</p> : null}
-      <p className="swb-hint">
-        The first launch downloads the full app bundle and can take a while. It
-        is cached for instant loads afterward.
-      </p>
-    </div>
-  )
-}
-
-// BrowserStartupPhaseRail renders the five boot phases as a connected rail. The
-// filled track reaches the current dot so the rail reads as one journey; the
-// current phase shows a spinner, completed phases a filled dot, pending phases a
-// muted ring, and an errored phase a destructive marker. Shared with the
-// quickstart loading page, so it inlines the boot critical style itself.
-export function BrowserStartupPhaseRail({
-  phases,
-}: {
-  phases: BrowserStartupPhaseView[]
-}) {
-  const failed = phases.some((phase) => phase.state === 'error')
-  const activeIndex = phaseRailActiveIndex(phases)
-  const fillPct =
-    phases.length > 1 ? (activeIndex / (phases.length - 1)) * 100 : 0
-  return (
-    <div className="swb-rail">
-      <BootLoadingCriticalStyle />
-      <div aria-hidden="true" className="swb-rail-track">
-        <div
-          className={
-            failed ? 'swb-rail-fill swb-rail-fill--error' : 'swb-rail-fill'
-          }
-          style={{ width: `${fillPct}%` }}
-        />
-      </div>
-      <ol className="swb-steps" aria-label="Startup phases">
-        {phases.map((phase) => (
-          <li key={phase.id} className="swb-step" data-state={phase.state}>
-            <div className="swb-step-mark">
-              {phase.state === 'current' ? (
-                <span className="swb-spinner" aria-hidden="true" />
-              ) : (
-                <span className="swb-dot" aria-hidden="true" />
-              )}
-            </div>
-            <div className="swb-step-label">{phase.label}</div>
-          </li>
-        ))}
-      </ol>
-    </div>
-  )
-}
-
-// BrowserStartupDownloadList renders the live per-asset download breakdown from
-// the boot download registry: one labeled progress bar per boot asset (runtime,
-// app bundle, and any plugin modules) with streamed bytes and percent. It
-// renders nothing until a producer registers a download, so screens that never
-// stream bytes stay unchanged. Completed downloads retire from the list so a
-// finished byte counter never lingers under later boot phases; failed rows
-// stay visible as evidence.
-export function BrowserStartupDownloadList() {
-  const downloads = useBootDownloads().filter(
-    (download) => download.state !== 'complete',
-  )
-  if (downloads.length === 0) return null
-  return (
-    <ul
-      aria-label="Downloads"
-      data-sw-startup-downloads
-      className="swb-downloads"
-    >
-      {downloads.map((download) => (
-        <li key={download.id} data-sw-startup-download={download.id}>
-          <BrowserStartupDownloadRow download={download} />
-        </li>
-      ))}
-    </ul>
-  )
-}
-
-function BrowserStartupDownloadRow({ download }: { download: BootDownload }) {
-  const fraction = bootDownloadFraction(download)
-  const failed = download.state === 'error'
-  const pct =
-    fraction === undefined
-      ? undefined
-      : Math.max(0, Math.min(100, Math.round(fraction * 100)))
-  return (
-    <div className="swb-dl-row">
-      <div className="swb-dl-head">
-        <span className="swb-dl-label">{download.label}</span>
-        <span
-          data-sw-startup-download-detail
-          className={
-            failed
-              ? 'swb-mono swb-dl-detail swb-dl-detail--error'
-              : 'swb-mono swb-dl-detail'
-          }
-        >
-          {downloadDetailText(download)}
-        </span>
-      </div>
-      <div
-        className="swb-bar"
-        role="progressbar"
-        aria-valuemin={0}
-        aria-valuemax={100}
-        aria-valuenow={pct}
-      >
-        {pct === undefined && !failed ? (
-          <div className="swb-bar-fill swb-bar-fill--indeterminate" />
-        ) : (
-          <div className="swb-bar-fill" style={{ width: `${pct ?? 0}%` }} />
-        )}
-      </div>
-    </div>
-  )
-}
-
-// downloadDetailText renders the streamed byte counter, or the error message
-// when the download failed. A known total shows "loaded / total"; an unknown
-// total shows the bytes seen so far without a faked denominator.
-function downloadDetailText(download: BootDownload): string {
-  if (download.state === 'error') return download.error ?? 'Failed'
-  if (download.total !== undefined) {
-    return `${formatBytes(download.loaded, 1)} / ${formatBytes(download.total, 1)}`
-  }
-  if (download.loaded > 0) return formatBytes(download.loaded, 1)
-  return ''
-}
-
-// phaseRailActiveIndex returns the index the connecting track should fill to:
-// the current or errored phase when present, otherwise the last completed
-// phase (0 while nothing has completed yet).
-function phaseRailActiveIndex(phases: BrowserStartupPhaseView[]): number {
-  const current = phases.findIndex(
-    (phase) => phase.state === 'current' || phase.state === 'error',
-  )
-  if (current >= 0) return current
-  let lastComplete = 0
-  for (const [index, phase] of phases.entries()) {
-    if (phase.state === 'complete') lastComplete = index
-  }
-  return lastComplete
 }

--- a/app/loading/BrowserStartupDownloadList.tsx
+++ b/app/loading/BrowserStartupDownloadList.tsx
@@ -1,0 +1,89 @@
+import {
+  bootDownloadFraction,
+  formatBytes,
+  type BootDownload,
+} from '@aptre/bldr'
+
+import { cn } from '@s4wave/web/style/utils.js'
+
+// BrowserStartupDownloadList renders the live per-asset download breakdown from
+// the boot download registry: one labeled progress bar per boot asset (runtime,
+// app bundle, and any plugin modules) with streamed bytes and percent. It
+// renders nothing until a producer registers a download, so screens that never
+// stream bytes stay unchanged. Completed downloads retire from the list so a
+// finished byte counter never lingers under later boot phases; failed rows
+// stay visible as evidence.
+export function BrowserStartupDownloadList({
+  downloads,
+}: {
+  downloads: BootDownload[]
+}) {
+  const pendingDownloads = downloads.filter(
+    (download) => download.state !== 'complete',
+  )
+  if (pendingDownloads.length === 0) return null
+  return (
+    <ul
+      aria-label="Downloads"
+      data-sw-startup-downloads
+      className="swb-downloads"
+    >
+      {pendingDownloads.map((download) => (
+        <li key={download.id} data-sw-startup-download={download.id}>
+          <BrowserStartupDownloadRow download={download} />
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function BrowserStartupDownloadRow({ download }: { download: BootDownload }) {
+  const fraction = bootDownloadFraction(download)
+  const failed = download.state === 'error'
+  const pct =
+    fraction === undefined
+      ? undefined
+      : Math.max(0, Math.min(100, Math.round(fraction * 100)))
+  return (
+    <div className="swb-dl-row">
+      <div className="swb-dl-head">
+        <span className="swb-dl-label">{download.label}</span>
+        <span
+          data-sw-startup-download-detail
+          className={cn(
+            'swb-mono swb-dl-detail',
+            failed && 'swb-dl-detail--error',
+          )}
+        >
+          {downloadDetailText(download)}
+        </span>
+      </div>
+      <div
+        className="swb-bar"
+        role="progressbar"
+        aria-label={download.label}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={pct}
+      >
+        {pct === undefined && !failed ? (
+          <div className="swb-bar-fill swb-bar-fill--indeterminate" />
+        ) : (
+          <div className="swb-bar-fill" style={{ width: `${pct ?? 0}%` }} />
+        )}
+      </div>
+    </div>
+  )
+}
+
+// downloadDetailText renders the streamed byte counter, or the error message
+// when the download failed. A known total shows "loaded / total"; an unknown
+// total shows the bytes seen so far without a faked denominator.
+function downloadDetailText(download: BootDownload): string {
+  if (download.state === 'error') return download.error ?? 'Failed'
+  if (download.total !== undefined) {
+    return `${formatBytes(download.loaded, 1)} / ${formatBytes(download.total, 1)}`
+  }
+  if (download.loaded > 0) return formatBytes(download.loaded, 1)
+  return ''
+}

--- a/app/loading/BrowserStartupPhaseRail.tsx
+++ b/app/loading/BrowserStartupPhaseRail.tsx
@@ -1,0 +1,61 @@
+import { cn } from '@s4wave/web/style/utils.js'
+
+import type { BrowserStartupPhaseView } from './status/browser-startup-model.js'
+
+import { BootLoadingCriticalStyle } from './boot-loading-critical.js'
+
+// BrowserStartupPhaseRail renders the five boot phases as a connected rail. The
+// filled track reaches the current dot so the rail reads as one journey; the
+// current phase shows a spinner, completed phases a filled dot, pending phases a
+// muted ring, and an errored phase a destructive marker. Shared with the
+// quickstart loading page, so it inlines the boot critical style itself.
+export function BrowserStartupPhaseRail({
+  phases,
+}: {
+  phases: BrowserStartupPhaseView[]
+}) {
+  const failed = phases.some((phase) => phase.state === 'error')
+  const activeIndex = phaseRailActiveIndex(phases)
+  const fillPct =
+    phases.length > 1 ? (activeIndex / (phases.length - 1)) * 100 : 0
+  return (
+    <div className="swb-rail">
+      <BootLoadingCriticalStyle />
+      <div aria-hidden="true" className="swb-rail-track">
+        <div
+          className={cn('swb-rail-fill', failed && 'swb-rail-fill--error')}
+          style={{ width: `${fillPct}%` }}
+        />
+      </div>
+      <ol className="swb-steps" aria-label="Startup phases">
+        {phases.map((phase) => (
+          <li key={phase.id} className="swb-step" data-state={phase.state}>
+            <div className="swb-step-mark">
+              {phase.state === 'current' ? (
+                <span className="swb-spinner" aria-hidden="true" />
+              ) : (
+                <span className="swb-dot" aria-hidden="true" />
+              )}
+            </div>
+            <div className="swb-step-label">{phase.label}</div>
+          </li>
+        ))}
+      </ol>
+    </div>
+  )
+}
+
+// phaseRailActiveIndex returns the index the connecting track should fill to:
+// the current or errored phase when present, otherwise the last completed
+// phase (0 while nothing has completed yet).
+function phaseRailActiveIndex(phases: BrowserStartupPhaseView[]): number {
+  const current = phases.findIndex(
+    (phase) => phase.state === 'current' || phase.state === 'error',
+  )
+  if (current >= 0) return current
+  let lastComplete = 0
+  for (const [index, phase] of phases.entries()) {
+    if (phase.state === 'complete') lastComplete = index
+  }
+  return lastComplete
+}

--- a/app/loading/boot-loading-critical.tsx
+++ b/app/loading/boot-loading-critical.tsx
@@ -8,42 +8,35 @@
 // makes the boot surface self-contained: semantic `.swb-*` classes that resolve
 // against the design tokens when app.css is present and fall back to the
 // baked-in hex values when it is not, so the screen is branded from the first
-// paint regardless of stylesheet timing. Values mirror the static #sw-loading
-// shell in app/prerender/build.ts.
+// paint regardless of stylesheet timing. The static #sw-loading shell imports
+// this same stylesheet.
 
 const MONO_STACK = 'ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace'
 
 export const BOOT_LOADING_CRITICAL_CSS = `
-.swb-canvas{display:flex;align-items:center;justify-content:center;flex:1 1 0%;width:100%;height:100%;min-height:0;overflow:hidden;background:var(--color-background,#0a0a0a);color:var(--color-foreground,#fafafa);font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif}
-.swb-col{display:flex;flex-direction:column;align-items:center;gap:1.25rem;text-align:center;width:min(30rem,calc(100vw - 2rem))}
-.swb-logo{display:flex;height:5rem;width:5rem;align-items:center;justify-content:center;border-radius:1rem;background:color-mix(in srgb,var(--color-brand,#4f8cff) 10%,transparent);box-shadow:0 0 42px color-mix(in srgb,var(--color-brand,#4f8cff) 22%,transparent)}
-.swb-head{display:flex;flex-direction:column;align-items:center;gap:0.5rem}
-.swb-title{margin:0;font-size:1.5rem;font-weight:600;letter-spacing:-0.01em;line-height:1.2;color:var(--color-foreground,#fafafa)}
-.swb-detail{margin:0;font-size:0.875rem;line-height:1.4;color:color-mix(in srgb,var(--color-foreground-alt,#a1a1aa) 70%,transparent)}
-.swb-hint{margin:0;max-width:22rem;font-size:0.75rem;line-height:1.5;color:color-mix(in srgb,var(--color-foreground-alt,#a1a1aa) 52%,transparent)}
-.swb-progress-block{display:flex;flex-direction:column;align-items:center;gap:0.35rem;width:100%}
-.swb-progress-context{font-size:0.75rem;line-height:1.4;font-weight:500;color:color-mix(in srgb,var(--color-foreground-alt,#a1a1aa) 85%,transparent)}
-.swb-stall{margin:0;max-width:22rem;font-size:0.75rem;line-height:1.5;color:color-mix(in srgb,var(--color-warning,#f59e0b) 85%,transparent)}
-.swb-progress-wrap{margin-top:0.25rem;display:flex;width:min(16rem,calc(100vw - 4rem));align-items:center;gap:0.75rem}
-.swb-bar{position:relative;height:0.375rem;flex:1;overflow:hidden;border-radius:9999px;background:color-mix(in srgb,var(--color-foreground,#fafafa) 8%,transparent)}
-.swb-bar-fill{height:100%;border-radius:9999px;background:var(--color-brand,#4f8cff);transition:width 200ms ease}
-.swb-bar-fill--indeterminate{position:absolute;top:0;bottom:0;left:0;width:33%;animation:swb-indeterminate 1.1s ease-in-out infinite}
-.swb-bar-fill--stalled{position:relative;overflow:hidden}
-.swb-bar-fill--stalled::after{content:"";position:absolute;top:0;bottom:0;left:0;width:35%;border-radius:inherit;background:color-mix(in srgb,var(--color-foreground,#fafafa) 45%,transparent);animation:swb-shimmer 1.1s ease-in-out infinite}
+.swb-canvas{display:flex;align-items:center;justify-content:center;flex:1 1 0%;box-sizing:border-box;width:100%;height:100%;min-height:0;overflow:auto;padding:48px 24px;background:var(--color-background,#181617);color:var(--color-foreground,#faf8f9);font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif}
+.swb-col{display:flex;flex-direction:column;align-items:center;text-align:center;width:min(440px,100%);margin:auto}
+.swb-logo{display:block;flex:none;height:120px;width:120px;object-fit:contain;margin-bottom:44px}
+.swb-head{display:flex;flex-direction:column;align-items:center;gap:16px;width:100%}
+.swb-title{margin:0;font-size:36px;font-weight:600;letter-spacing:-1px;line-height:1.2;color:var(--color-foreground,#faf8f9)}
+.swb-detail{margin:0;font-size:18px;line-height:1.5;color:var(--color-foreground-alt,#aaa4a8)}
+.swb-hint{margin:20px 0 0;font-size:14px;line-height:1.5;color:var(--color-foreground-alt,#aaa4a8)}
+.swb-bar{position:relative;height:6px;flex:none;overflow:hidden;border-radius:9999px;background:color-mix(in srgb,var(--color-foreground,#fafafa) 10%,transparent)}
+.swb-bar-fill{height:100%;border-radius:9999px;background:var(--color-brand,#e96093);transition:width 200ms ease}
+.swb-bar-fill--indeterminate{position:absolute;top:0;bottom:0;left:0;width:33%;animation:swb-indeterminate 1.8s ease-in-out infinite}
 .swb-mono{font-family:${MONO_STACK};font-variant-numeric:tabular-nums}
-.swb-progress-label{width:2.75rem;text-align:right;font-size:0.7rem;color:color-mix(in srgb,var(--color-foreground-alt,#a1a1aa) 70%,transparent)}
 .swb-rail{position:relative;width:100%}
 .swb-rail-track{position:absolute;left:10%;right:10%;top:0.75rem;height:1px;transform:translateY(-50%);overflow:hidden;border-radius:9999px;background:color-mix(in srgb,var(--color-foreground,#fafafa) 10%,transparent);pointer-events:none}
-.swb-rail-fill{height:100%;border-radius:9999px;background:var(--color-brand,#4f8cff);transition:width 500ms ease}
+.swb-rail-fill{height:100%;border-radius:9999px;background:var(--color-brand,#e96093);transition:width 500ms ease}
 .swb-rail-fill--error{background:color-mix(in srgb,var(--color-destructive,#ef4444) 70%,transparent)}
 .swb-steps{position:relative;display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:0.5rem;margin:0;padding:0;list-style:none}
 .swb-step{min-width:0}
 .swb-step-mark{display:flex;height:1.5rem;align-items:center;justify-content:center}
 .swb-dot{display:block;box-sizing:border-box;height:0.625rem;width:0.625rem;border-radius:9999px;transition:all 300ms ease}
-.swb-step[data-state="pending"] .swb-dot{border:1px solid color-mix(in srgb,var(--color-foreground,#fafafa) 25%,transparent);background:var(--color-background,#0a0a0a)}
-.swb-step[data-state="complete"] .swb-dot{background:var(--color-brand,#4f8cff)}
+.swb-step[data-state="pending"] .swb-dot{border:1px solid color-mix(in srgb,var(--color-foreground,#fafafa) 25%,transparent);background:var(--color-background,#181617)}
+.swb-step[data-state="complete"] .swb-dot{background:var(--color-brand,#e96093)}
 .swb-step[data-state="error"] .swb-dot{height:0.75rem;width:0.75rem;background:var(--color-destructive,#ef4444);box-shadow:0 0 0 4px color-mix(in srgb,var(--color-destructive,#ef4444) 25%,transparent)}
-.swb-spinner{display:block;box-sizing:border-box;height:0.875rem;width:0.875rem;border-radius:9999px;border:2px solid color-mix(in srgb,var(--color-brand,#4f8cff) 25%,transparent);border-top-color:var(--color-brand,#4f8cff);animation:swb-spin 0.7s linear infinite}
+.swb-spinner{display:block;box-sizing:border-box;height:0.875rem;width:0.875rem;border-radius:9999px;border:2px solid color-mix(in srgb,var(--color-brand,#e96093) 25%,transparent);border-top-color:var(--color-brand,#e96093);animation:swb-spin 0.7s linear infinite}
 .swb-step-label{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;text-align:center;font-size:0.65rem;font-weight:500;transition:color 300ms ease}
 .swb-step[data-state="pending"] .swb-step-label{color:color-mix(in srgb,var(--color-foreground-alt,#a1a1aa) 55%,transparent)}
 .swb-step[data-state="complete"] .swb-step-label{color:color-mix(in srgb,var(--color-foreground-alt,#a1a1aa) 85%,transparent)}
@@ -51,19 +44,31 @@ export const BOOT_LOADING_CRITICAL_CSS = `
 .swb-step[data-state="error"] .swb-step-label{color:var(--color-destructive,#ef4444)}
 .swb-downloads{display:flex;width:100%;flex-direction:column;gap:0.75rem;margin:0;padding:0;list-style:none}
 .swb-dl-row{display:flex;width:100%;flex-direction:column;gap:0.25rem}
-.swb-dl-head{display:flex;align-items:center;justify-content:space-between;gap:0.5rem;font-size:0.7rem}
+.swb-dl-head{display:flex;align-items:flex-start;flex-wrap:wrap;justify-content:space-between;gap:0.5rem;font-size:0.7rem}
 .swb-dl-label{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-weight:500;color:color-mix(in srgb,var(--color-foreground,#fafafa) 85%,transparent)}
-.swb-dl-detail{flex-shrink:0;font-size:0.7rem;color:color-mix(in srgb,var(--color-foreground-alt,#a1a1aa) 70%,transparent)}
+.swb-dl-detail{flex-shrink:0;max-width:100%;overflow-wrap:anywhere;font-size:0.7rem;color:color-mix(in srgb,var(--color-foreground-alt,#a1a1aa) 70%,transparent)}
 .swb-dl-detail--error{color:var(--color-destructive,#ef4444)}
-.swb-error{margin:0.25rem 0 0;max-width:20rem;border:1px solid color-mix(in srgb,var(--color-destructive,#ef4444) 15%,transparent);border-radius:0.375rem;background:color-mix(in srgb,var(--color-destructive,#ef4444) 5%,transparent);padding:0.5rem 0.75rem;font-size:0.75rem;line-height:1.5;color:var(--color-destructive,#ef4444)}
+.swb-error{margin:24px 0 0;max-width:100%;overflow-wrap:anywhere;border:1px solid color-mix(in srgb,var(--color-destructive,#ef4444) 30%,transparent);border-radius:8px;background:color-mix(in srgb,var(--color-destructive,#ef4444) 5%,transparent);padding:12px 16px;font-size:14px;line-height:1.5;color:var(--color-destructive,#ef4444)}
 .swb-actions{display:flex;flex-wrap:wrap;align-items:center;justify-content:center;gap:0.5rem;margin-top:0.25rem}
 .swb-btn{display:inline-flex;align-items:center;gap:0.5rem;height:2.25rem;padding:0 0.75rem;border-radius:0.375rem;font-size:0.875rem;font-weight:500;cursor:pointer;transition:background 150ms ease,border-color 150ms ease,color 150ms ease}
 .swb-btn--primary{border:1px solid color-mix(in srgb,var(--color-foreground,#fafafa) 10%,transparent);background:color-mix(in srgb,var(--color-foreground,#fafafa) 5%,transparent);color:var(--color-foreground,#fafafa)}
 .swb-btn--ghost{border:0;background:transparent;color:color-mix(in srgb,var(--color-foreground-alt,#a1a1aa) 80%,transparent)}
+.swb-activity{width:min(380px,100%);margin-top:36px}
+.swb-disclosure{width:100%;margin-top:32px;font-size:14px;color:var(--color-foreground-alt,#aaa4a8)}
+.swb-disclosure summary{display:inline-flex;align-items:center;gap:10px;cursor:pointer;padding:8px 12px;list-style:none;border-radius:6px}
+.swb-disclosure summary::-webkit-details-marker{display:none}
+.swb-disclosure summary::after{content:"";width:6px;height:6px;border-right:1px solid currentColor;border-bottom:1px solid currentColor;transform:rotate(45deg) translateY(-2px)}
+.swb-disclosure[open] summary::after{transform:rotate(225deg) translate(-2px,-2px)}
+.swb-disclosure summary:hover{color:var(--color-foreground,#faf8f9)}
+.swb-disclosure summary:focus-visible,.swb-btn:focus-visible{outline:2px solid var(--color-brand,#e96093);outline-offset:4px}
+.swb-diagnostics{margin-top:16px;padding:16px;border:1px solid color-mix(in srgb,var(--color-foreground,#fafafa) 12%,transparent);border-radius:8px;text-align:left}
+.swb-status{margin:0;font-size:13px;line-height:1.5;overflow-wrap:anywhere}
+.swb-diagnostics .swb-downloads{margin-top:16px}
+[data-sw-boot-state="error"] .swb-activity,[data-sw-boot-state="error"] .swb-detail,[data-sw-boot-state="error"] .swb-hint{display:none}
+@media(max-width:600px){.swb-logo{width:80px;height:80px;margin-bottom:32px}.swb-title{font-size:28px;letter-spacing:-.6px}.swb-detail{font-size:16px}.swb-activity{margin-top:28px}.swb-disclosure{margin-top:24px}}
 @keyframes swb-spin{to{transform:rotate(360deg)}}
-@keyframes swb-indeterminate{0%{left:-33%}100%{left:100%}}
-@keyframes swb-shimmer{0%{transform:translateX(-100%)}100%{transform:translateX(300%)}}
-@media (prefers-reduced-motion:reduce){.swb-spinner,.swb-bar-fill--indeterminate,.swb-bar-fill--stalled::after{animation:none}.swb-bar-fill--indeterminate{left:0;width:100%}.swb-bar-fill--stalled::after{display:none}.swb-dot,.swb-step-label,.swb-bar-fill,.swb-rail-fill,.swb-btn{transition:none}}
+@keyframes swb-indeterminate{0%,100%{left:0}50%{left:67%}}
+@media (prefers-reduced-motion:reduce){.swb-spinner,.swb-bar-fill--indeterminate{animation:none}.swb-bar-fill--indeterminate{left:33%;width:33%}.swb-dot,.swb-step-label,.swb-bar-fill,.swb-rail-fill,.swb-btn{transition:none}}
 `.trim()
 
 // BootLoadingCriticalStyle inlines the boot critical CSS into the document.

--- a/app/prerender/build.ts
+++ b/app/prerender/build.ts
@@ -34,9 +34,9 @@ import type { PageMetadata } from './metadata.js'
 import {
   ROOT_BOOT_VISIBILITY_CSS,
   ROOT_BOOT_VISIBILITY_SCRIPT,
-  ROOT_LOADING_STYLE,
 } from './root-loading-shell.js'
 import { ROOT_LANDING_SHELL_CLASS } from './root-landing-shell.js'
+import { buildStartupShell } from './startup-shell.js'
 
 const SITE_ORIGIN = process.env.SITE_ORIGIN ?? SPACEWAVE_PUBLIC_BASE_URL
 
@@ -368,73 +368,7 @@ async function buildRootTemplate(ctx: PrerenderContext) {
 
   const canonicalUrl = ctx.siteOrigin + '/'
 
-  const body = `<div id="sw-landing" class="${ROOT_LANDING_SHELL_CLASS}">${landingHtml}</div>
-      <style>@keyframes sw-boot-shimmer{0%{transform:translateX(-100%)}100%{transform:translateX(300%)}}[data-sw-boot-progress][data-sw-boot-progress-stalled]{position:relative;overflow:hidden}[data-sw-boot-progress][data-sw-boot-progress-stalled]::after{content:"";position:absolute;top:0;bottom:0;left:0;width:35%;border-radius:inherit;background:color-mix(in srgb,var(--color-foreground,#fafafa) 45%,transparent);animation:sw-boot-shimmer 1.1s ease-in-out infinite}@media (prefers-reduced-motion:reduce){[data-sw-boot-progress][data-sw-boot-progress-stalled]::after{display:none;animation:none}}</style>
-      <div id="sw-loading" data-sw-boot-state="loading" style="${ROOT_LOADING_STYLE}">
-        <div style="display:flex;align-items:center;justify-content:center;flex:1 1 0%;height:100%;min-height:0;width:100%;background:var(--color-background,#0a0a0a);color:var(--color-foreground,#fafafa);overflow:hidden">
-          <div style="display:flex;width:min(30rem,calc(100vw - 2rem));flex-direction:column;align-items:center;gap:1.25rem;text-align:center">
-            <div style="display:flex;height:5rem;width:5rem;align-items:center;justify-content:center;border-radius:1rem;background:color-mix(in srgb,var(--color-brand,var(--color-logo-blue,#4f8cff)) 10%,transparent);box-shadow:0 0 42px color-mix(in srgb,var(--color-brand,var(--color-logo-blue,#4f8cff)) 22%,transparent)">
-              <img src="${ctx.iconUrl}" alt="" width="44" height="44" style="display:block;height:2.75rem;width:2.75rem;border-radius:0.75rem"/>
-            </div>
-            <div style="display:flex;flex-direction:column;align-items:center;gap:0.5rem">
-              <h1 style="margin:0;font-size:1.5rem;font-weight:600;letter-spacing:0;color:var(--color-foreground,#fafafa)">Spacewave</h1>
-              <p data-sw-boot-status style="margin:0;font-size:0.875rem;color:color-mix(in srgb,var(--color-foreground-alt,#a1a1aa) 70%,transparent)">Prepare: Loading the app shell.</p>
-              <div style="margin-top:0.5rem;display:flex;width:min(16rem,calc(100vw - 4rem));align-items:center;gap:0.75rem">
-                <div style="height:0.375rem;flex:1;overflow:hidden;border-radius:9999px;background:color-mix(in srgb,var(--color-foreground,#fafafa) 8%,transparent)">
-                  <div data-sw-boot-progress role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="2" style="height:100%;width:2%;border-radius:9999px;background:var(--color-brand,var(--color-logo-blue,#4f8cff));transition:width 200ms"></div>
-                </div>
-                <span data-sw-boot-progress-label style="width:2rem;text-align:right;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;font-size:0.65rem;color:color-mix(in srgb,var(--color-foreground-alt,#a1a1aa) 70%,transparent);font-variant-numeric:tabular-nums">2%</span>
-              </div>
-              <p data-sw-boot-error style="display:none;margin:0.5rem 0 0;max-width:20rem;border:1px solid color-mix(in srgb,var(--color-destructive,#ef4444) 15%,transparent);border-radius:0.375rem;background:color-mix(in srgb,var(--color-destructive,#ef4444) 5%,transparent);padding:0.5rem 0.75rem;font-size:0.75rem;line-height:1.5;color:var(--color-destructive,#ef4444)"></p>
-              <div data-sw-boot-error-actions style="display:none;align-items:center;justify-content:center;gap:0.5rem;margin-top:0.25rem">
-                <button data-sw-boot-retry type="button" style="height:2.25rem;border:1px solid color-mix(in srgb,var(--color-foreground,#fafafa) 10%,transparent);border-radius:0.375rem;background:color-mix(in srgb,var(--color-foreground,#fafafa) 5%,transparent);padding:0 0.75rem;color:var(--color-foreground,#fafafa);font-size:0.875rem;font-weight:500">Retry</button>
-                <button data-sw-boot-back type="button" style="height:2.25rem;border:0;border-radius:0.375rem;background:transparent;padding:0 0.75rem;color:color-mix(in srgb,var(--color-foreground-alt,#a1a1aa) 80%,transparent);font-size:0.875rem;font-weight:500">Back</button>
-              </div>
-            </div>
-            <ol aria-label="Startup phases" style="display:grid;width:100%;grid-template-columns:repeat(5,minmax(0,1fr));gap:0.5rem;margin:0;padding:0;list-style:none">
-              <li data-sw-boot-phase="prepare" data-sw-boot-phase-state="current" style="min-width:0"><div style="display:flex;height:1.5rem;align-items:center;justify-content:center"><span data-sw-boot-phase-dot style="display:block;height:0.625rem;width:0.625rem;border-radius:9999px;background:var(--color-brand,var(--color-logo-blue,#4f8cff))"></span></div><div data-sw-boot-phase-label style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;text-align:center;font-size:0.65rem;font-weight:500;color:var(--color-foreground,#fafafa)">Prepare</div></li>
-              <li data-sw-boot-phase="connect" data-sw-boot-phase-state="pending" style="min-width:0"><div style="display:flex;height:1.5rem;align-items:center;justify-content:center"><span data-sw-boot-phase-dot style="display:block;height:0.625rem;width:0.625rem;border-radius:9999px;background:color-mix(in srgb,var(--color-foreground,#fafafa) 15%,transparent)"></span></div><div data-sw-boot-phase-label style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;text-align:center;font-size:0.65rem;font-weight:500;color:color-mix(in srgb,var(--color-foreground-alt,#a1a1aa) 40%,transparent)">Connect</div></li>
-              <li data-sw-boot-phase="runtime" data-sw-boot-phase-state="pending" style="min-width:0"><div style="display:flex;height:1.5rem;align-items:center;justify-content:center"><span data-sw-boot-phase-dot style="display:block;height:0.625rem;width:0.625rem;border-radius:9999px;background:color-mix(in srgb,var(--color-foreground,#fafafa) 15%,transparent)"></span></div><div data-sw-boot-phase-label style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;text-align:center;font-size:0.65rem;font-weight:500;color:color-mix(in srgb,var(--color-foreground-alt,#a1a1aa) 40%,transparent)">Runtime</div></li>
-              <li data-sw-boot-phase="frame" data-sw-boot-phase-state="pending" style="min-width:0"><div style="display:flex;height:1.5rem;align-items:center;justify-content:center"><span data-sw-boot-phase-dot style="display:block;height:0.625rem;width:0.625rem;border-radius:9999px;background:color-mix(in srgb,var(--color-foreground,#fafafa) 15%,transparent)"></span></div><div data-sw-boot-phase-label style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;text-align:center;font-size:0.65rem;font-weight:500;color:color-mix(in srgb,var(--color-foreground-alt,#a1a1aa) 40%,transparent)">App</div></li>
-              <li data-sw-boot-phase="done" data-sw-boot-phase-state="pending" style="min-width:0"><div style="display:flex;height:1.5rem;align-items:center;justify-content:center"><span data-sw-boot-phase-dot style="display:block;height:0.625rem;width:0.625rem;border-radius:9999px;background:color-mix(in srgb,var(--color-foreground,#fafafa) 15%,transparent)"></span></div><div data-sw-boot-phase-label style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;text-align:center;font-size:0.65rem;font-weight:500;color:color-mix(in srgb,var(--color-foreground-alt,#a1a1aa) 40%,transparent)">Done</div></li>
-            </ol>
-            <div data-sw-boot-downloads style="display:none;flex-direction:column;gap:0.75rem;width:100%"></div>
-            <div aria-hidden="true" style="position:relative;height:7.5rem;width:100%;overflow:hidden;border-radius:0.5rem;border:1px solid color-mix(in srgb,var(--color-foreground,#fafafa) 8%,transparent);background:color-mix(in srgb,var(--color-background-card,#171717) 35%,transparent);box-shadow:0 1.5rem 4rem color-mix(in srgb,var(--color-background-dark,#000) 45%,transparent)">
-              <div style="display:flex;height:1.75rem;align-items:center;gap:0.375rem;border-bottom:1px solid color-mix(in srgb,var(--color-foreground,#fafafa) 8%,transparent);background:color-mix(in srgb,var(--color-background-card,#171717) 70%,transparent);padding:0 0.75rem">
-                <span style="height:0.5rem;width:0.5rem;border-radius:9999px;background:color-mix(in srgb,var(--color-destructive,#ef4444) 75%,transparent)"></span>
-                <span style="height:0.5rem;width:0.5rem;border-radius:9999px;background:color-mix(in srgb,var(--color-warning,#f59e0b) 75%,transparent)"></span>
-                <span style="height:0.5rem;width:0.5rem;border-radius:9999px;background:color-mix(in srgb,var(--color-success,#22c55e) 75%,transparent)"></span>
-                <span style="margin-left:0.5rem;height:0.5rem;width:4.5rem;border-radius:9999px;background:color-mix(in srgb,var(--color-foreground,#fafafa) 8%,transparent)"></span>
-              </div>
-              <div style="display:grid;height:calc(100% - 1.75rem);grid-template-columns:4.25rem 1fr">
-                <div style="display:flex;flex-direction:column;gap:0.5rem;border-right:1px solid color-mix(in srgb,var(--color-foreground,#fafafa) 6%,transparent);background:color-mix(in srgb,var(--color-background-dark,#000) 35%,transparent);padding:0.5rem">
-                  <span data-sw-boot-preview="0" style="height:0.5rem;border-radius:9999px;background:color-mix(in srgb,var(--color-brand,var(--color-logo-blue,#4f8cff)) 55%,transparent)"></span>
-                  <span data-sw-boot-preview="1" style="height:0.5rem;border-radius:9999px;background:color-mix(in srgb,var(--color-foreground,#fafafa) 10%,transparent)"></span>
-                  <span data-sw-boot-preview="2" style="height:0.5rem;border-radius:9999px;background:color-mix(in srgb,var(--color-foreground,#fafafa) 10%,transparent)"></span>
-                  <span data-sw-boot-preview="3" style="height:0.5rem;border-radius:9999px;background:color-mix(in srgb,var(--color-foreground,#fafafa) 10%,transparent)"></span>
-                </div>
-                <div style="display:grid;grid-template-columns:1fr 5.5rem;gap:0.75rem;padding:0.75rem">
-                  <div style="display:flex;flex-direction:column;gap:0.5rem">
-                    <span style="height:0.625rem;width:6rem;border-radius:9999px;background:color-mix(in srgb,var(--color-foreground,#fafafa) 20%,transparent)"></span>
-                    <div style="display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:0.5rem">
-                      <span data-sw-boot-preview="0" style="height:3rem;border-radius:0.375rem;border:1px solid color-mix(in srgb,var(--color-brand,var(--color-logo-blue,#4f8cff)) 20%,transparent);background:color-mix(in srgb,var(--color-brand,var(--color-logo-blue,#4f8cff)) 15%,transparent)"></span>
-                      <span data-sw-boot-preview="1" style="height:3rem;border-radius:0.375rem;border:1px solid color-mix(in srgb,var(--color-foreground,#fafafa) 6%,transparent);background:color-mix(in srgb,var(--color-foreground,#fafafa) 4%,transparent)"></span>
-                      <span data-sw-boot-preview="2" style="height:3rem;border-radius:0.375rem;border:1px solid color-mix(in srgb,var(--color-foreground,#fafafa) 6%,transparent);background:color-mix(in srgb,var(--color-foreground,#fafafa) 4%,transparent)"></span>
-                    </div>
-                    <span style="height:0.5rem;width:10.5rem;border-radius:9999px;background:color-mix(in srgb,var(--color-foreground,#fafafa) 10%,transparent)"></span>
-                  </div>
-                  <div style="display:flex;flex-direction:column;justify-content:flex-end;gap:0.375rem;border-radius:0.375rem;border:1px solid color-mix(in srgb,var(--color-foreground,#fafafa) 6%,transparent);background:color-mix(in srgb,var(--color-background,#0a0a0a) 35%,transparent);padding:0.5rem">
-                    <span data-sw-boot-preview="0" style="height:0.375rem;width:72%;border-radius:9999px;background:color-mix(in srgb,var(--color-brand,var(--color-logo-blue,#4f8cff)) 65%,transparent)"></span>
-                    <span data-sw-boot-preview="1" style="height:0.375rem;width:55%;border-radius:9999px;background:color-mix(in srgb,var(--color-foreground,#fafafa) 10%,transparent)"></span>
-                    <span data-sw-boot-preview="2" style="height:0.375rem;width:88%;border-radius:9999px;background:color-mix(in srgb,var(--color-foreground,#fafafa) 10%,transparent)"></span>
-                  </div>
-                </div>
-              </div>
-              <span style="position:absolute;right:1rem;bottom:1rem;height:0.5rem;width:0.5rem;border-radius:9999px;background:color-mix(in srgb,var(--color-brand,var(--color-logo-blue,#4f8cff)) 60%,transparent);box-shadow:0 0 18px var(--color-brand,var(--color-logo-blue,#4f8cff))"></span>
-            </div>
-          </div>
-        </div>
-      </div>`
+  const body = `<div id="sw-landing" class="${ROOT_LANDING_SHELL_CLASS}">${landingHtml}</div>${buildStartupShell(ctx.iconUrl)}`
 
   const rootHtml = buildPageHtml({
     body,

--- a/app/prerender/startup-progress.e2e.test.tsx
+++ b/app/prerender/startup-progress.e2e.test.tsx
@@ -87,7 +87,7 @@ describe('browser startup progress surfaces', () => {
     resetBootDownloadsForTest()
     resetBrowserStartupMarksForTest()
     window.matchMedia = originalMatchMedia
-    await page.viewport(1280, 800)
+    await page.viewport(1518, 1094)
   })
 
   afterEach(async () => {
@@ -108,30 +108,12 @@ describe('browser startup progress surfaces', () => {
 
     await renderSurface(<AppLoadingScreen />)
 
-    // Detail copy is owned by browserStartupPhasePresentation in
-    // app/loading/status/browser-startup-model.ts.
-    await expect
-      .element(
-        page.getByText(
-          'Current app download: Loading the application interface.',
-        ),
-      )
-      .toBeInTheDocument()
-    await expect
-      .element(page.getByText('Prepare', { exact: true }))
-      .toBeInTheDocument()
-    await expect
-      .element(page.getByText('Connect', { exact: true }))
-      .toBeInTheDocument()
-    await expect
-      .element(page.getByText('Runtime', { exact: true }))
-      .toBeInTheDocument()
-    await expect
-      .element(page.getByText('App', { exact: true }))
-      .toBeInTheDocument()
-    await expect
-      .element(page.getByText('Done', { exact: true }))
-      .toBeInTheDocument()
+    await expect.element(page.getByText('Opening Spacewave')).toBeVisible()
+    await expect.element(page.getByText('Starting the app')).toBeVisible()
+    expect(document.querySelector('details')?.open).toBe(false)
+    expect(
+      document.querySelector('.swb-activity')?.getAttribute('aria-valuenow'),
+    ).toBeNull()
     const bounds = startupSurfaceBounds()
     expect(typeof bounds?.width).toBe('number')
     expect(typeof bounds?.height).toBe('number')
@@ -139,16 +121,20 @@ describe('browser startup progress surfaces', () => {
     await captureStartupEvidence('returning-user-runtime-desktop')
   })
 
-  it('renders the cold-cache app download with real byte progress', async () => {
+  it('does not display synthetic app-phase progress as downloaded bytes', async () => {
     localStorage.setItem('spacewave-has-session', '1')
     setBootPhaseProgress('app', 0.37)
 
     await renderSurface(<AppLoadingScreen />)
+    await page.getByText('Show details', { exact: true }).click()
 
     await expect
       .element(page.getByText('Current app download: Opening the application.'))
       .toBeInTheDocument()
-    await expect.element(page.getByText('87%')).toBeInTheDocument()
+    expect(
+      document.querySelector('.swb-activity')?.getAttribute('aria-valuenow'),
+    ).toBeNull()
+    await expect.element(page.getByText('87%')).not.toBeInTheDocument()
 
     await captureStartupEvidence('frame-download-progress-desktop')
   })
@@ -180,6 +166,7 @@ describe('browser startup progress surfaces', () => {
     ])
 
     await renderSurface(<AppLoadingScreen />)
+    await page.getByText('Show details', { exact: true }).click()
 
     await expect
       .element(
@@ -208,17 +195,18 @@ describe('browser startup progress surfaces', () => {
     await captureStartupEvidence('per-asset-download-breakdown-desktop')
   })
 
-  it('reaches the ready handoff at full progress', async () => {
+  it('retains the actual ready handoff evidence without a completion estimate', async () => {
     localStorage.setItem('spacewave-has-session', '1')
     setBootPhase('app')
     markBrowserStartupBoundary('webview.revealed', { startupRelevant: true })
 
     await renderSurface(<AppLoadingScreen />)
+    await page.getByText('Show details', { exact: true }).click()
 
     await expect
       .element(page.getByText('Startup complete. Rendering the first view…'))
       .toBeInTheDocument()
-    await expect.element(page.getByText('100%')).toBeInTheDocument()
+    await expect.element(page.getByText('100%')).not.toBeInTheDocument()
 
     await captureStartupEvidence('frame-ready-handoff-desktop')
   })
@@ -270,6 +258,7 @@ describe('browser startup progress surfaces', () => {
     setBootPhase('runtime-error', 'error')
 
     await renderSurface(<AppLoadingScreen />)
+    await page.getByText('Show details', { exact: true }).click()
 
     await expect
       .element(
@@ -291,6 +280,33 @@ describe('browser startup progress surfaces', () => {
     await captureStartupEvidence('returning-user-error')
   })
 
+  it('surfaces a failed frame download before the phase projection reaches error', async () => {
+    await page.viewport(390, 844)
+    setBootPhase('app')
+    setBootDownloads([
+      {
+        id: 'frame',
+        label: 'Interface frame',
+        loaded: 0,
+        state: 'error',
+        error: 'Interface did not become ready.',
+      },
+    ])
+    await renderSurface(<AppLoadingScreen />)
+    await expect
+      .element(page.getByRole('alert'))
+      .toHaveTextContent('Interface did not become ready.')
+    await expect
+      .element(page.getByRole('button', { name: 'Retry' }))
+      .toBeVisible()
+    expect(document.querySelector('.swb-activity')).toBeNull()
+    expect(document.querySelector('details')?.open).toBe(false)
+    await page.getByText('Show details', { exact: true }).click()
+    expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(
+      window.innerWidth,
+    )
+  })
+
   it('keeps reduced-motion startup progress readable', async () => {
     localStorage.setItem('spacewave-has-session', '1')
     setBootPhase('runtime')
@@ -307,6 +323,7 @@ describe('browser startup progress surfaces', () => {
     window.matchMedia = reducedMatchMedia
 
     await renderSurface(<AppLoadingScreen />)
+    await page.getByText('Show details', { exact: true }).click()
 
     await expect
       .element(
@@ -339,9 +356,7 @@ describe('browser startup progress surfaces', () => {
         ),
       )
       .toBeInTheDocument()
-    await expect
-      .element(page.getByText('Done', { exact: true }))
-      .toBeInTheDocument()
+    await expect.element(page.getByText('Opening Spacewave')).toBeVisible()
 
     const bounds = startupSurfaceBounds()
     expect(bounds).not.toBeNull()

--- a/app/prerender/startup-shell.e2e.test.ts
+++ b/app/prerender/startup-shell.e2e.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { page } from 'vitest/browser'
+
+import spacewaveIcon from '@s4wave/web/images/spacewave-icon.png'
+
+import { buildStartupShell } from './startup-shell.js'
+import {
+  writeBrowserBootStatus,
+  resetBrowserStartupMarksForTest,
+} from './boot-status.js'
+
+let host: HTMLDivElement | undefined
+
+afterEach(() => {
+  host?.remove()
+  host = undefined
+  globalThis.__swBootStatus = undefined
+  resetBrowserStartupMarksForTest()
+})
+
+describe('initial startup HTML', () => {
+  it('keeps status updates inside details and preserves usable error recovery', async () => {
+    await page.viewport(1518, 1094)
+    host = document.createElement('div')
+    host.style.cssText = 'position:fixed;inset:0;display:flex'
+    host.innerHTML = buildStartupShell(spacewaveIcon)
+    document.body.append(host)
+    const shell = host.querySelector<HTMLElement>('#sw-loading')!
+    shell.style.display = 'block'
+
+    writeBrowserBootStatus({
+      phase: 'runtime',
+      state: 'loading',
+      detail: 'Runtime channel opened.',
+      progress: 0.6,
+    })
+    await expect.element(page.getByText('Opening Spacewave')).toBeVisible()
+    expect(host.querySelector('details')?.open).toBe(false)
+    expect(
+      host.querySelector('[role="progressbar"]')?.getAttribute('aria-valuenow'),
+    ).toBeNull()
+    expect(host.querySelector('[data-sw-boot-status]')?.textContent).toContain(
+      'Connecting the Spacewave runtime.',
+    )
+    await page.screenshot({
+      path: '__screenshots__/browser-startup/initial-html-desktop.png',
+    })
+
+    await page.getByText('Show details', { exact: true }).click()
+    await expect
+      .element(page.getByText(/Connecting the Spacewave runtime/))
+      .toBeVisible()
+    writeBrowserBootStatus({
+      phase: 'runtime-error',
+      state: 'error',
+      detail: 'Network unavailable.',
+    })
+    await expect.element(page.getByRole('alert')).toBeVisible()
+    await expect
+      .element(page.getByRole('button', { name: 'Retry' }))
+      .toBeVisible()
+    await expect
+      .element(page.getByRole('button', { name: 'Back', exact: true }))
+      .toBeVisible()
+    expect(getComputedStyle(host.querySelector('.swb-activity')!).display).toBe(
+      'none',
+    )
+  })
+})

--- a/app/prerender/startup-shell.ts
+++ b/app/prerender/startup-shell.ts
@@ -1,0 +1,42 @@
+import { BOOT_LOADING_CRITICAL_CSS } from '../loading/boot-loading-critical.js'
+
+import { ROOT_LOADING_STYLE } from './root-loading-shell.js'
+
+// buildStartupShell renders the first loading surface with the same critical
+// styles as the React screen. The boot projection updates diagnostic evidence
+// without turning readiness milestones into download percentages.
+export function buildStartupShell(iconUrl: string): string {
+  const escapedIcon = iconUrl
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+  return `<style>${BOOT_LOADING_CRITICAL_CSS}</style>
+    <div id="sw-loading" data-sw-boot-state="loading" style="${ROOT_LOADING_STYLE}">
+      <div class="swb-canvas">
+        <div class="swb-col">
+          <img class="swb-logo" src="${escapedIcon}" alt="" width="120" height="120"/>
+          <div class="swb-head" aria-live="polite">
+            <h1 class="swb-title">Opening Spacewave</h1>
+            <p class="swb-detail">Starting the app</p>
+          </div>
+          <div class="swb-activity swb-bar" role="progressbar" aria-label="Opening Spacewave">
+            <div class="swb-bar-fill swb-bar-fill--indeterminate"></div>
+          </div>
+          <p class="swb-hint">Downloaded files are saved on this device.</p>
+          <p data-sw-boot-error class="swb-error" role="alert" style="display:none"></p>
+          <div data-sw-boot-error-actions class="swb-actions" style="display:none">
+            <button data-sw-boot-retry type="button" class="swb-btn swb-btn--primary">Retry</button>
+            <button data-sw-boot-back type="button" class="swb-btn swb-btn--ghost">Back</button>
+          </div>
+          <details class="swb-disclosure">
+            <summary>Show details</summary>
+            <div class="swb-diagnostics">
+              <p data-sw-boot-status class="swb-status">Loading the app shell.</p>
+              <div data-sw-boot-downloads class="swb-downloads" style="display:none"></div>
+            </div>
+          </details>
+        </div>
+      </div>
+    </div>`
+}

--- a/app/quickstart/QuickstartLoading.tsx
+++ b/app/quickstart/QuickstartLoading.tsx
@@ -1,4 +1,4 @@
-import { BrowserStartupPhaseRail } from '@s4wave/app/loading/AppLoadingScreen.js'
+import { BrowserStartupPhaseRail } from '@s4wave/app/loading/BrowserStartupPhaseRail.js'
 import { useBrowserStartupProjection } from '@s4wave/app/loading/status/browser-startup.js'
 import { useStaticHref } from '@s4wave/app/prerender/StaticContext.js'
 import { usePath } from '@s4wave/web/router/router.js'


### PR DESCRIPTION
The browser startup screen now uses one compact layout from the initial HTML through React startup. It replaces phase-derived percentages and the miniature app preview with an activity bar, keeps real download progress in an optional details disclosure, and shows failures with Retry and Back immediately.

Verified with focused unit tests, TypeScript and lint checks, and Chromium/WebKit browser checks covering the HTML-to-React handoff, download details, errors, mobile layout, and reduced motion. Inspected the served desktop and mobile screens.
