### PR TITLE
perf(blob): overlap bounded streaming chunk reads

### DIFF
--- a/db/block/blob/chunked.go
+++ b/db/block/blob/chunked.go
@@ -67,7 +67,7 @@ func (r *ChunkIndex) AppendChunk(chkSet *sbset.SubBlockSet, idx int, size, start
 
 // ReadFromChunks reads up to len(buf) data from the chunks, starting at byte index start.
 // Attempts to start reading from chunkIdx, but will search for the chunk containing start.
-// If the chunk at chunkIdx does not contain start, will binary-search for the appropriate chunk.
+// If the chunk at chunkIdx does not contain start, searches for the appropriate chunk.
 // The value of outChunkIdx should be saved and passed again when stepping through the chunks sequentially.
 // Returns io.EOF if start is past the last chunk.
 func ReadFromChunks(
@@ -80,8 +80,9 @@ func ReadFromChunks(
 }
 
 type chunkReadCache struct {
-	idx  int
-	data []byte
+	idx   int
+	data  []byte
+	ahead *chunkReadAhead
 }
 
 func readFromChunks(
@@ -147,7 +148,10 @@ func fetchChunkDataNoCursorCache(
 	}
 	var data []byte
 	var err error
-	if trace.IsEnabled() {
+	if cache != nil && cache.ahead != nil {
+		cache.data = nil
+		data, err = cache.ahead.read(chunkIdx)
+	} else if trace.IsEnabled() {
 		_, task := trace.NewTask(ctx, "db/block/blob/chunk-fetch")
 		data, err = chunk.FetchDataNoCache(ctx, chunkCursor, false)
 		task.End()

--- a/db/block/blob/read-ahead.go
+++ b/db/block/blob/read-ahead.go
@@ -1,0 +1,85 @@
+package blob
+
+import (
+	"context"
+
+	"github.com/aperturerobotics/util/conc"
+	"github.com/aperturerobotics/util/promise"
+	"github.com/s4wave/spacewave/db/block"
+	"github.com/s4wave/spacewave/db/block/sbset"
+)
+
+const (
+	// Streaming reads overlap at most eight chunks. The window is four MiB,
+	// except that a larger demanded chunk is read alone.
+	chunkReadAheadCount   = 8
+	chunkReadAheadBytes   = 4 << 20
+	chunkReadAheadMinRead = 32 << 10
+)
+
+// chunkReadAhead belongs to one Reader. Only the reader accesses pending;
+// workers resolve their own promises. Closing cancels and joins every fetch
+// before the reader releases its cursors.
+type chunkReadAhead struct {
+	ctx     context.Context
+	cancel  context.CancelFunc
+	chunks  *sbset.SubBlockSet
+	queue   *conc.ConcurrentQueue
+	pending map[int]*promise.Promise[[]byte]
+}
+
+func newChunkReadAhead(ctx context.Context, chunks *sbset.SubBlockSet) *chunkReadAhead {
+	ctx, cancel := context.WithCancel(ctx)
+	return &chunkReadAhead{
+		ctx:     ctx,
+		cancel:  cancel,
+		chunks:  chunks,
+		queue:   conc.NewConcurrentQueue(chunkReadAheadCount),
+		pending: make(map[int]*promise.Promise[[]byte], chunkReadAheadCount),
+	}
+}
+
+// read fills the bounded forward window and returns only the requested chunk's
+// result. A speculative error remains attached to its chunk until requested.
+func (r *chunkReadAhead) read(idx int) ([]byte, error) {
+	for previous := range r.pending {
+		if previous < idx {
+			delete(r.pending, previous)
+		}
+	}
+
+	var total uint64
+	end := min(r.chunks.Len(), idx+chunkReadAheadCount)
+	for next := idx; next < end; next++ {
+		value, cursor := r.chunks.Get(next)
+		chunk, ok := value.(*Chunk)
+		if !ok || cursor == nil {
+			if next == idx {
+				return nil, block.ErrUnexpectedType
+			}
+			break
+		}
+		size := chunk.GetSize()
+		if next > idx && (size > chunkReadAheadBytes || total > chunkReadAheadBytes-size) {
+			break
+		}
+		total += size
+		if r.pending[next] != nil {
+			continue
+		}
+
+		result := promise.NewPromise[[]byte]()
+		r.pending[next] = result
+		r.queue.Enqueue(func() {
+			data, err := fetchChunkDataNoCursorCache(r.ctx, chunk, cursor, next, nil)
+			result.SetResult(data, err)
+		})
+	}
+	return r.pending[idx].Await(r.ctx)
+}
+
+func (r *chunkReadAhead) close() {
+	r.cancel()
+	_ = r.queue.WaitIdle(context.Background(), nil)
+	clear(r.pending)
+}

--- a/db/block/blob/read-ahead_test.go
+++ b/db/block/blob/read-ahead_test.go
@@ -1,0 +1,240 @@
+package blob
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/s4wave/spacewave/db/block"
+	block_mock "github.com/s4wave/spacewave/db/block/mock"
+)
+
+func TestBlobReaderReadAheadBoundsAndClose(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		chunkSize   int
+		count       int
+		wantFetches int
+	}{
+		{name: "concurrency", chunkSize: 64 << 10, count: 12, wantFetches: 8},
+		{name: "bytes", chunkSize: 2 << 20, count: 6, wantFetches: 2},
+		{name: "oversized-demand", chunkSize: 5 << 20, count: 2, wantFetches: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+			reader, store := newReadAheadFixture(t, ctx, tc.count, tc.chunkSize)
+			defer reader.Close()
+
+			buf := make([]byte, 32<<10)
+			readDone := make(chan error, 1)
+			go func() {
+				_, err := io.ReadFull(reader, buf)
+				readDone <- err
+			}()
+			seen := make(map[int]bool)
+			for range tc.wantFetches {
+				seen[waitChunkFetch(t, ctx, store)] = true
+			}
+			for idx := range tc.wantFetches {
+				if !seen[idx] {
+					t.Fatalf("window omitted chunk %d: %v", idx, seen)
+				}
+			}
+			close(store.gates[0])
+			if err := <-readDone; err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(buf, bytes.Repeat([]byte{1}, len(buf))) {
+				t.Fatal("first chunk bytes changed")
+			}
+
+			if err := reader.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if got := store.active.Load(); got != 0 {
+				t.Fatalf("Close returned with %d active reads", got)
+			}
+			if got := store.calls.Load(); got != int32(tc.wantFetches) {
+				t.Fatalf("fetched %d chunks, want bounded window of %d", got, tc.wantFetches)
+			}
+		})
+	}
+}
+
+func TestBlobReaderSmallReadDoesNotReadAhead(t *testing.T) {
+	reader, store := newReadAheadFixture(t, t.Context(), 3, 64<<10)
+	defer reader.Close()
+	close(store.gates[0])
+	if _, err := io.ReadFull(reader, make([]byte, 32)); err != nil {
+		t.Fatal(err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := store.calls.Load(); got != 1 {
+		t.Fatalf("small read fetched %d chunks, want 1", got)
+	}
+}
+
+func TestBlobReaderReadAheadPreservesErrorOrder(t *testing.T) {
+	reader, store := newReadAheadFixture(t, t.Context(), 3, 64<<10)
+	defer reader.Close()
+	wantErr := errors.New("unavailable second chunk")
+	store.failIdx, store.failErr = 1, wantErr
+	for _, gate := range store.gates {
+		close(gate)
+	}
+
+	buf := make([]byte, 3*64<<10)
+	n, err := io.ReadFull(reader, buf)
+	if n != 64<<10 || !errors.Is(err, wantErr) {
+		t.Fatalf("read = %d, %v; want first chunk then %v", n, err, wantErr)
+	}
+	if !bytes.Equal(buf[:n], bytes.Repeat([]byte{1}, n)) {
+		t.Fatal("bytes preceding the failed chunk changed")
+	}
+}
+
+func TestBlobReaderReadAheadSeekCancelsOldWindow(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	reader, store := newReadAheadFixture(t, ctx, 10, 64<<10)
+	defer reader.Close()
+	close(store.gates[0])
+	buf := make([]byte, 64<<10)
+	if _, err := io.ReadFull(reader, buf); err != nil {
+		t.Fatal(err)
+	}
+	for range 8 {
+		waitChunkFetch(t, ctx, store)
+	}
+
+	if _, err := reader.Seek(9*64<<10, io.SeekStart); err != nil {
+		t.Fatal(err)
+	}
+	if got := store.active.Load(); got != 0 {
+		t.Fatalf("Seek returned with %d old reads active", got)
+	}
+	close(store.gates[9])
+	if _, err := io.ReadFull(reader, buf); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(buf, bytes.Repeat([]byte{10}, len(buf))) {
+		t.Fatal("Seek returned old window bytes")
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := store.calls.Load(); got != 9 {
+		t.Fatalf("fetched %d chunks, want original eight and seek target", got)
+	}
+}
+
+func TestBlobReaderReadAheadParentCancellation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	reader, store := newReadAheadFixture(t, ctx, 10, 64<<10)
+	defer reader.Close()
+	readDone := make(chan error, 1)
+	go func() {
+		_, err := reader.Read(make([]byte, 32<<10))
+		readDone <- err
+	}()
+	for range 8 {
+		waitChunkFetch(t, ctx, store)
+	}
+	cancel()
+	if err := <-readDone; !errors.Is(err, context.Canceled) {
+		t.Fatalf("read error = %v, want cancellation", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := store.active.Load(); got != 0 {
+		t.Fatalf("canceled reader retained %d active reads", got)
+	}
+}
+
+// chunkFetchStore gates real stored chunks so tests observe overlapping reads
+// and cancellation without relying on elapsed time for synchronization.
+type chunkFetchStore struct {
+	block.StoreOps
+	indices map[string]int
+	gates   []chan struct{}
+	started chan int
+	active  atomic.Int32
+	calls   atomic.Int32
+	failIdx int
+	failErr error
+}
+
+func (s *chunkFetchStore) GetBlock(ctx context.Context, ref *block.BlockRef) ([]byte, bool, error) {
+	idx, ok := s.indices[ref.MarshalString()]
+	if !ok {
+		return s.StoreOps.GetBlock(ctx, ref)
+	}
+	s.calls.Add(1)
+	s.active.Add(1)
+	defer s.active.Add(-1)
+	s.started <- idx
+	select {
+	case <-ctx.Done():
+		return nil, false, ctx.Err()
+	case <-s.gates[idx]:
+	}
+	if idx == s.failIdx {
+		return nil, false, s.failErr
+	}
+	return s.StoreOps.GetBlock(ctx, ref)
+}
+
+func waitChunkFetch(t *testing.T, ctx context.Context, store *chunkFetchStore) int {
+	t.Helper()
+	select {
+	case idx := <-store.started:
+		return idx
+	case <-ctx.Done():
+		t.Fatal("expected overlapping chunk read did not start")
+		return -1
+	}
+}
+
+func newReadAheadFixture(t *testing.T, ctx context.Context, count, size int) (*Reader, *chunkFetchStore) {
+	t.Helper()
+	base := block_mock.NewMockStore(0)
+	tx, cursor := block.NewTransaction(base, nil, nil, nil)
+	root := &Blob{BlobType: BlobType_BlobType_CHUNKED, TotalSize: uint64(count * size), ChunkIndex: &ChunkIndex{}}
+	cursor.SetBlock(root, true)
+	chunks := root.ChunkIndex.GetChunkSet(cursor.FollowSubBlock(4))
+	for idx := range count {
+		data := bytes.Repeat([]byte{byte(idx + 1)}, size)
+		root.ChunkIndex.AppendChunk(chunks, idx, uint64(size), uint64(idx*size), data)
+	}
+	ref, _, err := tx.Write(ctx, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store := &chunkFetchStore{
+		StoreOps: base,
+		indices:  make(map[string]int, count),
+		gates:    make([]chan struct{}, count),
+		started:  make(chan int, count*2),
+		failIdx:  -1,
+	}
+	_, cursor = block.NewTransaction(store, nil, ref, nil)
+	reader, err := NewReader(ctx, cursor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for idx, chunk := range reader.root.GetChunkIndex().GetChunks() {
+		store.indices[chunk.GetDataRef().MarshalString()] = idx
+		store.gates[idx] = make(chan struct{})
+	}
+	return reader, store
+}

--- a/db/block/blob/reader.go
+++ b/db/block/blob/reader.go
@@ -10,20 +10,21 @@ import (
 	"github.com/s4wave/spacewave/db/block/sbset"
 )
 
-// Reader reads from a blob.
+// Reader reads from a blob. Streaming reads retain a bounded window of chunk
+// data. Read, Seek, and Close must not be called concurrently.
 type Reader struct {
 	ctx       context.Context
 	ctxCancel context.CancelFunc
 	bcs       *block.Cursor
 
 	root *Blob
-	// idx is the current read index
+	// idx is the current read index.
 	idx int
 	// chunkIdx is the previous chunk we read from.
-	// this speeds up seeking for idx for sequential reads.
+	// This speeds up seeking for idx during sequential reads.
 	chunkIdx int
 	chunkSet *sbset.SubBlockSet
-	// chunkCache keeps only the active chunk data. The cursor-level cache is
+	// chunkCache keeps active data and bounded read-ahead. The cursor cache is
 	// intentionally bypassed for sequential reads so large HTTP readbacks do not
 	// retain every chunk, but repeated small reads inside one chunk must still
 	// avoid refetching the same block.
@@ -66,7 +67,7 @@ func NewRawReader(ctx context.Context, blob *Blob) *Reader {
 }
 
 // Read implements the reader interface.
-// Read and Seek are not concurrent safe.
+// Read and Seek must not run concurrently.
 func (r *Reader) Read(p []byte) (n int, err error) {
 	readStart := r.idx
 	if readStart < 0 {
@@ -105,6 +106,9 @@ func (r *Reader) Read(p []byte) (n int, err error) {
 		}
 		copy(p, rawBuf[readStart:readEnd])
 	case BlobType_BlobType_CHUNKED:
+		if r.chunkCache.ahead == nil && len(p) >= chunkReadAheadMinRead && r.chunkSet.Len() > 1 {
+			r.chunkCache.ahead = newChunkReadAhead(r.ctx, r.chunkSet)
+		}
 		chkRead, outChkIdx, err := readFromChunks(r.ctx, r.chunkSet, p, readStart, r.chunkIdx, &r.chunkCache)
 		if err == io.EOF {
 			// readStart must be past the end of the chunks.
@@ -138,7 +142,7 @@ func (r *Reader) Read(p []byte) (n int, err error) {
 // Seeking to an offset before the start of the file is an error.
 // Seeking to any positive offset is legal, but the behavior of subsequent
 // I/O operations on the underlying object is implementation-dependent.
-// Read and Seek are not concurrent safe.
+// Read and Seek must not run concurrently.
 func (r *Reader) Seek(offset int64, whence int) (int64, error) {
 	blobSize := r.root.GetTotalSize()
 	if blobSize > math.MaxInt64 {
@@ -154,13 +158,20 @@ func (r *Reader) Seek(offset int64, whence int) (int64, error) {
 	if nextPos < 0 {
 		return 0, errors.New("seek to before start of blob")
 	}
+	if nextPos != int64(r.idx) && r.chunkCache.ahead != nil {
+		r.chunkCache.ahead.close()
+		r.chunkCache.ahead = nil
+	}
 	r.idx = int(nextPos)
 	return nextPos, nil
 }
 
-// Close closes the reader, canceling the context.
+// Close cancels the reader and waits for its outstanding chunk reads.
 func (r *Reader) Close() error {
 	r.ctxCancel()
+	if r.chunkCache.ahead != nil {
+		r.chunkCache.ahead.close()
+	}
 	r.chunkCache = chunkReadCache{}
 	return nil
 }


### PR DESCRIPTION
Streaming large blobs fetched each chunk only after the previous read finished. Add reader-owned read-ahead for streaming reads, bounded to eight chunks and 4 MiB, while preserving ordered errors and cancelling and joining work on seek, close, or parent cancellation.

Three paired browser runs reduced median cold startup from 24.53 s to 17.48 s (28.7%); locally cached startup was unchanged at 10.92 s. All twelve runs reached the Drive document without errors. Focused race tests, vet, and JS/Wasm tests passed, and the production GoScript browser build passed. The GoScript unit harness stopped at an unrelated generated math/rand/v2 generic-method type error.
