### PR TITLE
fix(browser): preserve offline startup and active sessions

### DIFF
--- a/app/prerender/browser-release.ts
+++ b/app/prerender/browser-release.ts
@@ -7,6 +7,7 @@ export interface BrowserReleaseShellAssets {
   entrypointDecompressedSize?: number
   serviceWorker: string
   sharedWorker: string
+  opfsWorker?: string
   wasm?: string
   css: string[]
 }

--- a/app/prerender/build.ts
+++ b/app/prerender/build.ts
@@ -61,6 +61,8 @@ interface BldrManifest {
   entrypointDecompressedSize?: number
   serviceWorker: string
   sharedWorker: string
+  opfsWorker?: string
+  requiredStaticAssets?: string[]
   wasm?: string
   css: string[]
 }
@@ -212,11 +214,15 @@ export function buildPrerenderContext(
       entrypointDecompressedSize: manifest.entrypointDecompressedSize,
       serviceWorker: manifest.serviceWorker,
       sharedWorker: manifest.sharedWorker,
+      opfsWorker: manifest.opfsWorker,
       wasm: manifest.wasm,
       css: manifest.css,
     },
     ['/', ...STATIC_ROUTES.map((page) => page.path), ...blogPaths],
-    collectRequiredStaticAssetUrls(OUTPUT_DIR),
+    [
+      ...(manifest.requiredStaticAssets ?? []),
+      ...collectRequiredStaticAssetUrls(OUTPUT_DIR),
+    ],
   )
   const browserReleasePath = join(DIST_DIR, 'browser-release.json')
   writeFileSync(

--- a/app/prerender/html-template.test.ts
+++ b/app/prerender/html-template.test.ts
@@ -19,6 +19,7 @@ describe('buildPageHtml', () => {
     })
 
     expect(html).toContain('<meta name="darkreader-lock"/>')
+    expect(html).toContain('<link rel="icon" href="/static/assets/icon.png"/>')
     expect(html.indexOf('<meta name="darkreader-lock"/>')).toBeLessThan(
       html.indexOf('<title>Spacewave</title>'),
     )

--- a/app/prerender/html-template.ts
+++ b/app/prerender/html-template.ts
@@ -68,7 +68,7 @@ export function buildPageHtml(opts: PageHtmlOptions): string {
   <title>${opts.title}</title>
   <meta name="description" content="${opts.description}"/>
   <meta name="robots" content="index, follow"/>${canonicalTag}
-  <link rel="icon" href="/favicon.ico" type="image/x-icon"/>
+  <link rel="icon" href="${opts.iconUrl}"/>
   <link rel="apple-touch-icon" href="${opts.iconUrl}"/>
   <meta name="theme-color" content="${themeColor}"/>
   <meta property="og:type" content="${ogType}"/>

--- a/bldr.star
+++ b/bldr.star
@@ -143,6 +143,13 @@ def browser_spacewave_core_config(web_go_compiler=None):
         cloud_api_endpoint=BROWSER_RELEASE_CLOUD_API_ENDPOINT,
     )
 
+# The local release server has no cloud signaling service. Local sessions still
+# exercise their full storage and RPC paths without a remote transport retry loop.
+def e2e_browser_spacewave_core_config(web_go_compiler=None):
+    conf = browser_spacewave_core_config(web_go_compiler)
+    conf["configSet"]["provider-local"] = config_entry("provider/local", 1)
+    return conf
+
 def spacewave_launcher_controller_config(
         dist_peer_ids=[PRODUCTION_DIST_PEER_ID],
         endpoints=[{"url": PRODUCTION_RELEASE_CONFIG_URL}],
@@ -573,7 +580,7 @@ BROWSER_RELEASE_MANIFESTS = [
 ]
 BROWSER_RELEASE_E2E_MANIFESTS = [
     "spacewave-launcher",
-    "spacewave-core", "spacewave-web", "spacewave-app", "spacewave-sql", "spacewave-cli-plugin", "web",
+    "spacewave-core", "spacewave-web", "spacewave-app", "spacewave-notes", "spacewave-sql", "spacewave-cli-plugin", "web",
     "spacewave-browser",
 ]
 DESKTOP_RELEASE_MANIFESTS = [
@@ -616,6 +623,14 @@ BROWSER_RELEASE_LAZY_PLUGIN_FIXTURE_LOAD_PLUGINS = BROWSER_RELEASE_LOAD_PLUGINS 
 # select, and the spacewave-sql fixture without a populated Release World.
 def browser_e2e_embed_manifests(go_platform_id):
     return browser_release_embed_manifests(go_platform_id) + [
+        {"manifestId": "spacewave-core",
+         "platformId": go_platform_id},
+        {"manifestId": "spacewave-web",
+         "platformId": "js"},
+        {"manifestId": "spacewave-app",
+         "platformId": "js"},
+        {"manifestId": "web",
+         "platformId": "web/js/wasm"},
         {"manifestId": "spacewave-notes",
          "platformId": "js"},
         {"manifestId": "spacewave-notes",
@@ -665,7 +680,7 @@ build("release-web-e2e",
     targets=["browser"],
     manifestOverrides={
         "spacewave-launcher": e2e_release_wasm_launcher_config(),
-        "spacewave-core": browser_spacewave_core_config(),
+        "spacewave-core": e2e_browser_spacewave_core_config(),
         "spacewave-browser": dist_release_config(
             BROWSER_RELEASE_E2E_EMBED_MANIFESTS,
             BROWSER_RELEASE_E2E_LOAD_PLUGINS,
@@ -678,12 +693,12 @@ build("release-web-e2e",
 build("release-web-e2e-assets",
     manifests=[
         "spacewave-launcher",
-        "spacewave-core", "spacewave-web", "spacewave-app", "spacewave-sql", "spacewave-cli-plugin", "web",
+        "spacewave-core", "spacewave-web", "spacewave-app", "spacewave-notes", "spacewave-sql", "spacewave-cli-plugin", "web",
     ],
     targets=["browser"],
     manifestOverrides={
         "spacewave-launcher": e2e_release_wasm_launcher_config(),
-        "spacewave-core": browser_spacewave_core_config(),
+        "spacewave-core": e2e_browser_spacewave_core_config(),
     },
 )
 build("release-web-e2e-dist",
@@ -701,17 +716,17 @@ build("release-web-e2e-tinygo-core",
     manifests=["spacewave-core"],
     targets=["browser"],
     manifestOverrides={
-        "spacewave-core": browser_spacewave_core_config("GO_COMPILER_TINYGO"),
+        "spacewave-core": e2e_browser_spacewave_core_config("GO_COMPILER_TINYGO"),
     },
 )
 build("release-web-e2e-tinygo-assets",
     manifests=[
         "spacewave-launcher",
-        "spacewave-core", "spacewave-web", "spacewave-app", "spacewave-sql", "spacewave-cli-plugin", "web",
+        "spacewave-core", "spacewave-web", "spacewave-app", "spacewave-notes", "spacewave-sql", "spacewave-cli-plugin", "web",
     ],
     targets=["browser"],
     manifestOverrides={
-        "spacewave-core": browser_spacewave_core_config("GO_COMPILER_TINYGO"),
+        "spacewave-core": e2e_browser_spacewave_core_config("GO_COMPILER_TINYGO"),
         "spacewave-launcher": e2e_release_wasm_launcher_config(),
     },
 )
@@ -733,7 +748,7 @@ build("release-web-e2e-tinygo",
     manifests=BROWSER_RELEASE_E2E_MANIFESTS,
     targets=["browser"],
     manifestOverrides={
-        "spacewave-core": browser_spacewave_core_config("GO_COMPILER_TINYGO"),
+        "spacewave-core": e2e_browser_spacewave_core_config("GO_COMPILER_TINYGO"),
         "spacewave-launcher": e2e_release_wasm_launcher_config(),
         "spacewave-browser": dist_release_config(
             BROWSER_RELEASE_E2E_EMBED_MANIFESTS,
@@ -747,7 +762,7 @@ build("release-web-e2e-goscript",
     manifests=BROWSER_RELEASE_E2E_MANIFESTS,
     targets=["browser"],
     manifestOverrides={
-        "spacewave-core": browser_spacewave_core_config("GO_COMPILER_GOSCRIPT"),
+        "spacewave-core": e2e_browser_spacewave_core_config("GO_COMPILER_GOSCRIPT"),
         "spacewave-launcher": e2e_release_wasm_launcher_config(web_go_compiler="GO_COMPILER_GOSCRIPT"),
         "spacewave-browser": dist_release_config(
             BROWSER_RELEASE_E2E_GOSCRIPT_EMBED_MANIFESTS,

--- a/bldr/devtool/cli-process-supervisor_test.go
+++ b/bldr/devtool/cli-process-supervisor_test.go
@@ -119,8 +119,7 @@ func TestCliSubprocessSupervisorTerminateKillsAfterTimeout(t *testing.T) {
 	if time.Since(started) > time.Second {
 		t.Fatalf("terminate took %s, want bounded kill timeout", time.Since(started))
 	}
-	var exitErr *exec.ExitError
-	if !errors.As(err, &exitErr) {
+	if _, ok := errors.AsType[*exec.ExitError](err); !ok {
 		t.Fatalf("terminate error = %T %[1]v, want exec.ExitError", err)
 	}
 }

--- a/bldr/dist/compiler/webrtc_config_test.go
+++ b/bldr/dist/compiler/webrtc_config_test.go
@@ -8,7 +8,7 @@ func TestBrowserIceServersForBundle(t *testing.T) {
 		Username:   "user",
 		Credential: "secret",
 	}})
-	if degenerate := browserIceServersForBundle([]*IceServer{nil, &IceServer{}}); len(degenerate) != 0 {
+	if degenerate := browserIceServersForBundle([]*IceServer{nil, {}}); len(degenerate) != 0 {
 		t.Fatalf("degenerate ICE servers = %#v, want empty for bundle default", degenerate)
 	}
 	if len(configured) != 1 || configured[0].URLs[0] != "turn:trusted.example:3478" ||

--- a/bldr/dist/entrypoint/bus.go
+++ b/bldr/dist/entrypoint/bus.go
@@ -451,7 +451,7 @@ func BuildDistBus(
 	return distBus, nil
 }
 
-// newReleaseSchedulerConfig keeps entrypoint-mounted buckets authoritative.
+// newReleaseSchedulerConfig copies remote manifests after startup for offline use.
 func newReleaseSchedulerConfig(
 	projectID,
 	engineID,
@@ -472,11 +472,11 @@ func newReleaseSchedulerConfig(
 		// their manifest contents still need a complete local copy.
 		false,
 	)
-	// The embedded distribution and Release World buckets remain mounted for
-	// the entrypoint lifetime and stay authoritative without complete local copies.
+	// The embedded distribution is already covered by the offline asset cache.
+	// Release World manifests load on demand, then the startup-group gate lets
+	// the scheduler copy their complete DAGs for offline restarts.
 	pluginSchedConf.NoCopyBucketIds = []string{
 		bldr_dist.GetDistBucketID(projectID),
-		"spacewave-release",
 	}
 	return pluginSchedConf
 }

--- a/bldr/dist/entrypoint/bus_test.go
+++ b/bldr/dist/entrypoint/bus_test.go
@@ -32,7 +32,7 @@ func TestIsWebDistPlatform(t *testing.T) {
 	}
 }
 
-func TestReleaseSchedulerConfigKeepsReleaseWorldExternal(t *testing.T) {
+func TestReleaseSchedulerConfigCachesReleaseWorld(t *testing.T) {
 	conf := newReleaseSchedulerConfig(
 		"project",
 		"engine",
@@ -41,8 +41,8 @@ func TestReleaseSchedulerConfigKeepsReleaseWorldExternal(t *testing.T) {
 		"peer",
 	)
 
-	if !slices.Contains(conf.GetNoCopyBucketIds(), "spacewave-release") {
-		t.Fatalf("release scheduler no-copy bucket IDs = %v, want spacewave-release", conf.GetNoCopyBucketIds())
+	if slices.Contains(conf.GetNoCopyBucketIds(), "spacewave-release") {
+		t.Fatalf("release scheduler no-copy bucket IDs = %v, must not suppress spacewave-release", conf.GetNoCopyBucketIds())
 	}
 }
 

--- a/bldr/dist/entrypoint/release_runtime_fixture_test.go
+++ b/bldr/dist/entrypoint/release_runtime_fixture_test.go
@@ -217,12 +217,13 @@ func TestLauncherOnlyReleaseConfigMountsWorldAndColdStartsRemoteCore(t *testing.
 		t.Fatal(err)
 	}
 	waitForManifestBucket(t, ctx, tb, "transient-plugin", worldBucketID(t, ctx, tb))
-
-	// The transient copy completing after the gate opens gives every scheduler
-	// copy routine a full execution opportunity. Core retaining only its valid
-	// external ref proves its no-copy class started no materializer and published
-	// no local replacement.
-	assertOnlyManifestBucket(t, ctx, tb, "spacewave-core", "spacewave-release")
+	waitForManifestBucket(t, ctx, tb, "spacewave-core", worldBucketID(t, ctx, tb))
+	// Materializing the same executable locally must preserve the running plugin.
+	select {
+	case pluginID := <-host.started:
+		t.Fatalf("offline copy restarted plugin %q", pluginID)
+	default:
+	}
 }
 
 func buildRemoteManifest(

--- a/bldr/e2e/comms/fixtures/goscript-webdocument-unixfs-fetch.ts
+++ b/bldr/e2e/comms/fixtures/goscript-webdocument-unixfs-fetch.ts
@@ -17,7 +17,7 @@ import {
   detectWorkerCommsConfig,
   type WorkerCommsDetectResult,
 } from '../../../web/bldr/worker-comms-detect.js'
-import { initBrowserReleaseAutoReload } from '../../../web/bldr/browser-release-update.js'
+import { initBrowserReleaseUpdates } from '../../../web/bldr/browser-release-update.js'
 import { timeoutPromise } from '../../../web/bldr/timeout.js'
 import { waitWorkerReady } from './wait-worker-ready.js'
 import { PluginStartInfo } from '../../../plugin/plugin.pb.js'
@@ -869,7 +869,7 @@ function installReleaseGenerationReloadProbe(eventLog: string[]): void {
   window.addEventListener('beforeunload', () => {
     recordEvent(eventLog, 'release-generation-beforeunload')
   })
-  initBrowserReleaseAutoReload()
+  initBrowserReleaseUpdates()
 }
 
 function dispatchReleaseGenerationMismatch(eventLog: string[]): void {
@@ -879,51 +879,6 @@ function dispatchReleaseGenerationMismatch(eventLog: string[]): void {
       data: { bldrPromotedGenerationId: 'fixture-next-generation' },
     }),
   )
-}
-
-function didReloadBeforeNormalClose(events: string[]): boolean {
-  const reloadIdx = events.findIndex(
-    (line) =>
-      line.includes('release-generation-beforeunload') ||
-      line.includes('release-generation-reload-run'),
-  )
-  if (reloadIdx < 0) {
-    return false
-  }
-  const normalCloseIdx = events.findIndex(
-    (line) =>
-      line.includes('RuntimeClientClosedError') ||
-      line.includes('runtime client generation 1 closed: normal-close'),
-  )
-  return normalCloseIdx < 0 || reloadIdx < normalCloseIdx
-}
-
-function releaseReloadResult(
-  eventLog: string[],
-): WebDocumentUnixFSFixtureResult {
-  recordEvent(eventLog, `release-generation-reload-run ${runCount}`)
-  const events = readPersistedEvents()
-  const reloadBeforeNormalClose = didReloadBeforeNormalClose(events)
-  return {
-    pass: true,
-    variant,
-    detail:
-      'release generation mismatch reloaded the page before normal-close evidence',
-    workerReady: false,
-    startInfo: false,
-    pluginToHostStream: false,
-    preFetchStream: false,
-    fetchSuccess: false,
-    postFetchStream: false,
-    restartSentinelStable: false,
-    releaseBroadcast: events.some((line) =>
-      line.includes('release-generation-broadcast'),
-    ),
-    reloadObserved: true,
-    reloadBeforeNormalClose,
-    reproduced: true,
-    eventLog: events,
-  }
 }
 
 function failureResult(
@@ -952,12 +907,6 @@ async function run() {
   }
   const eventLog = readPersistedEvents()
   recordEvent(eventLog, `run-start variant=${variant} run=${runCount}`)
-
-  if (variant === 'release-generation' && runCount > 1) {
-    window.__results = releaseReloadResult(eventLog)
-    log.textContent = 'DONE'
-    return
-  }
 
   const errors: string[] = []
   let worker: Worker | undefined
@@ -1068,8 +1017,8 @@ async function run() {
       await fetch.requestStarted
       releaseBroadcast = true
       dispatchReleaseGenerationMismatch(eventLog)
-      await timeoutPromise(fixtureTimeoutMs)
-      throw new Error('release generation mismatch did not reload the page')
+      fetch.releaseResponse()
+      fetchSuccess = await fetch.result
     } else if (variant === 'in-flight-reload') {
       mark('fetch-unixfs-inline-in-flight-reload')
       const fetch = startUnixFSInlineFileThroughProxyFetch(eventLog)
@@ -1238,12 +1187,10 @@ async function run() {
 
       const outcome = await Promise.race([
         trigger.waitOutcome(),
-        timeoutPromise(fixtureTimeoutMs).then(
-          (): TerminalOrphanOutcome => ({
-            failedFast: false,
-            err: 'terminal-orphan-timeout',
-          }),
-        ),
+        timeoutPromise(fixtureTimeoutMs).then((): TerminalOrphanOutcome => ({
+          failedFast: false,
+          err: 'terminal-orphan-timeout',
+        })),
       ])
       orphanElapsedMs = performance.now() - closeStartMs
       orphanOutcomeErr = outcome.err
@@ -1295,7 +1242,7 @@ async function run() {
       preFetchStream &&
       fetchSuccess &&
       postFetchStream &&
-      (variant === 'release-generation' || restartSentinelStable) &&
+      restartSentinelStable &&
       !failureReason &&
       errors.length === 0
     window.__results = {
@@ -1353,12 +1300,10 @@ async function run() {
   } catch (err) {
     window.__results = failureResult(eventLog, `error: ${String(err)}`)
   } finally {
-    if (!(variant === 'release-generation' && runCount === 1)) {
-      await replacementDocument?.close()
-      releaseLock?.()
-      worker?.terminate()
-      log.textContent = 'DONE'
-    }
+    await replacementDocument?.close()
+    releaseLock?.()
+    worker?.terminate()
+    log.textContent = 'DONE'
   }
 }
 

--- a/bldr/e2e/comms/webdocument_unixfs_fetch_test.go
+++ b/bldr/e2e/comms/webdocument_unixfs_fetch_test.go
@@ -68,23 +68,26 @@ func TestGoScriptForegroundUnixFSFetchDynamicRelayKeepsRoute(t *testing.T) {
 	t.Logf("dynamic relay events: %s", strings.Join(webDocumentResultEventLog(trace.results), " | "))
 }
 
-// TestGoScriptForegroundUnixFSFetchReleaseGenerationMismatchReloadsBeforeNormalClose
-// verifies that a promoted-generation mismatch broadcast is sufficient to reload
-// the foreground route while the UnixFS-looking fetch is in flight.
-func TestGoScriptForegroundUnixFSFetchReleaseGenerationMismatchReloadsBeforeNormalClose(t *testing.T) {
+// TestGoScriptForegroundUnixFSFetchReleaseGenerationKeepsRoute
+// verifies that caching a new release preserves an in-flight foreground fetch.
+func TestGoScriptForegroundUnixFSFetchReleaseGenerationKeepsRoute(t *testing.T) {
 	installWebDocumentRouteFixtureAssets(t)
 
-	trace := runWebDocumentRouteFixture(t, "chromium", webDocumentRouteReleaseGeneration)
-	results := trace.results
-	if pass, ok := results["pass"].(bool); !ok || !pass {
-		t.Fatalf("release-generation fixture failed: %v", results["detail"])
+	for _, browser := range []string{"chromium", "webkit"} {
+		t.Run(browser, func(t *testing.T) {
+			trace := runWebDocumentRouteFixture(t, browser, webDocumentRouteReleaseGeneration)
+			results := trace.results
+			if pass, ok := results["pass"].(bool); !ok || !pass {
+				t.Fatalf("release-generation fixture failed: %v", results["detail"])
+			}
+			assertBoolResult(t, results, "releaseBroadcast", true)
+			assertBoolResult(t, results, "reloadObserved", false)
+			assertBoolResult(t, results, "reloadBeforeNormalClose", false)
+			assertBoolResult(t, results, "reproduced", false)
+			assertBoolResult(t, results, "restartSentinelStable", true)
+			t.Logf("release-generation events: %s", strings.Join(webDocumentResultEventLog(results), " | "))
+		})
 	}
-	assertBoolResult(t, results, "releaseBroadcast", true)
-	assertBoolResult(t, results, "reloadObserved", true)
-	assertBoolResult(t, results, "reloadBeforeNormalClose", true)
-	assertBoolResult(t, results, "reproduced", true)
-	assertBoolResult(t, results, "restartSentinelStable", false)
-	t.Logf("release-generation events: %s", strings.Join(webDocumentResultEventLog(results), " | "))
 }
 
 // TestGoScriptForegroundUnixFSFetchInFlightReloadZeroDocumentRace verifies that

--- a/bldr/web/bldr/browser-release-state.test.ts
+++ b/bldr/web/bldr/browser-release-state.test.ts
@@ -45,6 +45,8 @@ describe('browser release state helpers', () => {
       '/entrypoint/gen-a/runtime.wasm.gz',
       '/images/favicon.ico',
       '/images/logo.png',
+      '/manifest-pack.json',
+      '/manifest.pack.kvf',
       '/opfs-worker-gen-a.mjs',
       '/pricing',
       '/shw-gen-a.mjs',

--- a/bldr/web/bldr/browser-release-state.ts
+++ b/bldr/web/bldr/browser-release-state.ts
@@ -102,6 +102,8 @@ export function buildReleaseCachePaths(
   addPath(release.shellAssets.sharedWorker)
   addPath(release.shellAssets.opfsWorker)
   addPath(release.shellAssets.wasm)
+  addPath(release.defaultManifestBundle?.metadata)
+  addPath(release.defaultManifestBundle?.pack)
   for (const path of release.shellAssets.css) {
     addPath(path)
   }

--- a/bldr/web/bldr/browser-release-update.test.ts
+++ b/bldr/web/bldr/browser-release-update.test.ts
@@ -1,34 +1,20 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import {
-  initBrowserReleaseAutoReload,
-  shouldReloadForPromotedGeneration,
-} from './browser-release-update.js'
-
-describe('browser release update reload policy', () => {
-  it('does not reload when the promoted generation matches the active shell', () => {
-    expect(
-      shouldReloadForPromotedGeneration('deadbeefcafebabe', 'deadbeefcafebabe'),
-    ).toBe(false)
-  })
-
-  it('reloads when the promoted generation changes', () => {
-    expect(
-      shouldReloadForPromotedGeneration('deadbeefcafebabe', 'feedfacecafed00d'),
-    ).toBe(true)
-  })
-
-  it('ignores empty promotion messages', () => {
-    expect(
-      shouldReloadForPromotedGeneration('deadbeefcafebabe', undefined),
-    ).toBe(false)
-  })
-})
+import { initBrowserReleaseUpdates } from './browser-release-update.js'
 
 describe('browser release lifecycle sync probes', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
+  })
+
+  it('does not install an automatic reload handler for release promotion', () => {
+    const addEventListener = vi.fn()
+    vi.stubGlobal('navigator', { serviceWorker: { addEventListener } })
+    vi.spyOn(document, 'addEventListener').mockImplementation(() => {})
+    vi.spyOn(window, 'addEventListener').mockImplementation(() => {})
+    initBrowserReleaseUpdates()
+    expect(addEventListener).not.toHaveBeenCalled()
   })
 
   it('posts bldrSyncManifest when the page becomes visible, focused, or online', () => {
@@ -46,7 +32,7 @@ describe('browser release lifecycle sync probes', () => {
       value: 'visible',
     })
 
-    initBrowserReleaseAutoReload()
+    initBrowserReleaseUpdates()
     document.dispatchEvent(new Event('visibilitychange'))
     window.dispatchEvent(new Event('focus'))
     window.dispatchEvent(new Event('online'))

--- a/bldr/web/bldr/browser-release-update.ts
+++ b/bldr/web/bldr/browser-release-update.ts
@@ -1,25 +1,6 @@
-// BrowserReleaseUpdateMessage is the ServiceWorker shell-update broadcast shape.
-export interface BrowserReleaseUpdateMessage {
-  bldrPromotedGenerationId?: string
-}
-
 // BrowserReleaseSyncRequestMessage asks the SW to refresh the release manifest.
 export interface BrowserReleaseSyncRequestMessage {
   bldrSyncManifest: true
-}
-
-// shouldReloadForPromotedGeneration checks if the tab should reload.
-export function shouldReloadForPromotedGeneration(
-  currentGenerationId: string | undefined,
-  promotedGenerationId: string | undefined,
-): boolean {
-  if (!promotedGenerationId) {
-    return false
-  }
-  if (!currentGenerationId) {
-    return true
-  }
-  return currentGenerationId !== promotedGenerationId
 }
 
 // postBrowserReleaseSyncRequest asks the controlling ServiceWorker to sync.
@@ -33,26 +14,11 @@ declare global {
   var __swGenerationId: string | undefined
 }
 
-// initBrowserReleaseAutoReload reloads the tab when a newer promoted shell arrives.
-export function initBrowserReleaseAutoReload(): void {
+// initBrowserReleaseUpdates refreshes the offline cache without interrupting active tabs.
+export function initBrowserReleaseUpdates(): void {
   if (!('serviceWorker' in navigator)) {
     return
   }
-
-  navigator.serviceWorker.addEventListener('message', (ev: MessageEvent) => {
-    const data = ev.data as BrowserReleaseUpdateMessage
-    if (!data || typeof data !== 'object') {
-      return
-    }
-    if (
-      shouldReloadForPromotedGeneration(
-        globalThis.__swGenerationId,
-        data.bldrPromotedGenerationId,
-      )
-    ) {
-      window.location.reload()
-    }
-  })
 
   document.addEventListener('visibilitychange', () => {
     if (document.visibilityState === 'visible') {

--- a/bldr/web/bldr/service-worker.test.ts
+++ b/bldr/web/bldr/service-worker.test.ts
@@ -17,6 +17,7 @@ import {
   resolveBrowserRuntimeFetchClientId,
   syncLatestBrowserRelease,
   swFetch,
+  swActivate,
 } from './service-worker.js'
 import type { OpenWebRuntimePortResult } from './web-document-tracker.js'
 
@@ -304,7 +305,46 @@ describe('service worker browser release requests', () => {
     vi.restoreAllMocks()
   })
 
-  it('returns a fresh manifest when the network wins within the budget', async () => {
+  it.each([
+    ['bytes=2-5', 206, '2345', 'bytes 2-5/10'],
+    ['bytes=-3', 206, '789', 'bytes 7-9/10'],
+    ['bytes=8-', 206, '89', 'bytes 8-9/10'],
+    ['bytes=20-30', 416, '', 'bytes */10'],
+  ])(
+    'serves cached pack ranges without transferring the whole pack: %s',
+    async (range, status, body, contentRange) => {
+      const caches = globalThis.caches as unknown as FakeCacheStorage
+      const release = buildRelease('range-release')
+      release.requiredStaticAssets = ['/assets.kvfile']
+      await writeBrowserReleaseState(caches, {
+        ...createEmptyBrowserReleaseState(),
+        promotedCurrent: release,
+      })
+      await writeGenerationCacheResponse(
+        caches,
+        release.generationId,
+        '/assets.kvfile',
+        new Response('0123456789'),
+      )
+      const response = await swFetch(
+        buildFetchOnlyEvent('/assets.kvfile', { headers: { Range: range } }),
+      )
+      expect(response.status).toBe(status)
+      expect(response.headers.get('Content-Range')).toBe(contentRange)
+      expect(await response.text()).toBe(body)
+      expect(fetch).not.toHaveBeenCalled()
+      const whole = await swFetch(buildFetchOnlyEvent('/assets.kvfile'))
+      expect(await whole.text()).toBe('0123456789')
+    },
+  )
+
+  it('activates without waiting for any offline-cache download', async () => {
+    vi.mocked(fetch).mockImplementation(() => new Promise(() => {}))
+    await swActivate()
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('returns the complete cached generation while staging a fresh manifest', async () => {
     const cachedRelease = buildRelease('gen-a')
     const freshRelease = buildRelease('gen-b')
     await writeBrowserReleaseState(
@@ -326,7 +366,7 @@ describe('service worker browser release requests', () => {
 
     const response = await handleBrowserReleaseRequest(ev)
 
-    expect(await response.json()).toEqual(freshRelease)
+    expect(await response.json()).toEqual(cachedRelease)
     expect(waitUntilPromises).toHaveLength(1)
     await waitUntilPromises[0]
   })
@@ -385,8 +425,7 @@ describe('service worker browser release requests', () => {
     )
   })
 
-  it('returns the cached manifest when the network misses the budget', async () => {
-    vi.useFakeTimers()
+  it('returns the cached manifest without waiting for a stalled network', async () => {
     const cachedRelease = buildRelease('gen-a')
     const freshRelease = buildRelease('gen-b')
     await writeBrowserReleaseState(
@@ -401,14 +440,11 @@ describe('service worker browser release requests', () => {
     vi.mocked(fetch).mockImplementation(() =>
       Promise.resolve(new Response('asset', { status: 200 })),
     )
-    const info = vi.spyOn(console, 'info').mockImplementation(() => {})
     const { ev, waitUntilPromises } = buildFetchEvent(
       'https://example.test/browser-release.json',
     )
 
-    const responsePromise = handleBrowserReleaseRequest(ev)
-    await vi.advanceTimersByTimeAsync(800)
-    const response = await responsePromise
+    const response = await handleBrowserReleaseRequest(ev)
 
     expect(await response.json()).toEqual(cachedRelease)
     expect(waitUntilPromises).toHaveLength(1)
@@ -419,13 +455,6 @@ describe('service worker browser release requests', () => {
       }),
     )
     await waitUntilPromises[0]
-
-    expect(info).toHaveBeenCalledWith(
-      'ServiceWorker: %s: browser release manifest fetch missed %dms budget: latency=%dms',
-      expect.any(String),
-      800,
-      800,
-    )
   })
 
   it('returns the cached manifest when the network is offline', async () => {

--- a/bldr/web/bldr/service-worker.ts
+++ b/bldr/web/bldr/service-worker.ts
@@ -63,13 +63,9 @@ const CACHES: Record<string, Cache | undefined> = {
   [controlCacheName]: undefined,
 }
 const serviceWorkerFetchTracker = new ServiceWorkerFetchTracker()
-const browserReleaseNetworkRaceTimeoutMs = 800
-// Lifecycle probes trade immediate already-open-tab release pickup for bounded
-// refocus churn; activation and direct manifest fetches stay strong.
+// Lifecycle probes bound repeated refocus checks; direct manifest fetches
+// always check for updates in the background.
 const browserReleaseLifecycleSyncFreshMs = 30000
-const browserReleaseNetworkRaceTimedOut = Symbol(
-  'browserReleaseNetworkRaceTimedOut',
-)
 
 // BrowserReleaseSyncOptions selects release-sync freshness semantics.
 export interface BrowserReleaseSyncOptions {
@@ -278,21 +274,6 @@ function buildGenerationCacheName(generationId: string): string {
   return `bldr-generation-${generationId}`
 }
 
-async function notifyPromotedGenerationReload(
-  previousGenerationId: string,
-  promotedGenerationId: string,
-): Promise<void> {
-  if (previousGenerationId === promotedGenerationId) {
-    return
-  }
-  const currClients = await self.clients.matchAll({ type: 'window' })
-  for (const client of currClients) {
-    client.postMessage({
-      bldrPromotedGenerationId: promotedGenerationId,
-    })
-  }
-}
-
 async function getControlCache(): Promise<Cache> {
   const cached = CACHES[controlCacheName]
   if (cached) {
@@ -352,11 +333,48 @@ function buildHeadResponse(response: Response): Response {
   })
 }
 
-function responseForMethod(request: Request, response: Response): Response {
-  if (request.method === 'HEAD') {
-    return buildHeadResponse(response)
+async function responseForMethod(
+  request: Request,
+  response: Response,
+): Promise<Response> {
+  if (request.method === 'HEAD') return buildHeadResponse(response)
+  const range = request.headers.get('Range')
+  if (request.method !== 'GET' || response.status !== 200 || !range)
+    return response
+  const ifRange = request.headers.get('If-Range')
+  if (
+    ifRange &&
+    ifRange !== response.headers.get('ETag') &&
+    ifRange !== response.headers.get('Last-Modified')
+  )
+    return response
+  const match = /^bytes=(\d*)-(\d*)$/.exec(range)
+  // Unsupported range forms retain the complete response, as HTTP permits.
+  if (!match || (!match[1] && !match[2])) return response
+  const body = await response.blob()
+  const size = body.size
+  const start = match[1]
+    ? Number(match[1])
+    : Math.max(0, size - Number(match[2]))
+  const end =
+    match[1] && match[2] ? Math.min(Number(match[2]), size - 1) : size - 1
+  const headers = new Headers(response.headers)
+  headers.set('Accept-Ranges', 'bytes')
+  // Cache bodies contain decoded bytes, which are the range reader's offsets.
+  headers.delete('Content-Encoding')
+  if (
+    !Number.isSafeInteger(start) ||
+    !Number.isSafeInteger(end) ||
+    start > end ||
+    start >= size
+  ) {
+    headers.set('Content-Range', `bytes */${size}`)
+    headers.set('Content-Length', '0')
+    return new Response(null, { status: 416, headers })
   }
-  return response
+  headers.set('Content-Range', `bytes ${start}-${end}/${size}`)
+  headers.set('Content-Length', String(end - start + 1))
+  return new Response(body.slice(start, end + 1), { status: 206, headers })
 }
 
 async function readCachedJson<T>(row: CacheRow): Promise<T | null> {
@@ -492,9 +510,12 @@ async function stageBrowserRelease(
       )
       return false
     }
+    if (await cache.match(request)) continue
     let response: Response
     try {
-      response = await fetch(new Request(request.url, { cache: 'reload' }))
+      response = await fetch(
+        new Request(request.url, { cache: 'reload', priority: 'low' }),
+      )
     } catch (error) {
       console.warn(
         'ServiceWorker: %s: failed to stage %s for %s: %s',
@@ -577,7 +598,6 @@ export async function syncLatestBrowserRelease(
   await cacheStableBootAsset()
 
   state = state ?? (await loadBrowserReleaseState())
-  const previousPromotedRelease = state.promotedCurrent
   const release =
     options.discoveredRelease ?? (await fetchLatestBrowserRelease())
   if (!release) {
@@ -619,21 +639,11 @@ export async function syncLatestBrowserRelease(
   if (options.lifecycleProbe) {
     browserReleaseLifecycleSyncLastSuccessMs = lifecycleProbeStartedMs
   }
-  if (
-    previousPromotedRelease &&
-    state.promotedCurrent &&
-    !sameBrowserRelease(previousPromotedRelease, state.promotedCurrent)
-  ) {
-    await notifyPromotedGenerationReload(
-      previousPromotedRelease.generationId,
-      state.promotedCurrent.generationId,
-    )
-  }
   return state
 }
 
 function runBrowserReleaseSync(
-  promise: Promise<BrowserReleaseState>,
+  promise: Promise<BrowserReleaseState | null>,
 ): Promise<void> {
   return promise.then(
     () => undefined,
@@ -918,7 +928,8 @@ async function matchStaticPluginAsset(
   if (!response || activePluginRoots.get(asset.pluginId) !== asset.rootHash) {
     return null
   }
-  const cachedResponse = responseForMethod(request, response)
+  const cachedResponse = await responseForMethod(request, response)
+  if (activePluginRoots.get(asset.pluginId) !== asset.rootHash) return null
   const headers = new Headers(cachedResponse.headers)
   headers.set('X-Bldr-Plugin-Asset-Cache', 'generation')
   return new Response(cachedResponse.body, {
@@ -976,43 +987,15 @@ export async function handleBrowserReleaseRequest(
   const request = ev.request
   const state = await loadBrowserReleaseState()
   if (state.promotedCurrent) {
-    const startTime = performance.now()
-    const latestReleasePromise = fetchLatestBrowserRelease()
-    const raceWinner = await Promise.race([
-      latestReleasePromise,
-      new Promise<typeof browserReleaseNetworkRaceTimedOut>((resolve) => {
-        setTimeout(
-          () => resolve(browserReleaseNetworkRaceTimedOut),
-          browserReleaseNetworkRaceTimeoutMs,
-        )
-      }),
-    ])
-    if (raceWinner !== browserReleaseNetworkRaceTimedOut) {
-      if (raceWinner) {
-        ev.waitUntil(
-          runBrowserReleaseSync(
-            syncLatestBrowserRelease({ discoveredRelease: raceWinner }),
-          ),
-        )
-        return buildJsonResponse(request.method, raceWinner)
-      }
-      ev.waitUntil(runBrowserReleaseSync(syncLatestBrowserRelease()))
-      return buildJsonResponse(request.method, state.promotedCurrent)
-    }
+    // A complete generation can start immediately. Discover and stage updates
+    // for the next navigation without putting the network on this tab's path.
     ev.waitUntil(
       runBrowserReleaseSync(
-        latestReleasePromise.then((lateRelease) => {
-          if (lateRelease) {
-            console.info(
-              'ServiceWorker: %s: browser release manifest fetch missed %dms budget: latency=%dms',
-              serviceWorkerId,
-              browserReleaseNetworkRaceTimeoutMs,
-              Math.round(performance.now() - startTime),
-            )
-            return syncLatestBrowserRelease({ discoveredRelease: lateRelease })
-          }
-          return syncLatestBrowserRelease()
-        }),
+        fetchLatestBrowserRelease().then((release) =>
+          release
+            ? syncLatestBrowserRelease({ discoveredRelease: release })
+            : null,
+        ),
       ),
     )
     return buildJsonResponse(request.method, state.promotedCurrent)
@@ -1090,7 +1073,7 @@ async function swInstall() {
 }
 
 // swActivate is called when the service worker becomes active.
-async function swActivate() {
+export async function swActivate() {
   markStartupBoundary('service-worker.activate-start', {
     source: 'service-worker',
     serviceWorkerId,
@@ -1099,7 +1082,8 @@ async function swActivate() {
 
   await self.clients.claim()
   await getControlCache()
-  await runBrowserReleaseSync(syncLatestBrowserRelease())
+  // Offline staging runs under the document's sync message. Fetch events cannot
+  // run until activation settles, so network downloads must not be awaited here.
   markStartupBoundary('service-worker.activate-ready', {
     source: 'service-worker',
     serviceWorkerId,

--- a/bldr/web/bldr/web-document.test.ts
+++ b/bldr/web/bldr/web-document.test.ts
@@ -373,36 +373,92 @@ describe('WebDocument service worker startup', () => {
     resetStartupMarksForTest()
   })
 
-  it('reloads without throwing when registration leaves the page uncontrolled', async () => {
+  it('waits for first-install control without reloading', async () => {
     const reload = vi.fn()
-    const storage = installSessionStorage()
-    vi.stubGlobal('location', {
-      href: 'https://example.test/app',
-      reload,
-    })
+    vi.stubGlobal('location', { href: 'https://example.test/app', reload })
+    const serviceWorker = {
+      controller: null as ServiceWorker | null,
+      addEventListener: vi.fn(),
+      register: vi.fn(),
+    }
+    vi.stubGlobal('navigator', { serviceWorker })
+    const control = Promise.withResolvers<ServiceWorker>()
+    const sw = { postMessage: vi.fn() } as unknown as ServiceWorker
+    const doc = buildTestWebDocument()
+    const ready = vi.fn()
+    const wb = {
+      register: vi.fn().mockResolvedValue({}),
+      update: vi.fn(),
+      controlling: control.promise,
+    }
+    const started = doc.initServiceWorker(wb, '/sw.mjs', ready)
+    await Promise.resolve()
+    expect(reload).not.toHaveBeenCalled()
+    expect(ready).not.toHaveBeenCalled()
+    serviceWorker.controller = sw
+    control.resolve(sw)
+    await started
+    expect(ready).toHaveBeenCalledOnce()
+    expect(reload).not.toHaveBeenCalled()
+    expect(wb.register).toHaveBeenCalledWith({ immediate: true })
+    expect(wb.update).not.toHaveBeenCalled()
+    doc.serviceWorkerPort?.close()
+  })
+
+  it('attaches a controlled tab before registration settles or fails offline', async () => {
+    const sw = { postMessage: vi.fn() } as unknown as ServiceWorker
     vi.stubGlobal('navigator', {
       serviceWorker: {
-        controller: null,
+        controller: sw,
         addEventListener: vi.fn(),
         register: vi.fn(),
       },
     })
-
+    const registration = Promise.withResolvers<ServiceWorkerRegistration>()
     const doc = buildTestWebDocument()
-    const wb: TestWorkbox = {
-      register: vi
-        .fn()
-        .mockResolvedValue({
-          scope: 'https://example.test/',
-        } as ServiceWorkerRegistration),
-      update: vi.fn().mockResolvedValue(undefined),
+    const ready = vi.fn()
+    const wb = {
+      register: vi.fn(() => registration.promise),
+      update: vi.fn(),
       controlling: new Promise<ServiceWorker>(() => {}),
     }
-
-    await expect(doc.initServiceWorker(wb, '/sw.mjs')).resolves.toBeUndefined()
-    expect(storage.getItem('bldr-sw-controller-reload')).toBe('/sw.mjs')
-    expect(reload).toHaveBeenCalledOnce()
+    const started = doc.initServiceWorker(wb, '/sw.mjs', ready)
+    expect(ready).toHaveBeenCalledOnce()
+    expect(doc.serviceWorkerPort).toBeDefined()
+    registration.reject(new Error('offline'))
+    await started
+    expect(ready).toHaveBeenCalledOnce()
+    expect(wb.update).not.toHaveBeenCalled()
+    doc.serviceWorkerPort?.close()
   })
+
+  it.each([null, {}])(
+    'recovers an uncontrolled forced reload only once with installing=%j',
+    async (installing) => {
+      const reload = vi.fn()
+      installSessionStorage()
+      vi.stubGlobal('location', { href: 'https://example.test/app', reload })
+      vi.spyOn(performance, 'getEntriesByType').mockReturnValue([
+        { type: 'reload' } as PerformanceNavigationTiming,
+      ])
+      vi.stubGlobal('navigator', {
+        serviceWorker: {
+          controller: null,
+          addEventListener: vi.fn(),
+          register: vi.fn(),
+        },
+      })
+      const wb = {
+        register: vi.fn().mockResolvedValue({ active: {}, installing }),
+        update: vi.fn(),
+        controlling: new Promise<ServiceWorker>(() => {}),
+      }
+      await buildTestWebDocument().initServiceWorker(wb, '/sw.mjs')
+      expect(reload).toHaveBeenCalledOnce()
+      await buildTestWebDocument().initServiceWorker(wb, '/sw.mjs')
+      expect(reload).toHaveBeenCalledOnce()
+    },
+  )
 
   it('rebinds the tracker port without duplicating the ServiceWorker message listener', async () => {
     installSessionStorage()
@@ -431,11 +487,9 @@ describe('WebDocument service worker startup', () => {
     vi.stubGlobal('navigator', { serviceWorker })
     const doc = buildTestWebDocument()
     const wb: TestWorkbox = {
-      register: vi
-        .fn()
-        .mockResolvedValue({
-          scope: 'https://example.test/',
-        } as ServiceWorkerRegistration),
+      register: vi.fn().mockResolvedValue({
+        scope: 'https://example.test/',
+      } as ServiceWorkerRegistration),
       update: vi.fn().mockResolvedValue(undefined),
       controlling: Promise.resolve(firstSw),
     }
@@ -445,7 +499,7 @@ describe('WebDocument service worker startup', () => {
     controllerChangeListeners[0](new Event('controllerchange'))
 
     expect(messageListeners).toHaveLength(1)
-    expect(secondPostMessage).toHaveBeenCalledOnce()
+    expect(secondPostMessage).toHaveBeenCalledTimes(3)
     const [message, transfer] = secondPostMessage.mock.calls[0] as [
       { from?: string; initPort?: MessagePort },
       Transferable[],
@@ -465,67 +519,7 @@ describe('WebDocument service worker startup', () => {
     secondPostMessage.mockClear()
   })
 
-  it('does not reload twice when the ServiceWorker controller is still missing', async () => {
-    const reload = vi.fn()
-    installSessionStorage({ 'bldr-sw-controller-reload': '/sw.mjs' })
-    vi.stubGlobal('location', {
-      href: 'https://example.test/app',
-      reload,
-    })
-    vi.stubGlobal('navigator', {
-      serviceWorker: {
-        controller: null,
-        addEventListener: vi.fn(),
-        register: vi.fn(),
-      },
-    })
-    const doc = buildTestWebDocument()
-    const wb: TestWorkbox = {
-      register: vi
-        .fn()
-        .mockResolvedValue({
-          scope: 'https://example.test/',
-        } as ServiceWorkerRegistration),
-      update: vi.fn().mockResolvedValue(undefined),
-      controlling: new Promise<ServiceWorker>(() => {}),
-    }
-
-    await expect(doc.initServiceWorker(wb, '/sw.mjs')).resolves.toBeUndefined()
-    expect(reload).not.toHaveBeenCalled()
-  })
-
-  it('clears bldr-sw-controller-reload when the page is controlled', async () => {
-    const storage = installSessionStorage({
-      'bldr-sw-controller-reload': '/sw.mjs',
-    })
-    const sw = { postMessage: vi.fn() } as unknown as ServiceWorker
-    vi.stubGlobal('navigator', {
-      serviceWorker: {
-        controller: sw,
-        addEventListener: vi.fn(),
-        register: vi.fn(),
-      },
-    })
-    const doc = buildTestWebDocument()
-    vi.spyOn(
-      doc as unknown as { initServiceWorkerPort: (sw: ServiceWorker) => void },
-      'initServiceWorkerPort',
-    ).mockImplementation(() => {})
-    const wb: TestWorkbox = {
-      register: vi
-        .fn()
-        .mockResolvedValue({
-          scope: 'https://example.test/',
-        } as ServiceWorkerRegistration),
-      update: vi.fn().mockResolvedValue(undefined),
-      controlling: Promise.resolve(sw),
-    }
-
-    await doc.initServiceWorker(wb, '/sw.mjs')
-    expect(storage.getItem('bldr-sw-controller-reload')).toBeNull()
-  })
-
-  it('starts the runtime from controllerchange when the awaited path returned early', async () => {
+  it('starts the runtime from controllerchange while registration is pending', async () => {
     const controllerChangeListeners: Array<(ev: Event) => void> = []
     installSessionStorage({ 'bldr-sw-controller-reload': '/sw.mjs' })
     vi.stubGlobal('location', {
@@ -553,19 +547,14 @@ describe('WebDocument service worker startup', () => {
     ).mockImplementation(() => {})
     const onControlReady = vi.fn()
     const wb: TestWorkbox = {
-      register: vi
-        .fn()
-        .mockResolvedValue({
-          scope: 'https://example.test/',
-        } as ServiceWorkerRegistration),
+      register: vi.fn().mockResolvedValue({
+        scope: 'https://example.test/',
+      } as ServiceWorkerRegistration),
       update: vi.fn().mockResolvedValue(undefined),
       controlling: new Promise<ServiceWorker>(() => {}),
     }
 
-    // The controller is already missing after a reload, so this returns before
-    // reaching onControlReady and nothing on the awaited path will ever start
-    // the runtime.
-    await doc.initServiceWorker(wb, '/sw.mjs', onControlReady)
+    void doc.initServiceWorker(wb, '/sw.mjs', onControlReady)
     expect(onControlReady).not.toHaveBeenCalled()
     expect(startRuntimeOnce).not.toHaveBeenCalled()
 
@@ -614,11 +603,9 @@ describe('WebDocument service worker startup', () => {
     const waitConn = vi.fn().mockReturnValue(new Promise(() => {}))
     doc.webRuntimeClient.waitConn = waitConn
     const wb: TestWorkbox = {
-      register: vi
-        .fn()
-        .mockResolvedValue({
-          scope: 'https://example.test/',
-        } as ServiceWorkerRegistration),
+      register: vi.fn().mockResolvedValue({
+        scope: 'https://example.test/',
+      } as ServiceWorkerRegistration),
       update: vi.fn().mockResolvedValue(undefined),
       controlling: Promise.resolve(sw),
     }

--- a/bldr/web/bldr/web-document.ts
+++ b/bldr/web/bldr/web-document.ts
@@ -1791,8 +1791,9 @@ export class WebDocument extends SimpleEventEmitter<WebDocumentEvents> {
       if (typeof data !== 'object' || !data.from || !data.init) {
         return
       }
-      const currSw = navigator.serviceWorker.controller || sw
+      const currSw = navigator.serviceWorker.controller
       // the service worker wants a new message port for requests
+      if (!currSw || this.closed) return
       this.initServiceWorkerPort(currSw)
       // A service worker talking to this document is proof that one controls
       // it, which is the condition the runtime start is waiting for.
@@ -1808,81 +1809,79 @@ export class WebDocument extends SimpleEventEmitter<WebDocumentEvents> {
       navigator.serviceWorker.addEventListener('message', swMessageCallback)
     }
 
-    navigator.serviceWorker.addEventListener('controllerchange', () => {
-      attachSwMessageListener()
-      const controller = navigator.serviceWorker.controller
-      if (!controller || this.closed) {
+    let boundController: ServiceWorker | undefined
+    const bindController = (controller: ServiceWorker) => {
+      if (this.closed) return
+      if (boundController === controller) {
+        this.taskEnsureWebRuntimeConnAfterStartGate()
         return
       }
-      // The elected DedicatedWorker lease outlives a ServiceWorker generation.
-      // Rebind immediately so the new tracker can route attached documents to
-      // the still-live host without waiting for a failed connection to solicit
-      // another registration.
+      boundController = controller
+      attachSwMessageListener()
       this.initServiceWorkerPort(controller)
-      // controllerchange is the event form of the condition the runtime start
-      // gate waits for. The awaited path below can return early or never
-      // settle, so this route must start the runtime rather than only rebind
-      // the port to it.
+      markStartupBoundary('service-worker.control-ready', {
+        source: 'browser',
+        documentId: this.webDocumentUuid,
+        runtimeId: this.webRuntimeId,
+      })
+      onControlReady?.()
       this.startRuntimeOnce?.()
       this.taskEnsureWebRuntimeConnAfterStartGate()
+      sessionStorage.removeItem(swControllerReloadSessionKey)
+      controller.postMessage({ crossTab: 'hello' })
+      controller.postMessage({ bldrSyncManifest: true })
+    }
+    navigator.serviceWorker.addEventListener('controllerchange', () => {
+      const controller = navigator.serviceWorker.controller
+      if (controller) bindController(controller)
     })
+    attachSwMessageListener()
 
-    // register the service worker
-    const wbReg = await wb.register() // ({ immediate: true })
-    markStartupBoundary('service-worker.register-ready', {
-      source: 'browser',
-      documentId: this.webDocumentUuid,
-      runtimeId: this.webRuntimeId,
-    })
-
-    // wait for the service worker to finish startup
-    // await wb.active()
-    await wb.update()
-    markStartupBoundary('service-worker.update-ready', {
-      source: 'browser',
-      documentId: this.webDocumentUuid,
-      runtimeId: this.webRuntimeId,
-    })
-    await registerUpdatedServiceWorker(swUrl, wbReg)
-
-    // workaround for ctrl + shift + r disabling service workers
-    // https://web.dev/service-worker-lifecycle/#shift-reload
-    // Skip this in Electron - it causes spurious reloads that orphan in-flight requests.
-    if (!this.isElectron && wbReg && !navigator.serviceWorker.controller) {
-      const lastReloadUrl = sessionStorage.getItem(swControllerReloadSessionKey)
-      if (lastReloadUrl !== swUrl) {
-        sessionStorage.setItem(swControllerReloadSessionKey, swUrl)
-        console.warn(
-          'WebDocument: service worker controller missing; reloading page',
-        )
-        location.reload()
+    // A controlled tab can attach to the running host immediately. Registration
+    // checks for updates independently of runtime readiness, including offline.
+    const controller = navigator.serviceWorker.controller
+    if (controller) bindController(controller)
+    try {
+      const registration = await wb.register({ immediate: true })
+      markStartupBoundary('service-worker.register-ready', {
+        source: 'browser',
+        documentId: this.webDocumentUuid,
+        runtimeId: this.webRuntimeId,
+      })
+      if (this.closed) return
+      // A forced reload bypasses an already-installed controller. Recover once;
+      // a first installation has no prior active worker and must wait for claim.
+      if (
+        !this.isElectron &&
+        registration?.active &&
+        !navigator.serviceWorker.controller &&
+        performance
+          .getEntriesByType('navigation')
+          .some(
+            (entry) => (entry as PerformanceNavigationTiming).type === 'reload',
+          )
+      ) {
+        if (sessionStorage.getItem(swControllerReloadSessionKey) !== swUrl) {
+          sessionStorage.setItem(swControllerReloadSessionKey, swUrl)
+          location.reload()
+        }
         return
       }
-      console.warn(
-        'WebDocument: service worker controller still missing after reload',
+      void registerUpdatedServiceWorker(swUrl, registration).catch(
+        (err: unknown) => {
+          console.warn('WebDocument: service worker update check failed', err)
+        },
       )
-      return
+      if (!boundController) {
+        // First installation becomes ready through clients.claim/controllerchange.
+        // Absence of a controller during installation is not a reload condition.
+        bindController(
+          navigator.serviceWorker.controller || (await wb.controlling),
+        )
+      }
+    } catch (err) {
+      console.warn('WebDocument: service worker registration failed', err)
     }
-    if (navigator.serviceWorker.controller) {
-      sessionStorage.removeItem(swControllerReloadSessionKey)
-    }
-
-    console.log('WebDocument: service worker registered')
-    const sw = await wb.controlling
-
-    console.log('WebDocument: service worker is controlling this page', sw)
-    markStartupBoundary('service-worker.control-ready', {
-      source: 'browser',
-      documentId: this.webDocumentUuid,
-      runtimeId: this.webRuntimeId,
-    })
-    onControlReady?.()
-    attachSwMessageListener()
-    this.initServiceWorkerPort(sw)
-
-    // Send "hello" to the ServiceWorker cross-tab broker.
-    // The SW creates direct MessagePort channels to every other tab.
-    sw.postMessage({ crossTab: 'hello' })
   }
 
   // notifyWebViewUpdated notifies all subscribers that the web view was updated.

--- a/bldr/web/boot/collector.test.ts
+++ b/bldr/web/boot/collector.test.ts
@@ -43,7 +43,7 @@ vi.mock('@aptre/bldr', () => ({
 }))
 
 vi.mock('../bldr/browser-release-update.js', () => ({
-  initBrowserReleaseAutoReload: vi.fn(),
+  initBrowserReleaseUpdates: vi.fn(),
 }))
 
 vi.mock('../bldr/startup-marks.js', () => ({

--- a/bldr/web/boot/validator.go
+++ b/bldr/web/boot/validator.go
@@ -496,8 +496,8 @@ func validateBootSpanStructure(spans []*BootSpan, total uint64) (map[string][]*B
 
 func validateBootSpanTree(start, end, threshold uint64, roots []*BootSpan, children map[string][]*BootSpan, violations *[]*BootValidationViolation) []bootInterval {
 	stack := make([]bootSpanFrame, 0, len(roots))
-	for idx := len(roots) - 1; idx >= 0; idx-- {
-		stack = append(stack, bootSpanFrame{span: roots[idx], start: start, end: end})
+	for _, root := range slices.Backward(roots) {
+		stack = append(stack, bootSpanFrame{span: root, start: start, end: end})
 	}
 	actionable := make([]bootInterval, 0, len(roots))
 	visited := make(map[string]struct{}, len(children))
@@ -539,8 +539,8 @@ func validateBootSpanTree(start, end, threshold uint64, roots []*BootSpan, child
 				StartMonotonicMicros: interval.start, EndMonotonicMicros: interval.end, SpanId: id,
 			})
 		}
-		for idx := len(nested) - 1; idx >= 0; idx-- {
-			stack = append(stack, bootSpanFrame{span: nested[idx], start: interval.start, end: interval.end})
+		for _, n := range slices.Backward(nested) {
+			stack = append(stack, bootSpanFrame{span: n, start: interval.start, end: interval.end})
 		}
 	}
 	return actionable

--- a/bldr/web/entrypoint/browser/README.md
+++ b/bldr/web/entrypoint/browser/README.md
@@ -6,3 +6,27 @@ The user navigates to the app, which loads the Go runtime in a WebWorker. The
 root WebView cannot be closed (as per browser policy). A service worker is used
 to intercept requests and forward them to the Go runtime for processing. The
 root page can create and close more pages through the WebView API.
+
+A controlled page attaches to the running runtime before checking for service-worker
+updates. Service-worker activation only establishes control; offline downloads run
+through separate events. A forced browser reload that bypasses an installed worker
+gets one recovery reload. Caching a new release does not reload active pages.
+An already cached release descriptor returns immediately while the service worker
+checks for a newer generation in the background.
+Missing boot-version metadata initializes in place, without deleting storage or
+reloading a fresh browser. Explicit older versions retain their migration path.
+
+Browser distributions publish an offline inventory containing the entrypoint,
+split runtime modules, web packages, and immutable kvfile. Startup reads the
+manifest DAG on demand through HTTP ranges. The service worker downloads complete
+assets in the background and serves ranges from its cache. Remote Release World
+plugin manifests are copied into local storage after the startup group is ready.
+Transient range failures are retried on the next read instead of being cached.
+The local provider accepts the browser distribution's same-origin signaling URL
+(`/`), so its configuration can start instead of leaving Quickstart waiting.
+
+The SharedWorker OPFS workaround currently selects a dedicated runtime worker.
+Web Locks elect its owning tab; other tabs attach through the service worker.
+Closing the owner requires another tab to start a replacement runtime. The bundled
+Drive startup benchmark measures cold startup, a second tab with a live owner,
+and restarts with warm storage separately.

--- a/bldr/web/entrypoint/browser/bundle/boot_reset_fixture_test.go
+++ b/bldr/web/entrypoint/browser/bundle/boot_reset_fixture_test.go
@@ -87,6 +87,7 @@ class StorageFixture {
 }
 
 const localStorage = new StorageFixture({
+  'spacewave-browser-app-state-version': '1000000',
   'spacewave-has-session': '1',
   'spacewave-has-interacted': '1',
   'spacewave-state-devtools': '{"open":true}',
@@ -482,10 +483,10 @@ function installEnvironment({ events, localStorage, sessionStorage, autoStart, e
   }
 }
 
-async function runCase({ name, autoStart, hash, readyState, allowPreload }) {
+async function runCase({ name, autoStart, hash, readyState, allowPreload, fresh = false }) {
   const events = []
   const entrypointURL = 'data:text/javascript,'
-  const localStorage = new StorageFixture({})
+  const localStorage = new StorageFixture(fresh ? {} : {'spacewave-browser-app-state-version': '1000000'})
   const sessionStorage = new StorageFixture({})
   installEnvironment({
     events,
@@ -499,6 +500,13 @@ async function runCase({ name, autoStart, hash, readyState, allowPreload }) {
   })
 
   new Function(script)()
+  if (fresh) {
+    await waitFor(() => events.includes('status:entrypoint'), name + ' entrypoint phase')
+    assert(!events.includes('reload'), name + ' reloaded a fresh browser')
+    assert(!events.some(event => event.startsWith('cleanup:')), name + ' cleaned fresh browser storage')
+    assert(localStorage.getItem('spacewave-browser-app-state-version') === '1000001', name + ' did not initialize version')
+    return
+  }
   await waitFor(() => events.includes('reload'), name + ' reset reload')
 
   const firstFetch = events.findIndex((event) => event.startsWith('fetch:'))
@@ -548,6 +556,7 @@ async function runCase({ name, autoStart, hash, readyState, allowPreload }) {
 }
 
 await runCase({ name: 'browser-hash', autoStart: false, hash: '#/u/1' })
+await runCase({ name: 'fresh-browser', autoStart: false, hash: '#/u/1', fresh: true })
 await runCase({ name: 'electron-autostart', autoStart: true, hash: '' })
 await runCase({ name: 'browser-post-load-root-complete', autoStart: false, hash: '', readyState: 'complete', allowPreload: true })
 await runCase({ name: 'browser-post-load-root-interactive', autoStart: false, hash: '', readyState: 'interactive', allowPreload: true })

--- a/bldr/web/entrypoint/browser/bundle/bundle.go
+++ b/bldr/web/entrypoint/browser/bundle/bundle.go
@@ -4,9 +4,11 @@ package entrypoint_browser_bundle
 
 import (
 	"context"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aperturerobotics/fastjson"
@@ -55,6 +57,7 @@ type BuildManifest struct {
 	SharedWorker               string                 `json:"sharedWorker"`
 	Wasm                       string                 `json:"wasm,omitempty"`
 	OpfsWorker                 string                 `json:"opfsWorker,omitempty"`
+	RequiredStaticAssets       []string               `json:"requiredStaticAssets,omitempty"`
 	CSS                        []string               `json:"css"`
 	AutoStart                  bool                   `json:"autoStart,omitempty"`
 	DefaultManifestBundle      *DefaultManifestBundle `json:"defaultManifestBundle,omitempty"`
@@ -64,6 +67,25 @@ const stableBootFilename = "boot.mjs"
 
 // WriteBuildManifest writes a manifest.json to the given directory.
 func WriteBuildManifest(dir string, manifest *BuildManifest) error {
+	// The entrypoint tree owns the runtime, split modules, web packages, and
+	// immutable kvfile. Every executable asset must survive an offline restart.
+	var runtimeAssets []string
+	err := fs.WalkDir(os.DirFS(dir), "entrypoint", func(path string, entry fs.DirEntry, err error) error {
+		if os.IsNotExist(err) && path == "entrypoint" {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if entry.Type().IsRegular() && !strings.HasSuffix(path, ".map") {
+			runtimeAssets = append(runtimeAssets, "/"+path)
+		}
+		return nil
+	})
+	if err != nil {
+		return errors.Wrap(err, "enumerate browser runtime assets")
+	}
+	manifest.RequiredStaticAssets = runtimeAssets
 	if err := writeBrowserReleaseManifest(dir, manifest); err != nil {
 		return err
 	}
@@ -87,6 +109,11 @@ func WriteBuildManifest(dir string, manifest *BuildManifest) error {
 		css.SetArrayItem(len(css.GetArray()), a.NewString(path))
 	}
 	obj.Set("css", css)
+	assets := a.NewArray()
+	for _, path := range manifest.RequiredStaticAssets {
+		assets.SetArrayItem(len(assets.GetArray()), a.NewString(path))
+	}
+	obj.Set("requiredStaticAssets", assets)
 	data := obj.MarshalTo(nil)
 	return os.WriteFile(filepath.Join(dir, "manifest.json"), data, 0o644)
 }
@@ -123,7 +150,11 @@ func writeBrowserReleaseManifest(dir string, manifest *BuildManifest) error {
 	routes := a.NewArray()
 	routes.SetArrayItem(0, a.NewString("/"))
 	obj.Set("prerenderedRoutes", routes)
-	obj.Set("requiredStaticAssets", a.NewArray())
+	assets := a.NewArray()
+	for _, path := range manifest.RequiredStaticAssets {
+		assets.SetArrayItem(len(assets.GetArray()), a.NewString(path))
+	}
+	obj.Set("requiredStaticAssets", assets)
 	if manifest.DefaultManifestBundle != nil {
 		bundle := a.NewObject()
 		bundle.Set("metadata", a.NewString(manifest.DefaultManifestBundle.Metadata))
@@ -399,6 +430,15 @@ function clearBootSessionState(){
 }
 async function resetHistoricalStateForBoot(){
   const storedVersion=storageGet(localStorage,bootStateVersionKey);
+  // A missing marker is not evidence of incompatible state. A fresh browser
+  // starts directly, and missing shell metadata must never erase user files.
+  if(!storedVersion){
+    storageSet(localStorage,bootStateVersionKey,bootStateVersion);
+    storageSet(sessionStorage,bootSessionStateVersionKey,bootStateVersion);
+    setBootResetDecision('initialized','no stored compatibility version');
+    clearBootResetReloadParam();
+    return false;
+  }
   if(storedVersion===bootStateVersion){
     if(storageGet(sessionStorage,bootSessionStateVersionKey)!==bootStateVersion){
       clearBootSessionState();

--- a/bldr/web/entrypoint/browser/bundle/bundle_test.go
+++ b/bldr/web/entrypoint/browser/bundle/bundle_test.go
@@ -454,3 +454,41 @@ func TestBuildRendererIndexUsesEntrypointPath(t *testing.T) {
 		t.Fatalf("renderer index unexpectedly referenced boot.mjs: %s", html)
 	}
 }
+
+// TestWriteBuildManifestOfflineRuntimeAssets verifies the offline inventory
+// includes the pack and lazy modules while excluding source maps.
+func TestWriteBuildManifestOfflineRuntimeAssets(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, "entrypoint", "test", "chunks")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{"entrypoint/test/assets.kvfile", "entrypoint/test/runtime-goscript.mjs", "entrypoint/test/chunks/lazy.js", "entrypoint/test/chunks/lazy.js.map"} {
+		if err := os.WriteFile(filepath.Join(dir, path), []byte("asset"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := WriteBuildManifest(dir, &BuildManifest{}); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"manifest.json", "browser-release.json"} {
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var parser fastjson.Parser
+		value, err := parser.ParseBytes(data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assets := value.GetArray("requiredStaticAssets")
+		if len(assets) != 3 {
+			t.Fatalf("%s: expected pack, runtime, and lazy module; got %s", name, data)
+		}
+		for idx, want := range []string{"/entrypoint/test/assets.kvfile", "/entrypoint/test/chunks/lazy.js", "/entrypoint/test/runtime-goscript.mjs"} {
+			if string(assets[idx].GetStringBytes()) != want {
+				t.Fatalf("%s: missing %s", name, want)
+			}
+		}
+	}
+}

--- a/bldr/web/entrypoint/entrypoint.test.ts
+++ b/bldr/web/entrypoint/entrypoint.test.ts
@@ -19,7 +19,7 @@ const hydrateRootMock = vi.hoisted(() =>
 )
 const waitConnMock = vi.hoisted(() => vi.fn(() => Promise.resolve()))
 const bldrRuntimeMock = vi.hoisted(() => ({ isDesktop: false }))
-const initBrowserReleaseAutoReloadMock = vi.hoisted(() => vi.fn())
+const initBrowserReleaseUpdatesMock = vi.hoisted(() => vi.fn())
 
 vi.mock('react-dom/client', () => ({
   createRoot: createRootMock,
@@ -45,7 +45,7 @@ vi.mock('@aptre/bldr', () => ({
 }))
 
 vi.mock('../bldr/browser-release-update.js', () => ({
-  initBrowserReleaseAutoReload: initBrowserReleaseAutoReloadMock,
+  initBrowserReleaseUpdates: initBrowserReleaseUpdatesMock,
 }))
 
 declare global {
@@ -145,7 +145,7 @@ describe('browser entrypoint boot readiness', () => {
     hydrateRootMock.mockClear()
     waitConnMock.mockClear()
     bldrRuntimeMock.isDesktop = false
-    initBrowserReleaseAutoReloadMock.mockClear()
+    initBrowserReleaseUpdatesMock.mockClear()
     renderedRootElements.length = 0
     globalThis.IS_REACT_ACT_ENVIRONMENT = true
     document.body.innerHTML = ''
@@ -165,7 +165,7 @@ describe('browser entrypoint boot readiness', () => {
     vi.useRealTimers()
     vi.unstubAllGlobals()
     bldrRuntimeMock.isDesktop = false
-    initBrowserReleaseAutoReloadMock.mockClear()
+    initBrowserReleaseUpdatesMock.mockClear()
     renderedRootElements.length = 0
     document.body.innerHTML = ''
     window.history.replaceState({}, '', '/')
@@ -187,7 +187,7 @@ describe('browser entrypoint boot readiness', () => {
 
     await importEntrypoint()
 
-    expect(initBrowserReleaseAutoReloadMock).not.toHaveBeenCalled()
+    expect(initBrowserReleaseUpdatesMock).not.toHaveBeenCalled()
   })
 
   it('initializes browser release auto reload in browser runtime', async () => {
@@ -196,7 +196,7 @@ describe('browser entrypoint boot readiness', () => {
 
     await importEntrypoint()
 
-    expect(initBrowserReleaseAutoReloadMock).toHaveBeenCalledTimes(1)
+    expect(initBrowserReleaseUpdatesMock).toHaveBeenCalledTimes(1)
   })
 
   it('resolves boot readiness after immediate render', async () => {

--- a/bldr/web/entrypoint/entrypoint.tsx
+++ b/bldr/web/entrypoint/entrypoint.tsx
@@ -9,7 +9,7 @@ import { isDesktop, WebDocument as BldrWebDocument } from '@aptre/bldr'
 import type { WebDocumentOptions } from '@aptre/bldr'
 
 import { initBootReportCollector } from '../boot/collector.js'
-import { initBrowserReleaseAutoReload } from '../bldr/browser-release-update.js'
+import { initBrowserReleaseUpdates } from '../bldr/browser-release-update.js'
 import { markStartupBoundary } from '../bldr/startup-marks.js'
 import { setAppPath } from './app-path.js'
 import {
@@ -110,7 +110,7 @@ if (
 const bldrRootProps: IBldrRootProps = { webDocumentOpts }
 
 if (!isDesktop) {
-  initBrowserReleaseAutoReload()
+  initBrowserReleaseUpdates()
 }
 bindBrowserBootStatusToStartupMarks()
 markStartupBoundary('shell.entrypoint-loaded', { source: 'browser' })

--- a/bldr/web/runtime/goscript/build/build_test.go
+++ b/bldr/web/runtime/goscript/build/build_test.go
@@ -939,7 +939,7 @@ export const Unused = 2
 	if err != nil {
 		t.Fatal(err)
 	}
-	minCode := strings.Split(string(minOut), "sourceMappingURL=")[0]
+	minCode, _, _ := strings.Cut(string(minOut), "sourceMappingURL=")
 	if len(minCode) >= len(readableOut) {
 		t.Fatalf("minified code size = %d, readable code size = %d", len(minCode), len(readableOut))
 	}

--- a/cmd/spacewave/cli/client.go
+++ b/cmd/spacewave/cli/client.go
@@ -920,8 +920,8 @@ func mountObjectChain(
 	}
 	var rels []func()
 	unwind := func() {
-		for i := len(rels) - 1; i >= 0; i-- {
-			rels[i]()
+		for _, rel := range slices.Backward(rels) {
+			rel()
 		}
 	}
 	fail := func(err error) (*objectMount, func(), error) {

--- a/cmd/spacewave/cli/device.go
+++ b/cmd/spacewave/cli/device.go
@@ -165,8 +165,10 @@ var deviceMountLinkedSession = func(
 	return prov.MountLinkedDeviceSession(ctx, req)
 }
 
-var deviceUpsertObject = upsertLinkedDeviceObject
-var deviceMountLocalSession = mountLocalDeviceSession
+var (
+	deviceUpsertObject      = upsertLinkedDeviceObject
+	deviceMountLocalSession = mountLocalDeviceSession
+)
 
 func newDeviceCommand(_ func() cli_entrypoint.CliBus) *cli.Command {
 	var statePath string

--- a/core/git/import-local.go
+++ b/core/git/import-local.go
@@ -119,7 +119,6 @@ func importOpenedLocalRepo(
 		}
 		return store.Commit()
 	})
-
 	// Return the published reference together with the captured checkout identity.
 	if err != nil {
 		return nil, "", "", errors.Wrap(err, "import local repository")

--- a/core/provider/local/p2p-sync_test.go
+++ b/core/provider/local/p2p-sync_test.go
@@ -186,7 +186,6 @@ func prepareSessionTransportBackends(ctx context.Context, t *testing.T, stA, stB
 	ipB := tptB.(*inproc.Inproc)
 	ipA.ConnectToInproc(ctx, ipB)
 	ipB.ConnectToInproc(ctx, ipA)
-
 }
 
 // addEstablishLink adds an EstablishLinkWithPeer directive to the bus.

--- a/core/rbac/roles.go
+++ b/core/rbac/roles.go
@@ -38,7 +38,8 @@ func BuiltinRoles() []*RbacRole {
 			Builtin:     true,
 			Rules: []*RbacRule{
 				{ResourceType: "RuntimeCapability", Verbs: []string{"execute"}},
-			}},
+			},
+		},
 		{
 			Id:          VerbAdmin,
 			DisplayName: "Admin",
@@ -50,14 +51,16 @@ func BuiltinRoles() []*RbacRole {
 				{ResourceType: ResourceTypeBlockStore, Verbs: []string{VerbWildcard}},
 				{ResourceType: ResourceTypeBillingAccount, Verbs: []string{VerbWildcard}},
 				{ResourceType: ResourceTypeSession, Verbs: []string{VerbWildcard}},
-			}},
+			},
+		},
 		{
 			Id:          "release_notify",
 			DisplayName: "Release notify",
 			Builtin:     true,
 			Rules: []*RbacRule{
 				{ResourceType: ResourceTypePlatform, Verbs: []string{"update_notify"}},
-			}},
+			},
+		},
 		{
 			Id:          RoleSubscriber,
 			DisplayName: "Subscriber",
@@ -67,7 +70,8 @@ func BuiltinRoles() []*RbacRole {
 				{ResourceType: ResourceTypeBlockStore, Verbs: []string{VerbCreate}},
 				{ResourceType: ResourceTypeSession, Verbs: []string{VerbCreate}},
 				{ResourceType: ResourceTypeOrganization, Verbs: []string{VerbView}},
-			}},
+			},
+		},
 		{
 			Id:          RoleSubscriberReadonly,
 			DisplayName: "Subscriber (Read-only)",
@@ -75,7 +79,8 @@ func BuiltinRoles() []*RbacRole {
 			Rules: []*RbacRule{
 				{ResourceType: ResourceTypeSession, Verbs: []string{VerbCreate}},
 				{ResourceType: ResourceTypeOrganization, Verbs: []string{VerbView}},
-			}},
+			},
+		},
 		{
 			Id:          "free",
 			DisplayName: "Free",
@@ -83,7 +88,8 @@ func BuiltinRoles() []*RbacRole {
 			Rules: []*RbacRule{
 				{ResourceType: ResourceTypeSession, Verbs: []string{VerbCreate}},
 				{ResourceType: ResourceTypeOrganization, Verbs: []string{VerbView}},
-			}},
+			},
+		},
 		{
 			Id:          RoleOwner,
 			DisplayName: "Owner",
@@ -91,7 +97,8 @@ func BuiltinRoles() []*RbacRole {
 			Rules: []*RbacRule{
 				{ResourceType: ResourceTypeSharedObject, Verbs: []string{VerbRead, VerbWriteOps, VerbValidate, VerbManageConfig, VerbTransfer}},
 				{ResourceType: ResourceTypeBlockStore, Verbs: []string{VerbRead, VerbPush, VerbPull, VerbManage, VerbTransfer}},
-			}},
+			},
+		},
 		{
 			Id:          RoleEditor,
 			DisplayName: "Editor",
@@ -99,7 +106,8 @@ func BuiltinRoles() []*RbacRole {
 			Rules: []*RbacRule{
 				{ResourceType: ResourceTypeSharedObject, Verbs: []string{VerbRead, VerbWriteOps}},
 				{ResourceType: ResourceTypeBlockStore, Verbs: []string{VerbRead, VerbPush, VerbPull}},
-			}},
+			},
+		},
 		{
 			Id:          RoleViewer,
 			DisplayName: "Viewer",
@@ -107,7 +115,8 @@ func BuiltinRoles() []*RbacRole {
 			Rules: []*RbacRule{
 				{ResourceType: ResourceTypeSharedObject, Verbs: []string{VerbRead}},
 				{ResourceType: ResourceTypeBlockStore, Verbs: []string{VerbRead, VerbPull}},
-			}},
+			},
+		},
 		{
 			Id:          "org:owner",
 			DisplayName: "Organization Owner",
@@ -116,7 +125,8 @@ func BuiltinRoles() []*RbacRole {
 				{ResourceType: ResourceTypeOrganization, Verbs: []string{VerbWildcard}},
 				{ResourceType: ResourceTypeSharedObject, Verbs: []string{VerbWildcard}},
 				{ResourceType: ResourceTypeBlockStore, Verbs: []string{VerbWildcard}},
-			}},
+			},
+		},
 		{
 			Id:          "org:member",
 			DisplayName: "Organization Member",
@@ -125,7 +135,8 @@ func BuiltinRoles() []*RbacRole {
 				{ResourceType: ResourceTypeOrganization, Verbs: []string{VerbView, VerbManageSpaces}},
 				{ResourceType: ResourceTypeSharedObject, Verbs: []string{VerbRead}},
 				{ResourceType: ResourceTypeBlockStore, Verbs: []string{VerbRead}},
-			}},
+			},
+		},
 		{
 			Id:          "org:billing",
 			DisplayName: "Organization Billing",
@@ -133,11 +144,13 @@ func BuiltinRoles() []*RbacRole {
 			Rules: []*RbacRule{
 				{ResourceType: ResourceTypeOrganization, Verbs: []string{VerbManageBilling}},
 				{ResourceType: ResourceTypeBillingAccount, Verbs: []string{VerbWildcard}},
-			}},
+			},
+		},
 		{
 			Id:          "disputed_locked",
 			DisplayName: "Disputed (Locked)",
 			Builtin:     true,
-			Rules:       []*RbacRule{}},
+			Rules:       []*RbacRule{},
+		},
 	}
 }

--- a/db/block/file/writer.go
+++ b/db/block/file/writer.go
@@ -516,7 +516,7 @@ func (w *Writer) compactOccludedRanges() {
 		return
 	}
 
-	for i := len(ranges) - 1; i >= 0; i-- {
+	for i := range slices.Backward(ranges) {
 		if rangeCoveredByHigherNonce(ranges, i) {
 			w.deleteRange(i)
 			ranges = w.root.GetRanges()

--- a/db/block/gc/refgraph.go
+++ b/db/block/gc/refgraph.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"io"
+	"slices"
 	"strconv"
 	"sync"
 
@@ -479,8 +480,8 @@ func (rg *RefGraph) hasRefAttempt(ctx context.Context, subject, object string) (
 		quadIDs = append(quadIDs, quadID)
 		postings = postings[n:]
 	}
-	for i := len(quadIDs) - 1; i >= 0; i-- {
-		quadID := quadIDs[i]
+	for _, quadID := range slices.Backward(quadIDs) {
+
 		logKey := cayley_flat.KeyEscape(cayley_hkv.Key{
 			[]byte("l"),
 			[]byte(strconv.FormatUint(quadID, 10)),

--- a/db/kvtx/block/okra/iterator.go
+++ b/db/kvtx/block/okra/iterator.go
@@ -3,6 +3,7 @@ package kvtx_block_okra
 import (
 	"bytes"
 	"context"
+	"slices"
 
 	"github.com/s4wave/spacewave/db/block"
 	"github.com/s4wave/spacewave/db/kvtx"
@@ -248,8 +249,8 @@ func (i *Iterator) firstAtOrAfter(path okraPagePath, key []byte) error {
 func (i *Iterator) lastAtOrBefore(path okraPagePath, key []byte) error {
 	for {
 		frame := path.leaf()
-		for idx := len(frame.page.GetEntries()) - 1; idx >= 0; idx-- {
-			ent := frame.page.GetEntries()[idx]
+		for idx, ent := range slices.Backward(frame.page.GetEntries()) {
+
 			if ent.GetAnchor() || len(key) != 0 && bytes.Compare(ent.GetKey(), key) > 0 {
 				continue
 			}
@@ -269,8 +270,8 @@ func (i *Iterator) lastAtOrBefore(path okraPagePath, key []byte) error {
 func (i *Iterator) lastBefore(path okraPagePath, key []byte) error {
 	for {
 		frame := path.leaf()
-		for idx := len(frame.page.GetEntries()) - 1; idx >= 0; idx-- {
-			ent := frame.page.GetEntries()[idx]
+		for idx, ent := range slices.Backward(frame.page.GetEntries()) {
+
 			if ent.GetAnchor() || bytes.Compare(ent.GetKey(), key) >= 0 {
 				continue
 			}

--- a/db/kvtx/block/store-tx.go
+++ b/db/kvtx/block/store-tx.go
@@ -14,7 +14,7 @@ type storeTx struct {
 	// BlockTx is the underlying block tx.
 	kvtx.BlockTx
 	// rel indicates if this tx is released
-	rel uint32
+	rel atomic.Uint32
 	// st is the store
 	st *Store
 	// writeTx is the write transaction.
@@ -110,7 +110,7 @@ func (s *storeTx) Discard() {
 
 // release releases the tx
 func (s *storeTx) release() bool {
-	rel := atomic.SwapUint32(&s.rel, 1)
+	rel := s.rel.Swap(1)
 	return rel != 1
 }
 

--- a/db/unixfs/billy/billy-fs_test.go
+++ b/db/unixfs/billy/billy-fs_test.go
@@ -101,8 +101,7 @@ func TestBillyFS_ErrorWrapping(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
-		var pe *os.PathError
-		if !errors.As(err, &pe) {
+		if _, ok := errors.AsType[*os.PathError](err); !ok {
 			t.Fatalf("expected *os.PathError, got %T: %v", err, err)
 		}
 		if !os.IsNotExist(err) {
@@ -381,8 +380,7 @@ func TestBillyFS_OpenFileExclusive(t *testing.T) {
 		if !os.IsNotExist(err) {
 			t.Errorf("expected os.IsNotExist, got %v", err)
 		}
-		var pe *os.PathError
-		if !errors.As(err, &pe) {
+		if _, ok := errors.AsType[*os.PathError](err); !ok {
 			t.Errorf("expected *os.PathError, got %T", err)
 		}
 	})

--- a/db/util/buffered-reader-at/buffered-reader-at.go
+++ b/db/util/buffered-reader-at/buffered-reader-at.go
@@ -108,6 +108,7 @@ func (br *BufferedReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
 				// If this is a DynamicReaderAt we can request the data and keep the entire result.
 				// For HTTP fetchers, this is used to handle status 200 when 206 is expected.
 				var data []byte
+				dataOffset := nr.offset
 				var readErr error
 				sliceReader, sliceReaderOk := br.reader.(SliceReaderAt)
 				if sliceReaderOk {
@@ -115,48 +116,42 @@ func (br *BufferedReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
 					if err != nil {
 						readErr = err
 					}
-					if len(readData) != 0 {
-						// Adjust the offset and size according to the returned offset.
-						// The size can be adjusted w/o a mutex lock but the offset requires a sort and mtx lock.
-						if readDataOffset != nr.offset {
-							br.mtx.Lock()
-							nr.offset = readDataOffset
-							slices.SortFunc(br.cache, func(a, b *cacheRange) int {
-								return int(a.offset - b.offset)
-							})
-							br.mtx.Unlock()
-						}
-					}
+					dataOffset = readDataOffset
 					data = readData
 				}
 
 				// if !sliceReaderOk or if the slice reader returned len(0) try ReadAt
-				if len(data) == 0 {
+				if !sliceReaderOk || (len(data) == 0 && readErr == nil) {
+					dataOffset = nr.offset
 					data = make([]byte, nr.size)
 					var readN int
 					readN, readErr = br.reader.ReadAt(data, nr.offset)
 					data = data[:min(readN, len(data))]
 				}
 
-				if len(data) != 0 { // avoid keeping a reference to the slice capacity
-					nr.size = int64(len(data))
-					nr.data = data
-				}
+				// Publish range metadata under the same lock used by cache lookup.
+				br.mtx.Lock()
+				offsetChanged := nr.offset != dataOffset
+				nr.offset = dataOffset
+				nr.size = int64(len(data))
+				nr.data = data
 				if readErr != nil && (readErr != io.EOF || len(data) == 0) {
 					nr.err = readErr
 				}
-				close(nr.done)
-
-				// If the size was zero, drop the range.
-				// (The calls waiting on the read will still get the readErr).
-				if nr.size == 0 {
-					br.mtx.Lock()
+				if nr.err != nil || nr.size == 0 {
+					// Existing waiters receive this attempt's error; later reads
+					// retry the source instead of retaining a poisoned cache page.
 					idx := slices.Index(br.cache, nr)
 					if idx >= 0 {
 						br.cache = slices.Delete(br.cache, idx, idx+1)
 					}
-					br.mtx.Unlock()
+				} else if offsetChanged {
+					slices.SortFunc(br.cache, func(a, b *cacheRange) int {
+						return int(a.offset - b.offset)
+					})
 				}
+				close(nr.done)
+				br.mtx.Unlock()
 			}(matchedRange)
 		}
 		br.mtx.Unlock()

--- a/db/util/buffered-reader-at/buffered-reader-at_test.go
+++ b/db/util/buffered-reader-at/buffered-reader-at_test.go
@@ -1,6 +1,7 @@
 package buffered_reader_at
 
 import (
+	"errors"
 	"io"
 	"sync"
 	"testing"
@@ -60,4 +61,37 @@ func TestConcurrentReadAt(t *testing.T) {
 		}(w)
 	}
 	wg.Wait()
+}
+
+type retryReader struct{ attempts int }
+
+func (r *retryReader) ReadAt(p []byte, off int64) (int, error) {
+	r.attempts++
+	if r.attempts == 1 {
+		return 0, errors.New("temporary network error")
+	}
+	for idx := range p {
+		p[idx] = byte(off + int64(idx))
+	}
+	return len(p), nil
+}
+
+func TestReadAtRetriesFailedRange(t *testing.T) {
+	source := &retryReader{}
+	reader := NewBufferedReaderAt(source, 16)
+	buf := make([]byte, 4)
+	if _, err := reader.ReadAt(buf, 3); err == nil {
+		t.Fatal("expected first read to fail")
+	}
+	if n, err := reader.ReadAt(buf, 3); err != nil || n != len(buf) {
+		t.Fatalf("retry: n=%d err=%v", n, err)
+	}
+	if source.attempts != 2 {
+		t.Fatalf("attempts=%d, want 2", source.attempts)
+	}
+	for idx, value := range buf {
+		if value != byte(idx+3) {
+			t.Fatalf("unexpected range: %v", buf)
+		}
+	}
 }

--- a/db/world/block/changelog-read.go
+++ b/db/world/block/changelog-read.go
@@ -105,8 +105,8 @@ func readWorldChangeBatch(
 	}
 
 	var changes []*WorldChange
-	for i := len(chunks) - 1; i >= 0; i-- {
-		changes = append(changes, chunks[i]...)
+	for _, chunk := range slices.Backward(chunks) {
+		changes = append(changes, chunk...)
 	}
 	return changes, nil
 }

--- a/e2e/releasewasm/drive-startup-bench_test.go
+++ b/e2e/releasewasm/drive-startup-bench_test.go
@@ -20,16 +20,17 @@ import (
 const driveBenchEnv = "E2E_WASM_DRIVE_BENCH"
 
 // TestGoScriptDriveStartupBenchBundled records the time-to-Drive bench for the
-// production bundled build across three runtime states on one owned
+// production bundled build across four runtime states on one owned
 // BrowserContext, writing the same run.json schema as the unbundled bench so
 // cells compare across harnesses. The bundled production path has no Resource
 // SDK client. An opt-in root-runtime trace is read directly from its browser
 // SharedWorker target.
 //
-//   - cold: a fresh context boots the bundled SharedWorker runtime over a cold
+//   - cold: a fresh context boots the bundled worker runtime over a cold
 //     HTTP cache and empty OPFS Space state.
+//   - live: a second tab attaches while the cold tab keeps the runtime alive.
 //   - warm: a return visitor; the cold page is closed to terminate the
-//     SharedWorker, then a fresh page in the same context reboots over the
+//     runtime, then a fresh page in the same context reboots over the
 //     retained HTTP cache and OPFS Space state.
 //   - cache-hot: the asset cache stays warm but the OPFS Space state is cleared
 //     before the reboot, isolating asset-load cost from Space-data cost.
@@ -62,7 +63,20 @@ func TestGoScriptDriveStartupBenchBundled(t *testing.T) {
 		cell:         "cold-bundled",
 	})
 
-	// warm: a return visitor. Closing the cold page terminates the SharedWorker
+	// A second tab must reuse the live host; warm startup below measures a
+	// different operation because closing every tab destroys that host.
+	livePage := testHarness.newPageInContext(t, benchCtx)
+	runBundledDriveBenchCell(t, livePage, bundledDriveBenchCellInput{
+		runStamp:     runStamp,
+		compiler:     string(compiler),
+		runtimeState: "live",
+		cell:         "live-bundled",
+	})
+	if err := livePage.Close(); err != nil {
+		t.Fatalf("close live page: %v", err)
+	}
+
+	// warm: a return visitor. Closing the cold page terminates the worker
 	// runtime (no remaining clients) so the next page boots a fresh worker over
 	// the warm HTTP cache and retained OPFS Space state.
 	if err := coldPage.Close(); err != nil {
@@ -180,6 +194,13 @@ func runBundledDriveBenchCell(t *testing.T, page playwright.Page, in bundledDriv
 		ServedBundle: bundle,
 	}
 	run.Browser.StartupMarks = readBundledStartupMarks(t, page)
+	if in.runtimeState == "live" {
+		for _, mark := range run.Browser.StartupMarks {
+			if mark.Label == "runtime.worker-created" && mark.Source == "browser" {
+				t.Error("second tab created a runtime instead of attaching to the live host")
+			}
+		}
+	}
 	if len(startupTrace) != 0 {
 		tracePath := filepath.Join(cellDir, "runtime.trace")
 		if err := drivebench.WriteArtifact(tracePath, startupTrace); err != nil {

--- a/e2e/releasewasm/offline-startup_test.go
+++ b/e2e/releasewasm/offline-startup_test.go
@@ -1,0 +1,77 @@
+//go:build !skip_e2e && !js
+
+package releasewasm
+
+import (
+	"strings"
+	"testing"
+
+	playwright "github.com/mxschmitt/playwright-go"
+)
+
+func TestGoScriptOfflineStartup(t *testing.T) {
+	compiler, err := resolveReleaseWasmCompiler()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compiler != releaseWasmCompilerGoScript {
+		t.Skip("requires the GoScript release build")
+	}
+	page := testHarness.newPage(t)
+	ctx := page.Context()
+	if _, err := page.Goto(testHarness.getBaseURL() + "/quickstart/drive"); err != nil {
+		t.Fatal(err)
+	}
+	waitForLiveApp(t, page)
+	if err := page.Locator("[data-testid='unixfs-browser']:visible").First().WaitFor(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := page.WaitForFunction(`async () => {
+		const cache = await caches.open('bldr-control')
+		const response = await cache.match('/__bldr/browser-release-state.json')
+		return response && (await response.json()).promotedCurrent
+	}`, nil, playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(browserWaitMS)}); err != nil {
+		t.Fatalf("complete background offline cache: %v", err)
+	}
+	desc, err := testHarness.browserRelease(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var packPath string
+	for _, asset := range desc.RequiredStaticAssets {
+		if strings.HasSuffix(asset, ".kvfile") {
+			packPath = asset
+			break
+		}
+	}
+	if packPath == "" {
+		t.Fatal("offline inventory has no kvfile")
+	}
+	if err := ctx.SetOffline(true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := page.Evaluate(`async path => {
+		const response = await fetch(path, {headers: {Range: 'bytes=0-15'}})
+		const body = await response.arrayBuffer()
+		if (response.status !== 206 || body.byteLength !== 16) {
+			throw new Error('cached kvfile range: status=' + response.status + ' bytes=' + body.byteLength)
+		}
+	}`, packPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := page.Close(); err != nil {
+		t.Fatal(err)
+	}
+	page = testHarness.newPageInContext(t, ctx)
+	if _, err := page.Goto(testHarness.getBaseURL() + "/quickstart/drive"); err != nil {
+		t.Fatal(err)
+	}
+	waitForLiveApp(t, page)
+	if err := page.Locator("[data-testid='unixfs-browser']:visible").First().WaitFor(); err != nil {
+		dumpPageState(t, page)
+		t.Fatalf("restart Drive offline after terminating its runtime: %v", err)
+	}
+	if _, err := waitForQuickstartDriveContentReady(t, page); err != "" {
+		t.Fatalf("read persisted Drive content offline: %s", err)
+	}
+}

--- a/e2e/releasewasm/releasewasm_test.go
+++ b/e2e/releasewasm/releasewasm_test.go
@@ -3126,7 +3126,7 @@ func releaseBoolField(m map[string]any, key string) bool {
 func waitForQuickstartDriveContentReady(t *testing.T, page playwright.Page) (*int, string) {
 	t.Helper()
 
-	err := page.Locator("text=getting-started.md").First().WaitFor(
+	err := page.Locator("[data-testid='unixfs-browser']:visible").Locator(`text="getting-started.md"`).First().WaitFor(
 		playwright.LocatorWaitForOptions{Timeout: playwright.Float(quickstartContentReadyRecordMS)},
 	)
 	if err != nil {

--- a/e2e/wasm/browser.go
+++ b/e2e/wasm/browser.go
@@ -198,8 +198,7 @@ func (h *Harness) newBrowserPage(s *TestSession) (playwright.Page, error) {
 
 func pageErrorMessage(err error) string {
 	msg := "page error: " + err.Error()
-	var pwErr *playwright.Error
-	if stderrors.As(err, &pwErr) {
+	if pwErr, ok := stderrors.AsType[*playwright.Error](err); ok {
 		stack := strings.TrimSpace(pwErr.Stack)
 		if stack != "" && stack != pwErr.Message {
 			msg += "\n" + stack

--- a/net/transport/common/quic/errors.go
+++ b/net/transport/common/quic/errors.go
@@ -18,8 +18,7 @@ var (
 // isCleanAcceptClose returns true if the error is an expected accept-loop
 // close: a zero-code application error, cancellation, or stream EOF.
 func isCleanAcceptClose(err error) bool {
-	var qe *quic.ApplicationError
-	if errors.As(err, &qe) {
+	if qe, ok := errors.AsType[*quic.ApplicationError](err); ok {
 		return qe != nil && qe.ErrorCode == 0
 	}
 

--- a/plugin/sql/controller.go
+++ b/plugin/sql/controller.go
@@ -2,6 +2,7 @@ package sql_plugin
 
 import (
 	"context"
+	"slices"
 
 	"github.com/aperturerobotics/controllerbus/bus"
 	"github.com/aperturerobotics/controllerbus/controller"
@@ -217,8 +218,8 @@ func (c *Controller) registerSQL(
 
 func releaseRefs(refs []resource_client.ResourceRef) {
 	// Release registrations in reverse order of acquisition.
-	for i := len(refs) - 1; i >= 0; i-- {
-		refs[i].Release()
+	for _, ref := range slices.Backward(refs) {
+		ref.Release()
 	}
 }
 

--- a/plugin/sql/handler_test.go
+++ b/plugin/sql/handler_test.go
@@ -634,8 +634,8 @@ func newSQLObjectTypeBridgeHarness(
 
 	var cleanupFns []func()
 	cleanup := func() {
-		for i := len(cleanupFns) - 1; i >= 0; i-- {
-			cleanupFns[i]()
+		for _, cleanupFn := range slices.Backward(cleanupFns) {
+			cleanupFn()
 		}
 	}
 

--- a/sdk/terminal/ssh_connect.go
+++ b/sdk/terminal/ssh_connect.go
@@ -484,8 +484,7 @@ func (r *TerminalResource) waitSSHSession(
 	waitErr := session.Wait()
 	exitCode := 0
 	if waitErr != nil {
-		var exitErr *ssh.ExitError
-		if stderrors.As(waitErr, &exitErr) {
+		if exitErr, ok := stderrors.AsType[*ssh.ExitError](waitErr); ok {
 			exitCode = exitErr.ExitStatus()
 		} else if !clientClosed.Load() {
 			errCh <- terminalConnectResult{err: waitErr}


### PR DESCRIPTION
Controlled browser pages now attach to their runtime before checking for service-worker updates, and caching a newer release leaves active tabs and file requests running. Missing boot-version metadata initializes without deleting storage.

The offline inventory includes runtime modules and manifest packs, the service worker serves cached byte ranges, and remote release manifests are copied after startup. Buffered reads publish range metadata under the cache lock and evict failed attempts so later reads can retry. The remaining edits apply Go iteration, error-matching, and atomic idioms.

Validation: 130 focused TypeScript tests, Bldr typechecking, tests in 15 packages covering the Go modernization, and focused race checks pass. Chromium passes a source-built offline Drive restart and persisted-content read. Chromium and WebKit both pass the in-flight file-fetch release-update regression.

WebKit's full offline journey remains unverified: its OPFS initialization fails with UnknownError before Drive starts. An independent blank-page control reproduces the same error in both the window and a dedicated worker, including after window warmup. The broader renderer package also fails TestBuildRendererRoutesCSSGraphThroughVite because its temporary Vite process cannot resolve @aptre/protobuf-es-lite/message; the targeted boot/manifest checks pass.
