### PR TITLE
feat(provider): add managed account enrollment and availability

### DIFF
--- a/.protoc-manifest.json
+++ b/.protoc-manifest.json
@@ -1137,7 +1137,7 @@
       ]
     },
     "github.com/s4wave/spacewave/core/provider/spacewave/api": {
-      "hash": "f542b19c31589b610ec89c740350c6eddf9655b37943b879edfd06a5758be4b5",
+      "hash": "9e1e43e6685e33f6e20ece55a0cb7ef625bd26ab81678b94a3a57ddbe0ecf708",
       "generatedFiles": [
         "core/provider/spacewave/api/api.pb.go",
         "core/provider/spacewave/api/api.pb.ts",

--- a/core/e2e/onboarding/application_test.go
+++ b/core/e2e/onboarding/application_test.go
@@ -11,7 +11,10 @@ import (
 
 	"github.com/aperturerobotics/fastjson"
 	"github.com/aperturerobotics/util/ulid"
+	provider_spacewave "github.com/s4wave/spacewave/core/provider/spacewave"
 	api "github.com/s4wave/spacewave/core/provider/spacewave/api"
+	"github.com/s4wave/spacewave/net/crypto"
+	"github.com/s4wave/spacewave/net/peer"
 )
 
 // TestApplicationRegistration exercises signed registration and operator readback
@@ -125,4 +128,91 @@ func TestApplicationRegistration(t *testing.T) {
 	if len(history.GetAssignments()) != 1 || !history.GetAssignments()[0].EqualVT(funded.GetAssignment()) {
 		t.Fatal("funding history does not contain the accepted assignment")
 	}
+
+	// Activate through the real lifecycle API before enrolling independent credentials.
+	changeState := func(revision uint64, state api.ApplicationState) {
+		t.Helper()
+		_, err := operatorClient.SetApplicationState(ctx, &api.SetApplicationStateRequest{
+			ApplicationId: app.GetId(), ExpectedRevision: revision, State: state,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	changeState(2, api.ApplicationState_APPLICATION_STATE_ACTIVE)
+	first, accountID := enrollApplicationTestSession(ctx, t, operatorClient, app.GetId(), 3)
+	second, recoveredID := enrollApplicationTestSession(ctx, t, operatorClient, app.GetId(), 3)
+	if accountID != recoveredID {
+		t.Fatal("independent credential recovered a different account")
+	}
+	for _, client := range []*provider_spacewave.SessionClient{first, second} {
+		if _, err := client.GetAccountInfo(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Paused Sessions survive, and disabling cannot resurrect them on reactivation.
+	changeState(3, api.ApplicationState_APPLICATION_STATE_PAUSED)
+	if _, err := first.GetAccountInfo(ctx); err == nil {
+		t.Fatal("paused application admitted an account operation")
+	}
+	changeState(4, api.ApplicationState_APPLICATION_STATE_ACTIVE)
+	if _, err := first.GetAccountInfo(ctx); err != nil {
+		t.Fatal(err)
+	}
+	changeState(5, api.ApplicationState_APPLICATION_STATE_DISABLED)
+	changeState(6, api.ApplicationState_APPLICATION_STATE_ACTIVE)
+	if _, err := first.GetAccountInfo(ctx); err == nil {
+		t.Fatal("reactivation restored a disabled Session")
+	}
+	third, reactivatedID := enrollApplicationTestSession(ctx, t, operatorClient, app.GetId(), 7)
+	if reactivatedID != accountID {
+		t.Fatal("fresh login after disable lost the managed account")
+	}
+	if _, err := third.GetAccountInfo(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// enrollApplicationTestSession independently signs a fresh login credential and
+// registers its Session through the ordinary provider API. The test operator
+// stands in for a trusted identity integration; no external login is simulated.
+func enrollApplicationTestSession(ctx context.Context, t *testing.T, operator *provider_spacewave.SessionClient, applicationID string, revision uint64) (*provider_spacewave.SessionClient, string) {
+	t.Helper()
+	entityKey, _, err := crypto.GenerateEd25519Key(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entityID, err := peer.IDFromPrivateKey(entityKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entity := provider_spacewave.NewEntityClientDirect(httpClient, env.cloudURL, "", entityKey, entityID)
+	request, err := entity.SignManagedAccountEnrollment(ctx, &api.ManagedAccountEnrollment{
+		ApplicationId:               applicationID,
+		Issuer:                      "https://identity.example",
+		Subject:                     "same-verified-subject",
+		KeypairPeerId:               entityID.String(),
+		ExpectedApplicationRevision: revision,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	enrolled, err := operator.EnrollManagedAccount(ctx, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sessionKey, _, err := crypto.GenerateEd25519Key(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessionID, err := peer.IDFromPrivateKey(sessionKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := entity.RegisterSessionDirect(ctx, sessionID.String(), "fresh profile"); err != nil {
+		t.Fatal(err)
+	}
+	return provider_spacewave.NewSessionClient(httpClient, env.cloudURL, "", sessionKey, sessionID.String()), enrolled.GetAccountId()
 }

--- a/core/e2e/onboarding/application_test.go
+++ b/core/e2e/onboarding/application_test.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/aperturerobotics/fastjson"
 	"github.com/aperturerobotics/util/ulid"
+	"github.com/s4wave/spacewave/core/provider"
 	provider_spacewave "github.com/s4wave/spacewave/core/provider/spacewave"
 	api "github.com/s4wave/spacewave/core/provider/spacewave/api"
+	"github.com/s4wave/spacewave/core/session"
 	"github.com/s4wave/spacewave/net/crypto"
 	"github.com/s4wave/spacewave/net/peer"
 )
@@ -175,10 +177,12 @@ func TestApplicationRegistration(t *testing.T) {
 }
 
 // enrollApplicationTestSession independently signs a fresh login credential and
-// registers its Session through the ordinary provider API. The test operator
+// registers and mounts its Device Session through the provider. The test operator
 // stands in for a trusted identity integration; no external login is simulated.
 func enrollApplicationTestSession(ctx context.Context, t *testing.T, operator *provider_spacewave.SessionClient, applicationID string, revision uint64) (*provider_spacewave.SessionClient, string) {
 	t.Helper()
+
+	// Create and prove possession of an independent managed account credential.
 	entityKey, _, err := crypto.GenerateEd25519Key(nil)
 	if err != nil {
 		t.Fatal(err)
@@ -203,6 +207,7 @@ func enrollApplicationTestSession(ctx context.Context, t *testing.T, operator *p
 		t.Fatal(err)
 	}
 
+	// Keep the Device key separate from the account's recovery authority.
 	sessionKey, _, err := crypto.GenerateEd25519Key(nil)
 	if err != nil {
 		t.Fatal(err)
@@ -211,8 +216,48 @@ func enrollApplicationTestSession(ctx context.Context, t *testing.T, operator *p
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := entity.RegisterSessionDirect(ctx, sessionID.String(), "fresh profile"); err != nil {
+
+	// Register and mount through the real provider and local Session controller.
+	prov, provRef, err := provider.ExLookupProvider(ctx, env.tb.Bus, "spacewave", false, nil)
+	if err != nil {
 		t.Fatal(err)
 	}
-	return provider_spacewave.NewSessionClient(httpClient, env.cloudURL, "", sessionKey, sessionID.String()), enrolled.GetAccountId()
+	t.Cleanup(provRef.Release)
+	ctrl, releaseCtrl, err := lookupSessionController(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(releaseCtrl)
+	entry, err := prov.(*provider_spacewave.Provider).RegisterDeviceSession(ctx, entityKey, sessionKey, "Fresh profile", ctrl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if entry.GetSessionRef().GetProviderResourceRef().GetProviderAccountId() != enrolled.GetAccountId() {
+		t.Fatal("Device registration changed the managed account")
+	}
+
+	// Retain the mounted Device for the test and verify the key it actually uses.
+	mounted, mountRef, err := session.ExMountSession(ctx, env.tb.Bus, entry.GetSessionRef(), false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(mountRef.Release)
+	if mounted.GetPeerId() != sessionID {
+		t.Fatal("mounted Device uses another peer identity")
+	}
+
+	// Read back cloud inventory after mounting to confirm the Device is registered.
+	client := provider_spacewave.NewSessionClient(httpClient, env.cloudURL, "", sessionKey, sessionID.String())
+	registered, err := client.ListSessions(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, row := range registered {
+		if row.GetPeerId() != sessionID.String() {
+			continue
+		}
+		return client, enrolled.GetAccountId()
+	}
+	t.Fatal("mounted Device is absent from cloud session inventory")
+	return nil, ""
 }

--- a/core/provider/spacewave/api/application.pb.go
+++ b/core/provider/spacewave/api/application.pb.go
@@ -489,6 +489,208 @@ func (x *ListApplicationFundingResponse) GetNextAfterRevision() uint64 {
 	return 0
 }
 
+// ManagedAccountEnrollment binds a new credential to a verified application identity.
+// The credential signs the domain-separated binary message; the application integration
+// separately authenticates the issuer and subject before submitting it to the provider.
+type ManagedAccountEnrollment struct {
+	unknownFields []byte
+	// ApplicationId identifies the application whose operator approves this enrollment.
+	ApplicationId string `protobuf:"bytes,1,opt,name=application_id,json=applicationId,proto3" json:"applicationId,omitempty"`
+	// Issuer is the verified identity provider's stable namespace, at most 512 UTF-8 bytes.
+	Issuer string `protobuf:"bytes,2,opt,name=issuer,proto3" json:"issuer,omitempty"`
+	// Subject is the verified identity within the issuer, at most 256 UTF-8 bytes.
+	Subject string `protobuf:"bytes,3,opt,name=subject,proto3" json:"subject,omitempty"`
+	// KeypairPeerId embeds the public key of the credential being enrolled.
+	KeypairPeerId string `protobuf:"bytes,4,opt,name=keypair_peer_id,json=keypairPeerId,proto3" json:"keypairPeerId,omitempty"`
+	// ExpectedApplicationRevision invalidates approvals after application configuration changes.
+	ExpectedApplicationRevision uint64 `protobuf:"varint,5,opt,name=expected_application_revision,json=expectedApplicationRevision,proto3" json:"expectedApplicationRevision,omitempty"`
+}
+
+func (x *ManagedAccountEnrollment) Reset() {
+	*x = ManagedAccountEnrollment{}
+}
+
+func (*ManagedAccountEnrollment) ProtoMessage() {}
+
+func (x *ManagedAccountEnrollment) GetApplicationId() string {
+	if x != nil {
+		return x.ApplicationId
+	}
+	return ""
+}
+
+func (x *ManagedAccountEnrollment) GetIssuer() string {
+	if x != nil {
+		return x.Issuer
+	}
+	return ""
+}
+
+func (x *ManagedAccountEnrollment) GetSubject() string {
+	if x != nil {
+		return x.Subject
+	}
+	return ""
+}
+
+func (x *ManagedAccountEnrollment) GetKeypairPeerId() string {
+	if x != nil {
+		return x.KeypairPeerId
+	}
+	return ""
+}
+
+func (x *ManagedAccountEnrollment) GetExpectedApplicationRevision() uint64 {
+	if x != nil {
+		return x.ExpectedApplicationRevision
+	}
+	return 0
+}
+
+// EnrollManagedAccountRequest asks the authenticated application operator to enroll a credential.
+// Only the approved integration submits verified external subjects; this is not a browser assertion.
+type EnrollManagedAccountRequest struct {
+	unknownFields []byte
+	// Enrollment identifies the verified subject and credential being authorized.
+	Enrollment *ManagedAccountEnrollment `protobuf:"bytes,1,opt,name=enrollment,proto3" json:"enrollment,omitempty"`
+	// Signature proves possession over "spacewave 2026-09-06 managed account enrollment v1." followed by Enrollment binary.
+	Signature []byte `protobuf:"bytes,2,opt,name=signature,proto3" json:"signature,omitempty"`
+}
+
+func (x *EnrollManagedAccountRequest) Reset() {
+	*x = EnrollManagedAccountRequest{}
+}
+
+func (*EnrollManagedAccountRequest) ProtoMessage() {}
+
+func (x *EnrollManagedAccountRequest) GetEnrollment() *ManagedAccountEnrollment {
+	if x != nil {
+		return x.Enrollment
+	}
+	return nil
+}
+
+func (x *EnrollManagedAccountRequest) GetSignature() []byte {
+	if x != nil {
+		return x.Signature
+	}
+	return nil
+}
+
+// EnrollManagedAccountResponse identifies the ordinary account retained across recovery.
+type EnrollManagedAccountResponse struct {
+	unknownFields []byte
+	// ApplicationId identifies the application that manages the account.
+	ApplicationId string `protobuf:"bytes,1,opt,name=application_id,json=applicationId,proto3" json:"applicationId,omitempty"`
+	// AccountId identifies the ordinary provider account for subsequent Session registration.
+	AccountId string `protobuf:"bytes,2,opt,name=account_id,json=accountId,proto3" json:"accountId,omitempty"`
+	// DomainId is the provider's account namespace.
+	DomainId string `protobuf:"bytes,3,opt,name=domain_id,json=domainId,proto3" json:"domainId,omitempty"`
+	// EntityId is the stable account name within its domain.
+	EntityId string `protobuf:"bytes,4,opt,name=entity_id,json=entityId,proto3" json:"entityId,omitempty"`
+	// KeypairPeerId confirms the newly authorized credential; existing credentials remain valid.
+	KeypairPeerId string `protobuf:"bytes,5,opt,name=keypair_peer_id,json=keypairPeerId,proto3" json:"keypairPeerId,omitempty"`
+}
+
+func (x *EnrollManagedAccountResponse) Reset() {
+	*x = EnrollManagedAccountResponse{}
+}
+
+func (*EnrollManagedAccountResponse) ProtoMessage() {}
+
+func (x *EnrollManagedAccountResponse) GetApplicationId() string {
+	if x != nil {
+		return x.ApplicationId
+	}
+	return ""
+}
+
+func (x *EnrollManagedAccountResponse) GetAccountId() string {
+	if x != nil {
+		return x.AccountId
+	}
+	return ""
+}
+
+func (x *EnrollManagedAccountResponse) GetDomainId() string {
+	if x != nil {
+		return x.DomainId
+	}
+	return ""
+}
+
+func (x *EnrollManagedAccountResponse) GetEntityId() string {
+	if x != nil {
+		return x.EntityId
+	}
+	return ""
+}
+
+func (x *EnrollManagedAccountResponse) GetKeypairPeerId() string {
+	if x != nil {
+		return x.KeypairPeerId
+	}
+	return ""
+}
+
+// SetApplicationStateRequest changes availability under application administration.
+type SetApplicationStateRequest struct {
+	unknownFields []byte
+	// ApplicationId selects the approved application.
+	ApplicationId string `protobuf:"bytes,1,opt,name=application_id,json=applicationId,proto3" json:"applicationId,omitempty"`
+	// State selects Active, Paused, or Disabled; Active requires accepted funding.
+	State ApplicationState `protobuf:"varint,2,opt,name=state,proto3" json:"state,omitempty"`
+	// ExpectedRevision fences concurrent configuration changes.
+	ExpectedRevision uint64 `protobuf:"varint,3,opt,name=expected_revision,json=expectedRevision,proto3" json:"expectedRevision,omitempty"`
+}
+
+func (x *SetApplicationStateRequest) Reset() {
+	*x = SetApplicationStateRequest{}
+}
+
+func (*SetApplicationStateRequest) ProtoMessage() {}
+
+func (x *SetApplicationStateRequest) GetApplicationId() string {
+	if x != nil {
+		return x.ApplicationId
+	}
+	return ""
+}
+
+func (x *SetApplicationStateRequest) GetState() ApplicationState {
+	if x != nil {
+		return x.State
+	}
+	return ApplicationState_APPLICATION_STATE_UNKNOWN
+}
+
+func (x *SetApplicationStateRequest) GetExpectedRevision() uint64 {
+	if x != nil {
+		return x.ExpectedRevision
+	}
+	return 0
+}
+
+// SetApplicationStateResponse returns current availability after the durable transition.
+type SetApplicationStateResponse struct {
+	unknownFields []byte
+	// Application contains the new configuration; disabled credentials are never restored.
+	Application *Application `protobuf:"bytes,1,opt,name=application,proto3" json:"application,omitempty"`
+}
+
+func (x *SetApplicationStateResponse) Reset() {
+	*x = SetApplicationStateResponse{}
+}
+
+func (*SetApplicationStateResponse) ProtoMessage() {}
+
+func (x *SetApplicationStateResponse) GetApplication() *Application {
+	if x != nil {
+		return x.Application
+	}
+	return nil
+}
+
 func (m *Application) CloneVT() *Application {
 	if m == nil {
 		return (*Application)(nil)
@@ -667,6 +869,97 @@ func (m *ListApplicationFundingResponse) CloneVT() *ListApplicationFundingRespon
 }
 
 func (m *ListApplicationFundingResponse) CloneMessageVT() protobuf_go_lite.CloneMessage {
+	return m.CloneVT()
+}
+
+func (m *ManagedAccountEnrollment) CloneVT() *ManagedAccountEnrollment {
+	if m == nil {
+		return (*ManagedAccountEnrollment)(nil)
+	}
+	r := new(ManagedAccountEnrollment)
+	r.ApplicationId = m.ApplicationId
+	r.Issuer = m.Issuer
+	r.Subject = m.Subject
+	r.KeypairPeerId = m.KeypairPeerId
+	r.ExpectedApplicationRevision = m.ExpectedApplicationRevision
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = slices.Clone(m.unknownFields)
+	}
+	return r
+}
+
+func (m *ManagedAccountEnrollment) CloneMessageVT() protobuf_go_lite.CloneMessage {
+	return m.CloneVT()
+}
+
+func (m *EnrollManagedAccountRequest) CloneVT() *EnrollManagedAccountRequest {
+	if m == nil {
+		return (*EnrollManagedAccountRequest)(nil)
+	}
+	r := new(EnrollManagedAccountRequest)
+	r.Enrollment = protobuf_go_lite.CloneVTValue(m.Enrollment)
+	r.Signature = protobuf_go_lite.CloneBytes(m.Signature)
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = slices.Clone(m.unknownFields)
+	}
+	return r
+}
+
+func (m *EnrollManagedAccountRequest) CloneMessageVT() protobuf_go_lite.CloneMessage {
+	return m.CloneVT()
+}
+
+func (m *EnrollManagedAccountResponse) CloneVT() *EnrollManagedAccountResponse {
+	if m == nil {
+		return (*EnrollManagedAccountResponse)(nil)
+	}
+	r := new(EnrollManagedAccountResponse)
+	r.ApplicationId = m.ApplicationId
+	r.AccountId = m.AccountId
+	r.DomainId = m.DomainId
+	r.EntityId = m.EntityId
+	r.KeypairPeerId = m.KeypairPeerId
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = slices.Clone(m.unknownFields)
+	}
+	return r
+}
+
+func (m *EnrollManagedAccountResponse) CloneMessageVT() protobuf_go_lite.CloneMessage {
+	return m.CloneVT()
+}
+
+func (m *SetApplicationStateRequest) CloneVT() *SetApplicationStateRequest {
+	if m == nil {
+		return (*SetApplicationStateRequest)(nil)
+	}
+	r := new(SetApplicationStateRequest)
+	r.ApplicationId = m.ApplicationId
+	r.State = m.State
+	r.ExpectedRevision = m.ExpectedRevision
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = slices.Clone(m.unknownFields)
+	}
+	return r
+}
+
+func (m *SetApplicationStateRequest) CloneMessageVT() protobuf_go_lite.CloneMessage {
+	return m.CloneVT()
+}
+
+func (m *SetApplicationStateResponse) CloneVT() *SetApplicationStateResponse {
+	if m == nil {
+		return (*SetApplicationStateResponse)(nil)
+	}
+	r := new(SetApplicationStateResponse)
+	r.Application = protobuf_go_lite.CloneVTValue(m.Application)
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = slices.Clone(m.unknownFields)
+	}
+	return r
+}
+
+func (m *SetApplicationStateResponse) CloneMessageVT() protobuf_go_lite.CloneMessage {
 	return m.CloneVT()
 }
 
@@ -927,6 +1220,139 @@ func (this *ListApplicationFundingResponse) EqualVT(that *ListApplicationFunding
 
 func (this *ListApplicationFundingResponse) EqualMessageVT(thatMsg any) bool {
 	that, ok := thatMsg.(*ListApplicationFundingResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+
+func (this *ManagedAccountEnrollment) EqualVT(that *ManagedAccountEnrollment) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.ApplicationId != that.ApplicationId {
+		return false
+	}
+	if this.Issuer != that.Issuer {
+		return false
+	}
+	if this.Subject != that.Subject {
+		return false
+	}
+	if this.KeypairPeerId != that.KeypairPeerId {
+		return false
+	}
+	if this.ExpectedApplicationRevision != that.ExpectedApplicationRevision {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *ManagedAccountEnrollment) EqualMessageVT(thatMsg any) bool {
+	that, ok := thatMsg.(*ManagedAccountEnrollment)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+
+func (this *EnrollManagedAccountRequest) EqualVT(that *EnrollManagedAccountRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !protobuf_go_lite.IsEqualVT(this.Enrollment, that.Enrollment) {
+		return false
+	}
+	if !protobuf_go_lite.EqualBytes(this.Signature, that.Signature) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *EnrollManagedAccountRequest) EqualMessageVT(thatMsg any) bool {
+	that, ok := thatMsg.(*EnrollManagedAccountRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+
+func (this *EnrollManagedAccountResponse) EqualVT(that *EnrollManagedAccountResponse) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.ApplicationId != that.ApplicationId {
+		return false
+	}
+	if this.AccountId != that.AccountId {
+		return false
+	}
+	if this.DomainId != that.DomainId {
+		return false
+	}
+	if this.EntityId != that.EntityId {
+		return false
+	}
+	if this.KeypairPeerId != that.KeypairPeerId {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *EnrollManagedAccountResponse) EqualMessageVT(thatMsg any) bool {
+	that, ok := thatMsg.(*EnrollManagedAccountResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+
+func (this *SetApplicationStateRequest) EqualVT(that *SetApplicationStateRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.ApplicationId != that.ApplicationId {
+		return false
+	}
+	if this.State != that.State {
+		return false
+	}
+	if this.ExpectedRevision != that.ExpectedRevision {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *SetApplicationStateRequest) EqualMessageVT(thatMsg any) bool {
+	that, ok := thatMsg.(*SetApplicationStateRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+
+func (this *SetApplicationStateResponse) EqualVT(that *SetApplicationStateResponse) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !protobuf_go_lite.IsEqualVT(this.Application, that.Application) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *SetApplicationStateResponse) EqualMessageVT(thatMsg any) bool {
+	that, ok := thatMsg.(*SetApplicationStateResponse)
 	if !ok {
 		return false
 	}
@@ -1634,6 +2060,312 @@ func (x *ListApplicationFundingResponse) UnmarshalJSON(b []byte) error {
 	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
 }
 
+// MarshalProtoJSON marshals the ManagedAccountEnrollment message to JSON.
+func (x *ManagedAccountEnrollment) MarshalProtoJSON(s *json.MarshalState) {
+	if x == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteObjectStart()
+	var wroteField bool
+	if x.ApplicationId != "" || s.HasField("applicationId") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("applicationId")
+		s.WriteString(x.ApplicationId)
+	}
+	if x.Issuer != "" || s.HasField("issuer") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("issuer")
+		s.WriteString(x.Issuer)
+	}
+	if x.Subject != "" || s.HasField("subject") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("subject")
+		s.WriteString(x.Subject)
+	}
+	if x.KeypairPeerId != "" || s.HasField("keypairPeerId") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("keypairPeerId")
+		s.WriteString(x.KeypairPeerId)
+	}
+	if x.ExpectedApplicationRevision != 0 || s.HasField("expectedApplicationRevision") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("expectedApplicationRevision")
+		s.WriteUint64(x.ExpectedApplicationRevision)
+	}
+	s.WriteObjectEnd()
+}
+
+// MarshalJSON marshals the ManagedAccountEnrollment to JSON.
+func (x *ManagedAccountEnrollment) MarshalJSON() ([]byte, error) {
+	return json.DefaultMarshalerConfig.Marshal(x)
+}
+
+// UnmarshalProtoJSON unmarshals the ManagedAccountEnrollment message from JSON.
+func (x *ManagedAccountEnrollment) UnmarshalProtoJSON(s *json.UnmarshalState) {
+	if s.ReadNil() {
+		return
+	}
+	s.ReadObject(func(key string) {
+		switch key {
+		default:
+			s.Skip() // ignore unknown field
+		case "application_id", "applicationId":
+			s.AddField("application_id")
+			x.ApplicationId = s.ReadString()
+		case "issuer":
+			s.AddField("issuer")
+			x.Issuer = s.ReadString()
+		case "subject":
+			s.AddField("subject")
+			x.Subject = s.ReadString()
+		case "keypair_peer_id", "keypairPeerId":
+			s.AddField("keypair_peer_id")
+			x.KeypairPeerId = s.ReadString()
+		case "expected_application_revision", "expectedApplicationRevision":
+			s.AddField("expected_application_revision")
+			x.ExpectedApplicationRevision = s.ReadUint64()
+		}
+	})
+}
+
+// UnmarshalJSON unmarshals the ManagedAccountEnrollment from JSON.
+func (x *ManagedAccountEnrollment) UnmarshalJSON(b []byte) error {
+	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
+}
+
+// MarshalProtoJSON marshals the EnrollManagedAccountRequest message to JSON.
+func (x *EnrollManagedAccountRequest) MarshalProtoJSON(s *json.MarshalState) {
+	if x == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteObjectStart()
+	var wroteField bool
+	if x.Enrollment != nil || s.HasField("enrollment") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("enrollment")
+		x.Enrollment.MarshalProtoJSON(s.WithField("enrollment"))
+	}
+	if len(x.Signature) > 0 || s.HasField("signature") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("signature")
+		s.WriteBytes(x.Signature)
+	}
+	s.WriteObjectEnd()
+}
+
+// MarshalJSON marshals the EnrollManagedAccountRequest to JSON.
+func (x *EnrollManagedAccountRequest) MarshalJSON() ([]byte, error) {
+	return json.DefaultMarshalerConfig.Marshal(x)
+}
+
+// UnmarshalProtoJSON unmarshals the EnrollManagedAccountRequest message from JSON.
+func (x *EnrollManagedAccountRequest) UnmarshalProtoJSON(s *json.UnmarshalState) {
+	if s.ReadNil() {
+		return
+	}
+	s.ReadObject(func(key string) {
+		switch key {
+		default:
+			s.Skip() // ignore unknown field
+		case "enrollment":
+			if s.ReadNil() {
+				x.Enrollment = nil
+				return
+			}
+			x.Enrollment = &ManagedAccountEnrollment{}
+			x.Enrollment.UnmarshalProtoJSON(s.WithField("enrollment", true))
+		case "signature":
+			s.AddField("signature")
+			x.Signature = s.ReadBytes()
+		}
+	})
+}
+
+// UnmarshalJSON unmarshals the EnrollManagedAccountRequest from JSON.
+func (x *EnrollManagedAccountRequest) UnmarshalJSON(b []byte) error {
+	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
+}
+
+// MarshalProtoJSON marshals the EnrollManagedAccountResponse message to JSON.
+func (x *EnrollManagedAccountResponse) MarshalProtoJSON(s *json.MarshalState) {
+	if x == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteObjectStart()
+	var wroteField bool
+	if x.ApplicationId != "" || s.HasField("applicationId") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("applicationId")
+		s.WriteString(x.ApplicationId)
+	}
+	if x.AccountId != "" || s.HasField("accountId") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("accountId")
+		s.WriteString(x.AccountId)
+	}
+	if x.DomainId != "" || s.HasField("domainId") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("domainId")
+		s.WriteString(x.DomainId)
+	}
+	if x.EntityId != "" || s.HasField("entityId") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("entityId")
+		s.WriteString(x.EntityId)
+	}
+	if x.KeypairPeerId != "" || s.HasField("keypairPeerId") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("keypairPeerId")
+		s.WriteString(x.KeypairPeerId)
+	}
+	s.WriteObjectEnd()
+}
+
+// MarshalJSON marshals the EnrollManagedAccountResponse to JSON.
+func (x *EnrollManagedAccountResponse) MarshalJSON() ([]byte, error) {
+	return json.DefaultMarshalerConfig.Marshal(x)
+}
+
+// UnmarshalProtoJSON unmarshals the EnrollManagedAccountResponse message from JSON.
+func (x *EnrollManagedAccountResponse) UnmarshalProtoJSON(s *json.UnmarshalState) {
+	if s.ReadNil() {
+		return
+	}
+	s.ReadObject(func(key string) {
+		switch key {
+		default:
+			s.Skip() // ignore unknown field
+		case "application_id", "applicationId":
+			s.AddField("application_id")
+			x.ApplicationId = s.ReadString()
+		case "account_id", "accountId":
+			s.AddField("account_id")
+			x.AccountId = s.ReadString()
+		case "domain_id", "domainId":
+			s.AddField("domain_id")
+			x.DomainId = s.ReadString()
+		case "entity_id", "entityId":
+			s.AddField("entity_id")
+			x.EntityId = s.ReadString()
+		case "keypair_peer_id", "keypairPeerId":
+			s.AddField("keypair_peer_id")
+			x.KeypairPeerId = s.ReadString()
+		}
+	})
+}
+
+// UnmarshalJSON unmarshals the EnrollManagedAccountResponse from JSON.
+func (x *EnrollManagedAccountResponse) UnmarshalJSON(b []byte) error {
+	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
+}
+
+// MarshalProtoJSON marshals the SetApplicationStateRequest message to JSON.
+func (x *SetApplicationStateRequest) MarshalProtoJSON(s *json.MarshalState) {
+	if x == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteObjectStart()
+	var wroteField bool
+	if x.ApplicationId != "" || s.HasField("applicationId") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("applicationId")
+		s.WriteString(x.ApplicationId)
+	}
+	if x.State != 0 || s.HasField("state") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("state")
+		x.State.MarshalProtoJSON(s)
+	}
+	if x.ExpectedRevision != 0 || s.HasField("expectedRevision") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("expectedRevision")
+		s.WriteUint64(x.ExpectedRevision)
+	}
+	s.WriteObjectEnd()
+}
+
+// MarshalJSON marshals the SetApplicationStateRequest to JSON.
+func (x *SetApplicationStateRequest) MarshalJSON() ([]byte, error) {
+	return json.DefaultMarshalerConfig.Marshal(x)
+}
+
+// UnmarshalProtoJSON unmarshals the SetApplicationStateRequest message from JSON.
+func (x *SetApplicationStateRequest) UnmarshalProtoJSON(s *json.UnmarshalState) {
+	if s.ReadNil() {
+		return
+	}
+	s.ReadObject(func(key string) {
+		switch key {
+		default:
+			s.Skip() // ignore unknown field
+		case "application_id", "applicationId":
+			s.AddField("application_id")
+			x.ApplicationId = s.ReadString()
+		case "state":
+			s.AddField("state")
+			x.State.UnmarshalProtoJSON(s)
+		case "expected_revision", "expectedRevision":
+			s.AddField("expected_revision")
+			x.ExpectedRevision = s.ReadUint64()
+		}
+	})
+}
+
+// UnmarshalJSON unmarshals the SetApplicationStateRequest from JSON.
+func (x *SetApplicationStateRequest) UnmarshalJSON(b []byte) error {
+	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
+}
+
+// MarshalProtoJSON marshals the SetApplicationStateResponse message to JSON.
+func (x *SetApplicationStateResponse) MarshalProtoJSON(s *json.MarshalState) {
+	if x == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteObjectStart()
+	var wroteField bool
+	if x.Application != nil || s.HasField("application") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("application")
+		x.Application.MarshalProtoJSON(s.WithField("application"))
+	}
+	s.WriteObjectEnd()
+}
+
+// MarshalJSON marshals the SetApplicationStateResponse to JSON.
+func (x *SetApplicationStateResponse) MarshalJSON() ([]byte, error) {
+	return json.DefaultMarshalerConfig.Marshal(x)
+}
+
+// UnmarshalProtoJSON unmarshals the SetApplicationStateResponse message from JSON.
+func (x *SetApplicationStateResponse) UnmarshalProtoJSON(s *json.UnmarshalState) {
+	if s.ReadNil() {
+		return
+	}
+	s.ReadObject(func(key string) {
+		switch key {
+		default:
+			s.Skip() // ignore unknown field
+		case "application":
+			if s.ReadNil() {
+				x.Application = nil
+				return
+			}
+			x.Application = &Application{}
+			x.Application.UnmarshalProtoJSON(s.WithField("application", true))
+		}
+	})
+}
+
+// UnmarshalJSON unmarshals the SetApplicationStateResponse from JSON.
+func (x *SetApplicationStateResponse) UnmarshalJSON(b []byte) error {
+	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
+}
+
 func (m *Application) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -2131,6 +2863,256 @@ func (m *ListApplicationFundingResponse) MarshalToSizedBufferVT(dAtA []byte) (in
 	return len(dAtA) - i, nil
 }
 
+func (m *ManagedAccountEnrollment) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ManagedAccountEnrollment) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *ManagedAccountEnrollment) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	if m.ExpectedApplicationRevision != 0 {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(m.ExpectedApplicationRevision))
+		i--
+		dAtA[i] = 0x28
+	}
+	if len(m.KeypairPeerId) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.KeypairPeerId)
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.Subject) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.Subject)
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.Issuer) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.Issuer)
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.ApplicationId) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.ApplicationId)
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *EnrollManagedAccountRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *EnrollManagedAccountRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *EnrollManagedAccountRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	if len(m.Signature) > 0 {
+		i = protobuf_go_lite.EncodeBytes(dAtA, i, m.Signature)
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.Enrollment != nil {
+		size, err := m.Enrollment.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *EnrollManagedAccountResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *EnrollManagedAccountResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *EnrollManagedAccountResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	if len(m.KeypairPeerId) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.KeypairPeerId)
+		i--
+		dAtA[i] = 0x2a
+	}
+	if len(m.EntityId) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.EntityId)
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.DomainId) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.DomainId)
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.AccountId) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.AccountId)
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.ApplicationId) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.ApplicationId)
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *SetApplicationStateRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SetApplicationStateRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *SetApplicationStateRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	if m.ExpectedRevision != 0 {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(m.ExpectedRevision))
+		i--
+		dAtA[i] = 0x18
+	}
+	if m.State != 0 {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(m.State))
+		i--
+		dAtA[i] = 0x10
+	}
+	if len(m.ApplicationId) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.ApplicationId)
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *SetApplicationStateResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SetApplicationStateResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *SetApplicationStateResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	if m.Application != nil {
+		size, err := m.Application.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *Application) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -2270,6 +3252,78 @@ func (m *ListApplicationFundingResponse) SizeVT() (n int) {
 		n += protobuf_go_lite.SizeMessage(1, l)
 	}
 	n += protobuf_go_lite.SizeVarintNonZero(1, m.NextAfterRevision)
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *ManagedAccountEnrollment) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.ApplicationId)
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.Issuer)
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.Subject)
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.KeypairPeerId)
+	n += protobuf_go_lite.SizeVarintNonZero(1, m.ExpectedApplicationRevision)
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *EnrollManagedAccountRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Enrollment != nil {
+		l = m.Enrollment.SizeVT()
+		n += protobuf_go_lite.SizeMessage(1, l)
+	}
+	n += protobuf_go_lite.SizeBytesNonEmpty(1, m.Signature)
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *EnrollManagedAccountResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.ApplicationId)
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.AccountId)
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.DomainId)
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.EntityId)
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.KeypairPeerId)
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *SetApplicationStateRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.ApplicationId)
+	n += protobuf_go_lite.SizeVarintNonZero(1, m.State)
+	n += protobuf_go_lite.SizeVarintNonZero(1, m.ExpectedRevision)
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *SetApplicationStateResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Application != nil {
+		l = m.Application.SizeVT()
+		n += protobuf_go_lite.SizeMessage(1, l)
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -2511,6 +3565,120 @@ func (x *ListApplicationFundingResponse) MarshalProtoText() string {
 }
 
 func (x *ListApplicationFundingResponse) String() string {
+	return x.MarshalProtoText()
+}
+
+func (x *ManagedAccountEnrollment) MarshalProtoText() string {
+	var sb protobuf_go_lite.TextBuilder
+	initialLen := protobuf_go_lite.TextStartMessage(&sb, "ManagedAccountEnrollment")
+	if x.ApplicationId != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "application_id")
+		protobuf_go_lite.TextWriteString(&sb, x.ApplicationId)
+	}
+	if x.Issuer != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "issuer")
+		protobuf_go_lite.TextWriteString(&sb, x.Issuer)
+	}
+	if x.Subject != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "subject")
+		protobuf_go_lite.TextWriteString(&sb, x.Subject)
+	}
+	if x.KeypairPeerId != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "keypair_peer_id")
+		protobuf_go_lite.TextWriteString(&sb, x.KeypairPeerId)
+	}
+	if x.ExpectedApplicationRevision != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "expected_application_revision")
+		protobuf_go_lite.TextWriteUint(&sb, x.ExpectedApplicationRevision)
+	}
+	return protobuf_go_lite.TextFinishMessage(&sb)
+}
+
+func (x *ManagedAccountEnrollment) String() string {
+	return x.MarshalProtoText()
+}
+
+func (x *EnrollManagedAccountRequest) MarshalProtoText() string {
+	var sb protobuf_go_lite.TextBuilder
+	initialLen := protobuf_go_lite.TextStartMessage(&sb, "EnrollManagedAccountRequest")
+	if x.Enrollment != nil {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "enrollment")
+		protobuf_go_lite.TextWriteTextMarshaler(&sb, x.Enrollment)
+	}
+	if len(x.Signature) != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "signature")
+		protobuf_go_lite.TextWriteBytes(&sb, x.Signature)
+	}
+	return protobuf_go_lite.TextFinishMessage(&sb)
+}
+
+func (x *EnrollManagedAccountRequest) String() string {
+	return x.MarshalProtoText()
+}
+
+func (x *EnrollManagedAccountResponse) MarshalProtoText() string {
+	var sb protobuf_go_lite.TextBuilder
+	initialLen := protobuf_go_lite.TextStartMessage(&sb, "EnrollManagedAccountResponse")
+	if x.ApplicationId != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "application_id")
+		protobuf_go_lite.TextWriteString(&sb, x.ApplicationId)
+	}
+	if x.AccountId != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "account_id")
+		protobuf_go_lite.TextWriteString(&sb, x.AccountId)
+	}
+	if x.DomainId != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "domain_id")
+		protobuf_go_lite.TextWriteString(&sb, x.DomainId)
+	}
+	if x.EntityId != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "entity_id")
+		protobuf_go_lite.TextWriteString(&sb, x.EntityId)
+	}
+	if x.KeypairPeerId != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "keypair_peer_id")
+		protobuf_go_lite.TextWriteString(&sb, x.KeypairPeerId)
+	}
+	return protobuf_go_lite.TextFinishMessage(&sb)
+}
+
+func (x *EnrollManagedAccountResponse) String() string {
+	return x.MarshalProtoText()
+}
+
+func (x *SetApplicationStateRequest) MarshalProtoText() string {
+	var sb protobuf_go_lite.TextBuilder
+	initialLen := protobuf_go_lite.TextStartMessage(&sb, "SetApplicationStateRequest")
+	if x.ApplicationId != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "application_id")
+		protobuf_go_lite.TextWriteString(&sb, x.ApplicationId)
+	}
+	if x.State != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "state")
+		protobuf_go_lite.TextWriteStringer(&sb, ApplicationState(x.State))
+	}
+	if x.ExpectedRevision != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "expected_revision")
+		protobuf_go_lite.TextWriteUint(&sb, x.ExpectedRevision)
+	}
+	return protobuf_go_lite.TextFinishMessage(&sb)
+}
+
+func (x *SetApplicationStateRequest) String() string {
+	return x.MarshalProtoText()
+}
+
+func (x *SetApplicationStateResponse) MarshalProtoText() string {
+	var sb protobuf_go_lite.TextBuilder
+	initialLen := protobuf_go_lite.TextStartMessage(&sb, "SetApplicationStateResponse")
+	if x.Application != nil {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "application")
+		protobuf_go_lite.TextWriteTextMarshaler(&sb, x.Application)
+	}
+	return protobuf_go_lite.TextFinishMessage(&sb)
+}
+
+func (x *SetApplicationStateResponse) String() string {
 	return x.MarshalProtoText()
 }
 
@@ -3244,6 +4412,388 @@ func (m *ListApplicationFundingResponse) UnmarshalVT(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
+		default:
+			iNdEx = preIndex
+			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protobuf_go_lite.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+
+func (m *ManagedAccountEnrollment) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	var err error
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		wire, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+		if err != nil {
+			return err
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ManagedAccountEnrollment: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ManagedAccountEnrollment: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ApplicationId", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.ApplicationId = v
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Issuer", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.Issuer = v
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Subject", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.Subject = v
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field KeypairPeerId", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.KeypairPeerId = v
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExpectedApplicationRevision", wireType)
+			}
+			m.ExpectedApplicationRevision = 0
+			m.ExpectedApplicationRevision, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protobuf_go_lite.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+
+func (m *EnrollManagedAccountRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	var err error
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		wire, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+		if err != nil {
+			return err
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: EnrollManagedAccountRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: EnrollManagedAccountRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Enrollment", wireType)
+			}
+			msgStart, postIndex, err := protobuf_go_lite.DecodeLengthDelimited(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			if m.Enrollment == nil {
+				m.Enrollment = &ManagedAccountEnrollment{}
+			}
+			if err := m.Enrollment.UnmarshalVT(dAtA[msgStart:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Signature", wireType)
+			}
+			m.Signature, iNdEx, err = protobuf_go_lite.DecodeBytesAppend(m.Signature, dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protobuf_go_lite.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+
+func (m *EnrollManagedAccountResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	var err error
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		wire, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+		if err != nil {
+			return err
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: EnrollManagedAccountResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: EnrollManagedAccountResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ApplicationId", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.ApplicationId = v
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AccountId", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.AccountId = v
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DomainId", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.DomainId = v
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EntityId", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.EntityId = v
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field KeypairPeerId", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.KeypairPeerId = v
+		default:
+			iNdEx = preIndex
+			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protobuf_go_lite.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+
+func (m *SetApplicationStateRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	var err error
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		wire, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+		if err != nil {
+			return err
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SetApplicationStateRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SetApplicationStateRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ApplicationId", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.ApplicationId = v
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field State", wireType)
+			}
+			m.State = 0
+			var _v uint64
+			_v, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+			m.State = ApplicationState(_v)
+			if err != nil {
+				return err
+			}
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExpectedRevision", wireType)
+			}
+			m.ExpectedRevision = 0
+			m.ExpectedRevision, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protobuf_go_lite.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+
+func (m *SetApplicationStateResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	var err error
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		wire, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+		if err != nil {
+			return err
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SetApplicationStateResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SetApplicationStateResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Application", wireType)
+			}
+			msgStart, postIndex, err := protobuf_go_lite.DecodeLengthDelimited(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			if m.Application == nil {
+				m.Application = &Application{}
+			}
+			if err := m.Application.UnmarshalVT(dAtA[msgStart:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])

--- a/core/provider/spacewave/api/application.pb.ts
+++ b/core/provider/spacewave/api/application.pb.ts
@@ -521,3 +521,213 @@ export const ListApplicationFundingResponse: MessageType<ListApplicationFundingR
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,
   })
+
+/**
+ * ManagedAccountEnrollment binds a new credential to a verified application identity.
+ * The credential signs the domain-separated binary message; the application integration
+ * separately authenticates the issuer and subject before submitting it to the provider.
+ *
+ * @generated from message provider.spacewave.api.ManagedAccountEnrollment
+ */
+export interface ManagedAccountEnrollment {
+  /**
+   * ApplicationId identifies the application whose operator approves this enrollment.
+   *
+   * @generated from field: string application_id = 1;
+   */
+  applicationId?: string
+  /**
+   * Issuer is the verified identity provider's stable namespace, at most 512 UTF-8 bytes.
+   *
+   * @generated from field: string issuer = 2;
+   */
+  issuer?: string
+  /**
+   * Subject is the verified identity within the issuer, at most 256 UTF-8 bytes.
+   *
+   * @generated from field: string subject = 3;
+   */
+  subject?: string
+  /**
+   * KeypairPeerId embeds the public key of the credential being enrolled.
+   *
+   * @generated from field: string keypair_peer_id = 4;
+   */
+  keypairPeerId?: string
+  /**
+   * ExpectedApplicationRevision invalidates approvals after application configuration changes.
+   *
+   * @generated from field: uint64 expected_application_revision = 5;
+   */
+  expectedApplicationRevision?: bigint
+}
+
+export const ManagedAccountEnrollment: MessageType<ManagedAccountEnrollment> =
+  /* @__PURE__ */ createMessageType({
+    typeName: 'provider.spacewave.api.ManagedAccountEnrollment',
+    fields: [
+      { no: 1, name: 'application_id', kind: 'scalar', T: ScalarType.STRING },
+      { no: 2, name: 'issuer', kind: 'scalar', T: ScalarType.STRING },
+      { no: 3, name: 'subject', kind: 'scalar', T: ScalarType.STRING },
+      { no: 4, name: 'keypair_peer_id', kind: 'scalar', T: ScalarType.STRING },
+      {
+        no: 5,
+        name: 'expected_application_revision',
+        kind: 'scalar',
+        T: ScalarType.UINT64,
+      },
+    ] satisfies readonly PartialFieldInfo[],
+    packedByDefault: true,
+  })
+
+/**
+ * EnrollManagedAccountRequest asks the authenticated application operator to enroll a credential.
+ * Only the approved integration submits verified external subjects; this is not a browser assertion.
+ *
+ * @generated from message provider.spacewave.api.EnrollManagedAccountRequest
+ */
+export interface EnrollManagedAccountRequest {
+  /**
+   * Enrollment identifies the verified subject and credential being authorized.
+   *
+   * @generated from field: provider.spacewave.api.ManagedAccountEnrollment enrollment = 1;
+   */
+  enrollment?: ManagedAccountEnrollment
+  /**
+   * Signature proves possession over "spacewave 2026-09-06 managed account enrollment v1." followed by Enrollment binary.
+   *
+   * @generated from field: bytes signature = 2;
+   */
+  signature?: Uint8Array
+}
+
+export const EnrollManagedAccountRequest: MessageType<EnrollManagedAccountRequest> =
+  /* @__PURE__ */ createMessageType({
+    typeName: 'provider.spacewave.api.EnrollManagedAccountRequest',
+    fields: [
+      {
+        no: 1,
+        name: 'enrollment',
+        kind: 'message',
+        T: () => ManagedAccountEnrollment,
+      },
+      { no: 2, name: 'signature', kind: 'scalar', T: ScalarType.BYTES },
+    ] satisfies readonly PartialFieldInfo[],
+    packedByDefault: true,
+  })
+
+/**
+ * EnrollManagedAccountResponse identifies the ordinary account retained across recovery.
+ *
+ * @generated from message provider.spacewave.api.EnrollManagedAccountResponse
+ */
+export interface EnrollManagedAccountResponse {
+  /**
+   * ApplicationId identifies the application that manages the account.
+   *
+   * @generated from field: string application_id = 1;
+   */
+  applicationId?: string
+  /**
+   * AccountId identifies the ordinary provider account for subsequent Session registration.
+   *
+   * @generated from field: string account_id = 2;
+   */
+  accountId?: string
+  /**
+   * DomainId is the provider's account namespace.
+   *
+   * @generated from field: string domain_id = 3;
+   */
+  domainId?: string
+  /**
+   * EntityId is the stable account name within its domain.
+   *
+   * @generated from field: string entity_id = 4;
+   */
+  entityId?: string
+  /**
+   * KeypairPeerId confirms the newly authorized credential; existing credentials remain valid.
+   *
+   * @generated from field: string keypair_peer_id = 5;
+   */
+  keypairPeerId?: string
+}
+
+export const EnrollManagedAccountResponse: MessageType<EnrollManagedAccountResponse> =
+  /* @__PURE__ */ createMessageType({
+    typeName: 'provider.spacewave.api.EnrollManagedAccountResponse',
+    fields: [
+      { no: 1, name: 'application_id', kind: 'scalar', T: ScalarType.STRING },
+      { no: 2, name: 'account_id', kind: 'scalar', T: ScalarType.STRING },
+      { no: 3, name: 'domain_id', kind: 'scalar', T: ScalarType.STRING },
+      { no: 4, name: 'entity_id', kind: 'scalar', T: ScalarType.STRING },
+      { no: 5, name: 'keypair_peer_id', kind: 'scalar', T: ScalarType.STRING },
+    ] satisfies readonly PartialFieldInfo[],
+    packedByDefault: true,
+  })
+
+/**
+ * SetApplicationStateRequest changes availability under application administration.
+ *
+ * @generated from message provider.spacewave.api.SetApplicationStateRequest
+ */
+export interface SetApplicationStateRequest {
+  /**
+   * ApplicationId selects the approved application.
+   *
+   * @generated from field: string application_id = 1;
+   */
+  applicationId?: string
+  /**
+   * State selects Active, Paused, or Disabled; Active requires accepted funding.
+   *
+   * @generated from field: provider.spacewave.api.ApplicationState state = 2;
+   */
+  state?: ApplicationState
+  /**
+   * ExpectedRevision fences concurrent configuration changes.
+   *
+   * @generated from field: uint64 expected_revision = 3;
+   */
+  expectedRevision?: bigint
+}
+
+export const SetApplicationStateRequest: MessageType<SetApplicationStateRequest> =
+  /* @__PURE__ */ createMessageType({
+    typeName: 'provider.spacewave.api.SetApplicationStateRequest',
+    fields: [
+      { no: 1, name: 'application_id', kind: 'scalar', T: ScalarType.STRING },
+      { no: 2, name: 'state', kind: 'enum', T: ApplicationState_Enum },
+      {
+        no: 3,
+        name: 'expected_revision',
+        kind: 'scalar',
+        T: ScalarType.UINT64,
+      },
+    ] satisfies readonly PartialFieldInfo[],
+    packedByDefault: true,
+  })
+
+/**
+ * SetApplicationStateResponse returns current availability after the durable transition.
+ *
+ * @generated from message provider.spacewave.api.SetApplicationStateResponse
+ */
+export interface SetApplicationStateResponse {
+  /**
+   * Application contains the new configuration; disabled credentials are never restored.
+   *
+   * @generated from field: provider.spacewave.api.Application application = 1;
+   */
+  application?: Application
+}
+
+export const SetApplicationStateResponse: MessageType<SetApplicationStateResponse> =
+  /* @__PURE__ */ createMessageType({
+    typeName: 'provider.spacewave.api.SetApplicationStateResponse',
+    fields: [
+      { no: 1, name: 'application', kind: 'message', T: () => Application },
+    ] satisfies readonly PartialFieldInfo[],
+    packedByDefault: true,
+  })

--- a/core/provider/spacewave/api/application.proto
+++ b/core/provider/spacewave/api/application.proto
@@ -126,3 +126,58 @@ message ListApplicationFundingResponse {
   // NextAfterRevision is the continuation cursor, or zero when there are no more assignments.
   uint64 next_after_revision = 2;
 }
+
+// ManagedAccountEnrollment binds a new credential to a verified application identity.
+// The credential signs the domain-separated binary message; the application integration
+// separately authenticates the issuer and subject before submitting it to the provider.
+message ManagedAccountEnrollment {
+  // ApplicationId identifies the application whose operator approves this enrollment.
+  string application_id = 1;
+  // Issuer is the verified identity provider's stable namespace, at most 512 UTF-8 bytes.
+  string issuer = 2;
+  // Subject is the verified identity within the issuer, at most 256 UTF-8 bytes.
+  string subject = 3;
+  // KeypairPeerId embeds the public key of the credential being enrolled.
+  string keypair_peer_id = 4;
+  // ExpectedApplicationRevision invalidates approvals after application configuration changes.
+  uint64 expected_application_revision = 5;
+}
+
+// EnrollManagedAccountRequest asks the authenticated application operator to enroll a credential.
+// Only the approved integration submits verified external subjects; this is not a browser assertion.
+message EnrollManagedAccountRequest {
+  // Enrollment identifies the verified subject and credential being authorized.
+  ManagedAccountEnrollment enrollment = 1;
+  // Signature proves possession over "spacewave 2026-09-06 managed account enrollment v1." followed by Enrollment binary.
+  bytes signature = 2;
+}
+
+// EnrollManagedAccountResponse identifies the ordinary account retained across recovery.
+message EnrollManagedAccountResponse {
+  // ApplicationId identifies the application that manages the account.
+  string application_id = 1;
+  // AccountId identifies the ordinary provider account for subsequent Session registration.
+  string account_id = 2;
+  // DomainId is the provider's account namespace.
+  string domain_id = 3;
+  // EntityId is the stable account name within its domain.
+  string entity_id = 4;
+  // KeypairPeerId confirms the newly authorized credential; existing credentials remain valid.
+  string keypair_peer_id = 5;
+}
+
+// SetApplicationStateRequest changes availability under application administration.
+message SetApplicationStateRequest {
+  // ApplicationId selects the approved application.
+  string application_id = 1;
+  // State selects Active, Paused, or Disabled; Active requires accepted funding.
+  ApplicationState state = 2;
+  // ExpectedRevision fences concurrent configuration changes.
+  uint64 expected_revision = 3;
+}
+
+// SetApplicationStateResponse returns current availability after the durable transition.
+message SetApplicationStateResponse {
+  // Application contains the new configuration; disabled credentials are never restored.
+  Application application = 1;
+}

--- a/core/provider/spacewave/client-application.go
+++ b/core/provider/spacewave/client-application.go
@@ -98,3 +98,77 @@ func (c *SessionClient) ListApplicationFunding(ctx context.Context, req *api.Lis
 	}
 	return &resp, nil
 }
+
+// SignManagedAccountEnrollment proves this credential's possession for a verified application identity.
+// The application integration authenticates the external identity before submitting the result.
+func (c *EntityClient) SignManagedAccountEnrollment(ctx context.Context, enrollment *api.ManagedAccountEnrollment) (*api.EnrollManagedAccountRequest, error) {
+	// Bind the proof to this credential and the caller-selected application revision.
+	if enrollment.GetKeypairPeerId() != c.peerID.String() {
+		return nil, errors.New("enrollment credential does not match entity client")
+	}
+	body, err := enrollment.MarshalVT()
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal managed account enrollment")
+	}
+	payload := append([]byte("spacewave 2026-09-06 managed account enrollment v1."), body...)
+
+	// Retain callback-based key custody when this client has no directly held key.
+	var signature []byte
+	if c.sign != nil {
+		signature, err = c.sign(ctx, payload)
+	} else if c.priv != nil {
+		signature, err = c.priv.Sign(payload)
+	} else {
+		return nil, errors.New("no signing credential configured")
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "sign managed account enrollment")
+	}
+	return &api.EnrollManagedAccountRequest{
+		Enrollment: enrollment,
+		Signature:  signature,
+	}, nil
+}
+
+// EnrollManagedAccount authorizes a new credential after the application's verified login.
+// The server requires this Session's account to operate the selected application.
+func (c *SessionClient) EnrollManagedAccount(ctx context.Context, req *api.EnrollManagedAccountRequest) (*api.EnrollManagedAccountResponse, error) {
+	// Carry the independently signed credential proof through the operator's request.
+	body, err := req.MarshalVT()
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal managed account enrollment request")
+	}
+
+	// Account creation and recovery share the provider's idempotent enrollment endpoint.
+	data, err := c.doPostBinary(ctx, "/api/applications/accounts/enroll", body, nil, SeedReasonMutation)
+	if err != nil {
+		return nil, errors.Wrap(err, "enroll managed account")
+	}
+
+	// Return the ordinary provider account retained across Device recovery.
+	var resp api.EnrollManagedAccountResponse
+	if err := resp.UnmarshalVT(data); err != nil {
+		return nil, errors.Wrap(err, "unmarshal managed account enrollment")
+	}
+	return &resp, nil
+}
+
+// SetApplicationState changes availability under the operator's revision fence.
+// Pausing preserves credentials; disabling revokes them before reactivation.
+func (c *SessionClient) SetApplicationState(ctx context.Context, req *api.SetApplicationStateRequest) (*api.SetApplicationStateResponse, error) {
+	body, err := req.MarshalVT()
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal application state")
+	}
+
+	data, err := c.doPostBinary(ctx, "/api/applications/state/set", body, nil, SeedReasonMutation)
+	if err != nil {
+		return nil, errors.Wrap(err, "set application state")
+	}
+
+	var resp api.SetApplicationStateResponse
+	if err := resp.UnmarshalVT(data); err != nil {
+		return nil, errors.Wrap(err, "unmarshal application state")
+	}
+	return &resp, nil
+}

--- a/core/provider/spacewave/device-session.go
+++ b/core/provider/spacewave/device-session.go
@@ -2,14 +2,71 @@ package provider_spacewave
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"time"
 
 	"github.com/pkg/errors"
 	provider "github.com/s4wave/spacewave/core/provider"
+	api "github.com/s4wave/spacewave/core/provider/spacewave/api"
 	"github.com/s4wave/spacewave/core/session"
 	"github.com/s4wave/spacewave/net/crypto"
 	"github.com/s4wave/spacewave/net/peer"
 )
+
+// RegisterDeviceSession authorizes an independently held Device key with an
+// account entity key and mounts the registered DEVICE Session. The caller
+// persists both keys before calling; retries reuse the Device's local resource
+// identity. Registration survives a failed local mount so retry can finish it.
+// This operation does not grant Space membership or create a World Device.
+func (p *Provider) RegisterDeviceSession(
+	ctx context.Context,
+	entityPriv crypto.PrivKey,
+	devicePriv crypto.PrivKey,
+	label string,
+	sessionCtrl session.SessionController,
+) (*session.SessionListEntry, error) {
+	// Require independently held account and Device identities.
+	if entityPriv == nil || devicePriv == nil {
+		return nil, errors.New("account and device private keys are required")
+	}
+	if sessionCtrl == nil {
+		return nil, errors.New("session controller is required")
+	}
+	entityPeer, err := peer.IDFromPrivateKey(entityPriv)
+	if err != nil {
+		return nil, errors.Wrap(err, "derive account peer")
+	}
+	devicePeer, err := peer.IDFromPrivateKey(devicePriv)
+	if err != nil {
+		return nil, errors.Wrap(err, "derive device peer")
+	}
+	if entityPeer == devicePeer {
+		return nil, errors.New("device key must differ from account key")
+	}
+	if label == "" {
+		label = "Spacewave Device"
+	}
+
+	// The signed registration derives the account from its current credential.
+	client := NewEntityClientDirect(p.GetHTTPClient(), p.GetEndpoint(), p.GetSigningEnvPrefix(), entityPriv, entityPeer)
+	registered, err := client.RegisterSessionWithRequest(ctx, &api.RegisterSessionRequest{
+		SessionPeerId: devicePeer.String(),
+		Type:          session.SessionType_SESSION_TYPE_DEVICE,
+		Label:         label,
+	}, "")
+	if err != nil {
+		return nil, errors.Wrap(err, "register device session")
+	}
+	if registered.GetAccountId() == "" {
+		return nil, errors.New("device registration returned no account")
+	}
+
+	// Match the stable local identity used by SpaceLink Device enrollment.
+	digest := sha256.Sum256([]byte(devicePeer))
+	sessionID := "device-" + hex.EncodeToString(digest[:16])
+	return p.MountLinkedDeviceSession(ctx, registered.GetAccountId(), sessionID, label, devicePriv, sessionCtrl)
+}
 
 // MountLinkedDeviceSession mounts a SpaceLink-approved DEVICE session without
 // re-registering it as a USER session.
@@ -21,6 +78,7 @@ func (p *Provider) MountLinkedDeviceSession(
 	sessionPriv crypto.PrivKey,
 	sessionCtrl session.SessionController,
 ) (*session.SessionListEntry, error) {
+	// Validate the approved registration before touching local session storage.
 	if accountID == "" {
 		return nil, errors.New("account id is required")
 	}
@@ -34,6 +92,7 @@ func (p *Provider) MountLinkedDeviceSession(
 		label = "Spacewave Device"
 	}
 
+	// Retain the account while seeding and mounting its Device Session.
 	provAccValue, relProvAcc, err := p.AccessProviderAccount(ctx, accountID, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "access provider account")
@@ -57,13 +116,14 @@ func (p *Provider) MountLinkedDeviceSession(
 		return nil, err
 	}
 
-	sess, relSess, err := sessProv.MountSession(ctx, sessRef, nil)
+	// Establish the mounted Session before publishing its local list entry.
+	_, relSess, err := sessProv.MountSession(ctx, sessRef, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "mount session")
 	}
 	defer relSess()
-	_ = sess
 
+	// Keep Device identity in the Session metadata used by local consumers.
 	sessionPeerID, err := peer.IDFromPrivateKey(sessionPriv)
 	if err != nil {
 		return nil, errors.Wrap(err, "derive session peer id")

--- a/sdk/provider/spacewave/application-client.test.ts
+++ b/sdk/provider/spacewave/application-client.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { EnrollManagedAccountRequest } from '@s4wave/core/provider/spacewave/api/application.pb.js'
+import { SigningPayload } from '@s4wave/core/provider/spacewave/api/api.pb.js'
+
+import {
+  ApplicationOperatorClient,
+  type ApplicationOperatorClientOptions,
+} from './application-client.js'
+
+interface CapturedRequest {
+  url: string
+  init: RequestInit
+  body: Uint8Array
+}
+
+// makeKeypair generates a real Ed25519 keypair for signature verification.
+async function makeKeypair(): Promise<{
+  privateKey: CryptoKey
+  publicKey: CryptoKey
+  rawPublic: Uint8Array
+}> {
+  const pair = await crypto.subtle.generateKey('Ed25519', true, [
+    'sign',
+    'verify',
+  ])
+  const rawPublic = new Uint8Array(
+    await crypto.subtle.exportKey('raw', pair.publicKey),
+  )
+  return { privateKey: pair.privateKey, publicKey: pair.publicKey, rawPublic }
+}
+
+// makeClient builds a client whose fetch records the request and replays the
+// given response.
+function makeClient(
+  keypair: Awaited<ReturnType<typeof makeKeypair>>,
+  respond: (body: Uint8Array) => Response | Promise<Response>,
+): { client: ApplicationOperatorClient; captured: CapturedRequest[] } {
+  const captured: CapturedRequest[] = []
+  const fetchImpl = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const signal = init?.signal
+      if (signal?.aborted) {
+        throw new DOMException('The operation was aborted.', 'AbortError')
+      }
+      const body = init!.body as Uint8Array
+      captured.push({
+        url: String(input),
+        init: init!,
+        body,
+      })
+      return respond(body)
+    },
+  )
+  const options: ApplicationOperatorClientOptions = {
+    apiOrigin: 'https://api.example.com',
+    signingEnvPrefix: 'spacewave',
+    sessionPeerId: '12D3KooWTest',
+    sign: async (payload) =>
+      new Uint8Array(
+        await crypto.subtle.sign(
+          'Ed25519',
+          keypair.privateKey,
+          payload.slice(),
+        ),
+      ),
+    fetch: fetchImpl as unknown as typeof globalThis.fetch,
+  }
+  return { client: new ApplicationOperatorClient(options), captured }
+}
+
+describe('ApplicationOperatorClient', () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    vi.restoreAllMocks()
+  })
+
+  it('signs and sends GetApplication with a verifiable Ed25519 signature', async () => {
+    const keypair = await makeKeypair()
+    // GetApplicationResponse{application: Application{id:"123"}}
+    const responseBody = new Uint8Array([
+      0x0a, 0x05, 0x0a, 0x03, 0x31, 0x32, 0x33,
+    ])
+    const { client, captured } = makeClient(
+      keypair,
+      () => new Response(responseBody, { status: 200 }),
+    )
+
+    const response = await client.getApplication('app-123')
+
+    expect(captured).toHaveLength(1)
+    const req = captured[0]
+    expect(req.url).toBe('https://api.example.com/api/applications/get')
+    expect(req.init.method).toBe('POST')
+    expect(req.init.redirect).toBe('manual')
+
+    const headers = new Headers(req.init.headers as HeadersInit)
+    expect(headers.get('Content-Type')).toBe('application/octet-stream')
+    expect(headers.get('Accept')).toBe('application/octet-stream')
+    expect(headers.get('X-Peer-ID')).toBe('12D3KooWTest')
+    // Go sets the header to the bare sorted key list (strings.Join(keys, ",")),
+    // while the payload carries "key=value" pairs.
+    expect(headers.get('X-Signed-Headers')).toBe('content-type')
+
+    // Reconstruct the signed payload from the request itself, exactly like the
+    // Go server does, and verify the Ed25519 signature with the real public key.
+    const payload = {
+      envPrefix: 'spacewave',
+      method: 'POST',
+      path: '/api/applications/get',
+      timestampMs: BigInt(headers.get('X-Timestamp') ?? '0'),
+      contentLength: BigInt(req.body.length),
+      bodyHashHex: headers.get('X-Sw-Hash') ?? '',
+      signedHeaders: `content-type=${headers.get('Content-Type')}`,
+    }
+    // The payload's signed_headers must be "key=value" pairs, independent of
+    // the X-Signed-Headers header format.
+    const payloadBytes = SigningPayload.toBinary(payload)
+    const signature = Uint8Array.from(
+      atob(headers.get('X-Signature') ?? ''),
+      (c) => c.charCodeAt(0),
+    )
+    const valid = await crypto.subtle.verify(
+      'Ed25519',
+      keypair.publicKey,
+      signature.slice(),
+      payloadBytes.slice(),
+    )
+    expect(valid).toBe(true)
+
+    // The decoded response must round-trip through the generated codec.
+    expect(response.application?.id).toBe('123')
+  })
+
+  it('encodes EnrollManagedAccountRequest identically to the Go MarshalVT contract', async () => {
+    const keypair = await makeKeypair()
+    const { client, captured } = makeClient(
+      keypair,
+      () => new Response(new Uint8Array(0), { status: 200 }),
+    )
+
+    const request = EnrollManagedAccountRequest.create({
+      enrollment: {
+        applicationId: 'app-123',
+        issuer: 'https://id.example.com',
+        subject: 'user-42',
+        keypairPeerId: '12D3KooWGOLDEN',
+        expectedApplicationRevision: BigInt(7),
+      },
+      signature: Uint8Array.from([1, 2, 3, 4, 5]),
+    })
+    await client.enrollManagedAccount(request)
+
+    const goHex =
+      '0a3c0a076170702d313233121668747470733a2f2f69642e6578616d706c652e636f6d1a07757365722d3432220e313244334b6f6f57474f4c44454e280712050102030405'
+    const expected = new Uint8Array(
+      goHex.match(/.{2}/g)!.map((h) => parseInt(h, 16)),
+    )
+    expect(captured[0].body).toEqual(expected)
+  })
+
+  it('propagates cancellation from the AbortSignal', async () => {
+    const keypair = await makeKeypair()
+    const controller = new AbortController()
+    const { client } = makeClient(keypair, () => {
+      throw new Error('should not reach response')
+    })
+
+    const promise = client.getApplication('app-123', controller.signal)
+    controller.abort()
+    await expect(promise).rejects.toThrow()
+  })
+
+  it('accepts http loopback origins for local development', () => {
+    const client = new ApplicationOperatorClient({
+      apiOrigin: 'http://127.0.0.1:8787',
+      signingEnvPrefix: 'spacewave',
+      sessionPeerId: '12D3KooWTest',
+      sign: async () => new Uint8Array(64),
+    })
+    expect(client).toBeInstanceOf(ApplicationOperatorClient)
+  })
+
+  it('rejects apiOrigin with path, query, credentials, or plain http', () => {
+    const base: ApplicationOperatorClientOptions = {
+      apiOrigin: 'https://api.example.com',
+      signingEnvPrefix: 'spacewave',
+      sessionPeerId: '12D3KooWTest',
+      sign: async () => new Uint8Array(64),
+    }
+    for (const bad of [
+      'https://api.example.com/base/path',
+      'https://api.example.com/?x=1',
+      'https://user:pass@api.example.com',
+      'ftp://api.example.com',
+      'http://api.example.com',
+      'not a url',
+    ]) {
+      expect(
+        () => new ApplicationOperatorClient({ ...base, apiOrigin: bad }),
+      ).toThrow()
+    }
+  })
+
+  it('rejects a redirect response instead of following it', async () => {
+    const keypair = await makeKeypair()
+    const { client, captured } = makeClient(
+      keypair,
+      () =>
+        new Response(null, {
+          status: 302,
+          headers: {
+            Location: 'https://evil.example.com/api/applications/get',
+          },
+        }),
+    )
+
+    await expect(client.getApplication('app-123')).rejects.toMatchObject({
+      statusCode: 302,
+    })
+    // Only the original request must have been sent; the redirect was not followed.
+    expect(captured).toHaveLength(1)
+  })
+
+  it('rejects non-2xx responses with the parsed cloud error', async () => {
+    const keypair = await makeKeypair()
+    const errorBody = new TextEncoder().encode(
+      JSON.stringify({
+        code: 'not_authorized',
+        message: 'nope',
+        retryable: false,
+      }),
+    )
+    const { client } = makeClient(
+      keypair,
+      () => new Response(errorBody, { status: 403 }),
+    )
+
+    await expect(client.getApplication('app-123')).rejects.toMatchObject({
+      statusCode: 403,
+      code: 'not_authorized',
+    })
+  })
+})

--- a/sdk/provider/spacewave/application-client.ts
+++ b/sdk/provider/spacewave/application-client.ts
@@ -1,0 +1,262 @@
+import type { Message, MessageType } from '@aptre/protobuf-es-lite/message'
+
+import {
+  EnrollManagedAccountRequest,
+  EnrollManagedAccountResponse,
+  GetApplicationRequest,
+  GetApplicationResponse,
+} from '@s4wave/core/provider/spacewave/api/application.pb.js'
+import {
+  ErrorResponse,
+  SigningPayload,
+} from '@s4wave/core/provider/spacewave/api/api.pb.js'
+
+// maxResponseBodySize is the maximum HTTP response body size (10 MiB).
+const maxResponseBodySize = 10 * 1024 * 1024
+
+// CloudError is a structured error returned by the Spacewave cloud API.
+// Message text comes from the server's ErrorResponse and never contains
+// local credential material.
+export class CloudError extends Error {
+  public readonly statusCode: number
+  public readonly code?: string
+  public readonly retryable?: boolean
+  public readonly retryAfterSeconds?: number
+
+  public constructor(
+    statusCode: number,
+    code?: string,
+    message?: string,
+    retryable?: boolean,
+    retryAfterSeconds?: number,
+  ) {
+    super(`${statusCode} ${code ?? 'unknown'}: ${message ?? 'request failed'}`)
+    this.name = 'CloudError'
+    this.statusCode = statusCode
+    this.code = code
+    this.retryable = retryable
+    this.retryAfterSeconds = retryAfterSeconds
+  }
+}
+
+// SigningFn signs the exact binary payload; key custody remains with the caller.
+export type SigningFn = (
+  payload: Uint8Array,
+  signal?: AbortSignal,
+) => Promise<Uint8Array>
+
+// ApplicationOperatorClientOptions configures the ApplicationOperatorClient.
+export interface ApplicationOperatorClientOptions {
+  // apiOrigin is the cloud API origin, e.g. "https://api.spacewave.dev".
+  apiOrigin: string
+  // signingEnvPrefix is the environment prefix carried in signed payloads.
+  signingEnvPrefix: string
+  // sessionPeerId is the base58 peer ID of the operator session, sent as X-Peer-ID.
+  sessionPeerId: string
+  // sign signs the serialized SigningPayload; keys are never handed to this client.
+  sign: SigningFn
+  // fetch overrides the global fetch implementation (for tests).
+  fetch?: typeof globalThis.fetch
+}
+
+// bytesToHex renders bytes as lowercase hex.
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+// sha256Hex hashes the request body and hex-encodes the digest.
+async function sha256Hex(body: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', body.slice().buffer)
+  return bytesToHex(new Uint8Array(digest))
+}
+
+// uint8ArrayToBase64 encodes bytes using standard base64.
+function uint8ArrayToBase64(bytes: Uint8Array): string {
+  let binary = ''
+  for (const b of bytes) binary += String.fromCharCode(b)
+  return btoa(binary)
+}
+
+// parseCloudError decodes a JSON ErrorResponse body into a CloudError.
+// Malformed bodies degrade to a status-only error rather than failing the call.
+function parseCloudError(statusCode: number, body: Uint8Array): CloudError {
+  try {
+    const resp = ErrorResponse.fromJsonString(new TextDecoder().decode(body))
+    return new CloudError(
+      statusCode,
+      resp.code,
+      resp.message,
+      resp.retryable,
+      resp.retryAfterSeconds,
+    )
+  } catch {
+    return new CloudError(statusCode)
+  }
+}
+
+// readBoundedBody reads the response body with a size limit.
+// Returns an error if the body exceeds maxResponseBodySize.
+async function readBoundedBody(response: Response): Promise<Uint8Array> {
+  const reader = response.body?.getReader()
+  if (!reader) return new Uint8Array(0)
+  const chunks: Uint8Array[] = []
+  let total = 0
+  try {
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      total += value.length
+      if (total > maxResponseBodySize) {
+        await reader.cancel()
+        throw new Error('response body exceeds maximum size')
+      }
+      chunks.push(value)
+    }
+  } finally {
+    reader.releaseLock()
+  }
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    out.set(chunk, offset)
+    offset += chunk.length
+  }
+  return out
+}
+
+// validateOrigin enforces an absolute origin: https, or http on loopback for
+// local development. No credentials, path, query, or fragment.
+function validateOrigin(value: string): string {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error('apiOrigin is not an absolute URL')
+  }
+  const isLoopback =
+    url.hostname === 'localhost' ||
+    url.hostname === '[::1]' ||
+    /^127(?:\.\d{1,3}){3}$/.test(url.hostname)
+  if (url.protocol !== 'https:' && !(url.protocol === 'http:' && isLoopback)) {
+    throw new Error('apiOrigin must use https or http on loopback')
+  }
+  if (
+    url.username !== '' ||
+    url.password !== '' ||
+    (url.pathname !== '/' && url.pathname !== '') ||
+    url.search !== '' ||
+    url.hash !== ''
+  ) {
+    throw new Error(
+      'apiOrigin must be a bare origin without path, query, or credentials',
+    )
+  }
+  return url.origin
+}
+
+// ApplicationOperatorClient performs Ed25519-signed cloud API calls for
+// application operators over the shared proto-binary HTTP contract.
+//
+// The signed payload is the deterministic proto binary of
+// provider.spacewave.api.SigningPayload; keys are held by the caller-supplied
+// sign callback, never by this client.
+export class ApplicationOperatorClient {
+  private readonly apiOrigin: string
+  private readonly signingEnvPrefix: string
+  private readonly sessionPeerId: string
+  private readonly sign: SigningFn
+  private readonly fetchImpl: typeof globalThis.fetch
+
+  public constructor(options: ApplicationOperatorClientOptions) {
+    this.apiOrigin = validateOrigin(options.apiOrigin)
+    this.signingEnvPrefix = options.signingEnvPrefix
+    this.sessionPeerId = options.sessionPeerId
+    this.sign = options.sign
+    this.fetchImpl = options.fetch ?? globalThis.fetch
+  }
+
+  // getApplication reads a product registration visible to this session's account.
+  public async getApplication(
+    applicationId: string,
+    signal?: AbortSignal,
+  ): Promise<GetApplicationResponse> {
+    const request: GetApplicationRequest = { applicationId }
+    return this.postBinary(
+      '/api/applications/get',
+      GetApplicationRequest,
+      GetApplicationResponse,
+      request,
+      signal,
+    )
+  }
+
+  // enrollManagedAccount submits the independently signed credential proof
+  // after the application's verified login.
+  public async enrollManagedAccount(
+    request: EnrollManagedAccountRequest,
+    signal?: AbortSignal,
+  ): Promise<EnrollManagedAccountResponse> {
+    return this.postBinary(
+      '/api/applications/accounts/enroll',
+      EnrollManagedAccountRequest,
+      EnrollManagedAccountResponse,
+      request,
+      signal,
+    )
+  }
+
+  // postBinary signs and executes a POST with proto-binary content, returning
+  // the decoded response message. Signed headers bind content-type, path,
+  // timestamp, content length, and body hash exactly as the Go client does.
+  private async postBinary<Req extends Message<Req>, Res extends Message<Res>>(
+    path: string,
+    requestType: MessageType<Req>,
+    responseType: MessageType<Res>,
+    request: Req,
+    signal?: AbortSignal,
+  ): Promise<Res> {
+    const body = requestType.toBinary(request)
+    const bodyHashHex = await sha256Hex(body)
+    const timestampMs = BigInt(Date.now())
+    const payload = SigningPayload.toBinary({
+      envPrefix: this.signingEnvPrefix,
+      method: 'POST',
+      path,
+      timestampMs,
+      contentLength: BigInt(body.length),
+      bodyHashHex,
+      signedHeaders: 'content-type=application/octet-stream',
+    })
+    const signature = await this.sign(payload, signal)
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/octet-stream',
+      Accept: 'application/octet-stream',
+      'X-Peer-ID': this.sessionPeerId,
+      'X-Timestamp': timestampMs.toString(),
+      'X-Sw-Hash': bodyHashHex,
+      'X-Signature': uint8ArrayToBase64(signature),
+      'X-Signed-Headers': 'content-type',
+    }
+
+    const response = await this.fetchImpl(
+      new URL(path, this.apiOrigin).toString(),
+      {
+        method: 'POST',
+        headers,
+        body: body.slice() as BodyInit,
+        // Never forward signed requests across redirects. Manual mode also
+        // works in workerd, which does not implement redirect: 'error'.
+        redirect: 'manual',
+        signal,
+      },
+    )
+
+    const bytes = await readBoundedBody(response)
+
+    if (response.status < 200 || response.status >= 300) {
+      throw parseCloudError(response.status, bytes)
+    }
+
+    return responseType.fromBinary(bytes)
+  }
+}


### PR DESCRIPTION
Adds signed managed-account credential enrollment and application availability APIs. A trusted application operator can recover the same provider account with a new credential; pause retains Sessions, while disable requires fresh enrollment after reactivation.

The signed Go-to-Worker integration covers recovery, ordinary Session registration, pause/resume, and disable/reactivate. Generation and the focused pre-commit checks pass. This PR is stacked on the application funding contract in #670.
