### PR TITLE
test(cli): align generation command with landing assets

### DIFF
--- a/cmd/spacewave/e2e/testdata/script/readme-dev-commands.txtar
+++ b/cmd/spacewave/e2e/testdata/script/readme-dev-commands.txtar
@@ -23,6 +23,6 @@ package-script test "bun run test:js && bun run test:browser && bun run test:go"
 package-script test:go "go test -tags skip_e2e -timeout=30s -v ./..."
 package-script lint "bun run lint:js && bun run lint:go"
 package-script typecheck "tsgo --noEmit -p tsconfig.json"
-package-script gen "bun run go:aptre -- generate && bun run gen:resource:python && bun run gen:session-journey:python && bun scripts/postprocess-generated.ts && bun run gen:rolldown-runner"
+package-script gen "bun run go:aptre -- generate && bun run gen:resource:python && bun run gen:session-journey:python && bun scripts/postprocess-generated.ts && bun run gen:rolldown-runner && bun run gen:landing-code"
 
 go-build ./cmd/spacewave


### PR DESCRIPTION
Update the CLI development-command fixture to include the landing asset generator already run by package.json. The focused readme-dev-commands trajectory passes on the current master base.