### PR TITLE
perf(block): avoid scanning unrelated parent references

### DIFF
--- a/db/block/handle.go
+++ b/db/block/handle.go
@@ -6,24 +6,21 @@ import "strconv"
 type handle struct {
 	// Node is the base graph node.
 	Node GraphNode
-	// parents are all blocks referencing this position
-	// note: FollowRef creates a new location on default.
-	// note: if isSubBlock is true, len(parents) >= 0
+
+	// parents are the traversed references targeting this position.
 	parents []*refHandle
-	// ref is the base block reference.
-	// may be nil
+	// ref is the base block reference, or nil before assignment.
 	ref *BlockRef
 	// isSubBlock indicates if this is a sub-block.
 	isSubBlock bool
-	// refHandles contains pointers to traversed references.
-	// nil initially
+	// refHandles indexes traversed outgoing references by their field IDs.
 	refHandles map[uint32]*refHandle
-	// dirty indicates the block has been changed
+	// dirty indicates the block has been changed.
 	dirty bool
 
-	// blk is the decoded block and/or sub-block pointer if known
+	// blk is the decoded block or sub-block pointer, when known.
 	blk any
-	// blkPreWrite is the pre write callback
+	// blkPreWrite transforms the decoded block before writing.
 	blkPreWrite func(b any) error
 }
 
@@ -33,8 +30,7 @@ func (h *handle) ID() int64 {
 }
 
 // Clone clones the handle object.
-// The Node, parents, and refhandles lists will be empty.
-// Note: does not clone the block object.
+// The graph node and traversed references are cleared; the decoded block is shared.
 func (h *handle) Clone() *handle {
 	return &handle{
 		ref:         h.ref.Clone(),
@@ -56,6 +52,7 @@ func (h *handle) Clone() *handle {
 //   - a double-quoted string ("...") possibly containing escaped quotes (\").
 //   - an HTML string (<...>).
 func (h *handle) DOTID() string {
+	// Identify a sub-block by its parent and reference field.
 	if h.isSubBlock {
 		var parentid string
 		var subBlockId uint32
@@ -66,10 +63,11 @@ func (h *handle) DOTID() string {
 		return parentid + "@" + strconv.FormatUint(uint64(subBlockId), 10)
 	}
 
+	// Identify a standalone block by its content reference.
 	return h.ref.MarshalString()
 }
 
-// Attributes returns the graph attributes
+// Attributes returns the decoded block's graph attributes, when available.
 func (h *handle) Attributes() []BlockGraphAttribute {
 	var res []BlockGraphAttribute
 	if h.blk != nil {
@@ -81,16 +79,13 @@ func (h *handle) Attributes() []BlockGraphAttribute {
 	return res
 }
 
-var _ GraphNode = (*handle)(nil)
-
 // refHandle is a block ref handle.
 type refHandle struct {
-	// id is the ref identifier.
-	// determined by code, usually ref field id
+	// id is the reference field identifier assigned by the block type.
 	id uint32
-	// src is the block handle src
+	// src is the referencing block handle.
 	src *handle
-	// target is the block handle target
+	// target is the referenced block handle.
 	target *handle
 }
 
@@ -104,17 +99,19 @@ func (r *refHandle) To() GraphNode {
 	return r.target
 }
 
-// ReversedEdge returns an edge that has
-// the end points of the receiver swapped.
+// ReversedEdge returns an edge with the source and target swapped.
 func (r *refHandle) ReversedEdge() GraphEdge {
 	return &refHandle{src: r.target, target: r.src}
 }
 
 // addParent adds a parent removing any existing parents from the source.
 func (h *handle) addParent(rh *refHandle) []*refHandle {
+	// Reject edges addressed to another block.
 	if rh.target != h {
 		return nil
 	}
+
+	// Replace the existing relation from this source before attaching its edge.
 	out := h.removeParent(rh.src)
 	h.parents = append(h.parents, rh)
 	return out
@@ -122,6 +119,22 @@ func (h *handle) addParent(rh *refHandle) []*refHandle {
 
 // removeParent removes parent references with oh as the source.
 func (h *handle) removeParent(oh *handle) []*refHandle {
+	// The source's outgoing references can disprove membership without scanning
+	// a heavily shared target. Cursor mutations retain both ends until removal.
+	if oh != nil && oh.refHandles != nil && len(oh.refHandles) < len(h.parents) {
+		found := false
+		for _, ref := range oh.refHandles {
+			if ref.target == h {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil
+		}
+	}
+
+	// Remove matching incoming edges without retaining their backing pointers.
 	var removed []*refHandle
 	for i := 0; i < len(h.parents); i++ {
 		parent := h.parents[i]
@@ -137,4 +150,7 @@ func (h *handle) removeParent(oh *handle) []*refHandle {
 }
 
 // _ is a type assertion
-var _ GraphEdge = (*refHandle)(nil)
+var (
+	_ GraphNode = (*handle)(nil)
+	_ GraphEdge = (*refHandle)(nil)
+)

--- a/db/block/handle_test.go
+++ b/db/block/handle_test.go
@@ -1,0 +1,40 @@
+package block
+
+import "testing"
+
+// TestSharedHandleReparenting preserves unrelated incoming references when a
+// source switches between shared targets.
+func TestSharedHandleReparenting(t *testing.T) {
+	// Give one target many parents with small outgoing reference sets.
+	_, root := NewTransaction(nil, nil, nil, nil)
+	target := root.FollowRef(1, nil)
+	parents := make([]*Cursor, 16)
+	for i := range parents {
+		parents[i] = root.FollowRef(uint32(i+2), nil)
+		parents[i].SetRef(1, target)
+	}
+	if got := len(target.Parents()); got != len(parents)+1 {
+		t.Fatalf("shared target has %d parents, want %d", got, len(parents)+1)
+	}
+
+	// Move one source while retaining the other incoming relationships.
+	other := root.FollowRef(100, nil)
+	parents[0].SetRef(1, other)
+	if got := len(target.Parents()); got != len(parents) {
+		t.Fatalf("old target has %d parents after reparenting, want %d", got, len(parents))
+	}
+	if got := len(other.Parents()); got != 2 {
+		t.Fatalf("new target has %d parents, want 2", got)
+	}
+	for _, parent := range target.Parents() {
+		if parent.pos == parents[0].pos {
+			t.Fatal("old target retained the moved parent")
+		}
+	}
+
+	// Repeating the assignment must not duplicate the incoming edge.
+	parents[0].SetRef(1, other)
+	if got := len(other.Parents()); got != 2 {
+		t.Fatalf("repeated assignment left %d parents, want 2", got)
+	}
+}


### PR DESCRIPTION
Adding new references to a heavily shared block repeatedly scanned every incoming edge, even when the source had never referenced that block. Use the existing outgoing-reference index to reject absent parents before scanning the target, preserving reparenting and edge removal.

Native block tests and the remote-delete GC test pass. The focused GoScript remote-delete sweep and reparenting checks passed on Linux (155.66 seconds for the sweep). Repository CI remains required before landing.
