### PR TITLE
perf(randstring): sample fresh identifiers from system entropy

### DIFF
--- a/net/util/randstring/benchmark_test.go
+++ b/net/util/randstring/benchmark_test.go
@@ -1,0 +1,10 @@
+package randstring
+
+import "testing"
+
+// BenchmarkRandomIdentifier measures fresh eight-letter identifiers.
+func BenchmarkRandomIdentifier(b *testing.B) {
+	for b.Loop() {
+		RandomIdentifier(8)
+	}
+}

--- a/net/util/randstring/randstring.go
+++ b/net/util/randstring/randstring.go
@@ -6,31 +6,46 @@ import (
 	"strings"
 )
 
+// letterBytes is the uniformly sampled output alphabet.
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
 const (
-	letterIdxBits = 6                    // 6 bits to represent a letter index
-	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
-	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
+	// letterIdxBits is the number of bits needed for an alphabet index.
+	letterIdxBits = 6
+	// letterIdxMask selects one candidate alphabet index.
+	letterIdxMask = 1<<letterIdxBits - 1
+	// letterIdxMax is the number of candidates in a nonnegative int64.
+	letterIdxMax = 63 / letterIdxBits
 )
 
-// RandString generates a random string with length n.
-// Not cryptographically safe.
-// Pass nil to use a random seed.
-// https://stackoverflow.com/questions/22892120
+// RandString generates n ASCII letters. A nil source uses crypto/rand directly;
+// a supplied source preserves its deterministic sequence and is not secure.
+// Failure to obtain system entropy panics. A negative length panics.
 func RandString(src *mrand.Rand, n int) string {
-	// Seed a local generator when the caller did not provide one.
-	if src == nil {
-		var seed [32]byte
-		_, _ = rand.Read(seed[:])
-
-		src = mrand.New(mrand.NewChaCha8(seed)) //nolint:gosec
-	}
-
 	// Build the requested identifier from random alphabet indexes.
 	sb := strings.Builder{}
 	sb.Grow(n)
 
-	// A src.Int64() generates 64 random bits, enough for letterIdxMax characters!
+	// Sample fresh letters in batches, rejecting indexes outside the alphabet.
+	if src == nil {
+		var buf [32]byte
+		for sb.Len() < n {
+			if _, err := rand.Read(buf[:]); err != nil {
+				panic(err)
+			}
+			for _, value := range buf {
+				if idx := int(value & letterIdxMask); idx < len(letterBytes) {
+					sb.WriteByte(letterBytes[idx])
+					if sb.Len() == n {
+						return sb.String()
+					}
+				}
+			}
+		}
+		return sb.String()
+	}
+
+	// Consume seeded values in the established order for reproducible output.
 	for i, cache, remain := n-1, src.Int64(), letterIdxMax; i >= 0; {
 		if remain == 0 {
 			cache, remain = src.Int64(), letterIdxMax

--- a/net/util/randstring/randstring_test.go
+++ b/net/util/randstring/randstring_test.go
@@ -3,21 +3,52 @@ package randstring
 import (
 	"math/rand/v2"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/aperturerobotics/util/prng"
 )
 
+// TestRandString preserves the seeded caller's exact output sequence.
 func TestRandString(t *testing.T) {
+	// Generate consecutive strings from the same seeded source.
 	rnd := rand.New(prng.BuildSeededRand([]byte("testing randstring"))) //nolint:gosec
 	strs := make([]string, 10)
 	for i := range strs {
 		strs[i] = RandString(rnd, 8)
 	}
+
+	// Compare the complete sequence, including generator advancement.
 	expected := []string{"EaTsEKPw", "nvvjMxQe", "JcnevYoi", "qhjIFzMl", "nIhGmfAT", "WCMJUZhe", "WAqmjYbL", "CgYZxfxR", "KphaTnzC", "iZDnLFYn"}
 	if !slices.Equal(strs, expected) {
 		t.Logf("expected: %#v", expected)
 		t.Logf("actual: %#v", strs)
 		t.FailNow()
 	}
+}
+
+// TestRandomIdentifier checks the fresh-entropy path and identifier contract.
+func TestRandomIdentifier(t *testing.T) {
+	// Exercise empty strings and identifiers spanning multiple entropy batches.
+	for _, length := range []int{0, 4, 8, 16, 100} {
+		value := RandString(nil, length)
+		if len(value) != length {
+			t.Fatalf("length %d: got %d", length, len(value))
+		}
+		if strings.Trim(value, letterBytes) != "" {
+			t.Fatalf("invalid alphabet: %q", value)
+		}
+	}
+
+	// Catch a constant-output runtime regression without testing random collisions.
+	first := RandomIdentifier(0)
+	if len(first) != 8 || strings.Trim(first, "abcdefghijklmnopqrstuvwxyz") != "" {
+		t.Fatalf("invalid default identifier: %q", first)
+	}
+	for range 10 {
+		if RandomIdentifier(0) != first {
+			return
+		}
+	}
+	t.Fatal("all fresh identifiers repeated")
 }


### PR DESCRIPTION
Fresh identifiers currently read system entropy, initialize ChaCha8, and discard the generator after producing a few letters. Sample the same alphabet directly from crypto/rand in bounded batches. Explicit seeded callers retain their existing sequence, and RandomIdentifier retains its default length and lowercase output.

Native package and packed-message tests pass. An isolated GoScript caller verifies lengths, alphabet, fresh output, and seeded repeatability. Local eight-letter benchmarks improve from 416 to 312 ns/op in native Go and from 63.5 to 11.5 ms per 10,000 IDs in GoScript (three-sample medians). These are component measurements.

The full package's GoScript test build remains blocked by missing crypto/hash imports in its existing PRNG test dependency. The optional Chromium runner also stops before execution on Vitest declaration errors.
