### PR TITLE
fix(session): enable headless guest invitation delivery

### DIFF
--- a/bldr/sdk/resource/client.ts
+++ b/bldr/sdk/resource/client.ts
@@ -1,6 +1,7 @@
 import '../dispose-symbol.js'
 
-import { createAbortController, retryWithAbort } from '@aptre/bldr'
+import { createAbortController } from '../../web/bldr/abort.js'
+import { retryWithAbort } from '../../web/bldr/retry.js'
 import type { ResourceService } from './resource_srpc.pb.js'
 import type {
   ResourceAttachRequest,

--- a/core/resource/session/spacewave-guest.go
+++ b/core/resource/session/spacewave-guest.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/s4wave/spacewave/core/sobject"
 	s4wave_provider_spacewave "github.com/s4wave/spacewave/sdk/provider/spacewave"
+	s4wave_session "github.com/s4wave/spacewave/sdk/session"
 )
 
 // ApproveGuestSpaceLink approves an independently keyed guest without registering
@@ -53,9 +54,18 @@ func (r *SpacewaveSessionResource) ApproveGuestSpaceLink(
 	); err != nil {
 		return nil, err
 	}
-	return shared.CreateSOInviteOp(
-		ctx, key, payload.GetRequestedRole(), r.swAcc.GetProviderID(),
-		verified.agentPeerID.String(), 1,
-		timestamppb.New(now.Add(localSpaceLinkInviteTTL)),
-	)
+
+	// Use the invitation owner so the signed grant is also registered with
+	// the cloud mailbox. A bare SO operation cannot admit an offline guest.
+	invite, err := r.parent.CreateSpaceInvite(ctx, &s4wave_session.CreateSpaceInviteRequest{
+		SpaceId:      resourceID,
+		Role:         payload.GetRequestedRole(),
+		TargetPeerId: verified.agentPeerID.String(),
+		MaxUses:      1,
+		ExpiresAt:    timestamppb.New(now.Add(localSpaceLinkInviteTTL)),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return invite.GetInviteMessage(), nil
 }


### PR DESCRIPTION
Headless guest admission needs both a worker-safe Resource client and a published invitation. Import cancellation and retry helpers directly so the Resource SDK does not initialize the browser document module in workerd. After verifying and consuming guest consent, issue the invitation through the existing Session invitation owner, which registers the cloud mailbox beacon.

Focused SpaceLink/invitation Go tests and 18 Resource client tests pass. A real workerd startup exposed the browser-barrel failure; the downstream runtime check is continuing with these changes.
