### PR TITLE
fix(bldr): release plugin clients after RPC lookup ends

### DIFF
--- a/bldr/plugin/host/scheduler/materialize-manifest_test.go
+++ b/bldr/plugin/host/scheduler/materialize-manifest_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aperturerobotics/controllerbus/config"
 	"github.com/aperturerobotics/controllerbus/controller"
+	"github.com/aperturerobotics/controllerbus/directive"
 	"github.com/aperturerobotics/starpc/srpc"
 	bldr_manifest "github.com/s4wave/spacewave/bldr/manifest"
 	bldr_manifest_materializer "github.com/s4wave/spacewave/bldr/manifest/materializer"
@@ -30,7 +31,7 @@ import (
 )
 
 // TestMaterializeManifestThroughPluginHostVolumeProxy exercises browser
-// worker source access with and without an instance key.
+// worker demand, copy completion, and release with and without an instance key.
 func TestMaterializeManifestThroughPluginHostVolumeProxy(t *testing.T) {
 	t.Run("empty instance key", func(t *testing.T) {
 		runBrowserCopyFixture(t, "")
@@ -102,7 +103,7 @@ func runBrowserCopyFixture(t *testing.T, instanceKey string) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	defer srcCursor.Release()
+	t.Cleanup(srcCursor.Release)
 	destCursor, _, err := bucket_lookup.BuildEmptyCursor(
 		ctx, hostTB.Bus, le, hostTB.StepFactorySet,
 		"mm-dest", hostTB.Volume.GetID(), destTransformConf, nil,
@@ -110,7 +111,7 @@ func runBrowserCopyFixture(t *testing.T, instanceKey string) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	defer destCursor.Release()
+	t.Cleanup(destCursor.Release)
 
 	// Small valid manifest: one nested FS directory node referenced by both
 	// dist and assets, so the graph is exactly two blocks.
@@ -153,14 +154,16 @@ func runBrowserCopyFixture(t *testing.T, instanceKey string) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	defer srcSel.Release()
+	t.Cleanup(srcSel.Release)
 
 	// Source blocks must be absent from the destination before the call.
 	rootRef := srcRef.GetRootRef()
 	for _, ref := range []*block.BlockRef{rootRef, dirRef} {
-		if _, exists, err := destCursor.GetBucket().GetBlock(ctx, ref); err != nil {
+		_, exists, err := destCursor.GetBucket().GetBlock(ctx, ref)
+		if err != nil {
 			t.Fatal(err.Error())
-		} else if exists {
+		}
+		if exists {
 			t.Fatal("test setup: destination already holds a source block")
 		}
 	}
@@ -179,6 +182,7 @@ func runBrowserCopyFixture(t *testing.T, instanceKey string) {
 	); err != nil {
 		t.Fatal(err.Error())
 	}
+
 	// Expose the host mux on the host bus under the web-worker server identity,
 	// exactly as host/web does, and route the plugin's host client through a
 	// bus invoker carrying that identity.
@@ -198,7 +202,7 @@ func runBrowserCopyFixture(t *testing.T, instanceKey string) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	defer relRpcServiceCtrl()
+	t.Cleanup(relRpcServiceCtrl)
 	hostClient := srpc.NewClient(srpc.NewServerPipe(srpc.NewServer(
 		bifrost_rpc.NewInvoker(hostTB.Bus, workerServerID, true),
 	)))
@@ -215,7 +219,7 @@ func runBrowserCopyFixture(t *testing.T, instanceKey string) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	defer relBridge()
+	t.Cleanup(relBridge)
 
 	// Plugin bus: mount the host volume proxy under the plugin-host volume
 	// alias, exactly as the plugin entrypoint does.
@@ -239,7 +243,7 @@ func runBrowserCopyFixture(t *testing.T, instanceKey string) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	defer relProxyVol()
+	t.Cleanup(relProxyVol)
 
 	// Serve the real Materializer on the plugin bus pipe.
 	pluginMux := srpc.NewMux()
@@ -251,25 +255,43 @@ func runBrowserCopyFixture(t *testing.T, instanceKey string) {
 	}
 	pluginClient := srpc.NewClient(srpc.NewServerPipe(srpc.NewServer(pluginMux)))
 
-	// Host bus: reach the plugin's services through the plugin pipe.
-	pluginBridge := bifrost_rpc.NewClientController(
-		le,
-		hostTB.Bus,
-		controller.NewInfo("test-plugin-bridge", controller.MustParseVersion("0.0.1"), "host bus bridge to plugin services"),
-		pluginClient,
-		[]string{bldr_plugin.PluginServiceIDPrefix + "bldr-materializer/"},
-	)
-	relPluginBridge, err := hostTB.Bus.AddController(ctx, pluginBridge, nil)
+	// Route the copy's RPC lookup through the scheduler's normal plugin demand.
+	// The fixture publishes its already constructed worker only for LoadPlugin.
+	ctrl := &Controller{bus: hostTB.Bus, conf: &Config{InstanceKey: instanceKey}}
+	demanded := make(chan string, 1)
+	released := make(chan struct{})
+	relPluginHandler, err := hostTB.Bus.AddHandler(directive.NewFuncHandler(
+		func(ctx context.Context, inst directive.Instance) ([]directive.Resolver, error) {
+			switch dir := inst.GetDirective().(type) {
+			case bifrost_rpc.LookupRpcClient:
+				return directive.R(bldr_plugin.ResolveLookupRpcClient(ctx, dir, ctrl))
+			case bldr_plugin.LoadPlugin:
+				if dir.LoadPluginID() != "bldr-materializer" {
+					return nil, nil
+				}
+				return directive.R(directive.NewFuncResolver(
+					func(ctx context.Context, handler directive.ResolverHandler) error {
+						demanded <- dir.LoadPluginInstanceKey()
+						defer close(released)
+						_, _ = handler.AddValue(bldr_plugin.NewRunningPlugin(pluginClient))
+						handler.MarkIdle(true)
+						<-ctx.Done()
+						return ctx.Err()
+					},
+				), nil)
+			}
+			return nil, nil
+		},
+	))
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	defer relPluginBridge()
+	t.Cleanup(relPluginHandler)
 
 	// Call the scheduler helper against the host bus. Bound the call so the
 	// RPC completes or fails within the deadline instead of hanging.
 	copyCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
-	defer cancel()
-	ctrl := &Controller{bus: hostTB.Bus, conf: &Config{InstanceKey: instanceKey}}
+	t.Cleanup(cancel)
 	copiedRef, _, err := ctrl.materializeManifest(
 		copyCtx,
 		"bldr-materializer",
@@ -279,6 +301,21 @@ func runBrowserCopyFixture(t *testing.T, instanceKey string) {
 	)
 	if err != nil {
 		t.Fatal(err.Error())
+	}
+
+	// The copy must demand the scheduler's instance and release it on completion.
+	select {
+	case got := <-demanded:
+		if got != instanceKey {
+			t.Fatalf("materializer instance key = %q, want %q", got, instanceKey)
+		}
+	default:
+		t.Fatal("copy completed without demanding the materializer plugin")
+	}
+	select {
+	case <-released:
+	case <-time.After(2 * time.Second):
+		t.Fatal("completed copy retained its materializer plugin demand")
 	}
 
 	// The copied root must match the source root hash and sit in the
@@ -321,7 +358,7 @@ func runBrowserCopyFixture(t *testing.T, instanceKey string) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	defer gotCursor.Release()
+	t.Cleanup(gotCursor.Release)
 	_, gotBcs := gotCursor.BuildTransaction(nil)
 	gotManifest, err := bldr_manifest.UnmarshalManifest(ctx, gotBcs)
 	if err != nil {

--- a/bldr/plugin/res-lookup-rpc-client.go
+++ b/bldr/plugin/res-lookup-rpc-client.go
@@ -3,7 +3,6 @@ package bldr_plugin
 import (
 	"context"
 	"strings"
-	"sync"
 
 	"github.com/aperturerobotics/controllerbus/directive"
 	"github.com/aperturerobotics/starpc/srpc"
@@ -18,7 +17,8 @@ type LookupRpcClientHandler interface {
 	// Released is a function to call if the client becomes invalid.
 	// Returns nil, nil, err if any error.
 	// Returns nil, nil, nil to skip resolving the client.
-	// Otherwise returns client, releaseFunc, nil
+	// Otherwise returns client, releaseFunc, nil. A nil release function means
+	// the handler owns the client without a caller reference.
 	WaitPluginHostClient(ctx context.Context, released func()) (srpc.Client, func(), error)
 
 	// WaitPluginClient waits for an RPC client for a plugin.
@@ -26,7 +26,8 @@ type LookupRpcClientHandler interface {
 	// Released is a function to call if the client becomes invalid.
 	// Returns nil, nil, err if any error.
 	// Returns nil, nil, nil to skip resolving the client.
-	// Otherwise returns client, releaseFunc, nil
+	// Otherwise returns client, releaseFunc, nil. A nil release function means
+	// the handler owns the client without a caller reference.
 	WaitPluginClient(ctx context.Context, released func(), pluginID string) (srpc.Client, func(), error)
 }
 
@@ -36,14 +37,13 @@ type LookupRpcClientHandler interface {
 //   - plugin/{plugin-id}/{service id}
 //   - plugin-host/{service id}
 type LookupRpcClientResolver struct {
-	// h is the handler
+	// h supplies retained plugin clients.
 	h LookupRpcClientHandler
-	// pluginID is the plugin identifier
-	// if empty we are looking up the plugin host
+	// pluginID identifies the plugin, or the host when empty.
 	pluginID string
-	// rpcClientCtr is the rpc client container
+	// rpcClientCtr publishes the current retained RPC client.
 	rpcClientCtr *ccontainer.CContainer[*srpc.Client]
-	// stripServiceIDPrefix is the prefix to strip from the service id, if any
+	// stripServiceIDPrefix is the prefix to strip from the service ID, if any.
 	stripServiceIDPrefix string
 }
 
@@ -51,25 +51,16 @@ type LookupRpcClientResolver struct {
 //
 // Usually you will want to use ResolveLookupRpcClient instead.
 // If pluginID is empty, addresses the plugin host.
-// stripServiceIDPrefix is the prefix to strip from the service id, if any
+// stripServiceIDPrefix is the prefix to strip from the service ID, if any.
 func NewLookupRpcClientResolver(h LookupRpcClientHandler, pluginID, stripServiceIDPrefix string) *LookupRpcClientResolver {
 	return &LookupRpcClientResolver{
 		h:                    h,
 		pluginID:             pluginID,
 		stripServiceIDPrefix: stripServiceIDPrefix,
-
-		rpcClientCtr: ccontainer.NewCContainer[*srpc.Client](nil),
+		rpcClientCtr:         ccontainer.NewCContainer[*srpc.Client](nil),
 	}
 }
 
-// ResolveLookupRpcClient resolves a LookupRpcClient directive with a plugin or plugin host.
-//
-// Resolves service IDs like:
-//   - plugin/{plugin-id}/{service id}
-//   - plugin-host/{service id}
-//
-// Returns nil, nil if the service ID does not match any of the known prefixes.
-// Returns an error if the plugin id is invalid.
 // matchPluginServiceID parses a service ID against the known plugin service
 // prefixes. Returns the plugin id and the service-id prefix to strip, or
 // empty strings when no prefix matches.
@@ -80,9 +71,9 @@ func matchPluginServiceID(serviceID string) (pluginID, stripPrefix string, ok bo
 	})
 	switch matchedPrefix {
 	case PluginServiceIDPrefix:
-		id, remoteServiceID, cutOk := strings.Cut(matchedService, "/")
-		if !cutOk || remoteServiceID == "" || id == "" {
-			// require the format: plugin/{plugin-id}/{service-id}
+		id, remoteServiceID, cutOK := strings.Cut(matchedService, "/")
+		if !cutOK || remoteServiceID == "" || id == "" {
+			// Plugin services require both a plugin ID and a service ID.
 			return "", "", false
 		}
 		if err := ValidatePluginID(id, false); err != nil {
@@ -96,6 +87,13 @@ func matchPluginServiceID(serviceID string) (pluginID, stripPrefix string, ok bo
 	}
 }
 
+// ResolveLookupRpcClient resolves a LookupRpcClient directive with a plugin or plugin host.
+//
+// Resolves service IDs like:
+//   - plugin/{plugin-id}/{service id}
+//   - plugin-host/{service id}
+//
+// Returns nil, nil if the service ID does not match any of the known prefixes.
 func ResolveLookupRpcClient(ctx context.Context, dir bifrost_rpc.LookupRpcClient, h LookupRpcClientHandler) (directive.Resolver, error) {
 	serviceID := dir.LookupRpcServiceID()
 
@@ -117,59 +115,58 @@ func (r *LookupRpcClientResolver) GetRpcClientCtr() *ccontainer.CContainer[*srpc
 	return r.rpcClientCtr
 }
 
-// Resolve resolves the values, emitting them to the handler.
-func (r *LookupRpcClientResolver) Resolve(rctx context.Context, handler directive.ResolverHandler) error {
-	ctx, ctxCancel := context.WithCancel(rctx)
-	defer ctxCancel()
-
+// Resolve publishes the current plugin client until the directive ends. A
+// released client is cleared and relinquished before requesting its replacement.
+func (r *LookupRpcClientResolver) Resolve(ctx context.Context, handler directive.ResolverHandler) error {
 	for {
-		_ = handler.ClearValues()
-		r.rpcClientCtr.SetValue(nil)
-
-		if ctx.Err() != nil {
-			return context.Canceled
-		}
-
-		pluginID := r.pluginID
-		var client srpc.Client
-		var rel func()
-		var err error
-
-		releasedWaitCh := make(chan struct{})
-		var releasedOnce sync.Once
-		releasedFn := func() {
-			releasedOnce.Do(func() {
-				close(releasedWaitCh)
-			})
-		}
-
-		if pluginID == "" {
-			client, rel, err = r.h.WaitPluginHostClient(ctx, releasedFn)
-		} else {
-			client, rel, err = r.h.WaitPluginClient(ctx, releasedFn, pluginID)
-		}
-		if err != nil || client == nil {
-			if rel != nil {
-				rel()
-			}
+		retry, err := r.resolveClient(ctx, handler)
+		if err != nil || !retry {
 			return err
-		}
-
-		if r.stripServiceIDPrefix != "" {
-			client = srpc.NewPrefixClient(client, []string{r.stripServiceIDPrefix})
-		}
-
-		value := client
-		r.rpcClientCtr.SetValue(&value)
-		_, _ = handler.AddValue(value)
-		handler.MarkIdle(true)
-
-		select {
-		case <-ctx.Done():
-		case <-releasedWaitCh:
 		}
 	}
 }
 
-// _ is a type assertion
+// resolveClient retains one client while its value is published. It returns true
+// when invalidation requires a replacement, false when the handler declines the
+// lookup, and an error when lookup or the parent context fails.
+func (r *LookupRpcClientResolver) resolveClient(ctx context.Context, handler directive.ResolverHandler) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+
+	// Client invalidation ends this publication without canceling the directive.
+	clientCtx, cancelClient := context.WithCancel(ctx)
+	defer cancelClient()
+	var client srpc.Client
+	var release func()
+	var err error
+	if r.pluginID == "" {
+		client, release, err = r.h.WaitPluginHostClient(ctx, cancelClient)
+	} else {
+		client, release, err = r.h.WaitPluginClient(ctx, cancelClient, r.pluginID)
+	}
+	if release != nil {
+		defer release()
+	}
+	if err != nil || client == nil {
+		return false, err
+	}
+	if clientCtx.Err() != nil {
+		return true, ctx.Err()
+	}
+
+	// Expose the service-prefixed client only while its retained value is valid.
+	if r.stripServiceIDPrefix != "" {
+		client = srpc.NewPrefixClient(client, []string{r.stripServiceIDPrefix})
+	}
+	r.rpcClientCtr.SetValue(&client)
+	defer r.rpcClientCtr.SetValue(nil)
+	_, _ = handler.AddValue(client)
+	defer handler.ClearValues()
+	handler.MarkIdle(true)
+	<-clientCtx.Done()
+	return true, ctx.Err()
+}
+
+// LookupRpcClientResolver implements the directive resolver contract.
 var _ directive.Resolver = (*LookupRpcClientResolver)(nil)

--- a/bldr/plugin/res-lookup-rpc-client_test.go
+++ b/bldr/plugin/res-lookup-rpc-client_test.go
@@ -1,0 +1,102 @@
+package bldr_plugin
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aperturerobotics/starpc/srpc"
+	"github.com/pkg/errors"
+)
+
+// TestLookupRpcClientReleasesBeforeReplacement checks client invalidation and
+// directive cancellation through the same retained-client lifetime.
+func TestLookupRpcClientReleasesBeforeReplacement(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	t.Cleanup(cancel)
+
+	// Each acquisition must follow release of the preceding client.
+	var acquisitions int32
+	var releases atomic.Int32
+	invalidators := make(chan func(), 1)
+	handler := lookupClientHandlerFunc(func(_ context.Context, invalidated func()) (srpc.Client, func(), error) {
+		if releases.Load() != acquisitions {
+			return nil, nil, errors.New("replacement acquired before previous client release")
+		}
+		acquisitions++
+		invalidators <- invalidated
+		return &testForwardingClient{}, func() { releases.Add(1) }, nil
+	})
+	resolver := NewLookupRpcClientResolver(handler, "materializer", "")
+	done := make(chan error, 1)
+	go func() { done <- resolver.Resolve(ctx, stubResolverHandler{}) }()
+
+	// Invalidate the published client and observe a replacement publication.
+	first, err := resolver.GetRpcClientCtr().WaitValue(ctx, nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	(<-invalidators)()
+	second, err := resolver.GetRpcClientCtr().WaitValueChange(ctx, first, nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if second == nil {
+		if _, err := resolver.GetRpcClientCtr().WaitValue(ctx, nil); err != nil {
+			t.Fatal(err.Error())
+		}
+	}
+
+	// Cancellation must release the replacement and clear the published client.
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("resolver returned %v, want context canceled", err)
+	}
+	if got := releases.Load(); got != 2 {
+		t.Fatalf("released %d clients, want 2", got)
+	}
+	if resolver.GetRpcClientCtr().GetValue() != nil {
+		t.Fatal("canceled resolver still publishes a client")
+	}
+}
+
+// TestLookupRpcClientHostNeedsNoRelease verifies that the host-owned client can
+// be withdrawn without a caller release function.
+func TestLookupRpcClientHostNeedsNoRelease(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	t.Cleanup(cancel)
+	resolver := NewLookupRpcClientResolver(&nilReleaseClientHandler{
+		client: &testForwardingClient{},
+	}, "", "")
+	done := make(chan error, 1)
+	go func() { done <- resolver.Resolve(ctx, stubResolverHandler{}) }()
+
+	// Wait for a real publication before canceling the host lookup.
+	if _, err := resolver.GetRpcClientCtr().WaitValue(ctx, nil); err != nil {
+		t.Fatal(err.Error())
+	}
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("resolver returned %v, want context canceled", err)
+	}
+	if resolver.GetRpcClientCtr().GetValue() != nil {
+		t.Fatal("canceled host lookup still publishes a client")
+	}
+}
+
+// lookupClientHandlerFunc supplies clients to both plugin lookup paths.
+type lookupClientHandlerFunc func(context.Context, func()) (srpc.Client, func(), error)
+
+// WaitPluginHostClient delegates the host lookup to the test function.
+func (f lookupClientHandlerFunc) WaitPluginHostClient(ctx context.Context, invalidated func()) (srpc.Client, func(), error) {
+	return f(ctx, invalidated)
+}
+
+// WaitPluginClient delegates the plugin lookup to the test function.
+func (f lookupClientHandlerFunc) WaitPluginClient(ctx context.Context, invalidated func(), _ string) (srpc.Client, func(), error) {
+	return f(ctx, invalidated)
+}
+
+// lookupClientHandlerFunc implements the retained-client lookup contract.
+var _ LookupRpcClientHandler = lookupClientHandlerFunc(nil)


### PR DESCRIPTION
RPC client lookup retained its plugin reference after a copy completed or a client became invalid. Scope each published client with its release function, withdraw it before releasing the reference, and release the old client before requesting a replacement.

The manifest-copy integration test now exercises scheduler plugin demand for both instance-key cases instead of bypassing it through a direct client bridge. Added coverage for replacement, cancellation, and host-owned clients without a release function.

Validation: `go test -race ./bldr/plugin ./bldr/plugin/host/scheduler`; the copy-and-release regression fails before the fix and passes afterward.
