### PR TITLE
perf(http): avoid duplicate opens for plain assets

### DIFF
--- a/bldr/manifest/materializer/server.go
+++ b/bldr/manifest/materializer/server.go
@@ -213,5 +213,5 @@ func newCopyStats(stats *bucket_lookup.ObjectCopyStats) *CopyStats {
 
 // _ is a type assertion
 var (
-	_ SRPCMaterializerServer = ((*Materializer)(nil))
+	_ SRPCMaterializerServer = (*Materializer)(nil)
 )

--- a/net/http/encoded-asset-file-server.go
+++ b/net/http/encoded-asset-file-server.go
@@ -17,6 +17,7 @@ const encodedAssetVary = "Accept-Encoding"
 // NewEncodedAssetFileServer serves an http.FileSystem with browser release
 // asset headers for precompressed immutable files.
 func NewEncodedAssetFileServer(hfs http.FileSystem) http.Handler {
+	// Keep directory, conditional, and range handling in the standard file server.
 	fileServer := http.FileServer(hfs)
 
 	// Apply immutable asset metadata before serving or decoding the file.
@@ -41,7 +42,14 @@ func applyEncodedAssetHeaders(rw http.ResponseWriter, req *http.Request, hfs htt
 		return
 	}
 
-	// Verify the encoded file exists before setting response headers.
+	// Plain assets need no metadata read; FileServer supplies the size and
+	// replaces Content-Type when it returns an HTTP error.
+	if encoded == "" {
+		rw.Header().Set("Content-Type", contentType)
+		return
+	}
+
+	// Verify the encoded file exists before advertising an encoded response.
 	st, err := statHTTPFile(hfs, reqPath)
 	if err != nil {
 		return
@@ -86,6 +94,7 @@ func encodedAssetContentType(name string) (string, string) {
 
 // contentTypeForAsset returns the content type for an asset file name.
 func contentTypeForAsset(name string) string {
+	// Keep browser module and release formats independent of host MIME tables.
 	switch {
 	case strings.HasSuffix(name, ".wasm"):
 		return "application/wasm"
@@ -100,6 +109,8 @@ func contentTypeForAsset(name string) string {
 	case strings.HasSuffix(name, ".kvfile"), strings.HasSuffix(name, ".packedmsg"):
 		return "application/octet-stream"
 	}
+
+	// Resolve other extensions through the registered MIME types.
 	if ext := path.Ext(name); ext != "" {
 		if contentType := mime.TypeByExtension(ext); contentType != "" {
 			return contentType
@@ -123,9 +134,12 @@ func acceptsEncoding(req *http.Request, want string) bool {
 // encodingQuality parses the q parameter from one Accept-Encoding element. A
 // missing q parameter means quality 1.
 func encodingQuality(params string) float64 {
+	// An omitted quality parameter accepts the encoding at full quality.
 	if params == "" {
 		return 1
 	}
+
+	// Honor an explicit quality and reject malformed values.
 	for param := range strings.SplitSeq(params, ";") {
 		key, value, ok := strings.Cut(strings.TrimSpace(param), "=")
 		if !ok || !strings.EqualFold(key, "q") {
@@ -162,6 +176,7 @@ func openHTTPFile(hfs http.FileSystem, name string) (http.File, error) {
 // cleanHTTPFilePath normalizes a request path and rejects traversal outside
 // the filesystem root.
 func cleanHTTPFilePath(name string) (string, error) {
+	// HTTP asset paths use slash separators on every host platform.
 	if strings.Contains(name, "\\") {
 		return "", fs.ErrPermission
 	}

--- a/net/http/encoded-asset-file-server_test.go
+++ b/net/http/encoded-asset-file-server_test.go
@@ -2,7 +2,6 @@ package bifrost_http
 
 import (
 	"errors"
-	"io"
 	"io/fs"
 	"net/http"
 	"net/http/httptest"
@@ -11,7 +10,67 @@ import (
 	"testing/fstest"
 )
 
+// testHTTPFileSystem exposes filesystem opens to the asset-serving tests.
+type testHTTPFileSystem func(string) (http.File, error)
+
+// Open opens a file through the test's instrumented filesystem.
+func (f testHTTPFileSystem) Open(name string) (http.File, error) {
+	return f(name)
+}
+
+// TestEncodedAssetFileServerPlainOpensOnce checks the ordinary module read path.
+func TestEncodedAssetFileServerPlainOpensOnce(t *testing.T) {
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		t.Run(method, func(t *testing.T) {
+			// Count opens against a real in-memory file.
+			files := http.FS(fstest.MapFS{
+				"app.mjs": &fstest.MapFile{Data: []byte("export default 1")},
+			})
+			opens := 0
+			handler := NewEncodedAssetFileServer(testHTTPFileSystem(func(name string) (http.File, error) {
+				opens++
+				return files.Open(name)
+			}))
+
+			// Serve the module without a separate metadata open.
+			rw := httptest.NewRecorder()
+			handler.ServeHTTP(rw, httptest.NewRequest(method, "/app.mjs", nil))
+			if rw.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", rw.Code)
+			}
+			if opens != 1 {
+				t.Fatalf("filesystem opens = %d, want 1", opens)
+			}
+			if got := rw.Header().Get("Content-Type"); got != "application/javascript" {
+				t.Fatalf("Content-Type = %q, want application/javascript", got)
+			}
+			wantBody := "export default 1"
+			if method == http.MethodHead {
+				wantBody = ""
+			}
+			if got := rw.Body.String(); got != wantBody {
+				t.Fatalf("body = %q, want %q", got, wantBody)
+			}
+		})
+	}
+}
+
+// TestEncodedAssetFileServerMissingModuleKeepsErrorType checks HTTP error metadata.
+func TestEncodedAssetFileServerMissingModuleKeepsErrorType(t *testing.T) {
+	handler := NewEncodedAssetFileServer(http.FS(fstest.MapFS{}))
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, httptest.NewRequest(http.MethodGet, "/missing.mjs", nil))
+	if rw.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rw.Code)
+	}
+	if got := rw.Header().Get("Content-Type"); got != "text/plain; charset=utf-8" {
+		t.Fatalf("Content-Type = %q, want text/plain; charset=utf-8", got)
+	}
+}
+
+// TestEncodedAssetFileServerGzipHeaders checks encoded response metadata.
 func TestEncodedAssetFileServerGzipHeaders(t *testing.T) {
+	// Populate the supported precompressed asset formats.
 	tests := []struct {
 		path        string
 		contentType string
@@ -29,60 +88,58 @@ func TestEncodedAssetFileServerGzipHeaders(t *testing.T) {
 	}
 	handler := NewEncodedAssetFileServer(http.FS(files))
 
+	// Verify every format preserves the stored bytes and advertises gzip.
 	for _, test := range tests {
 		rw := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "https://spacewave.local"+test.path, nil)
 		handler.ServeHTTP(rw, req)
-		res := rw.Result()
-		body, err := io.ReadAll(res.Body)
-		res.Body.Close()
-		if err != nil {
-			t.Fatal(err)
+		if rw.Code != http.StatusOK {
+			t.Fatalf("%s status = %d, want 200", test.path, rw.Code)
 		}
-		if res.StatusCode != http.StatusOK {
-			t.Fatalf("%s status = %d, want 200", test.path, res.StatusCode)
-		}
-		if got := res.Header.Get("Content-Encoding"); got != "gzip" {
+		if got := rw.Header().Get("Content-Encoding"); got != "gzip" {
 			t.Fatalf("%s Content-Encoding = %q, want gzip", test.path, got)
 		}
-		if got := res.Header.Get("Content-Type"); got != test.contentType {
+		if got := rw.Header().Get("Content-Type"); got != test.contentType {
 			t.Fatalf("%s Content-Type = %q, want %q", test.path, got, test.contentType)
 		}
-		if got := res.Header.Get("Vary"); got != encodedAssetVary {
+		if got := rw.Header().Get("Vary"); got != encodedAssetVary {
 			t.Fatalf("%s Vary = %q, want %q", test.path, got, encodedAssetVary)
 		}
-		if got := res.Header.Get("Content-Length"); got != "10" {
+		if got := rw.Header().Get("Content-Length"); got != "10" {
 			t.Fatalf("%s Content-Length = %q, want 10", test.path, got)
 		}
-		if string(body) != "gzip-bytes" {
-			t.Fatalf("%s body = %q, want gzip-bytes", test.path, string(body))
+		if got := rw.Body.String(); got != "gzip-bytes" {
+			t.Fatalf("%s body = %q, want gzip-bytes", test.path, got)
 		}
 	}
 }
 
+// TestEncodedAssetFileServerWasmContentType checks uncompressed WebAssembly metadata.
 func TestEncodedAssetFileServerWasmContentType(t *testing.T) {
+	// Serve an ordinary WebAssembly asset.
 	files := fstest.MapFS{
 		"entrypoint/runtime.wasm": &fstest.MapFile{Data: []byte("wasm-bytes")},
 	}
 	handler := NewEncodedAssetFileServer(http.FS(files))
 
+	// Preserve its browser MIME type without an encoding header.
 	rw := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "https://spacewave.local/entrypoint/runtime.wasm", nil)
 	handler.ServeHTTP(rw, req)
-	res := rw.Result()
-	res.Body.Close()
-	if res.StatusCode != http.StatusOK {
-		t.Fatalf("status = %d, want 200", res.StatusCode)
+	if rw.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rw.Code)
 	}
-	if got := res.Header.Get("Content-Type"); got != "application/wasm" {
+	if got := rw.Header().Get("Content-Type"); got != "application/wasm" {
 		t.Fatalf("Content-Type = %q, want application/wasm", got)
 	}
-	if got := res.Header.Get("Content-Encoding"); got != "" {
+	if got := rw.Header().Get("Content-Encoding"); got != "" {
 		t.Fatalf("Content-Encoding = %q, want empty", got)
 	}
 }
 
+// TestEncodedAssetFileServerModuleContentTypes checks MIME types for browser assets.
 func TestEncodedAssetFileServerModuleContentTypes(t *testing.T) {
+	// Populate the ordinary browser module and document formats.
 	tests := []struct {
 		path        string
 		contentType string
@@ -99,53 +156,52 @@ func TestEncodedAssetFileServerModuleContentTypes(t *testing.T) {
 	}
 	handler := NewEncodedAssetFileServer(http.FS(files))
 
+	// Verify uncompressed responses carry their format's MIME type.
 	for _, test := range tests {
 		rw := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "https://spacewave.local"+test.path, nil)
 		handler.ServeHTTP(rw, req)
-		res := rw.Result()
-		res.Body.Close()
-		if res.StatusCode != http.StatusOK {
-			t.Fatalf("%s status = %d, want 200", test.path, res.StatusCode)
+		if rw.Code != http.StatusOK {
+			t.Fatalf("%s status = %d, want 200", test.path, rw.Code)
 		}
-		if got := res.Header.Get("Content-Type"); got != test.contentType {
+		if got := rw.Header().Get("Content-Type"); got != test.contentType {
 			t.Fatalf("%s Content-Type = %q, want %q", test.path, got, test.contentType)
 		}
-		if got := res.Header.Get("Content-Encoding"); got != "" {
+		if got := rw.Header().Get("Content-Encoding"); got != "" {
 			t.Fatalf("%s Content-Encoding = %q, want empty", test.path, got)
 		}
 	}
 }
 
+// TestEncodedAssetFileServerMissingGzipDoesNotSetEncodedHeaders checks error metadata.
 func TestEncodedAssetFileServerMissingGzipDoesNotSetEncodedHeaders(t *testing.T) {
 	handler := NewEncodedAssetFileServer(http.FS(fstest.MapFS{}))
-
 	rw := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "https://spacewave.local/missing.wasm.gz", nil)
 	handler.ServeHTTP(rw, req)
-	res := rw.Result()
-	res.Body.Close()
-	if res.StatusCode != http.StatusNotFound {
-		t.Fatalf("status = %d, want 404", res.StatusCode)
+	if rw.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rw.Code)
 	}
-	if got := res.Header.Get("Content-Encoding"); got != "" {
+	if got := rw.Header().Get("Content-Encoding"); got != "" {
 		t.Fatalf("Content-Encoding = %q, want empty", got)
 	}
 }
 
+// TestCleanHTTPFilePathRejectsTraversal checks root confinement and valid normalization.
 func TestCleanHTTPFilePathRejectsTraversal(t *testing.T) {
+	// Reject traversal before normalizing path components.
 	tests := []string{
 		"../secrets/runtime.wasm.gz",
 		"/entrypoint/../secrets/runtime.wasm.gz",
 		`entrypoint\..\secrets\runtime.wasm.gz`,
 	}
-
 	for _, test := range tests {
 		if _, err := cleanHTTPFilePath(test); !errors.Is(err, fs.ErrPermission) {
 			t.Fatalf("cleanHTTPFilePath(%q) error = %v, want permission", test, err)
 		}
 	}
 
+	// Preserve a valid asset path relative to the filesystem root.
 	got, err := cleanHTTPFilePath("/entrypoint/runtime.wasm.gz")
 	if err != nil {
 		t.Fatalf("cleanHTTPFilePath(valid) error = %v", err)
@@ -155,29 +211,26 @@ func TestCleanHTTPFilePathRejectsTraversal(t *testing.T) {
 	}
 }
 
+// TestEncodedAssetFileServerBrotliQualityZeroDecodes checks explicit Brotli rejection.
 func TestEncodedAssetFileServerBrotliQualityZeroDecodes(t *testing.T) {
+	// Populate a stored Brotli asset.
 	files := fstest.MapFS{
 		"entrypoint/app.js.br": &fstest.MapFile{Data: []byte{0x0b, 0x01, 0x80, 'j', 's', 0x03}},
 	}
 	handler := NewEncodedAssetFileServer(http.FS(files))
 
+	// Decode it when the client's quality parameter refuses Brotli.
 	rw := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "https://spacewave.local/entrypoint/app.js.br", nil)
 	req.Header.Set("Accept-Encoding", "gzip, br;q=0")
 	handler.ServeHTTP(rw, req)
-	res := rw.Result()
-	body, err := io.ReadAll(res.Body)
-	res.Body.Close()
-	if err != nil {
-		t.Fatal(err)
+	if rw.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rw.Code)
 	}
-	if res.StatusCode != http.StatusOK {
-		t.Fatalf("status = %d, want 200", res.StatusCode)
-	}
-	if got := res.Header.Get("Content-Encoding"); got != "" {
+	if got := rw.Header().Get("Content-Encoding"); got != "" {
 		t.Fatalf("Content-Encoding = %q, want empty", got)
 	}
-	if !strings.Contains(string(body), "js") {
-		t.Fatalf("body = %q, want decoded brotli body", string(body))
+	if got := rw.Body.String(); !strings.Contains(got, "js") {
+		t.Fatalf("body = %q, want decoded brotli body", got)
 	}
 }


### PR DESCRIPTION
Ordinary JavaScript, CSS, HTML, and other recognized uncompressed assets now reach the standard file server without a separate metadata open. The file server still owns content length, conditional requests, ranges, and errors; precompressed assets retain their existing negotiation and metadata checks.

The focused race suite passes, including GET and HEAD checks that require exactly one filesystem open and a missing-module check that preserves the HTTP error MIME type. A complete-handler native benchmark reduced allocations from 19 to 16 per request and median time from 2,122 to 1,679 ns across three samples per implementation. These are handler-level savings, not a claim about browser startup time.
