### PR TITLE
feat(chat): expose canonical channel history metadata

### DIFF
--- a/.protoc-manifest.json
+++ b/.protoc-manifest.json
@@ -3438,7 +3438,7 @@
       ]
     },
     "github.com/s4wave/spacewave/sdk/chat/rpc": {
-      "hash": "d866c87b91b4934ddbf498b2e3ec693a29bb1a7b5e0ed40a5e84ec1cade072a4",
+      "hash": "ae0b9a9dd651daed800804e2bd4333e6935147063ee8edba9013dffe3e443183",
       "generatedFiles": [
         "sdk/chat/rpc/rpc.pb.go",
         "sdk/chat/rpc/rpc.pb.ts",

--- a/sdk/chat/chat-resource.go
+++ b/sdk/chat/chat-resource.go
@@ -86,8 +86,10 @@ func (r *ChatResource) GetChannelInfo(
 
 	// Project the metadata for the client.
 	return &spacewave_chat_rpc.GetChannelInfoResponse{
-		Name:  channel.GetName(),
-		Topic: channel.GetTopic(),
+		Name:         channel.GetName(),
+		Topic:        channel.GetTopic(),
+		MessageCount: channel.GetMessageCount(),
+		CreatedAt:    channel.GetCreatedAt().CloneVT(),
 	}, nil
 }
 

--- a/sdk/chat/chat-resource_test.go
+++ b/sdk/chat/chat-resource_test.go
@@ -85,6 +85,13 @@ func TestChatResourceSendsListsAndWatchesMessages(t *testing.T) {
 	if info.GetName() != "General" {
 		t.Fatalf("channel name = %q, want General", info.GetName())
 	}
+	if info.GetMessageCount() != 0 {
+		t.Fatalf("channel message count = %d, want 0", info.GetMessageCount())
+	}
+	if info.GetCreatedAt() == nil {
+		t.Fatal("channel creation timestamp is nil")
+	}
+	createdAt := info.GetCreatedAt().CloneVT()
 
 	sendResp, err := resource.SendMessage(ctx, &spacewave_chat_rpc.SendMessageRequest{Text: "hello goscript chat"})
 	if err != nil {
@@ -92,6 +99,16 @@ func TestChatResourceSendsListsAndWatchesMessages(t *testing.T) {
 	}
 	if sendResp.GetMessageKey() == "" {
 		t.Fatal("SendMessage returned empty message key")
+	}
+	updatedInfo, err := resource.GetChannelInfo(ctx, &spacewave_chat_rpc.GetChannelInfoRequest{})
+	if err != nil {
+		t.Fatalf("GetChannelInfo after send: %v", err)
+	}
+	if updatedInfo.GetMessageCount() != 1 {
+		t.Fatalf("channel message count = %d, want 1", updatedInfo.GetMessageCount())
+	}
+	if !updatedInfo.GetCreatedAt().EqualVT(createdAt) {
+		t.Fatal("channel creation timestamp changed after sending a message")
 	}
 
 	listResp, err := resource.ListMessages(ctx, &spacewave_chat_rpc.ListMessagesRequest{})

--- a/sdk/chat/rpc/rpc.pb.go
+++ b/sdk/chat/rpc/rpc.pb.go
@@ -107,6 +107,10 @@ type GetChannelInfoResponse struct {
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// Topic is the channel topic.
 	Topic string `protobuf:"bytes,2,opt,name=topic,proto3" json:"topic,omitempty"`
+	// MessageCount is the number of messages retained in channel history.
+	MessageCount uint64 `protobuf:"varint,3,opt,name=message_count,json=messageCount,proto3" json:"messageCount,omitempty"`
+	// CreatedAt is the channel creation timestamp.
+	CreatedAt *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=created_at,json=createdAt,proto3" json:"createdAt,omitempty"`
 }
 
 func (x *GetChannelInfoResponse) Reset() {
@@ -127,6 +131,20 @@ func (x *GetChannelInfoResponse) GetTopic() string {
 		return x.Topic
 	}
 	return ""
+}
+
+func (x *GetChannelInfoResponse) GetMessageCount() uint64 {
+	if x != nil {
+		return x.MessageCount
+	}
+	return 0
+}
+
+func (x *GetChannelInfoResponse) GetCreatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.CreatedAt
+	}
+	return nil
 }
 
 // ListMessagesRequest is a request for paginated messages.
@@ -331,6 +349,8 @@ func (m *GetChannelInfoResponse) CloneVT() *GetChannelInfoResponse {
 	r := new(GetChannelInfoResponse)
 	r.Name = m.Name
 	r.Topic = m.Topic
+	r.MessageCount = m.MessageCount
+	r.CreatedAt = protobuf_go_lite.CloneVTValue(m.CreatedAt)
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = slices.Clone(m.unknownFields)
 	}
@@ -506,6 +526,12 @@ func (this *GetChannelInfoResponse) EqualVT(that *GetChannelInfoResponse) bool {
 		return false
 	}
 	if this.Topic != that.Topic {
+		return false
+	}
+	if this.MessageCount != that.MessageCount {
+		return false
+	}
+	if !protobuf_go_lite.IsEqualVT(this.CreatedAt, that.CreatedAt) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -797,6 +823,16 @@ func (x *GetChannelInfoResponse) MarshalProtoJSON(s *json.MarshalState) {
 		s.WriteObjectField("topic")
 		s.WriteString(x.Topic)
 	}
+	if x.MessageCount != 0 || s.HasField("messageCount") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("messageCount")
+		s.WriteUint64(x.MessageCount)
+	}
+	if x.CreatedAt != nil || s.HasField("createdAt") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("createdAt")
+		x.CreatedAt.MarshalProtoJSON(s.WithField("createdAt"))
+	}
 	s.WriteObjectEnd()
 }
 
@@ -820,6 +856,16 @@ func (x *GetChannelInfoResponse) UnmarshalProtoJSON(s *json.UnmarshalState) {
 		case "topic":
 			s.AddField("topic")
 			x.Topic = s.ReadString()
+		case "message_count", "messageCount":
+			s.AddField("message_count")
+			x.MessageCount = s.ReadUint64()
+		case "created_at", "createdAt":
+			if s.ReadNil() {
+				x.CreatedAt = nil
+				return
+			}
+			x.CreatedAt = &timestamppb.Timestamp{}
+			x.CreatedAt.UnmarshalProtoJSON(s.WithField("created_at", true))
 		}
 	})
 }
@@ -1293,6 +1339,21 @@ func (m *GetChannelInfoResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error
 	if m.unknownFields != nil {
 		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
 	}
+	if m.CreatedAt != nil {
+		size, err := m.CreatedAt.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x22
+	}
+	if m.MessageCount != 0 {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(m.MessageCount))
+		i--
+		dAtA[i] = 0x18
+	}
 	if len(m.Topic) > 0 {
 		i = protobuf_go_lite.EncodeString(dAtA, i, m.Topic)
 		i--
@@ -1608,6 +1669,11 @@ func (m *GetChannelInfoResponse) SizeVT() (n int) {
 	_ = l
 	n += protobuf_go_lite.SizeStringNonEmpty(1, m.Name)
 	n += protobuf_go_lite.SizeStringNonEmpty(1, m.Topic)
+	n += protobuf_go_lite.SizeVarintNonZero(1, m.MessageCount)
+	if m.CreatedAt != nil {
+		l = m.CreatedAt.SizeVT()
+		n += protobuf_go_lite.SizeMessage(1, l)
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -1749,6 +1815,14 @@ func (x *GetChannelInfoResponse) MarshalProtoText() string {
 	if x.Topic != "" {
 		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "topic")
 		protobuf_go_lite.TextWriteString(&sb, x.Topic)
+	}
+	if x.MessageCount != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "message_count")
+		protobuf_go_lite.TextWriteUint(&sb, x.MessageCount)
+	}
+	if x.CreatedAt != nil {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "created_at")
+		protobuf_go_lite.TextWriteTextMarshaler(&sb, x.CreatedAt)
 	}
 	return protobuf_go_lite.TextFinishMessage(&sb)
 }
@@ -2078,6 +2152,30 @@ func (m *GetChannelInfoResponse) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			m.Topic = v
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MessageCount", wireType)
+			}
+			m.MessageCount = 0
+			m.MessageCount, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CreatedAt", wireType)
+			}
+			msgStart, postIndex, err := protobuf_go_lite.DecodeLengthDelimited(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			if m.CreatedAt == nil {
+				m.CreatedAt = &timestamppb.Timestamp{}
+			}
+			if err := m.CreatedAt.UnmarshalVT(dAtA[msgStart:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])

--- a/sdk/chat/rpc/rpc.pb.ts
+++ b/sdk/chat/rpc/rpc.pb.ts
@@ -110,6 +110,18 @@ export interface GetChannelInfoResponse {
    * @generated from field: string topic = 2;
    */
   topic?: string
+  /**
+   * MessageCount is the number of messages retained in channel history.
+   *
+   * @generated from field: uint64 message_count = 3;
+   */
+  messageCount?: bigint
+  /**
+   * CreatedAt is the channel creation timestamp.
+   *
+   * @generated from field: google.protobuf.Timestamp created_at = 4;
+   */
+  createdAt?: Date
 }
 
 export const GetChannelInfoResponse: MessageType<GetChannelInfoResponse> =
@@ -118,6 +130,8 @@ export const GetChannelInfoResponse: MessageType<GetChannelInfoResponse> =
     fields: [
       { no: 1, name: 'name', kind: 'scalar', T: ScalarType.STRING },
       { no: 2, name: 'topic', kind: 'scalar', T: ScalarType.STRING },
+      { no: 3, name: 'message_count', kind: 'scalar', T: ScalarType.UINT64 },
+      { no: 4, name: 'created_at', kind: 'message', T: () => Timestamp },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,
   })

--- a/sdk/chat/rpc/rpc.proto
+++ b/sdk/chat/rpc/rpc.proto
@@ -6,10 +6,15 @@ import "github.com/s4wave/spacewave/sdk/chat/content/content.proto";
 
 option go_package = "github.com/s4wave/spacewave/sdk/chat/rpc;spacewave_chat_rpc";
 
+// ChatResourceService serves authorized operations for one chat channel.
 service ChatResourceService {
+  // GetChannelInfo returns channel metadata and its retained history extent.
   rpc GetChannelInfo(GetChannelInfoRequest) returns (GetChannelInfoResponse);
+  // ListMessages returns a bounded page of channel history.
   rpc ListMessages(ListMessagesRequest) returns (ListMessagesResponse);
+  // WatchMessages streams channel messages after each shared-state change.
   rpc WatchMessages(WatchMessagesRequest) returns (stream WatchMessagesResponse);
+  // SendMessage appends one message or resolves an identical retry.
   rpc SendMessage(SendMessageRequest) returns (SendMessageResponse);
 }
 
@@ -32,7 +37,8 @@ message ChatMessageInfo {
 }
 
 // GetChannelInfoRequest is a request for channel info.
-message GetChannelInfoRequest {}
+message GetChannelInfoRequest {
+}
 
 // GetChannelInfoResponse contains channel metadata.
 message GetChannelInfoResponse {
@@ -40,6 +46,10 @@ message GetChannelInfoResponse {
   string name = 1;
   // Topic is the channel topic.
   string topic = 2;
+  // MessageCount is the number of messages retained in channel history.
+  uint64 message_count = 3;
+  // CreatedAt is the channel creation timestamp.
+  .google.protobuf.Timestamp created_at = 4;
 }
 
 // ListMessagesRequest is a request for paginated messages.
@@ -59,7 +69,8 @@ message ListMessagesResponse {
 }
 
 // WatchMessagesRequest is a request to stream messages.
-message WatchMessagesRequest {}
+message WatchMessagesRequest {
+}
 
 // WatchMessagesResponse contains a batch of new messages.
 message WatchMessagesResponse {

--- a/sdk/chat/rpc/rpc_srpc.pb.go
+++ b/sdk/chat/rpc/rpc_srpc.pb.go
@@ -14,12 +14,13 @@ type SRPCChatResourceServiceClient interface {
 	// SRPCClient returns the underlying SRPC client.
 	SRPCClient() srpc.Client
 
+	// GetChannelInfo returns channel metadata and its retained history extent.
 	GetChannelInfo(ctx context.Context, in *GetChannelInfoRequest) (*GetChannelInfoResponse, error)
-
+	// ListMessages returns a bounded page of channel history.
 	ListMessages(ctx context.Context, in *ListMessagesRequest) (*ListMessagesResponse, error)
-
+	// WatchMessages streams channel messages after each shared-state change.
 	WatchMessages(ctx context.Context, in *WatchMessagesRequest) (SRPCChatResourceService_WatchMessagesClient, error)
-
+	// SendMessage appends one message or resolves an identical retry.
 	SendMessage(ctx context.Context, in *SendMessageRequest) (*SendMessageResponse, error)
 }
 
@@ -103,12 +104,13 @@ func (c *srpcChatResourceServiceClient) SendMessage(ctx context.Context, in *Sen
 }
 
 type SRPCChatResourceServiceServer interface {
+	// GetChannelInfo returns channel metadata and its retained history extent.
 	GetChannelInfo(context.Context, *GetChannelInfoRequest) (*GetChannelInfoResponse, error)
-
+	// ListMessages returns a bounded page of channel history.
 	ListMessages(context.Context, *ListMessagesRequest) (*ListMessagesResponse, error)
-
+	// WatchMessages streams channel messages after each shared-state change.
 	WatchMessages(*WatchMessagesRequest, SRPCChatResourceService_WatchMessagesStream) error
-
+	// SendMessage appends one message or resolves an identical retry.
 	SendMessage(context.Context, *SendMessageRequest) (*SendMessageResponse, error)
 }
 

--- a/sdk/chat/rpc/rpc_srpc.pb.ts
+++ b/sdk/chat/rpc/rpc_srpc.pb.ts
@@ -21,12 +21,16 @@ import {
 } from 'starpc'
 
 /**
+ * ChatResourceService serves authorized operations for one chat channel.
+ *
  * @generated from service spacewave.chat.rpc.ChatResourceService
  */
 export const ChatResourceServiceDefinition = {
   typeName: 'spacewave.chat.rpc.ChatResourceService',
   methods: {
     /**
+     * GetChannelInfo returns channel metadata and its retained history extent.
+     *
      * @generated from rpc spacewave.chat.rpc.ChatResourceService.GetChannelInfo
      */
     GetChannelInfo: {
@@ -36,6 +40,8 @@ export const ChatResourceServiceDefinition = {
       kind: MethodKind.Unary,
     },
     /**
+     * ListMessages returns a bounded page of channel history.
+     *
      * @generated from rpc spacewave.chat.rpc.ChatResourceService.ListMessages
      */
     ListMessages: {
@@ -45,6 +51,8 @@ export const ChatResourceServiceDefinition = {
       kind: MethodKind.Unary,
     },
     /**
+     * WatchMessages streams channel messages after each shared-state change.
+     *
      * @generated from rpc spacewave.chat.rpc.ChatResourceService.WatchMessages
      */
     WatchMessages: {
@@ -54,6 +62,8 @@ export const ChatResourceServiceDefinition = {
       kind: MethodKind.ServerStreaming,
     },
     /**
+     * SendMessage appends one message or resolves an identical retry.
+     *
      * @generated from rpc spacewave.chat.rpc.ChatResourceService.SendMessage
      */
     SendMessage: {
@@ -66,10 +76,14 @@ export const ChatResourceServiceDefinition = {
 } as const
 
 /**
+ * ChatResourceService serves authorized operations for one chat channel.
+ *
  * @generated from service spacewave.chat.rpc.ChatResourceService
  */
 export interface ChatResourceService {
   /**
+   * GetChannelInfo returns channel metadata and its retained history extent.
+   *
    * @generated from rpc spacewave.chat.rpc.ChatResourceService.GetChannelInfo
    */
   GetChannelInfo(
@@ -78,6 +92,8 @@ export interface ChatResourceService {
   ): Promise<GetChannelInfoResponse>
 
   /**
+   * ListMessages returns a bounded page of channel history.
+   *
    * @generated from rpc spacewave.chat.rpc.ChatResourceService.ListMessages
    */
   ListMessages(
@@ -86,6 +102,8 @@ export interface ChatResourceService {
   ): Promise<ListMessagesResponse>
 
   /**
+   * WatchMessages streams channel messages after each shared-state change.
+   *
    * @generated from rpc spacewave.chat.rpc.ChatResourceService.WatchMessages
    */
   WatchMessages(
@@ -94,6 +112,8 @@ export interface ChatResourceService {
   ): MessageStream<WatchMessagesResponse>
 
   /**
+   * SendMessage appends one message or resolves an identical retry.
+   *
    * @generated from rpc spacewave.chat.rpc.ChatResourceService.SendMessage
    */
   SendMessage(
@@ -103,10 +123,14 @@ export interface ChatResourceService {
 }
 
 /**
+ * ChatResourceService serves authorized operations for one chat channel.
+ *
  * @generated from service spacewave.chat.rpc.ChatResourceService
  */
 export interface ChatResourceServiceHandler {
   /**
+   * GetChannelInfo returns channel metadata and its retained history extent.
+   *
    * @generated from rpc spacewave.chat.rpc.ChatResourceService.GetChannelInfo
    */
   GetChannelInfo(
@@ -116,6 +140,8 @@ export interface ChatResourceServiceHandler {
   ): Promise<GetChannelInfoResponse>
 
   /**
+   * ListMessages returns a bounded page of channel history.
+   *
    * @generated from rpc spacewave.chat.rpc.ChatResourceService.ListMessages
    */
   ListMessages(
@@ -125,6 +151,8 @@ export interface ChatResourceServiceHandler {
   ): Promise<ListMessagesResponse>
 
   /**
+   * WatchMessages streams channel messages after each shared-state change.
+   *
    * @generated from rpc spacewave.chat.rpc.ChatResourceService.WatchMessages
    */
   WatchMessages(
@@ -134,6 +162,8 @@ export interface ChatResourceServiceHandler {
   ): MessageStream<WatchMessagesResponse>
 
   /**
+   * SendMessage appends one message or resolves an identical retry.
+   *
    * @generated from rpc spacewave.chat.rpc.ChatResourceService.SendMessage
    */
   SendMessage(
@@ -158,6 +188,8 @@ export class ChatResourceServiceClient implements ChatResourceService {
     this.SendMessage = this.SendMessage.bind(this)
   }
   /**
+   * GetChannelInfo returns channel metadata and its retained history extent.
+   *
    * @generated from rpc spacewave.chat.rpc.ChatResourceService.GetChannelInfo
    */
   async GetChannelInfo(
@@ -175,6 +207,8 @@ export class ChatResourceServiceClient implements ChatResourceService {
   }
 
   /**
+   * ListMessages returns a bounded page of channel history.
+   *
    * @generated from rpc spacewave.chat.rpc.ChatResourceService.ListMessages
    */
   async ListMessages(
@@ -192,6 +226,8 @@ export class ChatResourceServiceClient implements ChatResourceService {
   }
 
   /**
+   * WatchMessages streams channel messages after each shared-state change.
+   *
    * @generated from rpc spacewave.chat.rpc.ChatResourceService.WatchMessages
    */
   WatchMessages(
@@ -209,6 +245,8 @@ export class ChatResourceServiceClient implements ChatResourceService {
   }
 
   /**
+   * SendMessage appends one message or resolves an identical retry.
+   *
    * @generated from rpc spacewave.chat.rpc.ChatResourceService.SendMessage
    */
   async SendMessage(


### PR DESCRIPTION
Expose the channel's retained message count and creation timestamp through GetChannelInfo. Clients can read the history extent directly from the canonical channel without scanning message pages.

The focused channel test checks that a send advances the count while preserving the creation time. Channel tests, generation, go fix, and focused lint pass.
