### PR TITLE
perf(opfs): avoid slicing complete immutable snapshots

### DIFF
--- a/db/opfs/read-snapshot.go
+++ b/db/opfs/read-snapshot.go
@@ -11,6 +11,7 @@ import (
 	"github.com/s4wave/spacewave/db/opfs/jsutil"
 )
 
+// readSnapshotDriver owns reads and release for one runtime snapshot.
 type readSnapshotDriver interface {
 	readSnapshotAt(snapshot *ReadSnapshot, p []byte, off int64) (int, error)
 	closeReadSnapshot(snapshot *ReadSnapshot) error
@@ -18,16 +19,22 @@ type readSnapshotDriver interface {
 
 // ReadSnapshot retains one immutable OPFS File and its resolved size.
 type ReadSnapshot struct {
-	// driver and runtime references select the direct, TinyGo, or remote path.
-	driver   readSnapshotDriver
-	name     string
-	handle   js.Value
+	// driver selects the direct, TinyGo, or remote operations.
+	driver readSnapshotDriver
+	// name identifies the source file in read errors.
+	name string
+	// handle retains the immutable File in the direct browser path.
+	handle js.Value
+	// tinyGoID identifies the retained File in the TinyGo reference table.
 	tinyGoID int
-	size     int64
+	// size is the immutable byte length recorded at open.
+	size int64
 
-	// mu serializes reads with exactly-once release.
-	mu       sync.Mutex
-	closed   bool
+	// mtx serializes reads with exactly-once release.
+	mtx sync.Mutex
+	// closed prevents reads after release and is guarded by mtx.
+	closed bool
+	// closeErr retains the release result and is guarded by mtx.
 	closeErr error
 }
 
@@ -63,8 +70,8 @@ func (d BrowserDriver) OpenReadSnapshot(dir js.Value, name string) (*ReadSnapsho
 // ReadAt reads immutable bytes starting at off.
 func (s *ReadSnapshot) ReadAt(p []byte, off int64) (int, error) {
 	// Serialize reads with release so the driver reference stays live.
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
 	if s.closed {
 		return 0, errors.New("opfs read snapshot is closed")
 	}
@@ -95,6 +102,7 @@ func (s *ReadSnapshot) ReadAt(p []byte, off int64) (int, error) {
 	return n, nil
 }
 
+// classifyReadSnapshotError maps a reclaimed snapshot to a retryable missing file.
 func classifyReadSnapshotError(err error) error {
 	// Treat a reclaimed immutable File as missing so manifest refresh can retry.
 	var jsErr *JSError
@@ -104,14 +112,20 @@ func classifyReadSnapshotError(err error) error {
 	return err
 }
 
+// readSnapshotAt copies an in-bounds immutable range into p.
 func (BrowserDriver) readSnapshotAt(snapshot *ReadSnapshot, p []byte, off int64) (int, error) {
 	// Route TinyGo reads through the retained JavaScript reference table.
 	if jsutil.UseTinyGoHelpers() {
 		return snapshot.readAtWithTinyGoImport(p, off)
 	}
 
-	// Slice the retained File without resolving its directory entry again.
-	blob := jsutil.Call(snapshot.handle, "slice", off, off+int64(len(p)))
+	// Reuse the retained File for whole reads; slice only a partial range.
+	blob := snapshot.handle
+	if off != 0 || int64(len(p)) != snapshot.size {
+		blob = jsutil.Call(blob, "slice", off, off+int64(len(p)))
+	}
+
+	// Copy the selected immutable bytes into the caller's buffer.
 	buffer, err := AwaitPromise(jsutil.Call(blob, "arrayBuffer"))
 	if err != nil {
 		return 0, errors.Wrap(err, "arrayBuffer")
@@ -130,8 +144,8 @@ func (s *ReadSnapshot) Size() (int64, error) {
 // Close releases the retained File or runtime token exactly once.
 func (s *ReadSnapshot) Close() error {
 	// Mark release before calling the driver so failures cannot double-release.
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
 	if s.closed {
 		return s.closeErr
 	}
@@ -140,6 +154,7 @@ func (s *ReadSnapshot) Close() error {
 	return s.closeErr
 }
 
+// closeReadSnapshot releases the retained runtime reference.
 func (BrowserDriver) closeReadSnapshot(snapshot *ReadSnapshot) error {
 	// Release TinyGo's explicit retained reference when present.
 	if jsutil.UseTinyGoHelpers() {

--- a/db/opfs/read-snapshot_test.go
+++ b/db/opfs/read-snapshot_test.go
@@ -1,0 +1,65 @@
+//go:build js && !tinygo
+
+package opfs
+
+import (
+	"io"
+	"syscall/js"
+	"testing"
+)
+
+// TestReadSnapshotWholeAndPartialRanges checks immutable File reads and EOF
+// while ensuring complete reads do not allocate an intermediate Blob.
+func TestReadSnapshotWholeAndPartialRanges(t *testing.T) {
+	// Retain a real browser File and count only its slice operations.
+	const content = "immutable snapshot bytes"
+	file := js.Global().Get("File").New([]any{content}, "snapshot.bin")
+	originalSlice := file.Get("slice")
+	sliceCalls := 0
+	slice := js.FuncOf(func(this js.Value, args []js.Value) any {
+		sliceCalls++
+		return originalSlice.Call("call", this, args[0], args[1])
+	})
+	t.Cleanup(slice.Release)
+	file.Set("slice", slice)
+	snapshot := &ReadSnapshot{
+		driver: BrowserDriver{},
+		name:   "snapshot.bin",
+		handle: file,
+		size:   int64(len(content)),
+	}
+	t.Cleanup(func() {
+		if err := snapshot.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	// Both exact and oversized reads use the complete immutable File.
+	for _, extra := range []int{0, 5} {
+		buf := make([]byte, len(content)+extra)
+		n, err := snapshot.ReadAt(buf, 0)
+		if n != len(content) || string(buf[:n]) != content {
+			t.Fatalf("whole read = (%d, %q), want %q", n, buf[:n], content)
+		}
+		wantErr := error(nil)
+		if extra != 0 {
+			wantErr = io.EOF
+		}
+		if err != wantErr {
+			t.Fatalf("whole read error = %v, want %v", err, wantErr)
+		}
+	}
+	if sliceCalls != 0 {
+		t.Fatalf("whole reads made %d slice calls", sliceCalls)
+	}
+
+	// Partial reads retain the range operation and return only requested bytes.
+	buf := make([]byte, 4)
+	n, err := snapshot.ReadAt(buf, 2)
+	if n != len(buf) || err != nil || string(buf) != content[2:6] {
+		t.Fatalf("partial read = (%d, %q, %v)", n, buf, err)
+	}
+	if sliceCalls != 1 {
+		t.Fatalf("partial read made %d slice calls, want 1", sliceCalls)
+	}
+}


### PR DESCRIPTION
Complete immutable OPFS snapshot reads currently create an intermediate Blob with `File.slice`. Read the retained File directly for that range and keep slicing partial ranges. Snapshot lifetime, bounds, EOF handling, and stored data remain unchanged.

Chromium passed the existing immutable-file test and the new exact, oversized, and partial-range test through native Go WebAssembly. The GoScript application build and same-Space offline reopen also passed with the latest compiler dependency. The standalone GoScript package-test command stopped at generated dependency type errors before browser execution.

An isolated Chromium OPFS comparison alternated six rounds of 80 reads per path. Median direct/sliced times were 10.95/25.05 ms at 64 KiB, 51.45/59.40 ms at 1 MiB, and 236.90/256.45 ms at 4 MiB. Full-startup comparisons varied and do not establish a production latency saving; the measured benefit is reduced snapshot read cost.
