### PR TITLE
feat(chat): expose channel-scoped message lookup

### DIFF
--- a/.protoc-manifest.json
+++ b/.protoc-manifest.json
@@ -3438,7 +3438,7 @@
       ]
     },
     "github.com/s4wave/spacewave/sdk/chat/rpc": {
-      "hash": "93f9ce287a43559f94fec61e3f7bfe9c4caaa580f551c4384afa52373542ec4a",
+      "hash": "35a694f4bd2dc827ca346ce96a7787359f43075da3f7c0b65a775a0eda6a87a0",
       "generatedFiles": [
         "sdk/chat/rpc/rpc.pb.go",
         "sdk/chat/rpc/rpc.pb.ts",

--- a/sdk/chat/chat-resource.go
+++ b/sdk/chat/chat-resource.go
@@ -110,6 +110,31 @@ func (r *ChatResource) GetChannelInfo(
 	}, nil
 }
 
+// GetMessage reads one channel message by its channel-scoped object key.
+func (r *ChatResource) GetMessage(
+	ctx context.Context,
+	req *spacewave_chat_rpc.GetMessageRequest,
+) (*spacewave_chat_rpc.GetMessageResponse, error) {
+	// Validate the requested key against the mounted channel.
+	key := req.GetMessageKey()
+	suffix, matches := strings.CutPrefix(key, r.objectKey+"/message/")
+	if !matches || suffix == "" || strings.Contains(suffix, "/") {
+		return nil, errors.New("message key belongs to another channel")
+	}
+
+	// Read the validated message through the owner projection.
+	message, err := r.readMessage(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	if message == nil {
+		return nil, world.ErrObjectNotFound
+	}
+
+	// Return the selected message projection.
+	return &spacewave_chat_rpc.GetMessageResponse{Message: message}, nil
+}
+
 // ListMessages returns a page of channel messages.
 func (r *ChatResource) ListMessages(
 	ctx context.Context,
@@ -158,18 +183,11 @@ func (r *ChatResource) ListMessages(
 		startIndex = endIndex - count
 		hasMore = startIndex != 0
 	case beforeKey != "":
-		suffix, matches := strings.CutPrefix(beforeKey, r.objectKey+"/message/")
-		if !matches || suffix == "" || strings.Contains(suffix, "/") {
-			return nil, errors.New("message cursor belongs to another channel")
-		}
-		message, err := r.readMessage(ctx, beforeKey)
+		messageResponse, err := r.GetMessage(ctx, &spacewave_chat_rpc.GetMessageRequest{MessageKey: beforeKey})
 		if err != nil {
 			return nil, err
 		}
-		if message == nil {
-			return nil, world.ErrObjectNotFound
-		}
-		endIndex = min(message.GetIndex(), messageCount)
+		endIndex = min(messageResponse.GetMessage().GetIndex(), messageCount)
 		count := min(uint64(limit), endIndex)
 		startIndex = endIndex - count
 		hasMore = startIndex != 0

--- a/sdk/chat/chat-resource_test.go
+++ b/sdk/chat/chat-resource_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
 	"github.com/aperturerobotics/starpc/srpc"
+	"github.com/pkg/errors"
 	"github.com/s4wave/spacewave/db/block"
 	"github.com/s4wave/spacewave/db/world"
 	db_world_testbed "github.com/s4wave/spacewave/db/world/testbed"
@@ -151,6 +152,43 @@ func TestChatResourceSendsListsAndWatchesMessages(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for WatchMessages to stop")
+	}
+}
+
+func TestChatResourceGetMessageValidatesChannelKey(t *testing.T) {
+	// Create one accepted event in the mounted channel.
+	ctx := t.Context()
+	wtb, err := db_world_testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wtb.Release()
+
+	ws := world.NewEngineWorldState(wtb.Engine, true)
+	createChatChannel(t, ctx, ws, GeneralChannelKey, "General")
+	resource := NewChatResource(ws, wtb.Engine, GeneralChannelKey, "peer-local")
+	sendResp, err := resource.SendMessage(ctx, &spacewave_chat_rpc.SendMessageRequest{Text: "accepted"})
+	if err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+
+	// Read the accepted event through the channel-scoped lookup.
+	messageResp, err := resource.GetMessage(ctx, &spacewave_chat_rpc.GetMessageRequest{MessageKey: sendResp.GetMessageKey()})
+	if err != nil {
+		t.Fatalf("GetMessage accepted: %v", err)
+	}
+	if messageResp.GetMessage().GetObjectKey() != sendResp.GetMessageKey() {
+		t.Fatalf("GetMessage key = %q, want %q", messageResp.GetMessage().GetObjectKey(), sendResp.GetMessageKey())
+	}
+
+	// Preserve the missing-object result and reject a foreign-channel key.
+	_, err = resource.GetMessage(ctx, &spacewave_chat_rpc.GetMessageRequest{MessageKey: GeneralChannelKey + "/message/missing"})
+	if !errors.Is(err, world.ErrObjectNotFound) {
+		t.Fatalf("GetMessage missing error = %v, want %v", err, world.ErrObjectNotFound)
+	}
+	_, err = resource.GetMessage(ctx, &spacewave_chat_rpc.GetMessageRequest{MessageKey: "other/message/0"})
+	if err == nil {
+		t.Fatal("GetMessage accepted a foreign-channel key")
 	}
 }
 

--- a/sdk/chat/rpc/rpc.pb.go
+++ b/sdk/chat/rpc/rpc.pb.go
@@ -157,6 +157,46 @@ func (x *GetChannelInfoResponse) GetCreatedAt() *timestamppb.Timestamp {
 	return nil
 }
 
+// GetMessageRequest identifies one channel message to read.
+type GetMessageRequest struct {
+	unknownFields []byte
+	// MessageKey is the channel-scoped object key to read.
+	MessageKey string `protobuf:"bytes,1,opt,name=message_key,json=messageKey,proto3" json:"messageKey,omitempty"`
+}
+
+func (x *GetMessageRequest) Reset() {
+	*x = GetMessageRequest{}
+}
+
+func (*GetMessageRequest) ProtoMessage() {}
+
+func (x *GetMessageRequest) GetMessageKey() string {
+	if x != nil {
+		return x.MessageKey
+	}
+	return ""
+}
+
+// GetMessageResponse contains the selected channel message.
+type GetMessageResponse struct {
+	unknownFields []byte
+	// Message is the selected message projection.
+	Message *ChatMessageInfo `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
+}
+
+func (x *GetMessageResponse) Reset() {
+	*x = GetMessageResponse{}
+}
+
+func (*GetMessageResponse) ProtoMessage() {}
+
+func (x *GetMessageResponse) GetMessage() *ChatMessageInfo {
+	if x != nil {
+		return x.Message
+	}
+	return nil
+}
+
 // ListMessagesRequest is a request for paginated messages.
 type ListMessagesRequest struct {
 	unknownFields []byte
@@ -487,6 +527,38 @@ func (m *GetChannelInfoResponse) CloneMessageVT() protobuf_go_lite.CloneMessage 
 	return m.CloneVT()
 }
 
+func (m *GetMessageRequest) CloneVT() *GetMessageRequest {
+	if m == nil {
+		return (*GetMessageRequest)(nil)
+	}
+	r := new(GetMessageRequest)
+	r.MessageKey = m.MessageKey
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = slices.Clone(m.unknownFields)
+	}
+	return r
+}
+
+func (m *GetMessageRequest) CloneMessageVT() protobuf_go_lite.CloneMessage {
+	return m.CloneVT()
+}
+
+func (m *GetMessageResponse) CloneVT() *GetMessageResponse {
+	if m == nil {
+		return (*GetMessageResponse)(nil)
+	}
+	r := new(GetMessageResponse)
+	r.Message = protobuf_go_lite.CloneVTValue(m.Message)
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = slices.Clone(m.unknownFields)
+	}
+	return r
+}
+
+func (m *GetMessageResponse) CloneMessageVT() protobuf_go_lite.CloneMessage {
+	return m.CloneVT()
+}
+
 func (m *ListMessagesRequest) CloneVT() *ListMessagesRequest {
 	if m == nil {
 		return (*ListMessagesRequest)(nil)
@@ -733,6 +805,46 @@ func (this *GetChannelInfoResponse) EqualVT(that *GetChannelInfoResponse) bool {
 
 func (this *GetChannelInfoResponse) EqualMessageVT(thatMsg any) bool {
 	that, ok := thatMsg.(*GetChannelInfoResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+
+func (this *GetMessageRequest) EqualVT(that *GetMessageRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.MessageKey != that.MessageKey {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *GetMessageRequest) EqualMessageVT(thatMsg any) bool {
+	that, ok := thatMsg.(*GetMessageRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+
+func (this *GetMessageResponse) EqualVT(that *GetMessageResponse) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !protobuf_go_lite.IsEqualVT(this.Message, that.Message) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *GetMessageResponse) EqualMessageVT(thatMsg any) bool {
+	that, ok := thatMsg.(*GetMessageResponse)
 	if !ok {
 		return false
 	}
@@ -1157,6 +1269,94 @@ func (x *GetChannelInfoResponse) UnmarshalProtoJSON(s *json.UnmarshalState) {
 
 // UnmarshalJSON unmarshals the GetChannelInfoResponse from JSON.
 func (x *GetChannelInfoResponse) UnmarshalJSON(b []byte) error {
+	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
+}
+
+// MarshalProtoJSON marshals the GetMessageRequest message to JSON.
+func (x *GetMessageRequest) MarshalProtoJSON(s *json.MarshalState) {
+	if x == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteObjectStart()
+	var wroteField bool
+	if x.MessageKey != "" || s.HasField("messageKey") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("messageKey")
+		s.WriteString(x.MessageKey)
+	}
+	s.WriteObjectEnd()
+}
+
+// MarshalJSON marshals the GetMessageRequest to JSON.
+func (x *GetMessageRequest) MarshalJSON() ([]byte, error) {
+	return json.DefaultMarshalerConfig.Marshal(x)
+}
+
+// UnmarshalProtoJSON unmarshals the GetMessageRequest message from JSON.
+func (x *GetMessageRequest) UnmarshalProtoJSON(s *json.UnmarshalState) {
+	if s.ReadNil() {
+		return
+	}
+	s.ReadObject(func(key string) {
+		switch key {
+		default:
+			s.Skip() // ignore unknown field
+		case "message_key", "messageKey":
+			s.AddField("message_key")
+			x.MessageKey = s.ReadString()
+		}
+	})
+}
+
+// UnmarshalJSON unmarshals the GetMessageRequest from JSON.
+func (x *GetMessageRequest) UnmarshalJSON(b []byte) error {
+	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
+}
+
+// MarshalProtoJSON marshals the GetMessageResponse message to JSON.
+func (x *GetMessageResponse) MarshalProtoJSON(s *json.MarshalState) {
+	if x == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteObjectStart()
+	var wroteField bool
+	if x.Message != nil || s.HasField("message") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("message")
+		x.Message.MarshalProtoJSON(s.WithField("message"))
+	}
+	s.WriteObjectEnd()
+}
+
+// MarshalJSON marshals the GetMessageResponse to JSON.
+func (x *GetMessageResponse) MarshalJSON() ([]byte, error) {
+	return json.DefaultMarshalerConfig.Marshal(x)
+}
+
+// UnmarshalProtoJSON unmarshals the GetMessageResponse message from JSON.
+func (x *GetMessageResponse) UnmarshalProtoJSON(s *json.UnmarshalState) {
+	if s.ReadNil() {
+		return
+	}
+	s.ReadObject(func(key string) {
+		switch key {
+		default:
+			s.Skip() // ignore unknown field
+		case "message":
+			if s.ReadNil() {
+				x.Message = nil
+				return
+			}
+			x.Message = &ChatMessageInfo{}
+			x.Message.UnmarshalProtoJSON(s.WithField("message", true))
+		}
+	})
+}
+
+// UnmarshalJSON unmarshals the GetMessageResponse from JSON.
+func (x *GetMessageResponse) UnmarshalJSON(b []byte) error {
 	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
 }
 
@@ -1913,6 +2113,85 @@ func (m *GetChannelInfoResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error
 	return len(dAtA) - i, nil
 }
 
+func (m *GetMessageRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetMessageRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *GetMessageRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	if len(m.MessageKey) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.MessageKey)
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetMessageResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetMessageResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *GetMessageResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	if m.Message != nil {
+		size, err := m.Message.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *ListMessagesRequest) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -2398,6 +2677,31 @@ func (m *GetChannelInfoResponse) SizeVT() (n int) {
 	return n
 }
 
+func (m *GetMessageRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.MessageKey)
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *GetMessageResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Message != nil {
+		l = m.Message.SizeVT()
+		n += protobuf_go_lite.SizeMessage(1, l)
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *ListMessagesRequest) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -2609,6 +2913,34 @@ func (x *GetChannelInfoResponse) MarshalProtoText() string {
 }
 
 func (x *GetChannelInfoResponse) String() string {
+	return x.MarshalProtoText()
+}
+
+func (x *GetMessageRequest) MarshalProtoText() string {
+	var sb protobuf_go_lite.TextBuilder
+	initialLen := protobuf_go_lite.TextStartMessage(&sb, "GetMessageRequest")
+	if x.MessageKey != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "message_key")
+		protobuf_go_lite.TextWriteString(&sb, x.MessageKey)
+	}
+	return protobuf_go_lite.TextFinishMessage(&sb)
+}
+
+func (x *GetMessageRequest) String() string {
+	return x.MarshalProtoText()
+}
+
+func (x *GetMessageResponse) MarshalProtoText() string {
+	var sb protobuf_go_lite.TextBuilder
+	initialLen := protobuf_go_lite.TextStartMessage(&sb, "GetMessageResponse")
+	if x.Message != nil {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "message")
+		protobuf_go_lite.TextWriteTextMarshaler(&sb, x.Message)
+	}
+	return protobuf_go_lite.TextFinishMessage(&sb)
+}
+
+func (x *GetMessageResponse) String() string {
 	return x.MarshalProtoText()
 }
 
@@ -3053,6 +3385,117 @@ func (m *GetChannelInfoResponse) UnmarshalVT(dAtA []byte) error {
 				m.CreatedAt = &timestamppb.Timestamp{}
 			}
 			if err := m.CreatedAt.UnmarshalVT(dAtA[msgStart:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protobuf_go_lite.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+
+func (m *GetMessageRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	var err error
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		wire, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+		if err != nil {
+			return err
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetMessageRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetMessageRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MessageKey", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.MessageKey = v
+		default:
+			iNdEx = preIndex
+			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protobuf_go_lite.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+
+func (m *GetMessageResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	var err error
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		wire, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+		if err != nil {
+			return err
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetMessageResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetMessageResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Message", wireType)
+			}
+			msgStart, postIndex, err := protobuf_go_lite.DecodeLengthDelimited(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			if m.Message == nil {
+				m.Message = &ChatMessageInfo{}
+			}
+			if err := m.Message.UnmarshalVT(dAtA[msgStart:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/sdk/chat/rpc/rpc.pb.ts
+++ b/sdk/chat/rpc/rpc.pb.ts
@@ -145,6 +145,52 @@ export const GetChannelInfoResponse: MessageType<GetChannelInfoResponse> =
   })
 
 /**
+ * GetMessageRequest identifies one channel message to read.
+ *
+ * @generated from message spacewave.chat.rpc.GetMessageRequest
+ */
+export interface GetMessageRequest {
+  /**
+   * MessageKey is the channel-scoped object key to read.
+   *
+   * @generated from field: string message_key = 1;
+   */
+  messageKey?: string
+}
+
+export const GetMessageRequest: MessageType<GetMessageRequest> =
+  /* @__PURE__ */ createMessageType({
+    typeName: 'spacewave.chat.rpc.GetMessageRequest',
+    fields: [
+      { no: 1, name: 'message_key', kind: 'scalar', T: ScalarType.STRING },
+    ] satisfies readonly PartialFieldInfo[],
+    packedByDefault: true,
+  })
+
+/**
+ * GetMessageResponse contains the selected channel message.
+ *
+ * @generated from message spacewave.chat.rpc.GetMessageResponse
+ */
+export interface GetMessageResponse {
+  /**
+   * Message is the selected message projection.
+   *
+   * @generated from field: spacewave.chat.rpc.ChatMessageInfo message = 1;
+   */
+  message?: ChatMessageInfo
+}
+
+export const GetMessageResponse: MessageType<GetMessageResponse> =
+  /* @__PURE__ */ createMessageType({
+    typeName: 'spacewave.chat.rpc.GetMessageResponse',
+    fields: [
+      { no: 1, name: 'message', kind: 'message', T: () => ChatMessageInfo },
+    ] satisfies readonly PartialFieldInfo[],
+    packedByDefault: true,
+  })
+
+/**
  * ListMessagesRequest is a request for paginated messages.
  *
  * @generated from message spacewave.chat.rpc.ListMessagesRequest

--- a/sdk/chat/rpc/rpc.proto
+++ b/sdk/chat/rpc/rpc.proto
@@ -11,6 +11,8 @@ option go_package = "github.com/s4wave/spacewave/sdk/chat/rpc;spacewave_chat_rpc
 service ChatResourceService {
   // GetChannelInfo returns channel metadata and its retained history extent.
   rpc GetChannelInfo(GetChannelInfoRequest) returns (GetChannelInfoResponse);
+  // GetMessage returns one message from this channel by object key.
+  rpc GetMessage(GetMessageRequest) returns (GetMessageResponse);
   // ListMessages returns a bounded page of channel history.
   rpc ListMessages(ListMessagesRequest) returns (ListMessagesResponse);
   // WatchMessages streams channel messages after each shared-state change.
@@ -57,6 +59,18 @@ message GetChannelInfoResponse {
   uint64 message_count = 3;
   // CreatedAt is the channel creation timestamp.
   .google.protobuf.Timestamp created_at = 4;
+}
+
+// GetMessageRequest identifies one channel message to read.
+message GetMessageRequest {
+  // MessageKey is the channel-scoped object key to read.
+  string message_key = 1;
+}
+
+// GetMessageResponse contains the selected channel message.
+message GetMessageResponse {
+  // Message is the selected message projection.
+  ChatMessageInfo message = 1;
 }
 
 // ListMessagesRequest is a request for paginated messages.

--- a/sdk/chat/rpc/rpc_srpc.pb.go
+++ b/sdk/chat/rpc/rpc_srpc.pb.go
@@ -16,6 +16,8 @@ type SRPCChatResourceServiceClient interface {
 
 	// GetChannelInfo returns channel metadata and its retained history extent.
 	GetChannelInfo(ctx context.Context, in *GetChannelInfoRequest) (*GetChannelInfoResponse, error)
+	// GetMessage returns one message from this channel by object key.
+	GetMessage(ctx context.Context, in *GetMessageRequest) (*GetMessageResponse, error)
 	// ListMessages returns a bounded page of channel history.
 	ListMessages(ctx context.Context, in *ListMessagesRequest) (*ListMessagesResponse, error)
 	// WatchMessages streams channel messages after each shared-state change.
@@ -49,6 +51,15 @@ func (c *srpcChatResourceServiceClient) SRPCClient() srpc.Client { return c.cc }
 func (c *srpcChatResourceServiceClient) GetChannelInfo(ctx context.Context, in *GetChannelInfoRequest) (*GetChannelInfoResponse, error) {
 	out := new(GetChannelInfoResponse)
 	err := c.cc.ExecCall(ctx, c.serviceID, "GetChannelInfo", in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *srpcChatResourceServiceClient) GetMessage(ctx context.Context, in *GetMessageRequest) (*GetMessageResponse, error) {
+	out := new(GetMessageResponse)
+	err := c.cc.ExecCall(ctx, c.serviceID, "GetMessage", in, out)
 	if err != nil {
 		return nil, err
 	}
@@ -128,6 +139,8 @@ func (c *srpcChatResourceServiceClient) UpdateReadPosition(ctx context.Context, 
 type SRPCChatResourceServiceServer interface {
 	// GetChannelInfo returns channel metadata and its retained history extent.
 	GetChannelInfo(context.Context, *GetChannelInfoRequest) (*GetChannelInfoResponse, error)
+	// GetMessage returns one message from this channel by object key.
+	GetMessage(context.Context, *GetMessageRequest) (*GetMessageResponse, error)
 	// ListMessages returns a bounded page of channel history.
 	ListMessages(context.Context, *ListMessagesRequest) (*ListMessagesResponse, error)
 	// WatchMessages streams channel messages after each shared-state change.
@@ -167,6 +180,7 @@ func (d *SRPCChatResourceServiceHandler) GetServiceID() string { return d.servic
 func (SRPCChatResourceServiceHandler) GetMethodIDs() []string {
 	return []string{
 		"GetChannelInfo",
+		"GetMessage",
 		"ListMessages",
 		"WatchMessages",
 		"SendMessage",
@@ -186,6 +200,8 @@ func (d *SRPCChatResourceServiceHandler) InvokeMethod(
 	switch methodID {
 	case "GetChannelInfo":
 		return true, d.InvokeMethod_GetChannelInfo(d.impl, strm)
+	case "GetMessage":
+		return true, d.InvokeMethod_GetMessage(d.impl, strm)
 	case "ListMessages":
 		return true, d.InvokeMethod_ListMessages(d.impl, strm)
 	case "WatchMessages":
@@ -207,6 +223,18 @@ func (SRPCChatResourceServiceHandler) InvokeMethod_GetChannelInfo(impl SRPCChatR
 		return err
 	}
 	out, err := impl.GetChannelInfo(strm.Context(), req)
+	if err != nil {
+		return err
+	}
+	return strm.MsgSend(out)
+}
+
+func (SRPCChatResourceServiceHandler) InvokeMethod_GetMessage(impl SRPCChatResourceServiceServer, strm srpc.Stream) error {
+	req := new(GetMessageRequest)
+	if err := strm.MsgRecv(req); err != nil {
+		return err
+	}
+	out, err := impl.GetMessage(strm.Context(), req)
 	if err != nil {
 		return err
 	}
@@ -275,6 +303,14 @@ type SRPCChatResourceService_GetChannelInfoStream interface {
 }
 
 type srpcChatResourceService_GetChannelInfoStream struct {
+	srpc.Stream
+}
+
+type SRPCChatResourceService_GetMessageStream interface {
+	srpc.Stream
+}
+
+type srpcChatResourceService_GetMessageStream struct {
 	srpc.Stream
 }
 

--- a/sdk/chat/rpc/rpc_srpc.pb.ts
+++ b/sdk/chat/rpc/rpc_srpc.pb.ts
@@ -5,6 +5,8 @@
 import {
   GetChannelInfoRequest,
   GetChannelInfoResponse,
+  GetMessageRequest,
+  GetMessageResponse,
   GetReadPositionsRequest,
   GetReadPositionsResponse,
   ListMessagesRequest,
@@ -41,6 +43,17 @@ export const ChatResourceServiceDefinition = {
       name: 'GetChannelInfo',
       I: GetChannelInfoRequest,
       O: GetChannelInfoResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * GetMessage returns one message from this channel by object key.
+     *
+     * @generated from rpc spacewave.chat.rpc.ChatResourceService.GetMessage
+     */
+    GetMessage: {
+      name: 'GetMessage',
+      I: GetMessageRequest,
+      O: GetMessageResponse,
       kind: MethodKind.Unary,
     },
     /**
@@ -118,6 +131,16 @@ export interface ChatResourceService {
   ): Promise<GetChannelInfoResponse>
 
   /**
+   * GetMessage returns one message from this channel by object key.
+   *
+   * @generated from rpc spacewave.chat.rpc.ChatResourceService.GetMessage
+   */
+  GetMessage(
+    request: GetMessageRequest,
+    abortSignal?: AbortSignal,
+  ): Promise<GetMessageResponse>
+
+  /**
    * ListMessages returns a bounded page of channel history.
    *
    * @generated from rpc spacewave.chat.rpc.ChatResourceService.ListMessages
@@ -186,6 +209,17 @@ export interface ChatResourceServiceHandler {
   ): Promise<GetChannelInfoResponse>
 
   /**
+   * GetMessage returns one message from this channel by object key.
+   *
+   * @generated from rpc spacewave.chat.rpc.ChatResourceService.GetMessage
+   */
+  GetMessage(
+    request: GetMessageRequest,
+    abortSignal: AbortSignal,
+    context: ServerContext,
+  ): Promise<GetMessageResponse>
+
+  /**
    * ListMessages returns a bounded page of channel history.
    *
    * @generated from rpc spacewave.chat.rpc.ChatResourceService.ListMessages
@@ -251,6 +285,7 @@ export class ChatResourceServiceClient implements ChatResourceService {
     this.service = opts?.service || ChatResourceServiceServiceName
     this.rpc = rpc
     this.GetChannelInfo = this.GetChannelInfo.bind(this)
+    this.GetMessage = this.GetMessage.bind(this)
     this.ListMessages = this.ListMessages.bind(this)
     this.WatchMessages = this.WatchMessages.bind(this)
     this.SendMessage = this.SendMessage.bind(this)
@@ -274,6 +309,25 @@ export class ChatResourceServiceClient implements ChatResourceService {
       abortSignal || undefined,
     )
     return GetChannelInfoResponse.fromBinary(result)
+  }
+
+  /**
+   * GetMessage returns one message from this channel by object key.
+   *
+   * @generated from rpc spacewave.chat.rpc.ChatResourceService.GetMessage
+   */
+  async GetMessage(
+    request: GetMessageRequest,
+    abortSignal?: AbortSignal,
+  ): Promise<GetMessageResponse> {
+    const requestMsg = GetMessageRequest.create(request)
+    const result = await this.rpc.request(
+      this.service,
+      ChatResourceServiceDefinition.methods.GetMessage.name,
+      GetMessageRequest.toBinary(requestMsg),
+      abortSignal || undefined,
+    )
+    return GetMessageResponse.fromBinary(result)
   }
 
   /**


### PR DESCRIPTION
Expose a channel-scoped GetMessage operation for resolving a retained message key. Missing keys return the existing object-not-found error, and foreign-channel keys are rejected. Pagination reuses the same lookup.

Validation: focused channel tests, generation, and channel lint passed.
