### PR TITLE
feat(chat): retain channel creator identity

### DIFF
--- a/.protoc-manifest.json
+++ b/.protoc-manifest.json
@@ -3418,7 +3418,7 @@
       ]
     },
     "github.com/s4wave/spacewave/sdk/chat": {
-      "hash": "90fb7c0156607bc842b3677ae6dea26834d418fd4aeffa93f125e25e7eaadb5c",
+      "hash": "c58ce9b5c4f4514b228a45e8f0ef50c49d48156faab2baa4a0c20b259308e5bb",
       "generatedFiles": [
         "sdk/chat/chat.pb.go",
         "sdk/chat/chat.pb.ts"
@@ -3438,7 +3438,7 @@
       ]
     },
     "github.com/s4wave/spacewave/sdk/chat/rpc": {
-      "hash": "35a694f4bd2dc827ca346ce96a7787359f43075da3f7c0b65a775a0eda6a87a0",
+      "hash": "71f9076c05d109d168a82e590bbdd5669d089c87b45bb0e89e9a99ea2e441f3a",
       "generatedFiles": [
         "sdk/chat/rpc/rpc.pb.go",
         "sdk/chat/rpc/rpc.pb.ts",

--- a/sdk/chat/chat-resource.go
+++ b/sdk/chat/chat-resource.go
@@ -103,10 +103,11 @@ func (r *ChatResource) GetChannelInfo(
 
 	// Project the metadata for the client.
 	return &spacewave_chat_rpc.GetChannelInfoResponse{
-		Name:         channel.GetName(),
-		Topic:        channel.GetTopic(),
-		MessageCount: channel.GetMessageCount(),
-		CreatedAt:    channel.GetCreatedAt().CloneVT(),
+		Name:          channel.GetName(),
+		Topic:         channel.GetTopic(),
+		MessageCount:  channel.GetMessageCount(),
+		CreatedAt:     channel.GetCreatedAt().CloneVT(),
+		CreatorPeerId: channel.GetCreatorPeerId(),
 	}, nil
 }
 

--- a/sdk/chat/chat-resource_test.go
+++ b/sdk/chat/chat-resource_test.go
@@ -414,6 +414,39 @@ func TestChatResourceAllowsAnonymousConstructionAndRead(t *testing.T) {
 	}
 }
 
+func TestChatResourceReportsChannelCreator(t *testing.T) {
+	ctx := t.Context()
+	wtb, err := db_world_testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wtb.Release()
+
+	// Initialize a real World so the operation writes through engine-backed state.
+	ws := world.NewEngineWorldState(wtb.Engine, true)
+	sender := wtb.Volume.GetPeerID()
+
+	// Apply channel creation with the testbed peer as the authenticated sender.
+	_, _, err = ws.ApplyWorldOp(ctx, &CreateChatChannelOp{
+		ObjectKey: GeneralChannelKey,
+		Name:      "General",
+		Timestamp: timestamppb.Now(),
+	}, sender)
+	if err != nil {
+		t.Fatalf("ApplyWorldOp: %v", err)
+	}
+
+	// Verify the resource projects the persisted creator identity.
+	resource := NewChatResource(ws, wtb.Engine, GeneralChannelKey, "peer-local")
+	info, err := resource.GetChannelInfo(ctx, &spacewave_chat_rpc.GetChannelInfoRequest{})
+	if err != nil {
+		t.Fatalf("GetChannelInfo: %v", err)
+	}
+	if info.GetCreatorPeerId() != sender.String() {
+		t.Fatalf("channel creator peer ID = %q, want %q", info.GetCreatorPeerId(), sender.String())
+	}
+}
+
 func TestChatResourceRejectsAnonymousSender(t *testing.T) {
 	ctx := t.Context()
 	wtb, err := db_world_testbed.Default(ctx)

--- a/sdk/chat/chat.pb.go
+++ b/sdk/chat/chat.pb.go
@@ -31,6 +31,8 @@ type ChatChannel struct {
 	// ReadPositions maps verified person peer identities to their shared read positions.
 	// Keys are external cryptographic identities, not World object references.
 	ReadPositions map[string]*state.ChatReadPosition `protobuf:"bytes,5,rep,name=read_positions,json=readPositions,proto3" json:"readPositions,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	// CreatorPeerId is the peer identity that created the channel.
+	CreatorPeerId string `protobuf:"bytes,6,opt,name=creator_peer_id,json=creatorPeerId,proto3" json:"creatorPeerId,omitempty"`
 }
 
 func (x *ChatChannel) Reset() {
@@ -72,6 +74,13 @@ func (x *ChatChannel) GetReadPositions() map[string]*state.ChatReadPosition {
 		return x.ReadPositions
 	}
 	return nil
+}
+
+func (x *ChatChannel) GetCreatorPeerId() string {
+	if x != nil {
+		return x.CreatorPeerId
+	}
+	return ""
 }
 
 // ChatMessage is a chat message world object linked to a channel.
@@ -270,6 +279,7 @@ func (m *ChatChannel) CloneVT() *ChatChannel {
 	r.Name = m.Name
 	r.Topic = m.Topic
 	r.MessageCount = m.MessageCount
+	r.CreatorPeerId = m.CreatorPeerId
 	r.CreatedAt = protobuf_go_lite.CloneVTValue(m.CreatedAt)
 	r.ReadPositions = protobuf_go_lite.CloneVTMap(m.ReadPositions)
 	if len(m.unknownFields) > 0 {
@@ -374,6 +384,9 @@ func (this *ChatChannel) EqualVT(that *ChatChannel) bool {
 		return false
 	}
 	if !protobuf_go_lite.EqualVTMapImplicit(this.ReadPositions, that.ReadPositions, func() *state.ChatReadPosition { return &state.ChatReadPosition{} }) {
+		return false
+	}
+	if this.CreatorPeerId != that.CreatorPeerId {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -588,6 +601,11 @@ func (x *ChatChannel) MarshalProtoJSON(s *json.MarshalState) {
 		}
 		s.WriteObjectEnd()
 	}
+	if x.CreatorPeerId != "" || s.HasField("creatorPeerId") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("creatorPeerId")
+		s.WriteString(x.CreatorPeerId)
+	}
 	s.WriteObjectEnd()
 }
 
@@ -633,6 +651,9 @@ func (x *ChatChannel) UnmarshalProtoJSON(s *json.UnmarshalState) {
 				v.UnmarshalProtoJSON(s)
 				x.ReadPositions[key] = &v
 			})
+		case "creator_peer_id", "creatorPeerId":
+			s.AddField("creator_peer_id")
+			x.CreatorPeerId = s.ReadString()
 		}
 	})
 }
@@ -931,6 +952,11 @@ func (m *ChatChannel) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
 	}
+	if len(m.CreatorPeerId) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.CreatorPeerId)
+		i--
+		dAtA[i] = 0x32
+	}
 	if len(m.ReadPositions) > 0 {
 		for k := range m.ReadPositions {
 			v := m.ReadPositions[k]
@@ -1217,6 +1243,7 @@ func (m *ChatChannel) SizeVT() (n int) {
 		mapEntrySize := protobuf_go_lite.SizeStringValue(1, k) + protobuf_go_lite.SizeMessage(1, l)
 		n += protobuf_go_lite.SizeMessage(1, mapEntrySize)
 	}
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.CreatorPeerId)
 	n += len(m.unknownFields)
 	return n
 }
@@ -1337,6 +1364,10 @@ func (x *ChatChannel) MarshalProtoText() string {
 			}
 		}
 		protobuf_go_lite.TextWriteMapEnd(&sb)
+	}
+	if x.CreatorPeerId != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "creator_peer_id")
+		protobuf_go_lite.TextWriteString(&sb, x.CreatorPeerId)
 	}
 	return protobuf_go_lite.TextFinishMessage(&sb)
 }
@@ -1552,6 +1583,16 @@ func (m *ChatChannel) UnmarshalVT(dAtA []byte) error {
 			}
 			m.ReadPositions[mapkey] = mapvalue
 			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CreatorPeerId", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.CreatorPeerId = v
 		default:
 			iNdEx = preIndex
 			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])

--- a/sdk/chat/chat.pb.ts
+++ b/sdk/chat/chat.pb.ts
@@ -50,6 +50,12 @@ export interface ChatChannel {
    * @generated from field: map<string, spacewave.chat.ChatReadPosition> read_positions = 5;
    */
   readPositions?: { [key: string]: ChatReadPosition }
+  /**
+   * CreatorPeerId is the peer identity that created the channel.
+   *
+   * @generated from field: string creator_peer_id = 6;
+   */
+  creatorPeerId?: string
 }
 
 export const ChatChannel: MessageType<ChatChannel> =
@@ -67,6 +73,7 @@ export const ChatChannel: MessageType<ChatChannel> =
         K: ScalarType.STRING,
         V: { kind: 'message', T: () => ChatReadPosition },
       },
+      { no: 6, name: 'creator_peer_id', kind: 'scalar', T: ScalarType.STRING },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,
   })

--- a/sdk/chat/chat.proto
+++ b/sdk/chat/chat.proto
@@ -21,6 +21,8 @@ message ChatChannel {
   // ReadPositions maps verified person peer identities to their shared read positions.
   // Keys are external cryptographic identities, not World object references.
   map<string, ChatReadPosition> read_positions = 5;
+  // CreatorPeerId is the peer identity that created the channel.
+  string creator_peer_id = 6;
 }
 
 // ChatMessage is a chat message world object linked to a channel.

--- a/sdk/chat/create-channel.go
+++ b/sdk/chat/create-channel.go
@@ -57,9 +57,10 @@ func (o *CreateChatChannelOp) ApplyWorldOp(
 
 	objKey := o.GetObjectKey()
 	channel := &ChatChannel{
-		Name:      o.GetName(),
-		Topic:     o.GetTopic(),
-		CreatedAt: o.GetTimestamp(),
+		Name:          o.GetName(),
+		Topic:         o.GetTopic(),
+		CreatedAt:     o.GetTimestamp(),
+		CreatorPeerId: sender.String(),
 	}
 
 	if _, _, err := world.CreateWorldObject(ctx, ws, objKey, func(bcs *block.Cursor) error {

--- a/sdk/chat/rpc/rpc.pb.go
+++ b/sdk/chat/rpc/rpc.pb.go
@@ -121,6 +121,8 @@ type GetChannelInfoResponse struct {
 	MessageCount uint64 `protobuf:"varint,3,opt,name=message_count,json=messageCount,proto3" json:"messageCount,omitempty"`
 	// CreatedAt is the channel creation timestamp.
 	CreatedAt *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=created_at,json=createdAt,proto3" json:"createdAt,omitempty"`
+	// CreatorPeerId is the peer identity that created the channel.
+	CreatorPeerId string `protobuf:"bytes,5,opt,name=creator_peer_id,json=creatorPeerId,proto3" json:"creatorPeerId,omitempty"`
 }
 
 func (x *GetChannelInfoResponse) Reset() {
@@ -155,6 +157,13 @@ func (x *GetChannelInfoResponse) GetCreatedAt() *timestamppb.Timestamp {
 		return x.CreatedAt
 	}
 	return nil
+}
+
+func (x *GetChannelInfoResponse) GetCreatorPeerId() string {
+	if x != nil {
+		return x.CreatorPeerId
+	}
+	return ""
 }
 
 // GetMessageRequest identifies one channel message to read.
@@ -516,6 +525,7 @@ func (m *GetChannelInfoResponse) CloneVT() *GetChannelInfoResponse {
 	r.Name = m.Name
 	r.Topic = m.Topic
 	r.MessageCount = m.MessageCount
+	r.CreatorPeerId = m.CreatorPeerId
 	r.CreatedAt = protobuf_go_lite.CloneVTValue(m.CreatedAt)
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = slices.Clone(m.unknownFields)
@@ -798,6 +808,9 @@ func (this *GetChannelInfoResponse) EqualVT(that *GetChannelInfoResponse) bool {
 		return false
 	}
 	if !protobuf_go_lite.IsEqualVT(this.CreatedAt, that.CreatedAt) {
+		return false
+	}
+	if this.CreatorPeerId != that.CreatorPeerId {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -1230,6 +1243,11 @@ func (x *GetChannelInfoResponse) MarshalProtoJSON(s *json.MarshalState) {
 		s.WriteObjectField("createdAt")
 		x.CreatedAt.MarshalProtoJSON(s.WithField("createdAt"))
 	}
+	if x.CreatorPeerId != "" || s.HasField("creatorPeerId") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("creatorPeerId")
+		s.WriteString(x.CreatorPeerId)
+	}
 	s.WriteObjectEnd()
 }
 
@@ -1263,6 +1281,9 @@ func (x *GetChannelInfoResponse) UnmarshalProtoJSON(s *json.UnmarshalState) {
 			}
 			x.CreatedAt = &timestamppb.Timestamp{}
 			x.CreatedAt.UnmarshalProtoJSON(s.WithField("created_at", true))
+		case "creator_peer_id", "creatorPeerId":
+			s.AddField("creator_peer_id")
+			x.CreatorPeerId = s.ReadString()
 		}
 	})
 }
@@ -2085,6 +2106,11 @@ func (m *GetChannelInfoResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error
 	if m.unknownFields != nil {
 		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
 	}
+	if len(m.CreatorPeerId) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.CreatorPeerId)
+		i--
+		dAtA[i] = 0x2a
+	}
 	if m.CreatedAt != nil {
 		size, err := m.CreatedAt.MarshalToSizedBufferVT(dAtA[:i])
 		if err != nil {
@@ -2673,6 +2699,7 @@ func (m *GetChannelInfoResponse) SizeVT() (n int) {
 		l = m.CreatedAt.SizeVT()
 		n += protobuf_go_lite.SizeMessage(1, l)
 	}
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.CreatorPeerId)
 	n += len(m.unknownFields)
 	return n
 }
@@ -2908,6 +2935,10 @@ func (x *GetChannelInfoResponse) MarshalProtoText() string {
 	if x.CreatedAt != nil {
 		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "created_at")
 		protobuf_go_lite.TextWriteTextMarshaler(&sb, x.CreatedAt)
+	}
+	if x.CreatorPeerId != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "creator_peer_id")
+		protobuf_go_lite.TextWriteString(&sb, x.CreatorPeerId)
 	}
 	return protobuf_go_lite.TextFinishMessage(&sb)
 }
@@ -3388,6 +3419,16 @@ func (m *GetChannelInfoResponse) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CreatorPeerId", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.CreatorPeerId = v
 		default:
 			iNdEx = preIndex
 			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])

--- a/sdk/chat/rpc/rpc.pb.ts
+++ b/sdk/chat/rpc/rpc.pb.ts
@@ -130,6 +130,12 @@ export interface GetChannelInfoResponse {
    * @generated from field: google.protobuf.Timestamp created_at = 4;
    */
   createdAt?: Date
+  /**
+   * CreatorPeerId is the peer identity that created the channel.
+   *
+   * @generated from field: string creator_peer_id = 5;
+   */
+  creatorPeerId?: string
 }
 
 export const GetChannelInfoResponse: MessageType<GetChannelInfoResponse> =
@@ -140,6 +146,7 @@ export const GetChannelInfoResponse: MessageType<GetChannelInfoResponse> =
       { no: 2, name: 'topic', kind: 'scalar', T: ScalarType.STRING },
       { no: 3, name: 'message_count', kind: 'scalar', T: ScalarType.UINT64 },
       { no: 4, name: 'created_at', kind: 'message', T: () => Timestamp },
+      { no: 5, name: 'creator_peer_id', kind: 'scalar', T: ScalarType.STRING },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,
   })

--- a/sdk/chat/rpc/rpc.proto
+++ b/sdk/chat/rpc/rpc.proto
@@ -59,6 +59,8 @@ message GetChannelInfoResponse {
   uint64 message_count = 3;
   // CreatedAt is the channel creation timestamp.
   .google.protobuf.Timestamp created_at = 4;
+  // CreatorPeerId is the peer identity that created the channel.
+  string creator_peer_id = 5;
 }
 
 // GetMessageRequest identifies one channel message to read.


### PR DESCRIPTION
Record the authenticated operation sender when a channel is created and expose that identity through GetChannelInfo. Existing channels retain an empty creator value.

Validated with channel package tests, protobuf generation, and focused lint.