### PR TITLE
feat(chat): enforce channel encryption policy

### DIFF
--- a/.protoc-manifest.json
+++ b/.protoc-manifest.json
@@ -3418,7 +3418,7 @@
       ]
     },
     "github.com/s4wave/spacewave/sdk/chat": {
-      "hash": "c58ce9b5c4f4514b228a45e8f0ef50c49d48156faab2baa4a0c20b259308e5bb",
+      "hash": "1be06a7edb9e6e3cd156517a8ec95a642cfd5d7db8cd9c24b51e9a2ba2a73c81",
       "generatedFiles": [
         "sdk/chat/chat.pb.go",
         "sdk/chat/chat.pb.ts"
@@ -3438,7 +3438,7 @@
       ]
     },
     "github.com/s4wave/spacewave/sdk/chat/rpc": {
-      "hash": "71f9076c05d109d168a82e590bbdd5669d089c87b45bb0e89e9a99ea2e441f3a",
+      "hash": "67cd15d9b0f479d313fa43806c18f0f0e36332a303024548386b84128b39a473",
       "generatedFiles": [
         "sdk/chat/rpc/rpc.pb.go",
         "sdk/chat/rpc/rpc.pb.ts",

--- a/sdk/chat/chat-resource.go
+++ b/sdk/chat/chat-resource.go
@@ -103,11 +103,12 @@ func (r *ChatResource) GetChannelInfo(
 
 	// Project the metadata for the client.
 	return &spacewave_chat_rpc.GetChannelInfoResponse{
-		Name:          channel.GetName(),
-		Topic:         channel.GetTopic(),
-		MessageCount:  channel.GetMessageCount(),
-		CreatedAt:     channel.GetCreatedAt().CloneVT(),
-		CreatorPeerId: channel.GetCreatorPeerId(),
+		Name:                channel.GetName(),
+		Topic:               channel.GetTopic(),
+		MessageCount:        channel.GetMessageCount(),
+		CreatedAt:           channel.GetCreatedAt().CloneVT(),
+		CreatorPeerId:       channel.GetCreatorPeerId(),
+		EncryptionAlgorithm: channel.GetEncryptionAlgorithm(),
 	}, nil
 }
 
@@ -304,7 +305,8 @@ func (r *ChatResource) commitMessage(ctx context.Context, req *spacewave_chat_rp
 		return nil, err
 	}
 	defer wtx.Discard()
-	if _, err := world.LookupObjectBody[*ChatChannel](ctx, wtx, r.objectKey, NewChatChannelBlock); err != nil {
+	channel, err := world.LookupObjectBody[*ChatChannel](ctx, wtx, r.objectKey, NewChatChannelBlock)
+	if err != nil {
 		return nil, err
 	}
 
@@ -312,6 +314,11 @@ func (r *ChatResource) commitMessage(ctx context.Context, req *spacewave_chat_rp
 	content, err := normalizeSendMessageContent(req)
 	if err != nil {
 		return nil, err
+	}
+
+	// Enforce the channel's immutable creation-time encryption policy.
+	if algorithm := channel.GetEncryptionAlgorithm(); algorithm != "" && content.GetCiphertext().GetAlgorithm() != algorithm {
+		return nil, errors.New("chat message ciphertext algorithm does not match channel")
 	}
 
 	// Resolve the sender-scoped retry before reserving a history position.

--- a/sdk/chat/chat.pb.go
+++ b/sdk/chat/chat.pb.go
@@ -33,6 +33,9 @@ type ChatChannel struct {
 	ReadPositions map[string]*state.ChatReadPosition `protobuf:"bytes,5,rep,name=read_positions,json=readPositions,proto3" json:"readPositions,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// CreatorPeerId is the peer identity that created the channel.
 	CreatorPeerId string `protobuf:"bytes,6,opt,name=creator_peer_id,json=creatorPeerId,proto3" json:"creatorPeerId,omitempty"`
+	// EncryptionAlgorithm is the immutable creation-time policy. Empty allows plaintext;
+	// otherwise sends require ciphertext using this algorithm.
+	EncryptionAlgorithm string `protobuf:"bytes,7,opt,name=encryption_algorithm,json=encryptionAlgorithm,proto3" json:"encryptionAlgorithm,omitempty"`
 }
 
 func (x *ChatChannel) Reset() {
@@ -79,6 +82,13 @@ func (x *ChatChannel) GetReadPositions() map[string]*state.ChatReadPosition {
 func (x *ChatChannel) GetCreatorPeerId() string {
 	if x != nil {
 		return x.CreatorPeerId
+	}
+	return ""
+}
+
+func (x *ChatChannel) GetEncryptionAlgorithm() string {
+	if x != nil {
+		return x.EncryptionAlgorithm
 	}
 	return ""
 }
@@ -209,6 +219,9 @@ type CreateChatChannelOp struct {
 	Topic string `protobuf:"bytes,3,opt,name=topic,proto3" json:"topic,omitempty"`
 	// Timestamp is the creation timestamp.
 	Timestamp *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	// EncryptionAlgorithm is the immutable creation-time policy. Empty allows plaintext;
+	// otherwise sends require ciphertext using this algorithm.
+	EncryptionAlgorithm string `protobuf:"bytes,5,opt,name=encryption_algorithm,json=encryptionAlgorithm,proto3" json:"encryptionAlgorithm,omitempty"`
 }
 
 func (x *CreateChatChannelOp) Reset() {
@@ -243,6 +256,13 @@ func (x *CreateChatChannelOp) GetTimestamp() *timestamppb.Timestamp {
 		return x.Timestamp
 	}
 	return nil
+}
+
+func (x *CreateChatChannelOp) GetEncryptionAlgorithm() string {
+	if x != nil {
+		return x.EncryptionAlgorithm
+	}
+	return ""
 }
 
 type ChatChannel_ReadPositionsEntry struct {
@@ -280,6 +300,7 @@ func (m *ChatChannel) CloneVT() *ChatChannel {
 	r.Topic = m.Topic
 	r.MessageCount = m.MessageCount
 	r.CreatorPeerId = m.CreatorPeerId
+	r.EncryptionAlgorithm = m.EncryptionAlgorithm
 	r.CreatedAt = protobuf_go_lite.CloneVTValue(m.CreatedAt)
 	r.ReadPositions = protobuf_go_lite.CloneVTMap(m.ReadPositions)
 	if len(m.unknownFields) > 0 {
@@ -354,6 +375,7 @@ func (m *CreateChatChannelOp) CloneVT() *CreateChatChannelOp {
 	r.ObjectKey = m.ObjectKey
 	r.Name = m.Name
 	r.Topic = m.Topic
+	r.EncryptionAlgorithm = m.EncryptionAlgorithm
 	r.Timestamp = protobuf_go_lite.CloneVTValue(m.Timestamp)
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = slices.Clone(m.unknownFields)
@@ -387,6 +409,9 @@ func (this *ChatChannel) EqualVT(that *ChatChannel) bool {
 		return false
 	}
 	if this.CreatorPeerId != that.CreatorPeerId {
+		return false
+	}
+	if this.EncryptionAlgorithm != that.EncryptionAlgorithm {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -494,6 +519,9 @@ func (this *CreateChatChannelOp) EqualVT(that *CreateChatChannelOp) bool {
 		return false
 	}
 	if !protobuf_go_lite.IsEqualVT(this.Timestamp, that.Timestamp) {
+		return false
+	}
+	if this.EncryptionAlgorithm != that.EncryptionAlgorithm {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -606,6 +634,11 @@ func (x *ChatChannel) MarshalProtoJSON(s *json.MarshalState) {
 		s.WriteObjectField("creatorPeerId")
 		s.WriteString(x.CreatorPeerId)
 	}
+	if x.EncryptionAlgorithm != "" || s.HasField("encryptionAlgorithm") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("encryptionAlgorithm")
+		s.WriteString(x.EncryptionAlgorithm)
+	}
 	s.WriteObjectEnd()
 }
 
@@ -654,6 +687,9 @@ func (x *ChatChannel) UnmarshalProtoJSON(s *json.UnmarshalState) {
 		case "creator_peer_id", "creatorPeerId":
 			s.AddField("creator_peer_id")
 			x.CreatorPeerId = s.ReadString()
+		case "encryption_algorithm", "encryptionAlgorithm":
+			s.AddField("encryption_algorithm")
+			x.EncryptionAlgorithm = s.ReadString()
 		}
 	})
 }
@@ -881,6 +917,11 @@ func (x *CreateChatChannelOp) MarshalProtoJSON(s *json.MarshalState) {
 		s.WriteObjectField("timestamp")
 		x.Timestamp.MarshalProtoJSON(s.WithField("timestamp"))
 	}
+	if x.EncryptionAlgorithm != "" || s.HasField("encryptionAlgorithm") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("encryptionAlgorithm")
+		s.WriteString(x.EncryptionAlgorithm)
+	}
 	s.WriteObjectEnd()
 }
 
@@ -914,6 +955,9 @@ func (x *CreateChatChannelOp) UnmarshalProtoJSON(s *json.UnmarshalState) {
 			}
 			x.Timestamp = &timestamppb.Timestamp{}
 			x.Timestamp.UnmarshalProtoJSON(s.WithField("timestamp", true))
+		case "encryption_algorithm", "encryptionAlgorithm":
+			s.AddField("encryption_algorithm")
+			x.EncryptionAlgorithm = s.ReadString()
 		}
 	})
 }
@@ -951,6 +995,11 @@ func (m *ChatChannel) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	_ = l
 	if m.unknownFields != nil {
 		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	if len(m.EncryptionAlgorithm) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.EncryptionAlgorithm)
+		i--
+		dAtA[i] = 0x3a
 	}
 	if len(m.CreatorPeerId) > 0 {
 		i = protobuf_go_lite.EncodeString(dAtA, i, m.CreatorPeerId)
@@ -1192,6 +1241,11 @@ func (m *CreateChatChannelOp) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
 	}
+	if len(m.EncryptionAlgorithm) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.EncryptionAlgorithm)
+		i--
+		dAtA[i] = 0x2a
+	}
 	if m.Timestamp != nil {
 		size, err := m.Timestamp.MarshalToSizedBufferVT(dAtA[:i])
 		if err != nil {
@@ -1244,6 +1298,7 @@ func (m *ChatChannel) SizeVT() (n int) {
 		n += protobuf_go_lite.SizeMessage(1, mapEntrySize)
 	}
 	n += protobuf_go_lite.SizeStringNonEmpty(1, m.CreatorPeerId)
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.EncryptionAlgorithm)
 	n += len(m.unknownFields)
 	return n
 }
@@ -1309,6 +1364,7 @@ func (m *CreateChatChannelOp) SizeVT() (n int) {
 		l = m.Timestamp.SizeVT()
 		n += protobuf_go_lite.SizeMessage(1, l)
 	}
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.EncryptionAlgorithm)
 	n += len(m.unknownFields)
 	return n
 }
@@ -1368,6 +1424,10 @@ func (x *ChatChannel) MarshalProtoText() string {
 	if x.CreatorPeerId != "" {
 		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "creator_peer_id")
 		protobuf_go_lite.TextWriteString(&sb, x.CreatorPeerId)
+	}
+	if x.EncryptionAlgorithm != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "encryption_algorithm")
+		protobuf_go_lite.TextWriteString(&sb, x.EncryptionAlgorithm)
 	}
 	return protobuf_go_lite.TextFinishMessage(&sb)
 }
@@ -1464,6 +1524,10 @@ func (x *CreateChatChannelOp) MarshalProtoText() string {
 	if x.Timestamp != nil {
 		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "timestamp")
 		protobuf_go_lite.TextWriteTextMarshaler(&sb, x.Timestamp)
+	}
+	if x.EncryptionAlgorithm != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "encryption_algorithm")
+		protobuf_go_lite.TextWriteString(&sb, x.EncryptionAlgorithm)
 	}
 	return protobuf_go_lite.TextFinishMessage(&sb)
 }
@@ -1593,6 +1657,16 @@ func (m *ChatChannel) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			m.CreatorPeerId = v
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EncryptionAlgorithm", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.EncryptionAlgorithm = v
 		default:
 			iNdEx = preIndex
 			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
@@ -1914,6 +1988,16 @@ func (m *CreateChatChannelOp) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EncryptionAlgorithm", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.EncryptionAlgorithm = v
 		default:
 			iNdEx = preIndex
 			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])

--- a/sdk/chat/chat.pb.ts
+++ b/sdk/chat/chat.pb.ts
@@ -56,6 +56,13 @@ export interface ChatChannel {
    * @generated from field: string creator_peer_id = 6;
    */
   creatorPeerId?: string
+  /**
+   * EncryptionAlgorithm is the immutable creation-time policy. Empty allows plaintext;
+   * otherwise sends require ciphertext using this algorithm.
+   *
+   * @generated from field: string encryption_algorithm = 7;
+   */
+  encryptionAlgorithm?: string
 }
 
 export const ChatChannel: MessageType<ChatChannel> =
@@ -74,6 +81,12 @@ export const ChatChannel: MessageType<ChatChannel> =
         V: { kind: 'message', T: () => ChatReadPosition },
       },
       { no: 6, name: 'creator_peer_id', kind: 'scalar', T: ScalarType.STRING },
+      {
+        no: 7,
+        name: 'encryption_algorithm',
+        kind: 'scalar',
+        T: ScalarType.STRING,
+      },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,
   })
@@ -231,6 +244,13 @@ export interface CreateChatChannelOp {
    * @generated from field: google.protobuf.Timestamp timestamp = 4;
    */
   timestamp?: Date
+  /**
+   * EncryptionAlgorithm is the immutable creation-time policy. Empty allows plaintext;
+   * otherwise sends require ciphertext using this algorithm.
+   *
+   * @generated from field: string encryption_algorithm = 5;
+   */
+  encryptionAlgorithm?: string
 }
 
 export const CreateChatChannelOp: MessageType<CreateChatChannelOp> =
@@ -241,6 +261,12 @@ export const CreateChatChannelOp: MessageType<CreateChatChannelOp> =
       { no: 2, name: 'name', kind: 'scalar', T: ScalarType.STRING },
       { no: 3, name: 'topic', kind: 'scalar', T: ScalarType.STRING },
       { no: 4, name: 'timestamp', kind: 'message', T: () => Timestamp },
+      {
+        no: 5,
+        name: 'encryption_algorithm',
+        kind: 'scalar',
+        T: ScalarType.STRING,
+      },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,
   })

--- a/sdk/chat/chat.proto
+++ b/sdk/chat/chat.proto
@@ -23,6 +23,9 @@ message ChatChannel {
   map<string, ChatReadPosition> read_positions = 5;
   // CreatorPeerId is the peer identity that created the channel.
   string creator_peer_id = 6;
+  // EncryptionAlgorithm is the immutable creation-time policy. Empty allows plaintext;
+  // otherwise sends require ciphertext using this algorithm.
+  string encryption_algorithm = 7;
 }
 
 // ChatMessage is a chat message world object linked to a channel.
@@ -66,4 +69,7 @@ message CreateChatChannelOp {
   string topic = 3;
   // Timestamp is the creation timestamp.
   .google.protobuf.Timestamp timestamp = 4;
+  // EncryptionAlgorithm is the immutable creation-time policy. Empty allows plaintext;
+  // otherwise sends require ciphertext using this algorithm.
+  string encryption_algorithm = 5;
 }

--- a/sdk/chat/create-channel.go
+++ b/sdk/chat/create-channel.go
@@ -57,10 +57,11 @@ func (o *CreateChatChannelOp) ApplyWorldOp(
 
 	objKey := o.GetObjectKey()
 	channel := &ChatChannel{
-		Name:          o.GetName(),
-		Topic:         o.GetTopic(),
-		CreatedAt:     o.GetTimestamp(),
-		CreatorPeerId: sender.String(),
+		Name:                o.GetName(),
+		Topic:               o.GetTopic(),
+		CreatedAt:           o.GetTimestamp(),
+		CreatorPeerId:       sender.String(),
+		EncryptionAlgorithm: o.GetEncryptionAlgorithm(),
 	}
 
 	if _, _, err := world.CreateWorldObject(ctx, ws, objKey, func(bcs *block.Cursor) error {

--- a/sdk/chat/encrypted-content_test.go
+++ b/sdk/chat/encrypted-content_test.go
@@ -4,10 +4,90 @@ import (
 	"context"
 	"testing"
 
+	"github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
 	"github.com/s4wave/spacewave/db/world"
 	db_world_testbed "github.com/s4wave/spacewave/db/world/testbed"
 	spacewave_chat_rpc "github.com/s4wave/spacewave/sdk/chat/rpc"
 )
+
+func TestEncryptedChannelRequiresConfiguredAlgorithm(t *testing.T) {
+	// Set up a real World and encrypted channel for policy checks.
+	ctx := t.Context()
+	tb, err := db_world_testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(tb.Release)
+	ws := world.NewEngineWorldState(tb.Engine, true)
+	const (
+		channelKey = "chat/channel/encrypted"
+		algorithm  = "m.megolm.v1.aes-sha2"
+	)
+
+	// Create the channel through its world operation with an immutable algorithm policy.
+	_, _, err = ws.ApplyWorldOp(ctx, &CreateChatChannelOp{
+		ObjectKey:           channelKey,
+		Name:                "Encrypted",
+		Timestamp:           timestamppb.Now(),
+		EncryptionAlgorithm: algorithm,
+	}, tb.Volume.GetPeerID())
+	if err != nil {
+		t.Fatalf("ApplyWorldOp: %v", err)
+	}
+	resource := NewChatResource(ws, tb.Engine, channelKey, "alice")
+	info, err := resource.GetChannelInfo(ctx, &spacewave_chat_rpc.GetChannelInfoRequest{})
+	if err != nil {
+		t.Fatalf("GetChannelInfo: %v", err)
+	}
+	if info.GetEncryptionAlgorithm() != algorithm {
+		t.Fatalf("channel encryption algorithm = %q, want %q", info.GetEncryptionAlgorithm(), algorithm)
+	}
+
+	// Reject plaintext and ciphertext using a different algorithm before creating history.
+	if _, err := resource.SendMessage(ctx, &spacewave_chat_rpc.SendMessageRequest{
+		TransactionId: "plaintext",
+		Text:          "must be encrypted",
+	}); err == nil {
+		t.Fatal("accepted plaintext on encrypted channel")
+	}
+	mismatched := &spacewave_chat_rpc.SendMessageRequest{
+		TransactionId: "mismatched",
+		Content: &ChatMessageContent{Content: &ChatMessageContent_Ciphertext{Ciphertext: &ChatCiphertext{
+			Algorithm: "other.algorithm", Ciphertext: "opaque", SenderKey: "sender", SessionId: "session",
+		}}},
+	}
+	if _, err := resource.SendMessage(ctx, mismatched); err == nil {
+		t.Fatal("accepted ciphertext with mismatched algorithm")
+	}
+
+	// Accept matching ciphertext and resolve an identical retry to the same event.
+	request := &spacewave_chat_rpc.SendMessageRequest{
+		TransactionId: "encrypted",
+		Content: &ChatMessageContent{Content: &ChatMessageContent_Ciphertext{Ciphertext: &ChatCiphertext{
+			Algorithm: algorithm, Ciphertext: "opaque", SenderKey: "sender", SessionId: "session",
+		}}},
+	}
+	accepted, err := resource.SendMessage(ctx, request)
+	if err != nil {
+		t.Fatalf("SendMessage encrypted: %v", err)
+	}
+	retry, err := resource.SendMessage(ctx, request)
+	if err != nil {
+		t.Fatalf("SendMessage retry: %v", err)
+	}
+	if retry.GetMessageKey() != accepted.GetMessageKey() {
+		t.Fatalf("encrypted retry key = %q, want %q", retry.GetMessageKey(), accepted.GetMessageKey())
+	}
+
+	// Confirm rejected attempts and the retry left one retained history entry.
+	info, err = resource.GetChannelInfo(ctx, &spacewave_chat_rpc.GetChannelInfoRequest{})
+	if err != nil {
+		t.Fatalf("GetChannelInfo after retry: %v", err)
+	}
+	if info.GetMessageCount() != 1 {
+		t.Fatalf("channel message count = %d, want 1", info.GetMessageCount())
+	}
+}
 
 // TestEncryptedContentRoundTrip preserves the exact envelope across retry, history, and watch.
 func TestEncryptedContentRoundTrip(t *testing.T) {

--- a/sdk/chat/rpc/rpc.pb.go
+++ b/sdk/chat/rpc/rpc.pb.go
@@ -123,6 +123,9 @@ type GetChannelInfoResponse struct {
 	CreatedAt *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=created_at,json=createdAt,proto3" json:"createdAt,omitempty"`
 	// CreatorPeerId is the peer identity that created the channel.
 	CreatorPeerId string `protobuf:"bytes,5,opt,name=creator_peer_id,json=creatorPeerId,proto3" json:"creatorPeerId,omitempty"`
+	// EncryptionAlgorithm reports the immutable creation-time policy. Empty allows plaintext;
+	// otherwise sends require ciphertext using this algorithm.
+	EncryptionAlgorithm string `protobuf:"bytes,6,opt,name=encryption_algorithm,json=encryptionAlgorithm,proto3" json:"encryptionAlgorithm,omitempty"`
 }
 
 func (x *GetChannelInfoResponse) Reset() {
@@ -162,6 +165,13 @@ func (x *GetChannelInfoResponse) GetCreatedAt() *timestamppb.Timestamp {
 func (x *GetChannelInfoResponse) GetCreatorPeerId() string {
 	if x != nil {
 		return x.CreatorPeerId
+	}
+	return ""
+}
+
+func (x *GetChannelInfoResponse) GetEncryptionAlgorithm() string {
+	if x != nil {
+		return x.EncryptionAlgorithm
 	}
 	return ""
 }
@@ -526,6 +536,7 @@ func (m *GetChannelInfoResponse) CloneVT() *GetChannelInfoResponse {
 	r.Topic = m.Topic
 	r.MessageCount = m.MessageCount
 	r.CreatorPeerId = m.CreatorPeerId
+	r.EncryptionAlgorithm = m.EncryptionAlgorithm
 	r.CreatedAt = protobuf_go_lite.CloneVTValue(m.CreatedAt)
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = slices.Clone(m.unknownFields)
@@ -811,6 +822,9 @@ func (this *GetChannelInfoResponse) EqualVT(that *GetChannelInfoResponse) bool {
 		return false
 	}
 	if this.CreatorPeerId != that.CreatorPeerId {
+		return false
+	}
+	if this.EncryptionAlgorithm != that.EncryptionAlgorithm {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -1248,6 +1262,11 @@ func (x *GetChannelInfoResponse) MarshalProtoJSON(s *json.MarshalState) {
 		s.WriteObjectField("creatorPeerId")
 		s.WriteString(x.CreatorPeerId)
 	}
+	if x.EncryptionAlgorithm != "" || s.HasField("encryptionAlgorithm") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("encryptionAlgorithm")
+		s.WriteString(x.EncryptionAlgorithm)
+	}
 	s.WriteObjectEnd()
 }
 
@@ -1284,6 +1303,9 @@ func (x *GetChannelInfoResponse) UnmarshalProtoJSON(s *json.UnmarshalState) {
 		case "creator_peer_id", "creatorPeerId":
 			s.AddField("creator_peer_id")
 			x.CreatorPeerId = s.ReadString()
+		case "encryption_algorithm", "encryptionAlgorithm":
+			s.AddField("encryption_algorithm")
+			x.EncryptionAlgorithm = s.ReadString()
 		}
 	})
 }
@@ -2106,6 +2128,11 @@ func (m *GetChannelInfoResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error
 	if m.unknownFields != nil {
 		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
 	}
+	if len(m.EncryptionAlgorithm) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.EncryptionAlgorithm)
+		i--
+		dAtA[i] = 0x32
+	}
 	if len(m.CreatorPeerId) > 0 {
 		i = protobuf_go_lite.EncodeString(dAtA, i, m.CreatorPeerId)
 		i--
@@ -2700,6 +2727,7 @@ func (m *GetChannelInfoResponse) SizeVT() (n int) {
 		n += protobuf_go_lite.SizeMessage(1, l)
 	}
 	n += protobuf_go_lite.SizeStringNonEmpty(1, m.CreatorPeerId)
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.EncryptionAlgorithm)
 	n += len(m.unknownFields)
 	return n
 }
@@ -2939,6 +2967,10 @@ func (x *GetChannelInfoResponse) MarshalProtoText() string {
 	if x.CreatorPeerId != "" {
 		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "creator_peer_id")
 		protobuf_go_lite.TextWriteString(&sb, x.CreatorPeerId)
+	}
+	if x.EncryptionAlgorithm != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "encryption_algorithm")
+		protobuf_go_lite.TextWriteString(&sb, x.EncryptionAlgorithm)
 	}
 	return protobuf_go_lite.TextFinishMessage(&sb)
 }
@@ -3429,6 +3461,16 @@ func (m *GetChannelInfoResponse) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			m.CreatorPeerId = v
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EncryptionAlgorithm", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.EncryptionAlgorithm = v
 		default:
 			iNdEx = preIndex
 			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])

--- a/sdk/chat/rpc/rpc.pb.ts
+++ b/sdk/chat/rpc/rpc.pb.ts
@@ -136,6 +136,13 @@ export interface GetChannelInfoResponse {
    * @generated from field: string creator_peer_id = 5;
    */
   creatorPeerId?: string
+  /**
+   * EncryptionAlgorithm reports the immutable creation-time policy. Empty allows plaintext;
+   * otherwise sends require ciphertext using this algorithm.
+   *
+   * @generated from field: string encryption_algorithm = 6;
+   */
+  encryptionAlgorithm?: string
 }
 
 export const GetChannelInfoResponse: MessageType<GetChannelInfoResponse> =
@@ -147,6 +154,12 @@ export const GetChannelInfoResponse: MessageType<GetChannelInfoResponse> =
       { no: 3, name: 'message_count', kind: 'scalar', T: ScalarType.UINT64 },
       { no: 4, name: 'created_at', kind: 'message', T: () => Timestamp },
       { no: 5, name: 'creator_peer_id', kind: 'scalar', T: ScalarType.STRING },
+      {
+        no: 6,
+        name: 'encryption_algorithm',
+        kind: 'scalar',
+        T: ScalarType.STRING,
+      },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,
   })

--- a/sdk/chat/rpc/rpc.proto
+++ b/sdk/chat/rpc/rpc.proto
@@ -61,6 +61,9 @@ message GetChannelInfoResponse {
   .google.protobuf.Timestamp created_at = 4;
   // CreatorPeerId is the peer identity that created the channel.
   string creator_peer_id = 5;
+  // EncryptionAlgorithm reports the immutable creation-time policy. Empty allows plaintext;
+  // otherwise sends require ciphertext using this algorithm.
+  string encryption_algorithm = 6;
 }
 
 // GetMessageRequest identifies one channel message to read.


### PR DESCRIPTION
Retain an optional creation-time encryption algorithm on each channel and expose it through channel metadata. The shared send operation rejects plaintext or ciphertext using another algorithm when a channel requires encryption; existing channels retain their text-capable behavior.

Validated with real World channel tests covering rejected sends, matching ciphertext, retry identity, and one retained history entry, plus generation and focused lint.