### PR TITLE
perf(bldr): omit application operations from the browser host

### DIFF
--- a/bldr.star
+++ b/bldr.star
@@ -198,9 +198,6 @@ def release_world_config_set(
             "cdnBaseUrl": cdn_base_url,
             "cacheBlockStoreId": cache_block_store_id,
         }),
-        "release-world-ops": config_entry("space/world/ops", 1, {
-            "engineId": RELEASE_WORLD_ENGINE_ID,
-        }),
     }
     if include_fetch:
         configs["release-world-fetch"] = config_entry("bldr/manifest/fetch/world", 1, {
@@ -254,9 +251,6 @@ def release_world_reader_config_set(
             "spaceId": space_id,
             "cdnBaseUrl": cdn_base_url,
             "suppliedBlockStoreId": RELEASE_WORLD_BLOCK_STORE_ID,
-        }),
-        "release-world-ops": config_entry("space/world/ops", 1, {
-            "engineId": RELEASE_WORLD_ENGINE_ID,
         }),
     }
 

--- a/bldr/dist/entrypoint/core.go
+++ b/bldr/dist/entrypoint/core.go
@@ -16,7 +16,6 @@ import (
 	storage_volume "github.com/s4wave/spacewave/bldr/storage/volume"
 	cdn_bstore_controller "github.com/s4wave/spacewave/core/cdn/bstore/controller"
 	cdn_world_controller "github.com/s4wave/spacewave/core/cdn/world/controller"
-	space_world_optypes "github.com/s4wave/spacewave/core/space/world/optypes"
 	block_store_bucket "github.com/s4wave/spacewave/db/block/store/bucket"
 	block_store_rpc "github.com/s4wave/spacewave/db/block/store/rpc"
 	block_store_rpc_lookup "github.com/s4wave/spacewave/db/block/store/rpc/lookup"
@@ -37,11 +36,13 @@ func NewCoreBus(
 	le *logrus.Entry,
 	opts ...cbc.Option,
 ) (bus.Bus, *static.Resolver, error) {
+	// Establish the bus before registering its platform factories.
 	b, sr, err := cbc.NewCoreBus(ctx, le, opts...)
 	if err != nil {
 		return nil, nil, err
 	}
 
+	// Bind factory constructors to the bus they will serve.
 	AddFactories(b, sr)
 	return b, sr, nil
 }
@@ -50,35 +51,41 @@ func NewCoreBus(
 // NOTE: Only add a factory here if it is absolutely needed by the entrypoint.
 // NOTE: this list will differ depending on the platform.
 func AddFactories(b bus.Bus, sr *static.Resolver) {
+	// Resolve plugin loading, service forwarding, and backing nodes.
 	sr.AddFactory(bldr_plugin_load.NewFactory(b))
 	sr.AddFactory(handle_rpc_viaplugin.NewFactory(b))
 	sr.AddFactory(lookup_concurrent.NewFactory(b))
 	sr.AddFactory(node_controller.NewFactory(b))
 
+	// Keep scheduling and platform hosts on the entrypoint bus.
 	sr.AddFactory(plugin_host_scheduler.NewFactory(b))
 	for _, factory := range plugin_host_default.PluginHostControllerFactories {
 		sr.AddFactory(factory(b))
 	}
 	addDesktopFactories(b, sr)
 
+	// Read executable manifests and assets through their world engines.
 	sr.AddFactory(unixfs_world_access.NewFactory(b))
 	sr.AddFactory(world_block_engine.NewFactory(b))
 	sr.AddFactory(cdn_world_controller.NewFactory(b))
 	sr.AddFactory(cdn_bstore_controller.NewFactory(b))
-	sr.AddFactory(space_world_optypes.NewFactory(b))
 
+	// Share volumes across host and plugin boundaries.
 	sr.AddFactory(volume_rpc_client.NewFactory(b))
 	sr.AddFactory(volume_rpc_server.NewFactory(b))
 
+	// Discover manifests from plugins and the published Release World.
 	sr.AddFactory(manifest_fetch_viaplugin.NewFactory(b))
 	sr.AddFactory(manifest_fetch_viaworld.NewFactory(b))
 
+	// Resolve local and remote block-store transports.
 	sr.AddFactory(block_store_bucket.NewFactory(b))
 	sr.AddFactory(block_store_rpc.NewFactory(b))
 	sr.AddFactory(block_store_rpc_lookup.NewFactory(b))
 	sr.AddFactory(block_store_rpc_server.NewFactory(b))
 	sr.AddFactory(block_store_s3_lookup.NewFactory(b))
 
+	// Supply the durable storage used by the distribution.
 	sr.AddFactory(storage_volume.NewFactory(b))
 	for _, st := range storage_default.BuildStorage(b, "") {
 		st.AddFactories(b, sr)

--- a/bldr/dist/entrypoint/desktop-factories.go
+++ b/bldr/dist/entrypoint/desktop-factories.go
@@ -8,11 +8,15 @@ import (
 	launcher "github.com/s4wave/spacewave/core/provider/spacewave/launcher/controller"
 	"github.com/s4wave/spacewave/core/resource/desktop/statusprojector"
 	resource_listener "github.com/s4wave/spacewave/core/resource/listener"
+	space_world_optypes "github.com/s4wave/spacewave/core/space/world/optypes"
 )
 
 // addDesktopFactories registers controllers that must run in the installed
 // desktop process rather than in one of its child plugins.
 func addDesktopFactories(b bus.Bus, sr *static.Resolver) {
+	// Installed hosts retain the application operation factory for local worlds.
+	sr.AddFactory(space_world_optypes.NewFactory(b))
+
 	// Replacement and relaunch target this process's executable and lifetime.
 	sr.AddFactory(launcher.NewFactory(b))
 

--- a/bldr/dist/entrypoint/release_fixture_test.go
+++ b/bldr/dist/entrypoint/release_fixture_test.go
@@ -27,12 +27,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// TestBrowserReleaseLazyPluginFixtureIsNonEmbeddedAndPublished keeps runtime plugins in Release World while embedding the bootstrap.
 func TestBrowserReleaseLazyPluginFixtureIsNonEmbeddedAndPublished(t *testing.T) {
+	// Read the authoritative release composition before checking its ownership.
 	result, err := bldr_project_starlark.Evaluate(filepath.Join("..", "..", "..", "bldr.star"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
+	// Select the fixture that obtains ordinary plugins from Release World.
 	build := result.Config.GetBuild()["release-web-lazy-plugin-fixture"]
 	if build == nil {
 		t.Fatal("missing release-web-lazy-plugin-fixture build")
@@ -47,13 +50,15 @@ func TestBrowserReleaseLazyPluginFixtureIsNonEmbeddedAndPublished(t *testing.T) 
 		t.Fatalf("decode browser fixture dist config: %v", err)
 	}
 	embeds := distConf.GetEmbedManifests()
-	if len(embeds) != 1 || embeds[0].GetManifestId() != "spacewave-launcher" || embeds[0].GetPlatformId() != "js" {
-		t.Fatalf("browser release embeds = %#v, want spacewave-launcher@js only", embeds)
+	if len(embeds) != 2 || embeds[0].GetManifestId() != "spacewave-launcher" || embeds[0].GetPlatformId() != "js" ||
+		embeds[1].GetManifestId() != "bldr-materializer" || embeds[1].GetPlatformId() != "js" {
+		t.Fatalf("browser release embeds = %#v, want launcher and materializer on js", embeds)
 	}
 	if !slices.Contains(distConf.GetLoadPlugins(), "spacewave-cli-plugin") {
 		t.Fatal("lazy fixture does not request terminal plugin through LoadPlugin")
 	}
 
+	// Require the launcher to delegate published-state reads to its host.
 	launcherOverride := build.GetManifestOverrides()["spacewave-launcher"]
 	if launcherOverride == nil {
 		t.Fatal("missing launcher fixture manifest override")
@@ -64,7 +69,6 @@ func TestBrowserReleaseLazyPluginFixtureIsNonEmbeddedAndPublished(t *testing.T) 
 	}
 	for _, id := range []string{
 		"release-world",
-		"release-world-ops",
 		"release-world-fetch",
 		"release-world-cdn-bucket",
 	} {
@@ -99,11 +103,13 @@ func TestBrowserReleaseLazyPluginFixtureIsNonEmbeddedAndPublished(t *testing.T) 
 			cdnBucketConf.GetBucketConfig().GetId())
 	}
 
+	// Keep the terminal fixture available through the release publisher.
 	publish := result.Config.GetPublish()["spacewave-release"]
 	if publish == nil || !slices.Contains(publish.GetManifests(), "spacewave-cli-plugin") {
 		t.Fatal("Release World publication omits the lazy terminal plugin")
 	}
 
+	// Every ordinary startup tuple must have a single release producer.
 	pluginRelease := result.Config.GetBuild()["plugin-release-browser"]
 	if pluginRelease == nil {
 		t.Fatal("missing plugin-release-browser build")
@@ -136,7 +142,9 @@ func TestBrowserReleaseLazyPluginFixtureIsNonEmbeddedAndPublished(t *testing.T) 
 	}
 }
 
+// TestReleaseLauncherBrowserAndNativeAuthorityComposition checks the single CDN authority for each host composition.
 func TestReleaseLauncherBrowserAndNativeAuthorityComposition(t *testing.T) {
+	// Read the authoritative release composition before checking its ownership.
 	result, err := bldr_project_starlark.Evaluate(filepath.Join("..", "..", "..", "bldr.star"))
 	if err != nil {
 		t.Fatal(err)
@@ -168,10 +176,13 @@ func TestReleaseLauncherBrowserAndNativeAuthorityComposition(t *testing.T) {
 					t.Fatalf("browser worker mounts Release World config %q", id)
 				}
 			}
-			for _, id := range []string{"release-world", "release-world-ops", "release-world-fetch", "release-world-cdn-bucket"} {
+			for _, id := range []string{"release-world", "release-world-fetch", "release-world-cdn-bucket"} {
 				if conf.GetHostConfigSet()[id] == nil {
 					t.Fatalf("browser host config missing %q", id)
 				}
+			}
+			if conf.GetHostConfigSet()["release-world-ops"] != nil {
+				t.Fatal("browser host requires the application operation catalogue")
 			}
 			if conf.GetHostConfigSet()["release-world-cdn-store"] != nil || conf.GetHostConfigSet()["release-world-cdn-server"] != nil {
 				t.Fatal("browser host creates a duplicate CDN store or unused RPC bridge")
@@ -186,6 +197,7 @@ func TestReleaseLauncherBrowserAndNativeAuthorityComposition(t *testing.T) {
 		})
 	}
 
+	// Native launchers borrow the host transport through block-store RPC.
 	launcher := result.Config.GetManifests()["spacewave-launcher"]
 	if launcher == nil {
 		t.Fatal("missing native launcher manifest")
@@ -193,6 +205,9 @@ func TestReleaseLauncherBrowserAndNativeAuthorityComposition(t *testing.T) {
 	var native bldr_plugin_compiler_go.Config
 	if err := native.UnmarshalJSON(launcher.GetBuilder().GetConfig()); err != nil {
 		t.Fatal(err)
+	}
+	if native.GetConfigSet()["release-world-ops"] != nil || native.GetHostConfigSet()["release-world-ops"] != nil {
+		t.Fatal("Release World state readers require the application operation catalogue")
 	}
 	if native.GetConfigSet()["release-world-fetch"] != nil {
 		t.Fatal("native plugin bus mounts a second Release World fetcher")
@@ -226,7 +241,9 @@ func TestReleaseLauncherBrowserAndNativeAuthorityComposition(t *testing.T) {
 	}
 }
 
+// TestReleaseWorkflowsSeparateEntrypointAndPluginProducers prevents competing release artifact producers.
 func TestReleaseWorkflowsSeparateEntrypointAndPluginProducers(t *testing.T) {
+	// Entrypoint builds must not produce ordinary runtime plugin roots.
 	entrypointWorkflow, err := os.ReadFile(filepath.Join("..", "..", "..", ".github", "workflows", "entrypoint-release.yml"))
 	if err != nil {
 		t.Fatal(err)
@@ -258,6 +275,7 @@ func TestReleaseWorkflowsSeparateEntrypointAndPluginProducers(t *testing.T) {
 		t.Fatal("entrypoint release does not derive SOURCE_DATE_EPOCH from the checked-out commit")
 	}
 
+	// Plugin publication owns those roots and their reproducible timestamps.
 	pluginWorkflow, err := os.ReadFile(filepath.Join("..", "..", "..", ".github", "workflows", "plugin-release.yml"))
 	if err != nil {
 		t.Fatal(err)
@@ -276,18 +294,23 @@ func TestReleaseWorkflowsSeparateEntrypointAndPluginProducers(t *testing.T) {
 	}
 }
 
+// TestBrowserReleasePublishedWorldFetchManifestPreflight reads published manifests through the host CDN engine.
 func TestBrowserReleasePublishedWorldFetchManifestPreflight(t *testing.T) {
+	// Keep the live CDN read opt-in for ordinary offline package tests.
 	if os.Getenv("E2E_RELEASE_WORLD_PREFLIGHT") != "1" {
 		t.Skip("set E2E_RELEASE_WORLD_PREFLIGHT=1 to probe the promoted Release World")
 	}
+	// Read the authoritative release composition before checking its ownership.
 	result, err := bldr_project_starlark.Evaluate(filepath.Join("..", "..", "..", "bldr.star"))
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Select the fixture that obtains ordinary plugins from Release World.
 	build := result.Config.GetBuild()["release-web-lazy-plugin-fixture"]
 	if build == nil {
 		t.Fatal("missing release-web-lazy-plugin-fixture build")
 	}
+	// Require the launcher to delegate published-state reads to its host.
 	launcherOverride := build.GetManifestOverrides()["spacewave-launcher"]
 	if launcherOverride == nil {
 		t.Fatal("missing launcher fixture manifest override")
@@ -306,8 +329,9 @@ func TestBrowserReleasePublishedWorldFetchManifestPreflight(t *testing.T) {
 	}
 	t.Logf("probing Release World space=%q base=%q", releaseWorldConf.GetSpaceId(), releaseWorldConf.GetCdnBaseUrl())
 
+	// Mount the published world with an isolated durable cache.
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
+	t.Cleanup(cancel)
 	b, _, err := NewCoreBus(ctx, logrus.NewEntry(logrus.New()))
 	if err != nil {
 		t.Fatal(err)
@@ -323,7 +347,7 @@ func TestBrowserReleasePublishedWorldFetchManifestPreflight(t *testing.T) {
 	if err != nil {
 		t.Fatalf("add default storage controller: %v", err)
 	}
-	defer storageCtrlRelease()
+	t.Cleanup(storageCtrlRelease)
 	_, _, distVolumeRef, err := loader.WaitExecControllerRunning(
 		ctx, b,
 		resolver.NewLoadControllerWithConfig(newDistStorageVolumeConfig(storageID, "spacewave")),
@@ -332,14 +356,14 @@ func TestBrowserReleasePublishedWorldFetchManifestPreflight(t *testing.T) {
 	if err != nil {
 		t.Fatalf("start dist storage volume: %v", err)
 	}
-	defer distVolumeRef.Release()
+	t.Cleanup(distVolumeRef.Release)
 	cdnCtrli, _, cdnRef, err := loader.WaitExecControllerRunning(
 		ctx, b, resolver.NewLoadControllerWithConfig(&releaseWorldConf), nil,
 	)
 	if err != nil {
 		t.Fatalf("mount Release World: %v", err)
 	}
-	defer cdnRef.Release()
+	t.Cleanup(cdnRef.Release)
 	cdnCtrl, ok := cdnCtrli.(*cdn_world_controller.Controller)
 	if !ok {
 		t.Fatalf("Release World controller type = %T", cdnCtrli)
@@ -355,12 +379,13 @@ func TestBrowserReleasePublishedWorldFetchManifestPreflight(t *testing.T) {
 	if err != nil {
 		t.Fatalf("start Release World FetchManifest resolver: %v", err)
 	}
-	defer fetchRef.Release()
+	t.Cleanup(fetchRef.Release)
 	engine, err := cdnCtrl.GetWorldEngine(ctx)
 	if err != nil {
 		t.Fatalf("get Release World engine: %v", err)
 	}
 
+	// Read each startup manifest and its first content block through the CDN engine.
 	for _, tuple := range []struct {
 		manifestID string
 		platformID string
@@ -383,7 +408,7 @@ func TestBrowserReleasePublishedWorldFetchManifestPreflight(t *testing.T) {
 			t.Fatalf("FetchManifest %s@%s: %v", tuple.manifestID, tuple.platformID, err)
 		}
 		if valueRef != nil {
-			defer valueRef.Release()
+			t.Cleanup(valueRef.Release)
 		}
 		if val == nil {
 			t.Fatalf("Release World preflight rejected tuple %s@%s: no provider value", tuple.manifestID, tuple.platformID)

--- a/bldr/dist/entrypoint/release_runtime_fixture_test.go
+++ b/bldr/dist/entrypoint/release_runtime_fixture_test.go
@@ -35,18 +35,21 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func TestLauncherOnlyReleaseConfigMountsWorldAndColdStartsRemoteCore(t *testing.T) {
+// TestBrowserBootstrapMountsWorldAndColdStartsRemoteCore checks remote startup followed by durable local materialization.
+func TestBrowserBootstrapMountsWorldAndColdStartsRemoteCore(t *testing.T) {
+	// Bound the complete startup and background-materialization scenario.
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	t.Cleanup(cancel)
 	le := logrus.NewEntry(logrus.New())
 
+	// Resolve the real bootstrap configuration before substituting fixture storage.
 	result, err := bldr_project_starlark.Evaluate(filepath.Join("..", "..", "..", "bldr.star"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	build := result.Config.GetBuild()["release-web-lazy-plugin-fixture"]
 	if build == nil {
-		t.Fatal("missing launcher-only release fixture")
+		t.Fatal("missing browser bootstrap release fixture")
 	}
 	browserOverride := build.GetManifestOverrides()["spacewave-browser"]
 	if browserOverride == nil {
@@ -54,11 +57,12 @@ func TestLauncherOnlyReleaseConfigMountsWorldAndColdStartsRemoteCore(t *testing.
 	}
 	var distConf bldr_dist_compiler.Config
 	if err := distConf.UnmarshalJSON(browserOverride.GetConfig()); err != nil {
-		t.Fatalf("verify launcher-only embedded config: %v", err)
+		t.Fatalf("verify browser bootstrap embedded config: %v", err)
 	}
 	embeds := distConf.GetEmbedManifests()
-	if len(embeds) != 1 || embeds[0].GetManifestId() != "spacewave-launcher" || embeds[0].GetPlatformId() != "js" {
-		t.Fatalf("embedded manifests = %#v, want launcher@js only", embeds)
+	if len(embeds) != 2 || embeds[0].GetManifestId() != "spacewave-launcher" || embeds[0].GetPlatformId() != "js" ||
+		embeds[1].GetManifestId() != "bldr-materializer" || embeds[1].GetPlatformId() != "js" {
+		t.Fatalf("embedded manifests = %#v, want launcher and materializer on js", embeds)
 	}
 
 	launcherOverride := build.GetManifestOverrides()["spacewave-launcher"]
@@ -77,6 +81,7 @@ func TestLauncherOnlyReleaseConfigMountsWorldAndColdStartsRemoteCore(t *testing.
 		t.Fatalf("launcher release-world-fetch config = %#v", embeddedFetch)
 	}
 
+	// Exercise the production scheduler over isolated in-memory stores.
 	tb, err := testbed.BuildTestbedWithSchedulerConfig(
 		ctx,
 		le,
@@ -87,9 +92,10 @@ func TestLauncherOnlyReleaseConfigMountsWorldAndColdStartsRemoteCore(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer tb.Release()
+	t.Cleanup(tb.Release)
 	tb.GetStaticResolver().AddFactory(manifest_fetch_world.NewFactory(tb.GetBus()))
 
+	// Publish executable refs in separate buckets that require later copying.
 	const releaseObjectKey = "spacewave/release/manifests"
 	if _, err := bldr_manifest_world.CreateManifestStoreInEngine(ctx, tb.GetWorldEngine(), releaseObjectKey); err != nil {
 		t.Fatal(err)
@@ -133,7 +139,7 @@ func TestLauncherOnlyReleaseConfigMountsWorldAndColdStartsRemoteCore(t *testing.
 	if err != nil {
 		t.Fatalf("mount launcher Release World on plugin-host bus: %v", err)
 	}
-	defer fetchSetRef.Release()
+	t.Cleanup(fetchSetRef.Release)
 
 	fetchValue, _, fetchRef, err := bus.ExecWaitValue[*bldr_manifest.FetchManifestValue](
 		ctx,
@@ -148,11 +154,12 @@ func TestLauncherOnlyReleaseConfigMountsWorldAndColdStartsRemoteCore(t *testing.
 	if err != nil {
 		t.Fatalf("launcher Release World FetchManifest: %v", err)
 	}
-	defer fetchRef.Release()
+	t.Cleanup(fetchRef.Release)
 	if len(fetchValue.GetManifestRefs()) != 1 || !fetchValue.GetManifestRefs()[0].EqualVT(coreRef) {
 		t.Fatalf("FetchManifest refs = %#v, want remote Core", fetchValue.GetManifestRefs())
 	}
 
+	// Hold the background copy gate until configured startup is admitted.
 	startupSource := newReleaseFixtureStartupSource()
 	startupGroup := plugin_entrypoint_controller.NewStartupGroupCoordinator(
 		[]string{"configured-startup-plugin"},
@@ -160,6 +167,7 @@ func TestLauncherOnlyReleaseConfigMountsWorldAndColdStartsRemoteCore(t *testing.
 	)
 	tb.GetScheduler().SetManifestCopyGate(startupGroup)
 
+	// Observe executable admission without requiring a JavaScript runtime.
 	host := &releaseFixturePluginHost{started: make(chan string, 4)}
 	hostCtrl := plugin_host_controller.NewController(
 		le,
@@ -171,13 +179,14 @@ func TestLauncherOnlyReleaseConfigMountsWorldAndColdStartsRemoteCore(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer releaseHost()
+	t.Cleanup(releaseHost)
 
+	// Start Core from its remote bucket while background copying is gated.
 	_, loadRef, err := tb.GetBus().AddDirective(bldr_plugin.NewLoadPlugin("spacewave-core"), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer loadRef.Release()
+	t.Cleanup(loadRef.Release)
 	if err := startupGroup.Start(ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -190,11 +199,12 @@ func TestLauncherOnlyReleaseConfigMountsWorldAndColdStartsRemoteCore(t *testing.
 		t.Fatalf("scheduler did not cold-start remote Core: %v", ctx.Err())
 	}
 
+	// Apply the same deferred-copy rule to an unconfigured runtime plugin.
 	_, transientLoadRef, err := tb.GetBus().AddDirective(bldr_plugin.NewLoadPlugin("transient-plugin"), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer transientLoadRef.Release()
+	t.Cleanup(transientLoadRef.Release)
 	select {
 	case pluginID := <-host.started:
 		if pluginID != "transient-plugin" {
@@ -204,11 +214,13 @@ func TestLauncherOnlyReleaseConfigMountsWorldAndColdStartsRemoteCore(t *testing.
 		t.Fatalf("scheduler did not start transient plugin: %v", ctx.Err())
 	}
 
+	// Confirm both executables still reference their original remote buckets.
 	waitForManifestBucket(t, ctx, tb, "spacewave-core", "spacewave-release")
 	waitForManifestBucket(t, ctx, tb, "transient-plugin", "transient-release-provider")
 	assertOnlyManifestBucket(t, ctx, tb, "spacewave-core", "spacewave-release")
 	assertOnlyManifestBucket(t, ctx, tb, "transient-plugin", "transient-release-provider")
 
+	// Admit background materialization and require both refs to become local.
 	startupSource.readyCtr.SetValue(bldr_plugin.NewPluginLoadState(
 		nil,
 		bldr_plugin.InitialCapabilityRegistrationComplete,
@@ -226,6 +238,7 @@ func TestLauncherOnlyReleaseConfigMountsWorldAndColdStartsRemoteCore(t *testing.
 	}
 }
 
+// buildRemoteManifest stores a minimal executable manifest in an isolated remote bucket.
 func buildRemoteManifest(
 	t *testing.T,
 	ctx context.Context,
@@ -234,6 +247,7 @@ func buildRemoteManifest(
 	bucketID, manifestID string,
 ) *bldr_manifest.ManifestRef {
 	t.Helper()
+	// Supply a minimal executable through the ordinary manifest builder.
 	distFS := memfs.New()
 	f, err := distFS.Create("core.js")
 	if err != nil {
@@ -245,6 +259,8 @@ func buildRemoteManifest(
 	if err := f.Close(); err != nil {
 		t.Fatal(err)
 	}
+
+	// Commit the fixture manifest into its independently addressed bucket.
 	meta := bldr_manifest.NewManifestMeta(manifestID, bldr_manifest.BuildType_RELEASE, "js", 1)
 	if _, _, _, err := tb.GetVolume().ApplyBucketConfig(ctx, &bucket.Config{Id: bucketID, Rev: 1}); err != nil {
 		t.Fatal(err)
@@ -276,23 +292,31 @@ func buildRemoteManifest(
 	return bldr_manifest.NewManifestRef(meta, ref)
 }
 
+// releaseFixtureStartupRef exposes controlled startup admission for the fixture.
 type releaseFixtureStartupRef struct {
+	// readyCtr publishes capability registration independently of plugin execution.
 	readyCtr *ccontainer.CContainer[bldr_plugin.PluginLoadState]
 }
 
+// GetRunningPluginCtr exposes no running executable for the controlled startup prerequisite.
 func (r *releaseFixtureStartupRef) GetRunningPluginCtr() ccontainer.Watchable[bldr_plugin.RunningPlugin] {
 	return ccontainer.NewCContainer[bldr_plugin.RunningPlugin](nil)
 }
 
+// GetPluginLoadStateCtr exposes the fixture-controlled capability registration state.
 func (r *releaseFixtureStartupRef) GetPluginLoadStateCtr() ccontainer.Watchable[bldr_plugin.PluginLoadState] {
 	return r.readyCtr
 }
 
+// releaseFixtureStartupSource controls the scheduler's background-copy gate.
 type releaseFixtureStartupSource struct {
-	ref      *releaseFixtureStartupRef
+	// ref is shared by all fixture startup references.
+	ref *releaseFixtureStartupRef
+	// readyCtr publishes the configured startup group's admission state.
 	readyCtr *ccontainer.CContainer[bldr_plugin.PluginLoadState]
 }
 
+// newReleaseFixtureStartupSource starts the background-copy prerequisite in its pending state.
 func newReleaseFixtureStartupSource() *releaseFixtureStartupSource {
 	readyCtr := ccontainer.NewCContainer(bldr_plugin.NewPluginLoadState(
 		nil,
@@ -304,12 +328,14 @@ func newReleaseFixtureStartupSource() *releaseFixtureStartupSource {
 	}
 }
 
+// AddPluginReference borrows the shared fixture prerequisite without allocating a new lifetime.
 func (s *releaseFixtureStartupSource) AddPluginReference(
 	_, _ string,
 ) (bldr_plugin.RunningPluginRef, func()) {
 	return s.ref, func() {}
 }
 
+// worldBucketID returns the scheduler world's backing bucket identity.
 func worldBucketID(t *testing.T, ctx context.Context, tb *testbed.Testbed) string {
 	t.Helper()
 	var bucketID string
@@ -322,6 +348,7 @@ func worldBucketID(t *testing.T, ctx context.Context, tb *testbed.Testbed) strin
 	return bucketID
 }
 
+// waitForManifestBucket waits on world sequence changes until the manifest reaches its destination.
 func waitForManifestBucket(
 	t *testing.T,
 	ctx context.Context,
@@ -358,6 +385,7 @@ func waitForManifestBucket(
 	}
 }
 
+// assertOnlyManifestBucket requires exactly one executable reference in the expected bucket.
 func assertOnlyManifestBucket(
 	t *testing.T,
 	ctx context.Context,
@@ -383,18 +411,25 @@ func assertOnlyManifestBucket(
 	}
 }
 
+// releaseFixturePluginHost observes scheduler admission without running JavaScript.
 type releaseFixturePluginHost struct {
+	// started records each admitted plugin before waiting for its cancellation.
 	started chan string
 }
 
+// GetPlatformId selects JavaScript manifests for the fixture host.
 func (h *releaseFixturePluginHost) GetPlatformId() string { return "js" }
+
+// Execute keeps the fixture host available until cancellation.
 func (h *releaseFixturePluginHost) Execute(ctx context.Context) error {
 	<-ctx.Done()
 	return context.Canceled
 }
 
+// ListPlugins reports no executables before scheduler admission.
 func (h *releaseFixturePluginHost) ListPlugins(context.Context) ([]string, error) { return nil, nil }
 
+// ExecutePlugin records admission and holds the executable until cancellation.
 func (h *releaseFixturePluginHost) ExecutePlugin(
 	ctx context.Context,
 	pluginID, instanceKey, entrypoint string,
@@ -409,4 +444,6 @@ func (h *releaseFixturePluginHost) ExecutePlugin(
 	<-ctx.Done()
 	return context.Canceled
 }
+
+// DeletePlugin accepts removal without maintaining an executable cache.
 func (h *releaseFixturePluginHost) DeletePlugin(context.Context, string) error { return nil }

--- a/bldr/project/starlark/evaluate_test.go
+++ b/bldr/project/starlark/evaluate_test.go
@@ -15,7 +15,9 @@ import (
 	bldr_plugin_compiler_go "github.com/s4wave/spacewave/bldr/plugin/compiler/go"
 )
 
+// TestEvaluateMinimal decodes a project, manifest, and build from Starlark.
 func TestEvaluateMinimal(t *testing.T) {
+	// Isolate the project and every file it may load.
 	dir := t.TempDir()
 	starFile := filepath.Join(dir, "bldr.star")
 	err := os.WriteFile(starFile, []byte(`
@@ -27,6 +29,7 @@ build("app", manifests=["test-manifest"], targets=["desktop"])
 		t.Fatal(err)
 	}
 
+	// Evaluate the fixture through the public project loader.
 	result, err := Evaluate(starFile)
 	if err != nil {
 		t.Fatal(err)
@@ -60,7 +63,9 @@ build("app", manifests=["test-manifest"], targets=["desktop"])
 	}
 }
 
+// TestEvaluateConfigEntry preserves controller configuration in the manifest builder.
 func TestEvaluateConfigEntry(t *testing.T) {
+	// Isolate the project and every file it may load.
 	dir := t.TempDir()
 	starFile := filepath.Join(dir, "bldr.star")
 	err := os.WriteFile(starFile, []byte(`
@@ -83,6 +88,7 @@ manifest("core",
 		t.Fatal(err)
 	}
 
+	// Evaluate the fixture through the public project loader.
 	result, err := Evaluate(starFile)
 	if err != nil {
 		t.Fatal(err)
@@ -93,7 +99,6 @@ manifest("core",
 		t.Fatal("manifest 'core' not found")
 	}
 
-	// The config should be valid JSON containing configSet.
 	configData := mc.GetBuilder().GetConfig()
 	if len(configData) == 0 {
 		t.Fatal("expected non-empty builder config")
@@ -101,7 +106,9 @@ manifest("core",
 	t.Logf("builder config JSON: %s", string(configData))
 }
 
+// TestEvaluateManifestOverrides retains platform-specific compiler overrides.
 func TestEvaluateManifestOverrides(t *testing.T) {
+	// Isolate the project and every file it may load.
 	dir := t.TempDir()
 	starFile := filepath.Join(dir, "bldr.star")
 	err := os.WriteFile(starFile, []byte(`
@@ -125,11 +132,13 @@ build("release-desktop-darwin-arm64",
 		t.Fatal(err)
 	}
 
+	// Evaluate the fixture through the public project loader.
 	result, err := Evaluate(starFile)
 	if err != nil {
 		t.Fatal(err)
 	}
 
+	// Validate native release selection and embedded startup requirements.
 	bc := result.Config.GetBuild()["release-desktop-darwin-arm64"]
 	if bc == nil {
 		t.Fatal("build target 'release-desktop-darwin-arm64' not found")
@@ -163,7 +172,9 @@ build("release-desktop-darwin-arm64",
 	}
 }
 
+// TestEvaluateRejectsRelativeLoadOutsideProject fences relative loads to the project root.
 func TestEvaluateRejectsRelativeLoadOutsideProject(t *testing.T) {
+	// Isolate the project and every file it may load.
 	dir := t.TempDir()
 	projectDir := filepath.Join(dir, "project")
 	if err := os.Mkdir(projectDir, 0o755); err != nil {
@@ -189,7 +200,9 @@ project(id="test")
 	}
 }
 
+// TestEvaluateRejectsGoVendorLoadOutsideVendor fences module loads to the vendor root.
 func TestEvaluateRejectsGoVendorLoadOutsideVendor(t *testing.T) {
+	// Isolate the project and every file it may load.
 	dir := t.TempDir()
 	vendorDir := filepath.Join(dir, "vendor")
 	if err := os.Mkdir(vendorDir, 0o755); err != nil {
@@ -215,7 +228,9 @@ project(id="test")
 	}
 }
 
+// TestEvaluateRejectsLoadSymlinkOutsideProject rejects symlinks that escape the project root.
 func TestEvaluateRejectsLoadSymlinkOutsideProject(t *testing.T) {
+	// Isolate the project and every file it may load.
 	dir := t.TempDir()
 	projectDir := filepath.Join(dir, "project")
 	if err := os.Mkdir(projectDir, 0o755); err != nil {
@@ -245,7 +260,9 @@ project(id="test")
 	}
 }
 
+// TestEvaluateRootDesktopReleaseBuildsJsEmbeds checks release producers, bootstrap tuples, and isolated browser fixtures.
 func TestEvaluateRootDesktopReleaseBuildsJsEmbeds(t *testing.T) {
+	// Check the repository's authoritative build graph.
 	starPath := "../../../bldr.star"
 	if _, err := os.Stat(starPath); err != nil {
 		t.Skipf("bldr.star not found at %s: %v", starPath, err)
@@ -256,6 +273,7 @@ func TestEvaluateRootDesktopReleaseBuildsJsEmbeds(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Require one native bootstrap producer for every supported host.
 	for _, host := range []struct {
 		name       string
 		platformID string
@@ -295,6 +313,7 @@ func TestEvaluateRootDesktopReleaseBuildsJsEmbeds(t *testing.T) {
 		}
 	}
 
+	// Check the application core's platform contract.
 	core := result.Config.GetManifests()["spacewave-core"]
 	if core == nil {
 		t.Fatal("spacewave-core manifest not found")
@@ -311,6 +330,8 @@ func TestEvaluateRootDesktopReleaseBuildsJsEmbeds(t *testing.T) {
 			t.Fatalf("spacewave-core config missing %s: %s", want, coreCfg)
 		}
 	}
+
+	// Keep release discovery on the configured host authority.
 	launcher := result.Config.GetManifests()["spacewave-launcher"]
 	if launcher == nil {
 		t.Fatal("spacewave-launcher manifest not found")
@@ -334,6 +355,8 @@ func TestEvaluateRootDesktopReleaseBuildsJsEmbeds(t *testing.T) {
 	if strings.Contains(launcherCfg, "staging.spacewave.app") {
 		t.Fatalf("spacewave-launcher public config contains staging endpoint: %s", launcherCfg)
 	}
+
+	// Preserve the installed app's background presence policy.
 	web := result.Config.GetManifests()["web"]
 	if web == nil {
 		t.Fatal("web manifest not found")
@@ -349,6 +372,7 @@ func TestEvaluateRootDesktopReleaseBuildsJsEmbeds(t *testing.T) {
 		}
 	}
 
+	// Keep split viewer backends outside the main application plugin.
 	app := result.Config.GetManifests()["spacewave-app"]
 	if app == nil {
 		t.Fatal("spacewave-app manifest not found")
@@ -367,6 +391,7 @@ func TestEvaluateRootDesktopReleaseBuildsJsEmbeds(t *testing.T) {
 		}
 	}
 
+	// Require all Notes entrypoints on their owning plugin.
 	notes := result.Config.GetManifests()["spacewave-notes"]
 	if notes == nil {
 		t.Fatal("notes manifest not found")
@@ -383,6 +408,7 @@ func TestEvaluateRootDesktopReleaseBuildsJsEmbeds(t *testing.T) {
 		}
 	}
 
+	// Keep VM viewers independently loadable from the startup group.
 	v86 := result.Config.GetManifests()["spacewave-v86"]
 	if v86 == nil {
 		t.Fatal("v86 manifest not found")
@@ -416,6 +442,7 @@ func TestEvaluateRootDesktopReleaseBuildsJsEmbeds(t *testing.T) {
 		}
 	}
 
+	// Validate native release selection and embedded startup requirements.
 	bc := result.Config.GetBuild()["release-desktop-darwin-arm64"]
 	if bc == nil {
 		t.Fatal("build target 'release-desktop-darwin-arm64' not found")
@@ -448,6 +475,7 @@ func TestEvaluateRootDesktopReleaseBuildsJsEmbeds(t *testing.T) {
 		}
 	}
 
+	// Require the CLI bootstrap without the desktop loader.
 	cliRelease := result.Config.GetBuild()["release-cli-darwin-arm64"]
 	if cliRelease == nil {
 		t.Fatal("build target 'release-cli-darwin-arm64' not found")
@@ -476,6 +504,7 @@ func TestEvaluateRootDesktopReleaseBuildsJsEmbeds(t *testing.T) {
 		t.Fatalf("release cli override unexpectedly includes desktop loader: %s", cliCfg)
 	}
 
+	// Keep production browser payloads separate from runtime plugin releases.
 	browserRelease := result.Config.GetBuild()["release-web"]
 	if browserRelease == nil {
 		t.Fatal("build target 'release-web' not found")
@@ -487,8 +516,8 @@ func TestEvaluateRootDesktopReleaseBuildsJsEmbeds(t *testing.T) {
 	if slices.Contains(browserRelease.GetManifests(), "spacewave-dist") {
 		t.Fatalf("browser release manifests unexpectedly include spacewave-dist: %v", browserRelease.GetManifests())
 	}
-	if got := browserRelease.GetManifests(); !slices.Equal(got, []string{"spacewave-launcher", "spacewave-browser"}) {
-		t.Fatalf("browser release manifests: got %v, want launcher and shell", got)
+	if got := browserRelease.GetManifests(); !slices.Equal(got, []string{"spacewave-launcher", "bldr-materializer", "spacewave-browser"}) {
+		t.Fatalf("browser release manifests: got %v, want launcher, materializer, and shell", got)
 	}
 	browserLauncherOverride := browserRelease.GetManifestOverrides()["spacewave-launcher"]
 	if browserLauncherOverride == nil {
@@ -530,14 +559,12 @@ func TestEvaluateRootDesktopReleaseBuildsJsEmbeds(t *testing.T) {
 		}
 	}
 
+	// Make the browser fixture self-contained and independent of production discovery.
 	e2eBrowserRelease := result.Config.GetBuild()["release-web-e2e"]
 	if e2eBrowserRelease == nil {
 		t.Fatal("build target 'release-web-e2e' not found")
 	}
-	if slices.Contains(e2eBrowserRelease.GetManifests(), "spacewave-notes") {
-		t.Fatalf("release-web-e2e should build Notes only through the js embed: %v", e2eBrowserRelease.GetManifests())
-	}
-	for _, want := range []string{"spacewave-launcher", "spacewave-core", "spacewave-web", "spacewave-app", "spacewave-cli-plugin", "web", "spacewave-browser"} {
+	for _, want := range []string{"spacewave-launcher", "bldr-materializer", "spacewave-core", "spacewave-web", "spacewave-app", "spacewave-notes", "spacewave-sql", "spacewave-cli-plugin", "web", "spacewave-browser"} {
 		if !slices.Contains(e2eBrowserRelease.GetManifests(), want) {
 			t.Fatalf("release-web-e2e manifests missing %s: %v", want, e2eBrowserRelease.GetManifests())
 		}
@@ -592,6 +619,10 @@ func TestEvaluateRootDesktopReleaseBuildsJsEmbeds(t *testing.T) {
 		"release-web-e2e",
 		e2eDistConf,
 		"web/js/wasm",
+		distEmbedManifestWant{manifestID: "spacewave-core", platformID: "web/js/wasm"},
+		distEmbedManifestWant{manifestID: "spacewave-web", platformID: "js"},
+		distEmbedManifestWant{manifestID: "spacewave-app", platformID: "js"},
+		distEmbedManifestWant{manifestID: "web", platformID: "web/js/wasm"},
 		distEmbedManifestWant{manifestID: "spacewave-notes", platformID: "js"},
 		distEmbedManifestWant{manifestID: "spacewave-notes", platformID: "web/js/wasm"},
 		distEmbedManifestWant{manifestID: "spacewave-sql", platformID: "js"},
@@ -607,16 +638,17 @@ func TestEvaluateRootDesktopReleaseBuildsJsEmbeds(t *testing.T) {
 		}
 	}
 
+	// Build fixture payloads before compiling the distribution that embeds them.
 	e2eAssetBuild := result.Config.GetBuild()["release-web-e2e-assets"]
 	if e2eAssetBuild == nil {
 		t.Fatal("build target 'release-web-e2e-assets' not found")
 	}
-	for _, want := range []string{"spacewave-launcher", "spacewave-core", "spacewave-web", "spacewave-app", "spacewave-cli-plugin", "web"} {
+	for _, want := range []string{"spacewave-launcher", "bldr-materializer", "spacewave-core", "spacewave-web", "spacewave-app", "spacewave-notes", "spacewave-sql", "spacewave-cli-plugin", "web"} {
 		if !slices.Contains(e2eAssetBuild.GetManifests(), want) {
 			t.Fatalf("release-web-e2e-assets manifests missing %s: %v", want, e2eAssetBuild.GetManifests())
 		}
 	}
-	for _, unexpected := range []string{"spacewave-browser", "spacewave-dist", "spacewave-notes"} {
+	for _, unexpected := range []string{"spacewave-browser", "spacewave-dist"} {
 		if slices.Contains(e2eAssetBuild.GetManifests(), unexpected) {
 			t.Fatalf("release-web-e2e-assets should not build %s: %v", unexpected, e2eAssetBuild.GetManifests())
 		}
@@ -636,6 +668,7 @@ func TestEvaluateRootDesktopReleaseBuildsJsEmbeds(t *testing.T) {
 		t.Fatalf("release-web-e2e-tinygo-assets manifests missing spacewave-cli-plugin: %v", tinygoE2EAssetBuild.GetManifests())
 	}
 
+	// Restrict the separate distribution phase to its JavaScript host output.
 	e2eDistBuild := result.Config.GetBuild()["release-web-e2e-dist"]
 	if e2eDistBuild == nil {
 		t.Fatal("build target 'release-web-e2e-dist' not found")
@@ -659,11 +692,16 @@ func TestEvaluateRootDesktopReleaseBuildsJsEmbeds(t *testing.T) {
 		"release-web-e2e-dist",
 		e2eDistOnlyConf,
 		"web/js/wasm",
+		distEmbedManifestWant{manifestID: "spacewave-core", platformID: "web/js/wasm"},
+		distEmbedManifestWant{manifestID: "spacewave-web", platformID: "js"},
+		distEmbedManifestWant{manifestID: "spacewave-app", platformID: "js"},
+		distEmbedManifestWant{manifestID: "web", platformID: "web/js/wasm"},
 		distEmbedManifestWant{manifestID: "spacewave-notes", platformID: "js"},
 		distEmbedManifestWant{manifestID: "spacewave-notes", platformID: "web/js/wasm"},
 		distEmbedManifestWant{manifestID: "spacewave-sql", platformID: "js"},
 	)
 
+	// Publish ordinary plugins for serving-origin runtime loading.
 	pluginReleaseBrowser := result.Config.GetBuild()["plugin-release-browser"]
 	if pluginReleaseBrowser == nil {
 		t.Fatal("build target 'plugin-release-browser' not found")
@@ -696,6 +734,7 @@ func TestEvaluateRootDesktopReleaseBuildsJsEmbeds(t *testing.T) {
 		}
 	}
 
+	// Keep independently loaded plugins reachable through release publication.
 	publish := result.Config.GetPublish()["spacewave-release"]
 	if publish == nil {
 		t.Fatal("publish target 'spacewave-release' not found")
@@ -707,7 +746,9 @@ func TestEvaluateRootDesktopReleaseBuildsJsEmbeds(t *testing.T) {
 	}
 }
 
+// TestEvaluateRootDesktopStatusProjectorPlatformBoundary keeps desktop services out of browser and CLI compositions.
 func TestEvaluateRootDesktopStatusProjectorPlatformBoundary(t *testing.T) {
+	// Check the repository's authoritative build graph.
 	starPath := "../../../bldr.star"
 	if _, err := os.Stat(starPath); err != nil {
 		t.Skipf("bldr.star not found at %s: %v", starPath, err)
@@ -718,6 +759,7 @@ func TestEvaluateRootDesktopStatusProjectorPlatformBoundary(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Check the application core's platform contract.
 	core := result.Config.GetManifests()["spacewave-core"]
 	if core == nil {
 		t.Fatal("spacewave-core manifest not found")
@@ -740,6 +782,7 @@ func TestEvaluateRootDesktopStatusProjectorPlatformBoundary(t *testing.T) {
 		t.Fatalf("js spacewave-core goCompiler: got %s, want GO_COMPILER_DEFAULT", jsConf.GetGoCompiler())
 	}
 
+	// Resolve the TinyGo proof lane without admitting native-only services.
 	tinygoBuild := result.Config.GetBuild()["plugin-release-browser-tinygo"]
 	if tinygoBuild == nil {
 		t.Fatal("build target 'plugin-release-browser-tinygo' not found")
@@ -755,6 +798,7 @@ func TestEvaluateRootDesktopStatusProjectorPlatformBoundary(t *testing.T) {
 		t.Fatalf("TinyGo web spacewave-core goCompiler: got %s, want GO_COMPILER_TINYGO", tinygoWebConf.GetGoCompiler())
 	}
 
+	// Match the TinyGo release host with its platform-specific core.
 	tinygoReleaseBuild := result.Config.GetBuild()["release-web-tinygo"]
 	if tinygoReleaseBuild == nil {
 		t.Fatal("build target 'release-web-tinygo' not found")
@@ -775,6 +819,7 @@ func TestEvaluateRootDesktopStatusProjectorPlatformBoundary(t *testing.T) {
 	tinygoReleaseDistConf := mustDistConfig(t, tinygoReleaseBrowserOverride.GetConfig())
 	assertDistBrowserStartupClosure(t, "release-web-tinygo", tinygoReleaseDistConf, "web/js/wasm")
 
+	// Require the complete embedded fixture on the TinyGo lane.
 	tinygoE2EReleaseBuild := result.Config.GetBuild()["release-web-e2e-tinygo"]
 	if tinygoE2EReleaseBuild == nil {
 		t.Fatal("build target 'release-web-e2e-tinygo' not found")
@@ -789,11 +834,16 @@ func TestEvaluateRootDesktopStatusProjectorPlatformBoundary(t *testing.T) {
 		"release-web-e2e-tinygo",
 		tinygoE2EDistConf,
 		"web/js/wasm",
+		distEmbedManifestWant{manifestID: "spacewave-core", platformID: "web/js/wasm"},
+		distEmbedManifestWant{manifestID: "spacewave-web", platformID: "js"},
+		distEmbedManifestWant{manifestID: "spacewave-app", platformID: "js"},
+		distEmbedManifestWant{manifestID: "web", platformID: "web/js/wasm"},
 		distEmbedManifestWant{manifestID: "spacewave-notes", platformID: "js"},
 		distEmbedManifestWant{manifestID: "spacewave-notes", platformID: "web/js/wasm"},
 		distEmbedManifestWant{manifestID: "spacewave-sql", platformID: "js"},
 	)
 
+	// Keep GoScript core, launcher, and embeds on the same selected compiler.
 	goscriptE2EReleaseBuild := result.Config.GetBuild()["release-web-e2e-goscript"]
 	if goscriptE2EReleaseBuild == nil {
 		t.Fatal("build target 'release-web-e2e-goscript' not found")
@@ -828,11 +878,16 @@ func TestEvaluateRootDesktopStatusProjectorPlatformBoundary(t *testing.T) {
 		"release-web-e2e-goscript",
 		goscriptE2EDistConf,
 		"js",
+		distEmbedManifestWant{manifestID: "spacewave-core", platformID: "js"},
+		distEmbedManifestWant{manifestID: "spacewave-web", platformID: "js"},
+		distEmbedManifestWant{manifestID: "spacewave-app", platformID: "js"},
+		distEmbedManifestWant{manifestID: "web", platformID: "web/js/wasm"},
 		distEmbedManifestWant{manifestID: "spacewave-notes", platformID: "js"},
 		distEmbedManifestWant{manifestID: "spacewave-notes", platformID: "web/js/wasm"},
 		distEmbedManifestWant{manifestID: "spacewave-sql", platformID: "js"},
 	)
 
+	// Exclude desktop presence services from the standalone CLI.
 	cli := result.Config.GetManifests()["spacewave"]
 	if cli == nil {
 		t.Fatal("spacewave CLI manifest not found")
@@ -841,6 +896,7 @@ func TestEvaluateRootDesktopStatusProjectorPlatformBoundary(t *testing.T) {
 	assertCliConfigOmitsDesktopStatusProjector(t, "spacewave CLI", cliConf)
 }
 
+// mustDistConfig decodes a distribution configuration or fails the test.
 func mustDistConfig(t *testing.T, data []byte) *bldr_dist_compiler.Config {
 	t.Helper()
 	conf := &bldr_dist_compiler.Config{}
@@ -850,6 +906,7 @@ func mustDistConfig(t *testing.T, data []byte) *bldr_dist_compiler.Config {
 	return conf
 }
 
+// assertDistEmbedPlatform requires a manifest tuple on the selected platform.
 func assertDistEmbedPlatform(
 	t *testing.T,
 	label string,
@@ -871,11 +928,15 @@ func assertDistEmbedPlatform(
 	t.Fatalf("%s embeds %s platforms %v, missing %q", label, manifestID, gotPlatformIDs, wantPlatformID)
 }
 
+// distEmbedManifestWant identifies one expected embedded executable tuple.
 type distEmbedManifestWant struct {
+	// manifestID names the executable producer.
 	manifestID string
+	// platformID selects its runtime artifact.
 	platformID string
 }
 
+// assertDistBrowserStartupClosure requires the browser startup plugins and their declared embeds.
 func assertDistBrowserStartupClosure(
 	t *testing.T,
 	label string,
@@ -898,6 +959,7 @@ func assertDistBrowserStartupClosure(
 
 	wantEmbedManifests := []distEmbedManifestWant{
 		{manifestID: "spacewave-launcher", platformID: goPlatformID},
+		{manifestID: "bldr-materializer", platformID: goPlatformID},
 	}
 	wantEmbedManifests = append(wantEmbedManifests, additionalEmbeds...)
 	for _, want := range wantEmbedManifests {
@@ -906,6 +968,7 @@ func assertDistBrowserStartupClosure(
 	assertDistEmbedManifests(t, label, conf, wantEmbedManifests)
 }
 
+// assertDistEmbedManifests compares the complete ordered embed tuple set.
 func assertDistEmbedManifests(
 	t *testing.T,
 	label string,
@@ -933,6 +996,7 @@ func assertDistEmbedManifests(
 	}
 }
 
+// distEmbedManifestTuples projects embedded manifests into tuple diagnostics.
 func distEmbedManifestTuples(embeds []*bldr_dist_compiler.EmbedManifest) []distEmbedManifestWant {
 	tuples := make([]distEmbedManifestWant, 0, len(embeds))
 	for _, embed := range embeds {
@@ -944,6 +1008,7 @@ func distEmbedManifestTuples(embeds []*bldr_dist_compiler.EmbedManifest) []distE
 	return tuples
 }
 
+// mustGoPluginConfig decodes a Go plugin configuration or fails the test.
 func mustGoPluginConfig(t *testing.T, data []byte) *bldr_plugin_compiler_go.Config {
 	t.Helper()
 	conf := bldr_plugin_compiler_go.NewConfig()
@@ -953,6 +1018,7 @@ func mustGoPluginConfig(t *testing.T, data []byte) *bldr_plugin_compiler_go.Conf
 	return conf
 }
 
+// assertBrowserLauncherOmitsReleaseWorld keeps Release World state ownership out of the browser launcher worker.
 func assertBrowserLauncherOmitsReleaseWorld(t *testing.T, label string, conf *bldr_plugin_compiler_go.Config) {
 	t.Helper()
 	for _, key := range []string{"release-world", "release-world-fetch", "release-world-ops"} {
@@ -971,6 +1037,7 @@ func assertBrowserLauncherOmitsReleaseWorld(t *testing.T, label string, conf *bl
 	}
 }
 
+// mustCliConfig decodes a CLI compiler configuration or fails the test.
 func mustCliConfig(t *testing.T, data []byte) *bldr_cli_compiler.Config {
 	t.Helper()
 	conf := &bldr_cli_compiler.Config{}
@@ -980,6 +1047,7 @@ func mustCliConfig(t *testing.T, data []byte) *bldr_cli_compiler.Config {
 	return conf
 }
 
+// flattenGoConfigForPlatform resolves platform overrides without modifying the base configuration.
 func flattenGoConfigForPlatform(
 	t *testing.T,
 	base *bldr_plugin_compiler_go.Config,
@@ -995,6 +1063,7 @@ func flattenGoConfigForPlatform(
 	return conf
 }
 
+// assertGoConfigHasDesktopStatusProjector requires the native status package and controller together.
 func assertGoConfigHasDesktopStatusProjector(
 	t *testing.T,
 	name string,
@@ -1013,6 +1082,7 @@ func assertGoConfigHasDesktopStatusProjector(
 	}
 }
 
+// assertGoConfigOmitsDesktopStatusProjector rejects native status packages and controllers on other platforms.
 func assertGoConfigOmitsDesktopStatusProjector(
 	t *testing.T,
 	name string,
@@ -1032,6 +1102,7 @@ func assertGoConfigOmitsDesktopStatusProjector(
 	}
 }
 
+// assertGoConfigIncludesHTTPExport requires the HTTP export package and controller together.
 func assertGoConfigIncludesHTTPExport(
 	t *testing.T,
 	name string,
@@ -1048,6 +1119,7 @@ func assertGoConfigIncludesHTTPExport(
 	}
 }
 
+// assertCliConfigOmitsDesktopStatusProjector keeps native status services out of CLI builds.
 func assertCliConfigOmitsDesktopStatusProjector(
 	t *testing.T,
 	name string,
@@ -1067,7 +1139,9 @@ func assertCliConfigOmitsDesktopStatusProjector(
 	}
 }
 
+// TestEvaluateManifestOverridesRejectsNonDict reports the offending manifest when an override is not a mapping.
 func TestEvaluateManifestOverridesRejectsNonDict(t *testing.T) {
+	// Isolate the project and every file it may load.
 	dir := t.TempDir()
 	starFile := filepath.Join(dir, "bldr.star")
 	err := os.WriteFile(starFile, []byte(`
@@ -1091,10 +1165,11 @@ build("bad",
 	}
 }
 
+// TestEvaluateLoad tracks the project and its loaded Starlark library.
 func TestEvaluateLoad(t *testing.T) {
+	// Isolate the project and every file it may load.
 	dir := t.TempDir()
 
-	// Write a library file.
 	libDir := filepath.Join(dir, "lib")
 	if err := os.MkdirAll(libDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -1106,7 +1181,6 @@ SHARED_PKGS = ["./shared/pkg1", "./shared/pkg2"]
 		t.Fatal(err)
 	}
 
-	// Write the root file that loads the library.
 	starFile := filepath.Join(dir, "bldr.star")
 	err = os.WriteFile(starFile, []byte(`
 load("lib/common.star", "SHARED_PKGS")
@@ -1120,6 +1194,7 @@ manifest("core",
 		t.Fatal(err)
 	}
 
+	// Evaluate the fixture through the public project loader.
 	result, err := Evaluate(starFile)
 	if err != nil {
 		t.Fatal(err)

--- a/core/cdn/sharedobject/body-resolver.go
+++ b/core/cdn/sharedobject/body-resolver.go
@@ -8,7 +8,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/s4wave/spacewave/core/sobject"
 	"github.com/s4wave/spacewave/core/space"
-	space_world_optypes "github.com/s4wave/spacewave/core/space/world/optypes"
 	"github.com/sirupsen/logrus"
 )
 
@@ -19,12 +18,14 @@ func ResolveMountSharedObjectBody(
 	dir sobject.MountSharedObjectBody,
 ) ([]directive.Resolver, error) {
 	return directive.R(directive.NewAccessResolver(func(ctx context.Context, released func()) (space.MountSharedObjectBodyValue, func(), error) {
+		// Admit only the CDN object implementation for this body type.
 		cdnSO, ok := dir.MountSharedObjectBodySource().(*CdnSharedObject)
 		if !ok {
 			return nil, nil, errors.Errorf("cdn body type on non-cdn shared object: %T", dir.MountSharedObjectBodySource())
 		}
 
-		we, err := NewWorldEngine(ctx, le, b, cdnSO, space_world_optypes.LookupWorldOp)
+		// Tie the read-only engine to the mounted body reference.
+		we, err := NewWorldEngine(ctx, le, b, cdnSO)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "build cdn world engine")
 		}
@@ -36,6 +37,7 @@ func ResolveMountSharedObjectBody(
 			body,
 		)
 
+		// Release the engine when the mount is withdrawn.
 		return ret, we.Release, nil
 	}), nil)
 }

--- a/core/cdn/sharedobject/engine.go
+++ b/core/cdn/sharedobject/engine.go
@@ -14,16 +14,9 @@ import (
 	transform_all "github.com/s4wave/spacewave/db/block/transform/all"
 	"github.com/s4wave/spacewave/db/bucket"
 	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
-	"github.com/s4wave/spacewave/db/world"
 	world_block "github.com/s4wave/spacewave/db/world/block"
 	"github.com/sirupsen/logrus"
 )
-
-// CdnEngineID is the world engine id used for the CDN Space. A
-// LookupOpController registered on the bus for this engine id resolves the
-// full alpha op surface so world RPCs against the CDN mount behave the same
-// as against an authored Space.
-const CdnEngineID = "cdn.spacewave/world"
 
 // WorldEngine is the read-only world engine constructed for a CdnSharedObject.
 // The engine supports SetRootRef for live refresh when the CDN root changes.
@@ -50,6 +43,7 @@ type WorldEngine struct {
 // Safe to call more than once; the cursor's own Release guards against
 // double-release.
 func (w *WorldEngine) Release() {
+	// Stop head updates before releasing their backing resources.
 	if w == nil {
 		return
 	}
@@ -57,10 +51,14 @@ func (w *WorldEngine) Release() {
 		w.refresh.ClearContext()
 		w.refresh = nil
 	}
+
+	// Drop the cursor reference held for this engine.
 	if w.Cursor != nil {
 		w.Cursor.Release()
 		w.Cursor = nil
 	}
+
+	// Borrowed caches remain owned by the block store.
 	if w.ownDecodedBlocks && w.decodedBlocks != nil {
 		w.decodedBlocks.Close()
 	}
@@ -75,8 +73,7 @@ func (w *WorldEngine) Release() {
 // wrapping in a resource.space SpaceSharedObjectBody.
 //
 // The caller owns the returned WorldEngine and must call Release when done.
-// lookupOp is supplied by the caller so the engine and any derived resource
-// surfaces share the same op lookup path.
+// Operation lookup belongs to the resource serving this engine.
 //
 // A background routine is started to watch the CdnSharedObject snapshot
 // container and advance the engine's root ref via SetRootRef whenever the
@@ -86,8 +83,8 @@ func NewWorldEngine(
 	le *logrus.Entry,
 	b bus.Bus,
 	so *CdnSharedObject,
-	lookupOp world.LookupOp,
 ) (*WorldEngine, error) {
+	// Require a published head before constructing a readable world.
 	inner, err := so.GetHeadInnerState()
 	if err != nil {
 		return nil, errors.Wrap(err, "load cdn head inner state")
@@ -109,10 +106,13 @@ func NewWorldEngine(
 			)
 		}
 	}
+
+	// Route authored bucket references through the CDN block store.
 	headRef := inner.GetHeadRef().CloneVT()
 	bucketID := so.GetBlockStore().GetID()
 	headRef.BucketId = bucketID
 
+	// Decode the published head with its declared transform chain.
 	sfs := transform_all.BuildFactorySet()
 	transformConf := headRef.GetTransformConf()
 	xfrm := block_transform.NewTransformerWithSteps(nil)
@@ -127,6 +127,7 @@ func NewWorldEngine(
 		}
 	}
 
+	// Share decoded blocks with sibling engines over this store.
 	blockStore := so.GetBlockStore()
 	decodedBlocks := blockStore.GetDecodedBlockCache()
 	ownDecodedBlocks := false
@@ -144,6 +145,7 @@ func NewWorldEngine(
 		}
 	}()
 
+	// Hold the CDN cursor for every read and subsequent head update.
 	cursor := bucket_lookup.NewCursor(
 		ctx,
 		b,
@@ -161,12 +163,14 @@ func NewWorldEngine(
 	cursor.SetBucketIDOverride(bucketID)
 	cursor.SetDecodedBlockCache(decodedBlocks)
 
-	bengine, err := world_block.NewEngine(ctx, le, cursor, lookupOp, nil, false)
+	// Build state access without importing application operation handlers.
+	bengine, err := world_block.NewEngine(ctx, le, cursor, nil, nil, false)
 	if err != nil {
 		cursor.Release()
 		return nil, errors.Wrap(err, "new world engine")
 	}
 
+	// Keep cursor and cache ownership together for release.
 	w := &WorldEngine{
 		Engine:           bengine,
 		Cursor:           cursor,
@@ -174,6 +178,7 @@ func NewWorldEngine(
 		ownDecodedBlocks: ownDecodedBlocks,
 	}
 
+	// Follow published heads for the lifetime of the returned engine.
 	watchable, _, _ := so.AccessSharedObjectState(ctx, nil)
 	w.refresh = routine.NewRoutineContainerWithLogger(le)
 	w.refresh.SetRoutine(func(rctx context.Context) error {
@@ -208,6 +213,7 @@ func NewWorldEngine(
 	})
 	w.refresh.SetContext(ctx, true)
 
+	// Transfer fallback-cache cleanup to the returned owner.
 	closeDecodedBlocks = false
 	return w, nil
 }

--- a/core/cdn/sharedobject/shared-object_test.go
+++ b/core/cdn/sharedobject/shared-object_test.go
@@ -8,16 +8,16 @@ import (
 	"time"
 
 	"github.com/s4wave/spacewave/bldr/util/packedmsg"
-	"github.com/s4wave/spacewave/db/bucket"
-
 	alpha_cdn "github.com/s4wave/spacewave/core/cdn"
 	cdn_bstore "github.com/s4wave/spacewave/core/cdn/bstore"
 	packfile "github.com/s4wave/spacewave/core/provider/spacewave/packfile"
 	"github.com/s4wave/spacewave/core/sobject"
 	sobject_world_engine "github.com/s4wave/spacewave/core/sobject/world/engine"
+	"github.com/s4wave/spacewave/db/bucket"
 	"github.com/sirupsen/logrus"
 )
 
+// testSpaceID identifies the isolated CDN fixture.
 const testSpaceID = "01kpftest0000000000000001"
 
 // newTestSharedObject builds a CdnSharedObject wrapped around a CdnBlockStore
@@ -33,6 +33,7 @@ func newTestSharedObject(t *testing.T, seed *sobject.SORoot) *CdnSharedObject {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(bs.Close)
 	if seed != nil {
 		bs.SetPointer(&alpha_cdn.CdnRootPointer{
 			SpaceId: testSpaceID,
@@ -61,6 +62,7 @@ func setTestPointer(t *testing.T, so *CdnSharedObject, ptr *alpha_cdn.CdnRootPoi
 	bs.SetPointer(ptr)
 }
 
+// TestMetadataSurface exposes CDN identity and public-read metadata.
 func TestMetadataSurface(t *testing.T) {
 	so := newTestSharedObject(t, nil)
 	if got := so.GetSharedObjectID(); got != testSpaceID {
@@ -83,6 +85,7 @@ func TestMetadataSurface(t *testing.T) {
 	}
 }
 
+// TestWritePathsRejected rejects every SharedObject mutation surface.
 func TestWritePathsRejected(t *testing.T) {
 	ctx := context.Background()
 	so := newTestSharedObject(t, nil)
@@ -103,6 +106,7 @@ func TestWritePathsRejected(t *testing.T) {
 	}
 }
 
+// TestSnapshotBeforeAndAfterPointer distinguishes an absent head from a decoded published head.
 func TestSnapshotBeforeAndAfterPointer(t *testing.T) {
 	ctx := context.Background()
 	so := newTestSharedObject(t, nil)
@@ -164,6 +168,7 @@ func TestSnapshotBeforeAndAfterPointer(t *testing.T) {
 	}
 }
 
+// TestEmptyInitializedPointerHasNoHead treats an unpopulated CDN pointer as loading.
 func TestEmptyInitializedPointerHasNoHead(t *testing.T) {
 	ctx := context.Background()
 	so := newTestSharedObject(t, &sobject.SORoot{
@@ -191,6 +196,7 @@ func TestEmptyInitializedPointerHasNoHead(t *testing.T) {
 	}
 }
 
+// TestWorldEngineMissingPublishedHeadReturnsSharedObjectLoadingHealth reports retryable loading health before publication.
 func TestWorldEngineMissingPublishedHeadReturnsSharedObjectLoadingHealth(t *testing.T) {
 	ctx := context.Background()
 	ptr := &alpha_cdn.CdnRootPointer{
@@ -208,7 +214,7 @@ func TestWorldEngineMissingPublishedHeadReturnsSharedObjectLoadingHealth(t *test
 		_, _ = w.Write(encoded)
 	})
 	hs := httptest.NewServer(mux)
-	defer hs.Close()
+	t.Cleanup(hs.Close)
 
 	bs, err := cdn_bstore.NewCdnBlockStore(cdn_bstore.Options{
 		CdnBaseURL: hs.URL,
@@ -218,6 +224,7 @@ func TestWorldEngineMissingPublishedHeadReturnsSharedObjectLoadingHealth(t *test
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(bs.Close)
 	so, err := NewCdnSharedObject(CdnSharedObjectOptions{
 		SpaceID:    testSpaceID,
 		BlockStore: bs,
@@ -226,7 +233,7 @@ func TestWorldEngineMissingPublishedHeadReturnsSharedObjectLoadingHealth(t *test
 		t.Fatal(err)
 	}
 
-	_, err = NewWorldEngine(ctx, logrus.NewEntry(logrus.New()), nil, so, nil)
+	_, err = NewWorldEngine(ctx, logrus.NewEntry(logrus.New()), nil, so)
 	if err == nil {
 		t.Fatal("expected missing published head to block world engine construction")
 	}
@@ -242,6 +249,7 @@ func TestWorldEngineMissingPublishedHeadReturnsSharedObjectLoadingHealth(t *test
 	}
 }
 
+// TestWorldEnginesBorrowBlockStoreDecodedCache shares decoded blocks without transferring cache ownership.
 func TestWorldEnginesBorrowBlockStoreDecodedCache(t *testing.T) {
 	ctx := context.Background()
 	head := &bucket.ObjectRef{}
@@ -262,11 +270,11 @@ func TestWorldEnginesBorrowBlockStoreDecodedCache(t *testing.T) {
 	}
 
 	le := logrus.NewEntry(logrus.New())
-	first, err := NewWorldEngine(ctx, le, nil, so, nil)
+	first, err := NewWorldEngine(ctx, le, nil, so)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer first.Release()
+	t.Cleanup(first.Release)
 	followed, err := first.Cursor.FollowRef(ctx, &bucket.ObjectRef{BucketId: "authoring-world"})
 	if err != nil {
 		t.Fatalf("follow authoring ref through CDN bucket override: %v", err)
@@ -276,11 +284,11 @@ func TestWorldEnginesBorrowBlockStoreDecodedCache(t *testing.T) {
 		t.Fatalf("followed bucket = %q, want %q", got, testSpaceID)
 	}
 	followed.Release()
-	second, err := NewWorldEngine(ctx, le, nil, so, nil)
+	second, err := NewWorldEngine(ctx, le, nil, so)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer second.Release()
+	t.Cleanup(second.Release)
 
 	if first.decodedBlocks != wantCache || second.decodedBlocks != wantCache {
 		t.Fatal("world engines did not borrow the block-store decoded cache")
@@ -294,6 +302,7 @@ func TestWorldEnginesBorrowBlockStoreDecodedCache(t *testing.T) {
 	}
 }
 
+// TestPackedPointerRejectsUndecodableRoot rejects corrupt metadata once packs are published.
 func TestPackedPointerRejectsUndecodableRoot(t *testing.T) {
 	so := newTestSharedObject(t, nil)
 	setTestPointer(t, so, &alpha_cdn.CdnRootPointer{
@@ -331,7 +340,7 @@ func TestRefreshSnapshotEmitsOnWatch(t *testing.T) {
 		_, _ = w.Write(encoded)
 	})
 	hs := httptest.NewServer(mux)
-	defer hs.Close()
+	t.Cleanup(hs.Close)
 
 	bs, err := cdn_bstore.NewCdnBlockStore(cdn_bstore.Options{
 		CdnBaseURL: hs.URL,
@@ -341,6 +350,7 @@ func TestRefreshSnapshotEmitsOnWatch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(bs.Close)
 	so, err := NewCdnSharedObject(CdnSharedObjectOptions{
 		SpaceID:    testSpaceID,
 		BlockStore: bs,
@@ -353,7 +363,7 @@ func TestRefreshSnapshotEmitsOnWatch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer rel()
+	t.Cleanup(rel)
 
 	initial := watch.GetValue()
 	if initial == nil {
@@ -365,7 +375,7 @@ func TestRefreshSnapshotEmitsOnWatch(t *testing.T) {
 	}
 
 	waitCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
-	defer cancel()
+	t.Cleanup(cancel)
 	next, err := watch.WaitValueChange(waitCtx, initial, nil)
 	if err != nil {
 		t.Fatalf("WaitValueChange: %v", err)
@@ -378,6 +388,7 @@ func TestRefreshSnapshotEmitsOnWatch(t *testing.T) {
 	}
 }
 
+// TestHealthSurfaceTracksPointerLifecycle publishes loading and ready health as the CDN head changes.
 func TestHealthSurfaceTracksPointerLifecycle(t *testing.T) {
 	t.Parallel()
 
@@ -388,7 +399,7 @@ func TestHealthSurfaceTracksPointerLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer rel()
+	t.Cleanup(rel)
 
 	initial := healthCtr.GetValue()
 	if initial == nil {
@@ -405,7 +416,7 @@ func TestHealthSurfaceTracksPointerLifecycle(t *testing.T) {
 	so.setHealth(nil)
 
 	loadingCtx, loadingCancel := context.WithTimeout(ctx, 2*time.Second)
-	defer loadingCancel()
+	t.Cleanup(loadingCancel)
 	next, err := healthCtr.WaitValueChange(loadingCtx, initial, nil)
 	if err != nil {
 		t.Fatalf("WaitValueChange() = %v", err)
@@ -432,7 +443,7 @@ func TestHealthSurfaceTracksPointerLifecycle(t *testing.T) {
 	so.setHealth(nil)
 
 	readyCtx, readyCancel := context.WithTimeout(ctx, 2*time.Second)
-	defer readyCancel()
+	t.Cleanup(readyCancel)
 	next, err = healthCtr.WaitValueChange(readyCtx, next, nil)
 	if err != nil {
 		t.Fatalf("WaitValueChange() = %v", err)

--- a/core/cdn/world/controller/controller.go
+++ b/core/cdn/world/controller/controller.go
@@ -12,7 +12,6 @@ import (
 	cdn_bstore "github.com/s4wave/spacewave/core/cdn/bstore"
 	cdn_sharedobject "github.com/s4wave/spacewave/core/cdn/sharedobject"
 	"github.com/s4wave/spacewave/core/sobject"
-	space_world_optypes "github.com/s4wave/spacewave/core/space/world/optypes"
 	block_store "github.com/s4wave/spacewave/db/block/store"
 	"github.com/s4wave/spacewave/db/world"
 	"github.com/sirupsen/logrus"
@@ -24,8 +23,10 @@ const ControllerID = "spacewave/cdn/world"
 // Version is the version of the world implementation.
 var Version = controller.MustParseVersion("0.0.1")
 
+// missingHeadRetryDelay bounds retries while a CDN Space has no published head.
 const missingHeadRetryDelay = time.Second
 
+// releaseWorldEngineID selects the shared Release World block-store authority.
 const releaseWorldEngineID = "spacewave-release-world"
 
 // ReleaseBlockStoreID identifies the block store shared by Release World
@@ -34,11 +35,17 @@ const ReleaseBlockStoreID = "spacewave-release-cdn"
 
 // Controller exposes a read-only CDN-backed world engine.
 type Controller struct {
-	le       *logrus.Entry
-	b        bus.Bus
-	conf     *Config
-	engine   *cdn_sharedobject.WorldEngine
-	ctr      *ccontainer.CContainer[world.Engine]
+	// le records engine and CDN failures.
+	le *logrus.Entry
+	// b resolves the configured block store.
+	b bus.Bus
+	// conf is the immutable mount configuration.
+	conf *Config
+	// engine owns the active CDN cursor and refresh routine.
+	engine *cdn_sharedobject.WorldEngine
+	// ctr publishes the engine after the current head becomes readable.
+	ctr *ccontainer.CContainer[world.Engine]
+	// storeCtr publishes block-store authority while this controller owns it.
 	storeCtr *ccontainer.CContainer[*blockStoreAuthority]
 }
 
@@ -70,6 +77,7 @@ func (c *Controller) ownsBlockStore() bool {
 // no CDN transport is opened here; the root pointer is still fetched so the
 // mount can build its world head.
 func (c *Controller) newBlockStore(ctx context.Context) (cdn_bstore.RootBlockStore, func(), error) {
+	// Reuse the configured authority when another bus owns the CDN store.
 	if suppliedID := c.conf.GetSuppliedBlockStoreId(); suppliedID != "" {
 		suppliedStore, _, suppliedRef, err := block_store.ExLookupFirstBlockStore(ctx, c.b, suppliedID, false, nil)
 		if err != nil {
@@ -88,6 +96,7 @@ func (c *Controller) newBlockStore(ctx context.Context) (cdn_bstore.RootBlockSto
 		return store, suppliedRef.Release, nil
 	}
 
+	// Otherwise own the CDN transport and its durable writeback cache.
 	pointerTTL, _ := c.conf.ParsePointerTTLDur()
 	store, releaseStore, err := cdn_bstore.NewCachedBlockStore(ctx, c.b, cdn_bstore.CachedBlockStoreOptions{
 		CdnBaseURL:           c.conf.GetCdnBaseUrl(),
@@ -102,6 +111,7 @@ func (c *Controller) newBlockStore(ctx context.Context) (cdn_bstore.RootBlockSto
 
 // Execute builds the CDN world engine and holds it until shutdown.
 func (c *Controller) Execute(ctx context.Context) error {
+	// Hold the backing store until the mount is withdrawn.
 	store, releaseStore, err := c.newBlockStore(ctx)
 	if err != nil {
 		return err
@@ -120,6 +130,8 @@ func (c *Controller) Execute(ctx context.Context) error {
 			authority.wait()
 		}()
 	}
+
+	// Represent the published CDN Space without creating authored state.
 	so, err := cdn_sharedobject.NewCdnSharedObject(cdn_sharedobject.CdnSharedObjectOptions{
 		SpaceID:    c.conf.GetSpaceId(),
 		BlockStore: store,
@@ -127,8 +139,10 @@ func (c *Controller) Execute(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// Wait for a readable head, then publish one engine until cancellation.
 	for {
-		engine, err := cdn_sharedobject.NewWorldEngine(ctx, c.le, c.b, so, space_world_optypes.LookupWorldOp)
+		engine, err := cdn_sharedobject.NewWorldEngine(ctx, c.le, c.b, so)
 		if err != nil {
 			if !shouldRetryMissingPublishedHead() || !isMissingPublishedHead(err) {
 				return err
@@ -191,6 +205,7 @@ func (c *Controller) Close() error {
 	return nil
 }
 
+// isMissingPublishedHead identifies the retryable absence of a CDN root.
 func isMissingPublishedHead(err error) bool {
 	health, ok := sobject.GetSharedObjectHealthFromError(err)
 	if !ok || health == nil {

--- a/core/resource/cdn/cdn-resource.go
+++ b/core/resource/cdn/cdn-resource.go
@@ -11,21 +11,22 @@ import (
 	cdn_sharedobject "github.com/s4wave/spacewave/core/cdn/sharedobject"
 	resource_space "github.com/s4wave/spacewave/core/resource/space"
 	space_resolve "github.com/s4wave/spacewave/core/space/resolve"
-	space_world_optypes "github.com/s4wave/spacewave/core/space/world/optypes"
 	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	"github.com/s4wave/spacewave/db/world"
 	s4wave_cdn "github.com/s4wave/spacewave/sdk/cdn"
 	"github.com/sirupsen/logrus"
 )
 
-// CdnResource is a per-mount handle implementing CdnResourceService for a
-// single CdnInstance. The resource does not own the instance; it is a thin
-// adapter so the root GetCdn RPC (added in a later iteration) can hand out
-// a resource reference without exposing the Registry directly.
+// CdnResource exposes one CDN instance through the resource protocol.
+// The instance outlives the resource and remains owned by its registry.
 type CdnResource struct {
-	le       *logrus.Entry
-	b        bus.Bus
-	mux      srpc.Invoker
+	// le records mount and copy failures.
+	le *logrus.Entry
+	// b resolves destination Spaces and their storage.
+	b bus.Bus
+	// mux serves this resource's RPC methods.
+	mux srpc.Invoker
+	// instance is borrowed from the CDN registry.
 	instance *CdnInstance
 }
 
@@ -64,19 +65,22 @@ func (r *CdnResource) MountCdnSpace(
 	ctx context.Context,
 	_ *s4wave_cdn.MountCdnSpaceRequest,
 ) (*s4wave_cdn.MountCdnSpaceResponse, error) {
+	// Bind the mount to the requesting resource client.
 	resourceCtx, err := resource_server.MustGetResourceClientContext(ctx)
 	if err != nil {
 		return nil, err
 	}
 
+	// Open the current published CDN head for this operation.
 	cdnSO := r.instance.GetSharedObject()
-	we, err := cdn_sharedobject.NewWorldEngine(ctx, r.le, r.b, cdnSO, space_world_optypes.LookupWorldOp)
+	we, err := cdn_sharedobject.NewWorldEngine(ctx, r.le, r.b, cdnSO)
 	if err != nil {
 		return nil, errors.Wrap(err, "build cdn world engine")
 	}
 	body := cdn_sharedobject.NewCdnSpaceBody(cdnSO, we)
 	spaceResource := resource_space.NewSpaceResource(r.le, r.b, body)
 
+	// Transfer engine release to the client resource reference.
 	id, err := resourceCtx.AddResource(spaceResource.GetMux(), we.Release)
 	if err != nil {
 		we.Release()
@@ -96,6 +100,7 @@ func (r *CdnResource) CopyV86ImageToSpace(
 	req *s4wave_cdn.CopyV86ImageToSpaceRequest,
 	strm s4wave_cdn.SRPCCdnResourceService_CopyV86ImageToSpaceStream,
 ) error {
+	// Validate both object identities before opening either Space.
 	ctx := strm.Context()
 	if req.GetDstSpaceId() == "" {
 		return errors.New("dst_space_id is required")
@@ -107,28 +112,33 @@ func (r *CdnResource) CopyV86ImageToSpace(
 		return errors.New("dst_object_key is required")
 	}
 
+	// Expose CDN acquisition progress before network reads begin.
 	if err := strm.Send(&s4wave_cdn.CopyV86ImageToSpaceProgress{
 		Stage: s4wave_cdn.CopyV86ImageToSpaceStage_CopyV86ImageToSpaceStage_FETCHING,
 	}); err != nil {
 		return err
 	}
 
+	// Open the current published CDN head for this operation.
 	cdnSO := r.instance.GetSharedObject()
-	srcEngine, err := cdn_sharedobject.NewWorldEngine(ctx, r.le, r.b, cdnSO, space_world_optypes.LookupWorldOp)
+	srcEngine, err := cdn_sharedobject.NewWorldEngine(ctx, r.le, r.b, cdnSO)
 	if err != nil {
 		return errors.Wrap(err, "build cdn source world engine")
 	}
 	defer srcEngine.Release()
 
+	// Resolve write authority through the caller's session.
 	resolved, dstCleanup, err := space_resolve.ResolveSpace(ctx, r.b, req.GetSessionIdx(), req.GetDstSpaceId())
 	if err != nil {
 		return errors.Wrap(err, "resolve destination space")
 	}
 	defer dstCleanup()
 
+	// Keep the CDN source read-only while allowing destination writes.
 	src := world.NewEngineWorldState(srcEngine.Engine, false)
 	dst := world.NewEngineWorldState(resolved.Engine, true)
 
+	// Delegate block traversal and progress accounting to the copy owner.
 	if err := strm.Send(&s4wave_cdn.CopyV86ImageToSpaceProgress{
 		Stage: s4wave_cdn.CopyV86ImageToSpaceStage_CopyV86ImageToSpaceStage_COPYING,
 	}); err != nil {
@@ -157,6 +167,7 @@ func (r *CdnResource) CopyV86ImageToSpace(
 	))
 }
 
+// copyV86ImageProgress projects block-copy counters into the RPC progress message.
 func copyV86ImageProgress(
 	stage s4wave_cdn.CopyV86ImageToSpaceStage,
 	stats bucket_lookup.ObjectCopyStats,

--- a/forge/lib/v86/wazero/asset-options.go
+++ b/forge/lib/v86/wazero/asset-options.go
@@ -1,0 +1,76 @@
+package v86_wazero
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// DefaultCdnBaseURL serves the harness's published image fixtures.
+	DefaultCdnBaseURL = "https://cdn-staging.spacewave.app"
+	// DefaultCdnSpaceID identifies the fixture Space on the CDN.
+	DefaultCdnSpaceID = "01kpn3x0y79yr94ps1yae206vp"
+	// DefaultV86ImageKey selects the default boot image in the fixture Space.
+	DefaultV86ImageKey = "v86image-01kszf4rsev1s7zkq2ms2y5r0w"
+	// DefaultAssetCacheSubdir stores disposable boot files below the repository.
+	DefaultAssetCacheSubdir = ".tmp/v86-wazero"
+)
+
+// AssetOptions configures where the harness finds the real v86 image.
+type AssetOptions struct {
+	// Le records hydration activity; nil selects the harness's standard logger.
+	Le *logrus.Entry
+	// CacheDir stores downloaded boot files.
+	CacheDir string
+	// AssetDir takes precedence when it already contains a complete image.
+	AssetDir string
+	// V86Dir supplies emulator and BIOS files from a local checkout.
+	V86Dir string
+	// V86FSDir supplies the guest kernel and filesystem beside V86Dir.
+	V86FSDir string
+	// CdnBaseURL serves image metadata and content blocks.
+	CdnBaseURL string
+	// CdnSpaceID identifies the published fixture Space.
+	CdnSpaceID string
+	// ImageKey selects a preferred V86Image object within the Space.
+	ImageKey string
+	// Refresh bypasses cached downloads while retaining explicit local overrides.
+	Refresh bool
+}
+
+// OptionsFromEnv reads the V86_WAZERO_* and V86_DIR/V86FS_DIR environment variables.
+func OptionsFromEnv() AssetOptions {
+	return AssetOptions{
+		CacheDir:   strings.TrimSpace(os.Getenv("V86_WAZERO_CACHE_DIR")),
+		AssetDir:   strings.TrimSpace(os.Getenv("V86_WAZERO_ASSET_DIR")),
+		V86Dir:     strings.TrimSpace(os.Getenv("V86_DIR")),
+		V86FSDir:   strings.TrimSpace(os.Getenv("V86FS_DIR")),
+		CdnBaseURL: strings.TrimSpace(os.Getenv("V86_WAZERO_CDN_BASE_URL")),
+		CdnSpaceID: strings.TrimSpace(os.Getenv("V86_WAZERO_CDN_SPACE_ID")),
+		ImageKey:   strings.TrimSpace(os.Getenv("V86_WAZERO_IMAGE_KEY")),
+		Refresh:    strings.EqualFold(strings.TrimSpace(os.Getenv("V86_WAZERO_REFRESH")), "true"),
+	}
+}
+
+// withDefaults fills unset options with the standard fixture and cache locations.
+func (o AssetOptions) withDefaults() AssetOptions {
+	if o.Le == nil {
+		o.Le = logrus.NewEntry(logrus.StandardLogger())
+	}
+	if o.CdnBaseURL == "" {
+		o.CdnBaseURL = DefaultCdnBaseURL
+	}
+	if o.CdnSpaceID == "" {
+		o.CdnSpaceID = DefaultCdnSpaceID
+	}
+	if o.ImageKey == "" {
+		o.ImageKey = DefaultV86ImageKey
+	}
+	if o.CacheDir == "" {
+		o.CacheDir = filepath.Join(repoRootOrCwd(), DefaultAssetCacheSubdir)
+	}
+	return o
+}

--- a/forge/lib/v86/wazero/asset-set.go
+++ b/forge/lib/v86/wazero/asset-set.go
@@ -1,0 +1,25 @@
+package v86_wazero
+
+// AssetSet is the materialized v86 boot image used by the wazero harness.
+type AssetSet struct {
+	// Dir is the base directory containing the boot files.
+	Dir string
+	// ImageKey identifies the source V86Image object.
+	ImageKey string
+	// Wasm is the emulator module path.
+	Wasm string
+	// SeaBIOS is the machine BIOS path.
+	SeaBIOS string
+	// VGABIOS is the display BIOS path.
+	VGABIOS string
+	// Kernel is the guest kernel path.
+	Kernel string
+	// RootfsTar is the local guest filesystem archive path.
+	RootfsTar string
+	// RootfsJSON is the v86 filesystem index path.
+	RootfsJSON string
+	// RootfsFlatDir contains files addressed by the v86 filesystem index.
+	RootfsFlatDir string
+	// RootfsObjectKey identifies a CDN filesystem when no local archive is used.
+	RootfsObjectKey string
+}

--- a/forge/lib/v86/wazero/assets.go
+++ b/forge/lib/v86/wazero/assets.go
@@ -12,7 +12,6 @@ import (
 	"github.com/pkg/errors"
 	cdn_bstore "github.com/s4wave/spacewave/core/cdn/bstore"
 	cdn_sharedobject "github.com/s4wave/spacewave/core/cdn/sharedobject"
-	space_world_optypes "github.com/s4wave/spacewave/core/space/world/optypes"
 	"github.com/s4wave/spacewave/db/unixfs"
 	unixfs_billy "github.com/s4wave/spacewave/db/unixfs/billy"
 	unixfs_world "github.com/s4wave/spacewave/db/unixfs/world"
@@ -22,60 +21,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	DefaultCdnBaseURL       = "https://cdn-staging.spacewave.app"
-	DefaultCdnSpaceID       = "01kpn3x0y79yr94ps1yae206vp"
-	DefaultV86ImageKey      = "v86image-01kszf4rsev1s7zkq2ms2y5r0w"
-	DefaultAssetCacheSubdir = ".tmp/v86-wazero"
-)
-
-// AssetSet is the materialized v86 boot image used by the wazero harness.
-type AssetSet struct {
-	Dir             string
-	ImageKey        string
-	Wasm            string
-	SeaBIOS         string
-	VGABIOS         string
-	Kernel          string
-	RootfsTar       string
-	RootfsJSON      string
-	RootfsFlatDir   string
-	RootfsObjectKey string
-}
-
-// AssetOptions configures where the harness finds the real v86 image.
-type AssetOptions struct {
-	// Le is the logger entry for asset hydration; may be nil.
-	Le *logrus.Entry
-
-	CacheDir string
-	AssetDir string
-	V86Dir   string
-	V86FSDir string
-
-	CdnBaseURL string
-	CdnSpaceID string
-	ImageKey   string
-	Refresh    bool
-}
-
-// OptionsFromEnv reads the V86_WAZERO_* and V86_DIR/V86FS_DIR environment
-func OptionsFromEnv() AssetOptions {
-	refresh := strings.EqualFold(strings.TrimSpace(os.Getenv("V86_WAZERO_REFRESH")), "true")
-	return AssetOptions{
-		CacheDir:   strings.TrimSpace(os.Getenv("V86_WAZERO_CACHE_DIR")),
-		AssetDir:   strings.TrimSpace(os.Getenv("V86_WAZERO_ASSET_DIR")),
-		V86Dir:     strings.TrimSpace(os.Getenv("V86_DIR")),
-		V86FSDir:   strings.TrimSpace(os.Getenv("V86FS_DIR")),
-		CdnBaseURL: strings.TrimSpace(os.Getenv("V86_WAZERO_CDN_BASE_URL")),
-		CdnSpaceID: strings.TrimSpace(os.Getenv("V86_WAZERO_CDN_SPACE_ID")),
-		ImageKey:   strings.TrimSpace(os.Getenv("V86_WAZERO_IMAGE_KEY")),
-		Refresh:    refresh,
-	}
-}
-
-// ResolveAssets locates the v86 image from the configured directories or
+// ResolveAssets locates a complete local v86 image or downloads it from the CDN.
 func ResolveAssets(ctx context.Context, opts AssetOptions) (*AssetSet, error) {
+	// Prefer explicitly supplied local images over downloaded cache entries.
 	opts = opts.withDefaults()
 	if opts.AssetDir != "" {
 		if assets, ok := assetSetFromDir(opts.AssetDir, opts.ImageKey); ok {
@@ -87,40 +35,28 @@ func ResolveAssets(ctx context.Context, opts AssetOptions) (*AssetSet, error) {
 			return assets, nil
 		}
 	}
+
+	// Reuse a complete cached image unless a refresh was requested.
 	if !opts.Refresh {
 		if assets, ok := assetSetFromDir(opts.CacheDir, opts.ImageKey); ok {
 			return assets, nil
 		}
 	}
+
+	// Materialize the published image when no local source is usable.
 	return hydrateAssetsFromCdn(ctx, opts)
 }
 
-// withDefaults fills unset options with the repo-standard values.
-func (o AssetOptions) withDefaults() AssetOptions {
-	if o.Le == nil {
-		o.Le = logrus.NewEntry(logrus.StandardLogger())
-	}
-	if o.CdnBaseURL == "" {
-		o.CdnBaseURL = DefaultCdnBaseURL
-	}
-	if o.CdnSpaceID == "" {
-		o.CdnSpaceID = DefaultCdnSpaceID
-	}
-	if o.ImageKey == "" {
-		o.ImageKey = DefaultV86ImageKey
-	}
-	if o.CacheDir == "" {
-		o.CacheDir = filepath.Join(repoRootOrCwd(), DefaultAssetCacheSubdir)
-	}
-	return o
-}
-
-// repoRootOrCwd walks up to the repository root (the directory holding both
+// repoRootOrCwd finds the ancestor containing go.mod and bldr.star, or returns
+// the current directory when no repository root is found.
 func repoRootOrCwd() string {
+	// Use the current directory as the search origin and fallback.
 	wd, err := os.Getwd()
 	if err != nil {
 		return "."
 	}
+
+	// Accept only an ancestor that owns both module and build configuration.
 	for dir := wd; ; dir = filepath.Dir(dir) {
 		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
 			if _, err := os.Stat(filepath.Join(dir, "bldr.star")); err == nil {
@@ -134,8 +70,9 @@ func repoRootOrCwd() string {
 	}
 }
 
-// assetSetFromDir builds an AssetSet from a directory when it holds the
+// assetSetFromDir returns the directory's boot files when the image is complete.
 func assetSetFromDir(dir, imageKey string) (*AssetSet, bool) {
+	// Resolve the conventional paths for a complete boot image.
 	assets := &AssetSet{
 		Dir:           dir,
 		ImageKey:      imageKey,
@@ -147,6 +84,8 @@ func assetSetFromDir(dir, imageKey string) (*AssetSet, bool) {
 		RootfsJSON:    filepath.Join(dir, "fs.json"),
 		RootfsFlatDir: filepath.Join(dir, "flat"),
 	}
+
+	// A CDN rootfs reference can replace the local filesystem archive.
 	if rootfsKey, err := os.ReadFile(filepath.Join(dir, "rootfs.object-key")); err == nil {
 		assets.RootfsObjectKey = strings.TrimSpace(string(rootfsKey))
 	}
@@ -157,12 +96,14 @@ func assetSetFromDir(dir, imageKey string) (*AssetSet, bool) {
 	return nil, false
 }
 
-// assetSetFromV86Dirs builds an AssetSet pointing at the upstream v86 and
+// assetSetFromV86Dirs resolves boot files from v86 and v86fs checkouts.
 func assetSetFromV86Dirs(v86Dir, v86fsDir, imageKey string) (*AssetSet, bool) {
+	// Prefer the release emulator, with the checkout's debug build as fallback.
 	wasm := filepath.Join(v86Dir, "build", "v86.wasm")
 	if _, err := os.Stat(wasm); err != nil {
 		wasm = filepath.Join(v86Dir, "build", "v86-debug.wasm")
 	}
+	// Resolve the conventional paths for a complete boot image.
 	assets := &AssetSet{
 		Dir:           filepath.Dir(filepath.Dir(wasm)),
 		ImageKey:      imageKey,
@@ -180,7 +121,7 @@ func assetSetFromV86Dirs(v86Dir, v86fsDir, imageKey string) (*AssetSet, bool) {
 	return nil, false
 }
 
-// filesExist reports whether every named file exists in dir.
+// filesExist reports whether every path names a nonempty file.
 func filesExist(paths ...string) bool {
 	for _, path := range paths {
 		info, err := os.Stat(path)
@@ -191,21 +132,27 @@ func filesExist(paths ...string) bool {
 	return true
 }
 
-// hydrateAssetsFromCdn downloads the v86 image objects from the CDN into
+// hydrateAssetsFromCdn materializes boot files and a rootfs object reference
+// in the configured cache directory.
 func hydrateAssetsFromCdn(ctx context.Context, opts AssetOptions) (*AssetSet, error) {
+	// Prepare an output directory before opening CDN resources.
 	if err := os.MkdirAll(opts.CacheDir, 0o755); err != nil {
 		return nil, errors.Wrap(err, "create v86 wazero cache dir")
 	}
+
+	// Hold one published world across image selection and file reads.
 	ws, release, err := mountCdnWorld(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
 	defer release()
 
+	// Select a published V86Image before following its asset edges.
 	imageKey, err := resolveV86ImageKey(ctx, ws, opts.ImageKey)
 	if err != nil {
 		return nil, err
 	}
+	// Download boot files while leaving the large rootfs addressable by object key.
 	specs := []assetSpec{
 		{Pred: string(s4wave_vm.PredV86ImageWasm), FileName: "v86.wasm", OutName: "v86.wasm"},
 		{Pred: string(s4wave_vm.PredV86ImageBiosSeabios), FileName: "seabios.bin", OutName: "seabios.bin"},
@@ -217,6 +164,8 @@ func hydrateAssetsFromCdn(ctx context.Context, opts AssetOptions) (*AssetSet, er
 			return nil, err
 		}
 	}
+
+	// Retain the rootfs identity for lazy filesystem access.
 	rootfsKey, err := lookupEdge(ctx, ws, imageKey, string(s4wave_vm.PredV86ImageRootfs))
 	if err != nil {
 		return nil, err
@@ -227,6 +176,8 @@ func hydrateAssetsFromCdn(ctx context.Context, opts AssetOptions) (*AssetSet, er
 	if err := os.WriteFile(filepath.Join(opts.CacheDir, "rootfs.object-key"), []byte(rootfsKey+"\n"), 0o644); err != nil {
 		return nil, errors.Wrap(err, "write rootfs object key marker")
 	}
+
+	// Return only a cache entry with every required boot artifact.
 	assets, ok := assetSetFromDir(opts.CacheDir, imageKey)
 	if !ok {
 		return nil, errors.Errorf("hydrated v86 assets incomplete in %s", opts.CacheDir)
@@ -237,6 +188,7 @@ func hydrateAssetsFromCdn(ctx context.Context, opts AssetOptions) (*AssetSet, er
 
 // mountCdnWorld mounts the v86 image's shared object world for edge lookup.
 func mountCdnWorld(ctx context.Context, opts AssetOptions) (world_state.WorldState, func(), error) {
+	// Own the CDN transport until the mounted world is released.
 	store, err := cdn_bstore.NewCdnBlockStore(cdn_bstore.Options{
 		CdnBaseURL: opts.CdnBaseURL,
 		SpaceID:    opts.CdnSpaceID,
@@ -245,6 +197,8 @@ func mountCdnWorld(ctx context.Context, opts AssetOptions) (world_state.WorldSta
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "build cdn block store")
 	}
+
+	// Bind the published head to the transport's block store.
 	so, err := cdn_sharedobject.NewCdnSharedObject(cdn_sharedobject.CdnSharedObjectOptions{
 		SpaceID:    opts.CdnSpaceID,
 		BlockStore: store,
@@ -253,7 +207,9 @@ func mountCdnWorld(ctx context.Context, opts AssetOptions) (world_state.WorldSta
 		store.Close()
 		return nil, nil, errors.Wrap(err, "build cdn shared object")
 	}
-	we, err := cdn_sharedobject.NewWorldEngine(ctx, opts.Le, nil, so, space_world_optypes.LookupWorldOp)
+
+	// Keep the read engine and its backing transport under one release callback.
+	we, err := cdn_sharedobject.NewWorldEngine(ctx, opts.Le, nil, so)
 	if err != nil {
 		store.Close()
 		return nil, nil, errors.Wrap(err, "mount cdn world")
@@ -265,8 +221,10 @@ func mountCdnWorld(ctx context.Context, opts AssetOptions) (world_state.WorldSta
 	}, nil
 }
 
-// resolveV86ImageKey resolves the well-known image key to its canonical
+// resolveV86ImageKey prefers an existing requested image, otherwise selecting
+// the lexically greatest V86Image object key.
 func resolveV86ImageKey(ctx context.Context, ws world_state.WorldState, preferred string) (string, error) {
+	// Honor an existing explicit image before scanning the CDN catalogue.
 	if preferred != "" {
 		if _, found, err := ws.GetObject(ctx, preferred); err != nil {
 			return "", errors.Wrap(err, "probe preferred v86 image")
@@ -274,6 +232,8 @@ func resolveV86ImageKey(ctx context.Context, ws world_state.WorldState, preferre
 			return preferred, nil
 		}
 	}
+
+	// Choose deterministically when the preferred object is unavailable.
 	keys, err := world_types.ListObjectsWithType(ctx, ws, s4wave_vm.V86ImageTypeID)
 	if err != nil {
 		return "", errors.Wrap(err, "list cdn v86 images")
@@ -287,13 +247,17 @@ func resolveV86ImageKey(ctx context.Context, ws world_state.WorldState, preferre
 
 // assetSpec names one guest image file and the graph predicate linking it.
 type assetSpec struct {
-	Pred     string
+	// Pred identifies the image-to-file graph edge.
+	Pred string
+	// FileName selects the file inside the UnixFS object.
 	FileName string
-	OutName  string
+	// OutName names the materialized file in the cache.
+	OutName string
 }
 
-// writeCdnAsset resolves one image-file edge and writes the object bytes to
+// writeCdnAsset writes an image edge's UnixFS file into the cache directory.
 func writeCdnAsset(ctx context.Context, le *logrus.Entry, ws world_state.WorldState, imageKey string, spec assetSpec, dir string) error {
+	// Resolve the file object from the selected image's graph edge.
 	assetKey, err := lookupEdge(ctx, ws, imageKey, spec.Pred)
 	if err != nil {
 		return err
@@ -301,6 +265,8 @@ func writeCdnAsset(ctx context.Context, le *logrus.Entry, ws world_state.WorldSt
 	if assetKey == "" {
 		return errors.Errorf("v86 image %q missing %s edge", imageKey, spec.Pred)
 	}
+
+	// Materialize the selected file under its conventional boot name.
 	data, err := readUnixFSAsset(ctx, le, ws, assetKey, spec.FileName)
 	if err != nil {
 		return errors.Wrapf(err, "read %s asset object %q", spec.FileName, assetKey)
@@ -322,16 +288,20 @@ func lookupEdge(ctx context.Context, ws world_state.WorldState, subject, pred st
 
 // readUnixFSAsset extracts a single file from a unixfs object by name.
 func readUnixFSAsset(ctx context.Context, le *logrus.Entry, ws world_state.WorldState, objectKey, fileName string) ([]byte, error) {
+	// Hold the object's filesystem while reading its selected asset.
 	fsh, err := openFSHandleForObject(ctx, le, ws, objectKey)
 	if err != nil {
 		return nil, err
 	}
 	defer fsh.Release()
 
+	// Prefer the conventional filename over a single-file object fallback.
 	bfs := unixfs_billy.NewBillyFS(ctx, fsh, "", time.Time{})
 	if data, err := billy_util.ReadFile(bfs, fileName); err == nil {
 		return data, nil
 	}
+
+	// Accept an alternate name only when the object contains exactly one file.
 	entries, err := bfs.ReadDir(".")
 	if err != nil {
 		return nil, err
@@ -344,10 +314,13 @@ func readUnixFSAsset(ctx context.Context, le *logrus.Entry, ws world_state.World
 
 // openFSHandleForObject opens the unixfs handle rooted at an object key.
 func openFSHandleForObject(ctx context.Context, le *logrus.Entry, ws world_state.WorldState, objectKey string) (*unixfs.FSHandle, error) {
+	// Resolve the stored filesystem type before constructing its cursor.
 	fsType, _, err := unixfs_world.LookupFsType(ctx, ws, objectKey)
 	if err != nil {
 		return nil, errors.Wrap(err, "lookup fs type")
 	}
+
+	// Transfer cursor ownership into the filesystem handle.
 	fsCursor := unixfs_world.NewFSCursor(le, ws, objectKey, fsType, nil, false)
 	fsh, err := unixfs.NewFSHandle(fsCursor)
 	if err != nil {


### PR DESCRIPTION
CDN engines read world state directly, but their unused operation callback imported the application operation catalogue into the browser host. Remove that callback and the redundant Release World operation controllers. Keep operation handlers in the core plugin and native host, and migrate all CDN callers. Release fixtures now account for the embedded materializer and the complete E2E startup payload.

With the same GoScript compiler (523ce45c43a4), the host dependency graph drops from 699 to 564 packages and its module from 20.87 MB to 13.65 MB. Five fresh-browser runs per version measured median time to the persisted getting-started.md entry at 7.90 s before and 7.40 s after. A CPU-contended candidate outlier is included; these samples do not establish an exact saving across environments.

Validation: focused CDN, V86, entrypoint, and Starlark tests; GoScript browser build; published Release World manifest and root-block reads for Core, Web, App, the web UI, and terminal; fresh-browser Drive checks; offline reopening of the same saved Space route and guide. The native scheduler fixture also verifies remote startup followed by local materialization without restarting the executable.
