### PR TITLE
fix(invite): return the consumed invite state to joining peers

### DIFF
--- a/core/resource/session/local-spacelink-e2e_test.go
+++ b/core/resource/session/local-spacelink-e2e_test.go
@@ -340,6 +340,25 @@ func TestLocalSpaceLinkDeviceEnrollmentEndToEnd(t *testing.T) {
 	if joinResult.SharedObjectState == nil {
 		t.Fatal("invite join returned no owner shared object state")
 	}
+
+	// The joined snapshot must include the owner's post-acceptance invite use
+	// count so native and projected views observe the same authoritative state.
+	foundInvite := false
+	for _, returnedInvite := range joinResult.SharedObjectState.GetInvites() {
+		if returnedInvite.GetInviteId() != invite.GetInviteId() {
+			continue
+		}
+		foundInvite = true
+		if returnedInvite.GetUses() != 1 {
+			t.Fatalf("joined invite uses = %d, want 1", returnedInvite.GetUses())
+		}
+		break
+	}
+	if !foundInvite {
+		t.Fatalf("joined state omitted invite %q", invite.GetInviteId())
+	}
+
+	// The originating owner retains decryption authority over the joined copy.
 	if _, err := joinResult.OwnerGrant.DecryptInnerData(ownerMountedSO.GetPrivKey(), spaceID); err != nil {
 		t.Fatalf("originating owner cannot decrypt joined state: %v", err)
 	}

--- a/core/sobject/invite/server.go
+++ b/core/sobject/invite/server.go
@@ -189,6 +189,12 @@ func (s *Server) AcceptInvite(ctx context.Context, req *AcceptInviteRequest) (*A
 		return nil, errors.Wrap(err, "increment invite uses")
 	}
 
+	// Transfer the configuration after every acceptance mutation has completed.
+	ownerState, err = result.Host.GetHostState(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "read updated owner shared object state")
+	}
+
 	return &AcceptInviteResponse{
 		Grant:             grant,
 		SharedObjectId:    result.SharedObjectID,


### PR DESCRIPTION
An accepted invite returned the owner's SharedObject snapshot from before its use count was incremented. The joining peer therefore installed an older configuration revision even though acceptance had completed.

Read the final owner state after recording the invite use, while preserving the existing owner-grant validation. The native enrollment regression now checks that the returned invite has one recorded use.

Validation: invite package tests and the local Space-link enrollment end-to-end test pass. A two-client integration also confirms equal projected room state after joining.
