### PR TITLE
perf(bldr): gzip embedded manifests for GoScript browsers

### DIFF
--- a/bldr/dist/compiler/bundle.go
+++ b/bldr/dist/compiler/bundle.go
@@ -189,10 +189,6 @@ func BuildDistBundle(
 	}
 	defer nref.Release()
 
-	// workingID is a unique working id used to derive some at-rest crypto keys.
-	// XXX: may be replaced with something with more randomness later.
-	workingID := strings.Join([]string{ControllerID, meta.GetProjectId(), buildPlatform.GetPlatformID()}, "/")
-
 	// Start with a working db on-disk in the working dir.
 	workingDbVolID := "dist-working-vol"
 	workingDbVolConf, err := storage.BuildVolumeConfig("dist-working-vol", &volume_controller.Config{
@@ -203,6 +199,8 @@ func BuildDistBundle(
 		VolumeIdAlias:       []string{workingDbVolID, bldr_dist.StaticBlockStoreID},
 		DisablePeer:         true,
 		DisableEventBlockRm: true,
+		// GcIntervalDur disables collection because the scratch World has no durable root.
+		GcIntervalDur: "0",
 	})
 	if err != nil {
 		return err
@@ -229,7 +227,6 @@ func BuildDistBundle(
 
 	// Create the embedded manifests world.
 	embedWorldID := bldr_dist.DistWorldEngineID
-	embedObjStoreID := embedWorldID
 	bucketConf, err := bldr_dist.NewDistBucketConfig(meta.GetProjectId())
 	if err != nil {
 		return err
@@ -238,16 +235,18 @@ func BuildDistBundle(
 	if err != nil {
 		return err
 	}
-	embedXfrmConf, err := block_transform.NewConfig(buildEmbedTransformConf(workingID))
+	embedXfrmConf, err := block_transform.NewConfig(buildEmbedTransformConf(isWebPlatform && useGoScript))
 	if err != nil {
 		return err
 	}
 
+	// Reuse scratch blocks, but rebuild the head from this bundle's selected
+	// manifests and transform. A persisted head would restore an older codec.
 	embedEngineConf := world_block_engine.NewConfig(
 		embedWorldID,
 		workingDbVolID,
 		bucketConf.GetId(),
-		embedObjStoreID,
+		"",
 		&bucket.ObjectRef{TransformConf: embedXfrmConf.CloneVT()},
 		nil,
 		false,

--- a/bldr/dist/compiler/bundle/bundle.go
+++ b/bldr/dist/compiler/bundle/bundle.go
@@ -19,6 +19,8 @@ import (
 // BundleManifestsKvfile packs the world and its manifests in traversal order
 // for read locality. Only reachable blocks are included; prior build history
 // in the backing store does not affect the result.
+// The caller must finish writing the World before packing; accepted writes
+// are fenced before the archive reads blocks from their backing store.
 func BundleManifestsKvfile(
 	ctx context.Context,
 	le *logrus.Entry,
@@ -26,7 +28,13 @@ func BundleManifestsKvfile(
 	kvfileBlockPrefix []byte,
 	blkEng *world_block.Engine,
 ) error {
+	// Raw block traversal must see every accepted write, including deferred ones.
+	if _, err := blkEng.Sync(ctx); err != nil {
+		return err
+	}
 	nextRootRef := blkEng.GetRootRef()
+
+	// Write each reachable block once in stable traversal order.
 	seen := make(map[string]struct{})
 	walkWriteBlocks := func(bls *bucket_lookup.Cursor, ref *block.BlockRef, ctor block.Ctor) error {
 		return bucket_lookup.WalkObjectBlocks(
@@ -57,6 +65,7 @@ func BundleManifestsKvfile(
 		)
 	}
 
+	// Pack the World root followed by the referenced manifest DAGs.
 	return blkEng.AccessWorldState(ctx, nextRootRef, func(bls *bucket_lookup.Cursor) error {
 		if err := walkWriteBlocks(bls, nextRootRef.GetRootRef(), world_block.NewWorldBlock); err != nil {
 			return err

--- a/bldr/dist/compiler/bundle/bundle_test.go
+++ b/bldr/dist/compiler/bundle/bundle_test.go
@@ -30,7 +30,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// TestBundleManifestsKvfileWorldRootLifetime checks standalone archive reads,
+// deferred writes, unrelated build history, and a missing root.
 func TestBundleManifestsKvfileWorldRootLifetime(t *testing.T) {
+	// Build a scratch volume with the real World and block storage components.
 	ctx := t.Context()
 	log := logrus.New()
 	le := logrus.NewEntry(log)
@@ -58,7 +61,7 @@ func TestBundleManifestsKvfileWorldRootLifetime(t *testing.T) {
 		baseCursor.GetOpArgs(),
 		nil,
 	)
-	eng, err := world_block.NewEngine(ctx, le, ocs, world_mock.LookupMockOp, nil, false)
+	eng, err := world_block.NewEngine(ctx, le, ocs, world_mock.LookupMockOp, nil, false, world_block.WithDeferredDurability())
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -68,6 +71,7 @@ func TestBundleManifestsKvfileWorldRootLifetime(t *testing.T) {
 		}
 	})
 
+	// Store a complete manifest DAG with enough data to require nested blocks.
 	assetData := bytes.Repeat([]byte("packaged asset contents"), 16*1024)
 	assetDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(assetDir, "asset.bin"), assetData, 0o644); err != nil {
@@ -85,12 +89,13 @@ func TestBundleManifestsKvfileWorldRootLifetime(t *testing.T) {
 	manifestRef := ocs.GetRef().Clone()
 	manifestRef.RootRef = manifestRoot
 
+	// Leave the World update buffered so the packer must fence it before reading.
 	wtx, err := eng.NewTransaction(ctx, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
+	defer wtx.Discard()
 	if _, err := wtx.CreateObject(ctx, "bundle-root-closure-object", &bucket.ObjectRef{BucketId: tb.BucketId}); err != nil {
-		wtx.Discard()
 		t.Fatal(err.Error())
 	}
 	if _, err := wtx.CreateObject(ctx, "manifest-fixture", manifestRef); err != nil {
@@ -108,12 +113,14 @@ func TestBundleManifestsKvfileWorldRootLifetime(t *testing.T) {
 	}
 	rootRefStr := rootRef.MarshalString()
 
+	// Keep direct backing-store access for the history and missing-block checks.
 	kvtxVol, ok := tb.Volume.(volume_kvtx.KvtxVolume)
 	if !ok {
 		t.Fatalf("testbed volume type %T does not expose a kvtx store", tb.Volume)
 	}
 
 	t.Run("live world root", func(t *testing.T) {
+		// Pack accepted writes into an independent archive.
 		var buf bytes.Buffer
 		kvfileWriter := kvfile.NewWriter(&buf)
 		err := dist_compiler_bundle.BundleManifestsKvfile(
@@ -197,6 +204,7 @@ func TestBundleManifestsKvfileWorldRootLifetime(t *testing.T) {
 	})
 
 	t.Run("missing world root", func(t *testing.T) {
+		// Removing the durable root must fail packing instead of emitting an archive.
 		if err := ocs.GetBucket().RmBlock(ctx, rootRef); err != nil {
 			t.Fatal(err)
 		}
@@ -220,12 +228,15 @@ func TestBundleManifestsKvfileWorldRootLifetime(t *testing.T) {
 	})
 }
 
+// passthroughTransform keeps backing-store bytes directly readable by the fixture.
 type passthroughTransform struct{}
 
+// EncodeBlock preserves the input bytes.
 func (passthroughTransform) EncodeBlock(data []byte) ([]byte, error) {
 	return data, nil
 }
 
+// DecodeBlock preserves the encoded bytes.
 func (passthroughTransform) DecodeBlock(data []byte) ([]byte, error) {
 	return data, nil
 }

--- a/bldr/dist/compiler/xfrm.go
+++ b/bldr/dist/compiler/xfrm.go
@@ -2,12 +2,15 @@ package bldr_dist_compiler
 
 import (
 	"github.com/aperturerobotics/controllerbus/config"
+	transform_gzip "github.com/s4wave/spacewave/db/block/transform/gzip"
 	transform_s2 "github.com/s4wave/spacewave/db/block/transform/s2"
 )
 
-// buildEmbedTransformConf is the block transform conf to use for the embedded manifest world.
-func buildEmbedTransformConf(_ string) []config.Config {
-	return []config.Config{
-		&transform_s2.Config{},
+// buildEmbedTransformConf selects compression for newly embedded manifest blocks.
+// GoScript browsers decode gzip through their native decompression streams.
+func buildEmbedTransformConf(goScriptBrowser bool) []config.Config {
+	if goScriptBrowser {
+		return []config.Config{&transform_gzip.Config{}}
 	}
+	return []config.Config{&transform_s2.Config{}}
 }

--- a/bldr/dist/compiler/xfrm_test.go
+++ b/bldr/dist/compiler/xfrm_test.go
@@ -3,13 +3,31 @@ package bldr_dist_compiler
 import (
 	"testing"
 
-	transform_blockenc "github.com/s4wave/spacewave/db/block/transform/blockenc"
+	transform_gzip "github.com/s4wave/spacewave/db/block/transform/gzip"
+	transform_s2 "github.com/s4wave/spacewave/db/block/transform/s2"
 )
 
-func TestBuildEmbedTransformConfOmitsBlockEnc(t *testing.T) {
-	for _, step := range buildEmbedTransformConf("spacewave") {
-		if step.GetConfigID() == transform_blockenc.ConfigID {
-			t.Fatal("embed transform config must not include blockenc")
-		}
+// TestBuildEmbedTransformConf checks the decoder selected for each target.
+func TestBuildEmbedTransformConf(t *testing.T) {
+	for _, test := range []struct {
+		name            string
+		goScriptBrowser bool
+		configID        string
+	}{
+		{name: "native", configID: transform_s2.ConfigID},
+		{name: "goscript-browser", goScriptBrowser: true, configID: transform_gzip.ConfigID},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			steps := buildEmbedTransformConf(test.goScriptBrowser)
+			if len(steps) != 1 {
+				t.Fatalf("expected one compression step, got %d", len(steps))
+			}
+			if got := steps[0].GetConfigID(); got != test.configID {
+				t.Fatalf("compression step = %s, want %s", got, test.configID)
+			}
+			if err := steps[0].Validate(); err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
GoScript browser builds now embed manifests with gzip, using the browser's native decompression stream. Other targets retain S2. The scratch World gets a fresh head on each build so cached state cannot restore the previous codec; packing fences accepted writes before reading their backing blocks.

The embedded archive decreased from 60.47 MB to 43.81 MB (27.6%). Three comparable fresh-browser runs per build measured median file-row visibility at 6.225 seconds for S2 and 6.161 seconds for gzip; this is a size improvement with no established material startup-time gain.

Validation: focused race tests for archive packing, transform selection, and materializer copying passed. Both release GoScript builds passed, including a regression that failed without the packing fence. Embedded-cache offline reload passed; production background-copy completion was not newly measured.
