### PR TITLE
perf(db): retain segment spans within the shared cache budget

### DIFF
--- a/db/volume/js/opfs/blockshard/cache-coordinator.go
+++ b/db/volume/js/opfs/blockshard/cache-coordinator.go
@@ -59,7 +59,6 @@ type cacheEntry struct {
 	lookup         *segment.LookupMeta
 	lookupResource *cacheResource
 	blocks         map[int64]*cachedBlock
-	blockSpans     int
 	fills          map[segmentFillRange]*segmentFill
 	leases         int
 	loading        chan struct{}
@@ -460,18 +459,6 @@ func (c *cacheCoordinator) finishSpanFill(
 		}
 	}
 
-	// Preserve the per-segment span count without evicting a pinned span.
-	if admit && entry.blockSpans >= maxCachedSegmentSpans {
-		resource := c.oldestSpanLocked(entry)
-		if resource == nil {
-			c.stats.Bypasses++
-			admit = false
-		}
-		if resource != nil {
-			c.removeResourceLocked(resource, true)
-		}
-	}
-
 	// Reserve the exact backing allocation through the engine byte budget.
 	charge := uint64(cap(span.data))
 	if admit {
@@ -498,7 +485,6 @@ func (c *cacheCoordinator) finishSpanFill(
 		for off := fill.key.start; off < fill.key.end; off += cachedSegmentBlockSize {
 			entry.blocks[off] = &cachedBlock{span: cached}
 		}
-		entry.blockSpans++
 		fill.resource = resource
 		c.addResourceLocked(resource)
 		c.pinResourceLocked(lease, resource)
@@ -665,15 +651,6 @@ func (c *cacheCoordinator) oldestEvictableLocked(forHandle bool) *cacheResource 
 	return nil
 }
 
-func (c *cacheCoordinator) oldestSpanLocked(entry *cacheEntry) *cacheResource {
-	for resource := c.lruHead; resource != nil; resource = resource.next {
-		if resource.entry == entry && resource.kind == cacheResourceSpan && resource.pins == 0 {
-			return resource
-		}
-	}
-	return nil
-}
-
 func (c *cacheCoordinator) addResourceLocked(resource *cacheResource) {
 	// Mark the resource resident and link it at the recency tail.
 	resource.resident = true
@@ -777,7 +754,6 @@ func (c *cacheCoordinator) removeResourceLocked(resource *cacheResource, evictio
 				delete(entry.blocks, off)
 			}
 		}
-		entry.blockSpans--
 		span.resource = nil
 		resource.span = nil
 		c.stats.BlockBytes -= resource.bytes

--- a/db/volume/js/opfs/blockshard/cache-coordinator_test.go
+++ b/db/volume/js/opfs/blockshard/cache-coordinator_test.go
@@ -265,33 +265,93 @@ func TestCacheCoordinatorOpenFailureRollsBackHandle(t *testing.T) {
 	}
 }
 
-func TestCacheCoordinatorPerSegmentSpanLimitBypassesPinnedPressure(t *testing.T) {
-	// Build an immutable file spanning more fills than one segment admits.
-	data, meta := cacheCoordinatorLargeFixture(t)
-	cache := newCacheCoordinator(^uint64(0), 2)
-	lease, _ := acquireCoordinatorFixture(t, cache, 0, meta.Filename, data, meta)
+func TestCacheCoordinatorReusesSpansWithinGlobalByteBudget(t *testing.T) {
+	// Build one immutable file with a six-block working set that fits its cache.
+	const spanCount = 6
+	data := bytes.Repeat([]byte("reuse"), spanCount*cachedSegmentBlockSize/5)
+	reader := &cacheCoordinatorTestReader{data: data}
+	cache := newCacheCoordinator(uint64(len(data)), 1)
+	lease, key := newCoordinatorDataLease(cache, reader, int64(len(data)))
+	entry := lease.entry
 
-	// Pin more one-block spans than the shipping per-segment policy admits.
-	for i := range maxCachedSegmentSpans + 2 {
-		var dst [1]byte
-		if _, err := lease.ReadAt(dst[:], int64(i*cachedSegmentBlockSize)); err != nil {
-			t.Fatal(err)
+	// Read the working set twice through independent operation leases.
+	for pass := range 2 {
+		for i := range spanCount {
+			var dst [1]byte
+			if _, err := lease.ReadAt(dst[:], int64(i*cachedSegmentBlockSize)); err != nil {
+				t.Fatalf("pass %d span %d: %v", pass, i, err)
+			}
+			lease.Release()
+			if pass != 1 || i != spanCount-1 {
+				lease = newCoordinatorPeerLease(cache, entry)
+			}
 		}
 	}
+
+	// Require the second pass to reuse every globally admitted span.
 	stats := cache.snapshot()
-	if lease.entry.blockSpans > maxCachedSegmentSpans {
-		t.Fatalf("resident spans: got %d limit %d", lease.entry.blockSpans, maxCachedSegmentSpans)
+	wantBytes := uint64(len(data))
+	if reader.readCount() != spanCount || stats.ReadCalls != spanCount {
+		t.Fatalf("snapshot reads: reader=%d calls=%d want=%d", reader.readCount(), stats.ReadCalls, spanCount)
 	}
-	if len(lease.entry.blocks) > maxCachedSegmentSpans {
-		t.Fatalf("resident block views: got %d limit %d", len(lease.entry.blocks), maxCachedSegmentSpans)
+	if stats.FetchedBytes != wantBytes || stats.ChargedBytes != wantBytes || stats.BlockBytes != wantBytes {
+		t.Fatalf("resident bytes: fetched=%d charged=%d blocks=%d want=%d", stats.FetchedBytes, stats.ChargedBytes, stats.BlockBytes, wantBytes)
 	}
-	if stats.Bypasses == 0 {
-		t.Fatal("expected pinned span pressure to bypass admission")
+	if len(entry.blocks) != spanCount || stats.Evictions != 0 || stats.Bypasses != 0 {
+		t.Fatalf("resident spans: blocks=%d evictions=%d bypasses=%d", len(entry.blocks), stats.Evictions, stats.Bypasses)
 	}
 
-	// Release every retained resource after the pressure check.
+	// Retire the working set and release its reader.
+	cache.remove(key)
+	stats = cache.snapshot()
+	if stats.ChargedBytes != 0 || stats.PinnedBytes != 0 || stats.LiveHandles != 0 {
+		t.Fatalf("removed cache state: charged=%d pinned=%d handles=%d", stats.ChargedBytes, stats.PinnedBytes, stats.LiveHandles)
+	}
+	if reader.closeCount() != 1 {
+		t.Fatalf("removed reader closes: got %d want 1", reader.closeCount())
+	}
+}
+
+func TestCacheCoordinatorPinnedByteBudgetBypassesAdmission(t *testing.T) {
+	// Build an immutable file larger than the cache's four-block byte budget.
+	const admittedSpans = 4
+	const requestedSpans = admittedSpans + 2
+	data := bytes.Repeat([]byte("pinned"), requestedSpans*cachedSegmentBlockSize/6)
+	reader := &cacheCoordinatorTestReader{data: data}
+	byteLimit := uint64(admittedSpans * cachedSegmentBlockSize)
+	cache := newCacheCoordinator(byteLimit, 1)
+	lease, _ := newCoordinatorDataLease(cache, reader, int64(len(data)))
+
+	// Keep admitted spans pinned while later reads exceed the byte budget.
+	for i := range requestedSpans {
+		var dst [1]byte
+		if _, err := lease.ReadAt(dst[:], int64(i*cachedSegmentBlockSize)); err != nil {
+			t.Fatalf("span %d: %v", i, err)
+		}
+	}
+
+	// Require excess reads to succeed without exceeding the global budget.
+	stats := cache.snapshot()
+	if len(lease.entry.blocks) != admittedSpans {
+		t.Fatalf("resident block views: got %d want %d", len(lease.entry.blocks), admittedSpans)
+	}
+	if stats.ChargedBytes != byteLimit || stats.PinnedBytes != byteLimit {
+		t.Fatalf("pinned budget: charged=%d pinned=%d want=%d", stats.ChargedBytes, stats.PinnedBytes, byteLimit)
+	}
+	if stats.ReadCalls != requestedSpans || stats.Bypasses != requestedSpans-admittedSpans {
+		t.Fatalf("budget pressure: reads=%d bypasses=%d", stats.ReadCalls, stats.Bypasses)
+	}
+
+	// Release every pin and drain the admitted reader.
 	lease.Release()
 	cache.close()
+	stats = cache.snapshot()
+	if stats.ChargedBytes != 0 || stats.PinnedBytes != 0 || stats.LiveHandles != 0 {
+		t.Fatalf("closed cache state: charged=%d pinned=%d handles=%d", stats.ChargedBytes, stats.PinnedBytes, stats.LiveHandles)
+	}
+	if reader.closeCount() != 1 {
+		t.Fatalf("closed reader closes: got %d want 1", reader.closeCount())
+	}
 }
 
 func TestCacheCoordinatorChargesOneBackingAllocationPerSpan(t *testing.T) {
@@ -318,8 +378,8 @@ func TestCacheCoordinatorChargesOneBackingAllocationPerSpan(t *testing.T) {
 	if stats.ChargedBytes != wantCharge || stats.BlockBytes != wantCharge {
 		t.Fatalf("span charge: charged=%d blocks=%d want=%d", stats.ChargedBytes, stats.BlockBytes, wantCharge)
 	}
-	if lease.entry.blockSpans != 1 || len(lease.entry.blocks) != 3 {
-		t.Fatalf("resident span: spans=%d block_views=%d", lease.entry.blockSpans, len(lease.entry.blocks))
+	if len(lease.entry.blocks) != 3 {
+		t.Fatalf("resident block views: got %d want 3", len(lease.entry.blocks))
 	}
 	span := lease.entry.blocks[0].span
 	for off := int64(0); off < int64(len(data)); off += cachedSegmentBlockSize {
@@ -332,8 +392,8 @@ func TestCacheCoordinatorChargesOneBackingAllocationPerSpan(t *testing.T) {
 	lease.Release()
 	cache.remove(key)
 	stats = cache.snapshot()
-	if len(lease.entry.blocks) != 0 || lease.entry.blockSpans != 0 {
-		t.Fatalf("removed span: spans=%d block_views=%d", lease.entry.blockSpans, len(lease.entry.blocks))
+	if len(lease.entry.blocks) != 0 {
+		t.Fatalf("removed block views: got %d", len(lease.entry.blocks))
 	}
 	if stats.ChargedBytes != 0 || stats.BlockBytes != 0 || stats.LiveHandles != 0 {
 		t.Fatalf("removed charge: charged=%d blocks=%d handles=%d", stats.ChargedBytes, stats.BlockBytes, stats.LiveHandles)
@@ -427,8 +487,8 @@ func TestCacheCoordinatorSharesFailureAndAllowsRetry(t *testing.T) {
 	if stats.ChargedBytes != 0 || stats.BlockBytes != 0 || stats.Admissions != 0 {
 		t.Fatalf("failed fill residency: charged=%d blocks=%d admissions=%d", stats.ChargedBytes, stats.BlockBytes, stats.Admissions)
 	}
-	if len(leaseA.entry.fills) != 0 || len(leaseA.entry.blocks) != 0 || leaseA.entry.blockSpans != 0 {
-		t.Fatalf("failed fill state: fills=%d block_views=%d spans=%d", len(leaseA.entry.fills), len(leaseA.entry.blocks), leaseA.entry.blockSpans)
+	if len(leaseA.entry.fills) != 0 || len(leaseA.entry.blocks) != 0 {
+		t.Fatalf("failed fill state: fills=%d block_views=%d", len(leaseA.entry.fills), len(leaseA.entry.blocks))
 	}
 
 	// Start a new lease after failure and admit its successful retry.

--- a/db/volume/js/opfs/blockshard/cache-policy-replay_test.go
+++ b/db/volume/js/opfs/blockshard/cache-policy-replay_test.go
@@ -173,9 +173,10 @@ func runCachePolicyReplayWorkload(
 	median := walls[(len(walls)-1)/2]
 	p95 := walls[(95*len(walls)+99)/100-1]
 	t.Logf(
-		"cache-policy-summary block_bytes=%d max_spans=%d threshold_bytes=%d workload=%s repetitions=%d median_us=%d p95_us=%d",
+		"cache-policy-summary block_bytes=%d byte_limit=%d handle_limit=%d threshold_bytes=%d workload=%s repetitions=%d median_us=%d p95_us=%d",
 		cachedSegmentBlockSize,
-		maxCachedSegmentSpans,
+		defaultCacheByteLimit,
+		defaultCacheHandleLimit,
 		maxCachedSegmentRead,
 		workload.name,
 		len(samples),
@@ -194,9 +195,10 @@ func logCachePolicyReplaySample(
 	t.Helper()
 	stats := sample.stats
 	t.Logf(
-		"cache-policy-sample block_bytes=%d max_spans=%d threshold_bytes=%d workload=%s repetition=%d wall_us=%d retained_block_bytes=%d retained_metadata_bytes=%d retained_bytes=%d peak_retained_bytes=%d go_heap_delta_bytes=%d js_heap_delta_bytes=%d js_heap_status=%s live_handles=%d peak_handles=%d reads=%d fetched_bytes=%d hits=%d misses=%d admissions=%d evictions=%d bypasses=%d shared_fills=%d release_errors=%d",
+		"cache-policy-sample block_bytes=%d byte_limit=%d handle_limit=%d threshold_bytes=%d workload=%s repetition=%d wall_us=%d retained_block_bytes=%d retained_metadata_bytes=%d retained_bytes=%d peak_retained_bytes=%d go_heap_delta_bytes=%d js_heap_delta_bytes=%d js_heap_status=%s live_handles=%d peak_handles=%d reads=%d fetched_bytes=%d hits=%d misses=%d admissions=%d evictions=%d bypasses=%d shared_fills=%d release_errors=%d",
 		cachedSegmentBlockSize,
-		maxCachedSegmentSpans,
+		defaultCacheByteLimit,
+		defaultCacheHandleLimit,
 		maxCachedSegmentRead,
 		workload,
 		repetition,

--- a/db/volume/js/opfs/blockshard/cache-scale_test.go
+++ b/db/volume/js/opfs/blockshard/cache-scale_test.go
@@ -126,7 +126,7 @@ func TestCachedSegmentFileScale(t *testing.T) {
 	if jsStatus == "available" {
 		jsDelta = int64(jsAfter) - int64(jsBefore)
 	}
-	const rowFormat = "cache-scale policy_block_bytes=%d policy_max_spans=%d " +
+	const rowFormat = "cache-scale block_bytes=%d " +
 		"byte_limit=%d handle_limit=%d segments=%d entries_per_segment=%d " +
 		"retained_block_bytes=%d retained_metadata_bytes=%d retained_bytes=%d " +
 		"peak_retained_bytes=%d go_heap_bytes=%d go_heap_delta_bytes=%d " +
@@ -137,7 +137,6 @@ func TestCachedSegmentFileScale(t *testing.T) {
 	t.Logf(
 		rowFormat,
 		cachedSegmentBlockSize,
-		maxCachedSegmentSpans,
 		defaultCacheByteLimit,
 		defaultCacheHandleLimit,
 		count,

--- a/db/volume/js/opfs/blockshard/cache.go
+++ b/db/volume/js/opfs/blockshard/cache.go
@@ -15,9 +15,9 @@ import (
 )
 
 const (
-	cachedSegmentBlockSize = 64 * 1024
-	maxCachedSegmentSpans  = 4
-	maxCachedSegmentRead   = cachedSegmentBlockSize * maxCachedSegmentSpans
+	cachedSegmentBlockSize     = 64 * 1024
+	maxLocalCachedSegmentSpans = 4
+	maxCachedSegmentRead       = 4 * cachedSegmentBlockSize
 )
 
 type segmentReader interface {
@@ -233,7 +233,7 @@ func (f *cachedSegmentFile) getLocalSpan(blockOff, endBlock int64) (segmentDataS
 	fill.span = span
 	fill.err = err
 	if err == nil && !f.localRangeOverlapsLocked(key) {
-		if len(f.order) >= maxCachedSegmentSpans {
+		if len(f.order) >= maxLocalCachedSegmentSpans {
 			f.removeLocalSpanLocked(f.order[0])
 		}
 		cached := &localCachedSpan{segmentDataSpan: span}


### PR DESCRIPTION
The coordinated OPFS cache evicted spans after four allocations per segment even when its shared byte budget had room for the working set. Remove that redundant cap and use the existing global eviction policy. Standalone readers keep their local cap; read size, pin protection, and byte/handle limits remain unchanged.

In ten real-OPFS Chromium replay samples, the strided workload drops from 122 reads and 7.84 MB fetched to 12 reads and 0.77 MB. Median replay time drops from 55.7 ms to 17.3 ms, with retained cache bytes increasing from 0.27 MB to 0.79 MB within the existing budget. This is a component result; startup improvement is not yet measured.

Validation: the new reuse test fails before the change and passes after it; pinned-budget, coordinator, full browser-WASM package tests, and commit hooks pass. Changed-code lint reports zero issues. Full js/wasm package lint reports four pre-existing unused trace-context assignments in untouched files.
