### PR TITLE
perf(opfs): stream large existence lookup windows

### DIFF
--- a/db/volume/js/opfs/blockshard/cache-policy-replay_test.go
+++ b/db/volume/js/opfs/blockshard/cache-policy-replay_test.go
@@ -17,42 +17,67 @@ import (
 	"github.com/s4wave/spacewave/db/volume/js/opfs/segment"
 )
 
+// cachePolicyReplayEnv gates the destructive real-OPFS replay fixture.
 const cachePolicyReplayEnv = "SPACEWAVE_OPFS_CACHE_POLICY_REPLAY"
 
 // cachePolicyReplayFixture describes one immutable real-OPFS segment corpus.
 type cachePolicyReplayFixture struct {
+	// filename identifies the fixture within the replay directory.
 	filename string
-	data     []byte
-	meta     *SegmentMeta
-	keys     [][]byte
-	value    []byte
+	// data is the complete encoded segment.
+	data []byte
+	// meta describes the segment to the cache coordinator.
+	meta *SegmentMeta
+	// keys retain the encoded source order.
+	keys [][]byte
+	// value is the shared value expected from every lookup.
+	value []byte
 }
 
 // cachePolicyReplayWorkload fixes one request order over an immutable fixture.
 type cachePolicyReplayWorkload struct {
-	name    string
+	// name identifies samples in the replay output.
+	name string
+	// fixture supplies the immutable segment corpus.
 	fixture *cachePolicyReplayFixture
-	keys    [][]byte
+	// keys fixes the lookup order for every repetition.
+	keys [][]byte
+	// existsOnly selects existence lookup behavior.
+	existsOnly bool
 }
 
 // cachePolicyReplaySample retains one complete policy and workload observation.
 type cachePolicyReplaySample struct {
-	wall         time.Duration
-	goHeapDelta  int64
-	jsHeapDelta  int64
+	// wall is the elapsed lookup time.
+	wall time.Duration
+	// goHeapDelta is retained Go heap growth after collection.
+	goHeapDelta int64
+	// goTotalAllocDelta is total Go allocation during the replay.
+	goTotalAllocDelta uint64
+	// jsHeapDelta is sampled JavaScript heap growth when available.
+	jsHeapDelta int64
+	// jsHeapStatus describes JavaScript heap measurement availability.
 	jsHeapStatus string
-	stats        cacheStats
+	// stats is the cache state before coordinator shutdown.
+	stats cacheStats
 }
 
+// TestCachePolicyReplay measures cache behavior against deterministic segments
+// stored in real OPFS.
 func TestCachePolicyReplay(t *testing.T) {
 	// Keep the real-OPFS replay out of routine package checks.
 	if os.Getenv(cachePolicyReplayEnv) != "1" {
 		t.Skipf("set %s=1 to run the cache policy replay", cachePolicyReplayEnv)
 	}
 
-	// Create the point-scan and near-threshold immutable segment fixtures.
+	// Create the point-scan and window-size immutable segment fixtures.
 	point := newCachePolicyReplayFixture(t, "point.sst", 4096, 176)
-	window := newCachePolicyReplayFixture(t, "window.sst", 64, 12<<10)
+	window1K := newCachePolicyReplayFixture(t, "window-1k.sst", 64, 1<<10)
+	window4K := newCachePolicyReplayFixture(t, "window-4k.sst", 64, 4<<10)
+	window8K := newCachePolicyReplayFixture(t, "window-8k.sst", 64, 8<<10)
+	window12K := newCachePolicyReplayFixture(t, "window.sst", 64, 12<<10)
+
+	// Replace the replay directory and remove it after the run.
 	root, err := opfs.GetRoot()
 	if err != nil {
 		t.Fatal(err)
@@ -68,25 +93,44 @@ func TestCachePolicyReplay(t *testing.T) {
 			t.Error(err)
 		}
 	})
-	for _, fixture := range []*cachePolicyReplayFixture{point, window} {
+	for _, fixture := range []*cachePolicyReplayFixture{point, window1K, window4K, window8K, window12K} {
 		if err := opfs.WriteFile(dir, fixture.filename, fixture.data); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	// Exercise fixed sequential, strided, hotset, and threshold-window orders.
+	// Exercise identical value and existence lookups over each fixed order.
+	pointStrided := cachePolicyReplayStridedKeys(point.keys, 2053)
+	pointHotset := cachePolicyReplayRepeatedKeys(point.keys[2048:2112], 64)
+	windowHot := cachePolicyReplayRepeatedKeys(window12K.keys[32:33], 64)
 	workloads := []cachePolicyReplayWorkload{
 		{name: "point-sequential", fixture: point, keys: point.keys},
-		{name: "point-strided", fixture: point, keys: cachePolicyReplayStridedKeys(point.keys, 2053)},
-		{name: "point-hotset", fixture: point, keys: cachePolicyReplayRepeatedKeys(point.keys[2048:2112], 64)},
-		{name: "window-hot", fixture: window, keys: cachePolicyReplayRepeatedKeys(window.keys[32:33], 64)},
+		{name: "point-strided", fixture: point, keys: pointStrided},
+		{name: "point-hotset", fixture: point, keys: pointHotset},
+		{name: "window-hot", fixture: window12K, keys: windowHot},
+		{name: "point-sequential-exists", fixture: point, keys: point.keys, existsOnly: true},
+		{name: "point-strided-exists", fixture: point, keys: pointStrided, existsOnly: true},
+		{name: "point-hotset-exists", fixture: point, keys: pointHotset, existsOnly: true},
+		{name: "window-hot-exists", fixture: window12K, keys: windowHot, existsOnly: true},
+		{name: "window-1k-first-exists", fixture: window1K, keys: cachePolicyReplayRepeatedKeys(window1K.keys[32:33], 64), existsOnly: true},
+		{name: "window-1k-middle-exists", fixture: window1K, keys: cachePolicyReplayRepeatedKeys(window1K.keys[40:41], 64), existsOnly: true},
+		{name: "window-1k-last-exists", fixture: window1K, keys: cachePolicyReplayRepeatedKeys(window1K.keys[47:48], 64), existsOnly: true},
+		{name: "window-4k-first-exists", fixture: window4K, keys: cachePolicyReplayRepeatedKeys(window4K.keys[32:33], 64), existsOnly: true},
+		{name: "window-4k-middle-exists", fixture: window4K, keys: cachePolicyReplayRepeatedKeys(window4K.keys[40:41], 64), existsOnly: true},
+		{name: "window-4k-last-exists", fixture: window4K, keys: cachePolicyReplayRepeatedKeys(window4K.keys[47:48], 64), existsOnly: true},
+		{name: "window-8k-first-exists", fixture: window8K, keys: cachePolicyReplayRepeatedKeys(window8K.keys[32:33], 64), existsOnly: true},
+		{name: "window-8k-middle-exists", fixture: window8K, keys: cachePolicyReplayRepeatedKeys(window8K.keys[40:41], 64), existsOnly: true},
+		{name: "window-8k-last-exists", fixture: window8K, keys: cachePolicyReplayRepeatedKeys(window8K.keys[47:48], 64), existsOnly: true},
+		{name: "window-12k-middle-exists", fixture: window12K, keys: cachePolicyReplayRepeatedKeys(window12K.keys[40:41], 64), existsOnly: true},
+		{name: "window-12k-last-exists", fixture: window12K, keys: cachePolicyReplayRepeatedKeys(window12K.keys[47:48], 64), existsOnly: true},
 	}
 	for _, workload := range workloads {
 		runCachePolicyReplayWorkload(t, dir, workload)
 	}
 }
 
-// runCachePolicyReplayWorkload records ten fresh-cache samples and one summary.
+// runCachePolicyReplayWorkload records ten fresh-cache samples, verifies each
+// coordinator drains, and reports nearest-rank latency.
 func runCachePolicyReplayWorkload(
 	t *testing.T,
 	dir js.Value,
@@ -118,16 +162,18 @@ func runCachePolicyReplayWorkload(
 			if err != nil {
 				t.Fatal(err)
 			}
-			value, found, err := lease.lookup.Get(lease, key)
+			value, found, _, err := lease.lookup.Locate(lease, key, !workload.existsOnly)
 			lease.Release()
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !found || !bytes.Equal(value, workload.fixture.value) {
+			if !found || (!workload.existsOnly && !bytes.Equal(value, workload.fixture.value)) {
 				t.Fatalf("workload %s returned found=%t bytes=%d", workload.name, found, len(value))
 			}
 		}
 		wall := time.Since(started)
+		var goAllocated runtime.MemStats
+		runtime.ReadMemStats(&goAllocated)
 
 		// Capture retained cache and heap state before closing the coordinator.
 		runtime.GC()
@@ -142,11 +188,12 @@ func runCachePolicyReplayWorkload(
 			jsDelta = int64(jsAfter) - int64(jsBefore)
 		}
 		sample := cachePolicyReplaySample{
-			wall:         wall,
-			goHeapDelta:  int64(goAfter.HeapAlloc) - int64(goBefore.HeapAlloc),
-			jsHeapDelta:  jsDelta,
-			jsHeapStatus: jsStatus,
-			stats:        cache.snapshot(),
+			wall:              wall,
+			goHeapDelta:       int64(goAfter.HeapAlloc) - int64(goBefore.HeapAlloc),
+			goTotalAllocDelta: goAllocated.TotalAlloc - goBefore.TotalAlloc,
+			jsHeapDelta:       jsDelta,
+			jsHeapStatus:      jsStatus,
+			stats:             cache.snapshot(),
 		}
 
 		// Close every admitted resource and retain the drained counters.
@@ -193,9 +240,11 @@ func logCachePolicyReplaySample(
 	sample cachePolicyReplaySample,
 ) {
 	t.Helper()
+
+	// Emit the complete sample as one machine-readable row.
 	stats := sample.stats
 	t.Logf(
-		"cache-policy-sample block_bytes=%d byte_limit=%d handle_limit=%d threshold_bytes=%d workload=%s repetition=%d wall_us=%d retained_block_bytes=%d retained_metadata_bytes=%d retained_bytes=%d peak_retained_bytes=%d go_heap_delta_bytes=%d js_heap_delta_bytes=%d js_heap_status=%s live_handles=%d peak_handles=%d reads=%d fetched_bytes=%d hits=%d misses=%d admissions=%d evictions=%d bypasses=%d shared_fills=%d release_errors=%d",
+		"cache-policy-sample block_bytes=%d byte_limit=%d handle_limit=%d threshold_bytes=%d workload=%s repetition=%d wall_us=%d retained_block_bytes=%d retained_metadata_bytes=%d retained_bytes=%d peak_retained_bytes=%d go_heap_delta_bytes=%d go_total_alloc_delta_bytes=%d js_heap_delta_bytes=%d js_heap_status=%s live_handles=%d peak_handles=%d reads=%d fetched_bytes=%d hits=%d misses=%d admissions=%d evictions=%d bypasses=%d shared_fills=%d release_errors=%d",
 		cachedSegmentBlockSize,
 		defaultCacheByteLimit,
 		defaultCacheHandleLimit,
@@ -208,6 +257,7 @@ func logCachePolicyReplaySample(
 		stats.ChargedBytes,
 		stats.PeakChargedBytes,
 		sample.goHeapDelta,
+		sample.goTotalAllocDelta,
 		sample.jsHeapDelta,
 		sample.jsHeapStatus,
 		stats.LiveHandles,
@@ -232,6 +282,8 @@ func newCachePolicyReplayFixture(
 	valueSize int,
 ) *cachePolicyReplayFixture {
 	t.Helper()
+
+	// Encode ordered fixed-width keys with one shared immutable value.
 	entries := make([]segment.Entry, entryCount)
 	keys := make([][]byte, entryCount)
 	value := bytes.Repeat([]byte("v"), valueSize)
@@ -241,6 +293,8 @@ func newCachePolicyReplayFixture(
 		keys[i] = key
 		entries[i] = segment.Entry{Key: key, Value: value}
 	}
+
+	// Bind the encoded segment to the metadata consumed by the replay.
 	data := buildSegmentData(t, entries)
 	return &cachePolicyReplayFixture{
 		filename: filename,

--- a/db/volume/js/opfs/segment/lookup.go
+++ b/db/volume/js/opfs/segment/lookup.go
@@ -7,40 +7,57 @@ import (
 	"io"
 	"strconv"
 
-	trace "github.com/s4wave/spacewave/db/traceutil"
-
 	"github.com/pkg/errors"
+	trace "github.com/s4wave/spacewave/db/traceutil"
 )
 
+// maxExistenceWindowRead keeps small existence lookups to one buffered read;
+// larger windows stream entry metadata to avoid copying their values.
+const maxExistenceWindowRead = 64 * 1024
+
+// maxLookupWindowRead keeps value lookups through 256 KiB to one buffered
+// read; larger windows stream to bound allocation.
 const maxLookupWindowRead = 256 * 1024
 
 // LookupMeta is the metadata needed for point lookups without reparsing the
 // full SSTable on each access.
 type LookupMeta struct {
+	// Header describes the encoded segment sections.
 	Header *Header
+	// MinKey is the first key in the segment.
 	MinKey []byte
+	// MaxKey is the last key in the segment.
 	MaxKey []byte
-	Index  []IndexEntry
-	Bloom  *BloomFilter
+	// Index maps sparse keys to data-window offsets.
+	Index []IndexEntry
+	// Bloom rejects keys that cannot occur in the segment.
+	Bloom *BloomFilter
 }
 
 // LookupResult is the result of a batched segment lookup.
 type LookupResult struct {
-	Value     []byte
-	Found     bool
+	// Value contains a copied live value when the lookup requested values.
+	Value []byte
+	// Found reports whether the segment contains a live value.
+	Found bool
+	// Tombstone reports whether the segment contains a deletion marker.
 	Tombstone bool
 }
 
 // LookupStat is metadata for a lookup result that does not require loading the
 // value bytes.
 type LookupStat struct {
+	// ValueSize is the encoded live value length.
 	ValueSize int64
-	Found     bool
+	// Found reports whether the segment contains a live value.
+	Found bool
+	// Tombstone reports whether the segment contains a deletion marker.
 	Tombstone bool
 }
 
 // LoadLookupMeta loads only the SSTable metadata needed for point lookups.
 func LoadLookupMeta(r io.ReaderAt, size int64) (*LookupMeta, error) {
+	// Decode the fixed header after checking the minimum encoded size.
 	if size < HeaderSize+4 {
 		return nil, errors.New("file too small for SSTable")
 	}
@@ -54,6 +71,7 @@ func LoadLookupMeta(r io.ReaderAt, size int64) (*LookupMeta, error) {
 		return nil, errors.Wrap(err, "decode header")
 	}
 
+	// Decode the key bounds that guard every lookup.
 	keyMetaSize := 2 + int(hdr.MinKeySize) + 2 + int(hdr.MaxKeySize)
 	keyBuf := make([]byte, keyMetaSize)
 	if _, err := r.ReadAt(keyBuf, HeaderSize); err != nil {
@@ -78,6 +96,7 @@ func LoadLookupMeta(r io.ReaderAt, size int64) (*LookupMeta, error) {
 	maxKey := make([]byte, maxKeyLen)
 	copy(maxKey, keyBuf[off:off+maxKeyLen])
 
+	// Decode the optional sparse index.
 	var idx []IndexEntry
 	if hdr.IndexSize > 0 {
 		idxBuf := make([]byte, hdr.IndexSize)
@@ -90,6 +109,7 @@ func LoadLookupMeta(r io.ReaderAt, size int64) (*LookupMeta, error) {
 		}
 	}
 
+	// Decode the optional negative-lookup filter.
 	var bloom *BloomFilter
 	if hdr.BloomSize > 0 {
 		bloomBuf := make([]byte, hdr.BloomSize)
@@ -102,6 +122,7 @@ func LoadLookupMeta(r io.ReaderAt, size int64) (*LookupMeta, error) {
 		}
 	}
 
+	// Retain only metadata needed by point and batch lookups.
 	return &LookupMeta{
 		Header: hdr,
 		MinKey: minKey,
@@ -111,14 +132,14 @@ func LoadLookupMeta(r io.ReaderAt, size int64) (*LookupMeta, error) {
 	}, nil
 }
 
-// Get looks up a key using cached metadata and a single data-window read.
+// Get looks up a live value using cached segment metadata.
 func (m *LookupMeta) Get(r io.ReaderAt, key []byte) ([]byte, bool, error) {
 	val, found, _, err := m.Locate(r, key, true)
 	return val, found, err
 }
 
-// Has checks whether a key exists using cached metadata and a single data-window
-// read. Tombstoned keys return false.
+// Has checks whether a key exists without materializing a result value.
+// Tombstoned keys return false.
 func (m *LookupMeta) Has(r io.ReaderAt, key []byte) (bool, error) {
 	_, found, _, err := m.Locate(r, key, false)
 	return found, err
@@ -127,10 +148,12 @@ func (m *LookupMeta) Has(r io.ReaderAt, key []byte) (bool, error) {
 // Stat resolves a key and returns the value size without materializing the
 // value. Tombstoned keys return Found=false with Tombstone=true.
 func (m *LookupMeta) Stat(r io.ReaderAt, key []byte) (LookupStat, error) {
+	// Trace the complete metadata lookup.
 	ctx := context.Background()
 	_, task := trace.NewTask(ctx, "hydra/opfs-segment/lookup-meta/stat")
 	defer task.End()
 
+	// Reject keys excluded by the segment bounds or bloom filter.
 	keyStr := string(key)
 	if keyStr < string(m.MinKey) || keyStr > string(m.MaxKey) {
 		return LookupStat{}, nil
@@ -139,6 +162,7 @@ func (m *LookupMeta) Stat(r io.ReaderAt, key []byte) (LookupStat, error) {
 		return LookupStat{}, nil
 	}
 
+	// Select and validate the sparse-index window.
 	start, limit := SearchIndex(m.Index, key, m.Header.DataSize)
 	if limit < start {
 		return LookupStat{}, errors.New("invalid data window")
@@ -147,6 +171,8 @@ func (m *LookupMeta) Stat(r io.ReaderAt, key []byte) (LookupStat, error) {
 	if err != nil {
 		return LookupStat{}, err
 	}
+
+	// Buffer common windows and stream larger windows to bound allocation.
 	if windowSize <= maxLookupWindowRead {
 		window := make([]byte, windowSize)
 		if _, err := r.ReadAt(window, int64(m.Header.DataOffset)+int64(start)); err != nil {
@@ -160,10 +186,12 @@ func (m *LookupMeta) Stat(r io.ReaderAt, key []byte) (LookupStat, error) {
 // Locate resolves a key using cached metadata.
 // Returns either a live value, a tombstone marker, or a miss.
 func (m *LookupMeta) Locate(r io.ReaderAt, key []byte, loadValue bool) ([]byte, bool, bool, error) {
+	// Trace the complete point lookup.
 	ctx := context.Background()
 	ctx, task := trace.NewTask(ctx, "hydra/opfs-segment/lookup-meta/locate")
 	defer task.End()
 
+	// Reject keys excluded by the segment bounds or bloom filter.
 	keyStr := string(key)
 	if keyStr < string(m.MinKey) || keyStr > string(m.MaxKey) {
 		return nil, false, false, nil
@@ -172,6 +200,7 @@ func (m *LookupMeta) Locate(r io.ReaderAt, key []byte, loadValue bool) ([]byte, 
 		return nil, false, false, nil
 	}
 
+	// Select and validate the sparse-index window.
 	_, subtask := trace.NewTask(ctx, "hydra/opfs-segment/lookup-meta/locate/search-index")
 	start, limit := SearchIndex(m.Index, key, m.Header.DataSize)
 	subtask.End()
@@ -185,35 +214,42 @@ func (m *LookupMeta) Locate(r io.ReaderAt, key []byte, loadValue bool) ([]byte, 
 	}
 	trace.Log(ctx, "window", "size="+strconv.Itoa(windowSize))
 
-	if windowSize <= maxLookupWindowRead {
-		_, subtask = trace.NewTask(ctx, "hydra/opfs-segment/lookup-meta/locate/read-window")
-		window := make([]byte, windowSize)
-		if _, err := r.ReadAt(window, int64(m.Header.DataOffset)+int64(start)); err != nil {
-			subtask.End()
-			return nil, false, false, errors.Wrap(err, "read data window")
-		}
-		subtask.End()
-
-		taskCtx, subtask := trace.NewTask(ctx, "hydra/opfs-segment/lookup-meta/locate/scan-window")
-		val, found, tombstone, err := locateInWindowBytes(taskCtx, window, keyStr, loadValue)
+	// Stream large windows so existence checks avoid copying value bytes and
+	// value lookups bound their allocation.
+	if (!loadValue && windowSize > maxExistenceWindowRead) || windowSize > maxLookupWindowRead {
+		_, subtask = trace.NewTask(ctx, "hydra/opfs-segment/lookup-meta/locate/scan-window-streamed")
+		val, found, tombstone, err := locateInWindowReader(r, int64(m.Header.DataOffset), start, limit, key, loadValue)
 		subtask.End()
 		return val, found, tombstone, err
 	}
 
-	_, subtask = trace.NewTask(ctx, "hydra/opfs-segment/lookup-meta/locate/scan-window-streamed")
-	val, found, tombstone, err := locateInWindowReader(r, int64(m.Header.DataOffset), start, limit, key, loadValue)
+	// Read a common window once before scanning it in memory.
+	_, subtask = trace.NewTask(ctx, "hydra/opfs-segment/lookup-meta/locate/read-window")
+	window := make([]byte, windowSize)
+	if _, err := r.ReadAt(window, int64(m.Header.DataOffset)+int64(start)); err != nil {
+		subtask.End()
+		return nil, false, false, errors.Wrap(err, "read data window")
+	}
+	subtask.End()
+
+	// Resolve the requested key from the buffered window.
+	taskCtx, subtask := trace.NewTask(ctx, "hydra/opfs-segment/lookup-meta/locate/scan-window")
+	val, found, tombstone, err := locateInWindowBytes(taskCtx, window, keyStr, loadValue)
 	subtask.End()
 	return val, found, tombstone, err
 }
 
+// locateInWindowBytes searches one buffered sparse-index window.
 func locateInWindowBytes(
 	ctx context.Context,
 	window []byte,
 	keyStr string,
 	loadValue bool,
 ) ([]byte, bool, bool, error) {
+	// Scan ordered entries until the key is found or passed.
 	off := 0
 	for off < len(window) {
+		// Decode the next entry key.
 		if off+2 > len(window) {
 			break
 		}
@@ -224,12 +260,15 @@ func locateInWindowBytes(
 		}
 		entryKey := string(window[off : off+keyLen])
 		off += keyLen
+
+		// Decode the value marker and length.
 		if off+4 > len(window) {
 			break
 		}
 		valLen := binary.BigEndian.Uint32(window[off : off+4])
 		off += 4
 
+		// Return the matching live value or tombstone state.
 		if entryKey == keyStr {
 			if valLen == TombstoneLen {
 				return nil, false, true, nil
@@ -253,6 +292,8 @@ func locateInWindowBytes(
 		if entryKey > keyStr {
 			return nil, false, false, nil
 		}
+
+		// Advance past an unmatched live value without copying it.
 		if valLen != TombstoneLen {
 			valLenInt, err := uint32ToInt(valLen)
 			if err != nil {
@@ -267,6 +308,7 @@ func locateInWindowBytes(
 	return nil, false, false, nil
 }
 
+// locateInWindowReader searches one sparse-index window through bounded reads.
 func locateInWindowReader(
 	r io.ReaderAt,
 	dataOffset int64,
@@ -275,9 +317,11 @@ func locateInWindowReader(
 	key []byte,
 	loadValue bool,
 ) ([]byte, bool, bool, error) {
+	// Scan ordered entry headers until the key is found or passed.
 	off := start
 	var header [4]byte
 	for off < limit {
+		// Read the next entry key through bounded requests.
 		if limit-off < 2 {
 			break
 		}
@@ -298,6 +342,7 @@ func locateInWindowReader(
 		}
 		off += keyLen
 
+		// Read the value marker and length.
 		if limit-off < 4 {
 			break
 		}
@@ -307,6 +352,7 @@ func locateInWindowReader(
 		valLen := binary.BigEndian.Uint32(header[:4])
 		off += 4
 
+		// Return the matching live value or tombstone state.
 		cmp := bytes.Compare(entryKey, key)
 		if cmp == 0 {
 			if valLen == TombstoneLen {
@@ -334,6 +380,7 @@ func locateInWindowReader(
 			return nil, false, false, nil
 		}
 
+		// Advance past an unmatched live value without reading it.
 		if valLen == TombstoneLen {
 			continue
 		}
@@ -345,9 +392,12 @@ func locateInWindowReader(
 	return nil, false, false, nil
 }
 
+// statInWindowBytes resolves value metadata in one buffered sparse-index window.
 func statInWindowBytes(window []byte, keyStr string) (LookupStat, error) {
+	// Scan ordered entries until the key is found or passed.
 	off := 0
 	for off < len(window) {
+		// Decode the next entry key.
 		if off+2 > len(window) {
 			break
 		}
@@ -358,12 +408,15 @@ func statInWindowBytes(window []byte, keyStr string) (LookupStat, error) {
 		}
 		entryKey := string(window[off : off+keyLen])
 		off += keyLen
+
+		// Decode the value marker and length.
 		if off+4 > len(window) {
 			break
 		}
 		valLen := binary.BigEndian.Uint32(window[off : off+4])
 		off += 4
 
+		// Return metadata for the matching live value or tombstone.
 		if entryKey == keyStr {
 			if valLen == TombstoneLen {
 				return LookupStat{Tombstone: true}, nil
@@ -376,6 +429,8 @@ func statInWindowBytes(window []byte, keyStr string) (LookupStat, error) {
 		if entryKey > keyStr {
 			return LookupStat{}, nil
 		}
+
+		// Advance past an unmatched live value.
 		if valLen != TombstoneLen {
 			valLenInt, err := uint32ToInt(valLen)
 			if err != nil {
@@ -390,6 +445,7 @@ func statInWindowBytes(window []byte, keyStr string) (LookupStat, error) {
 	return LookupStat{}, nil
 }
 
+// statInWindowReader resolves value metadata through bounded reads.
 func statInWindowReader(
 	r io.ReaderAt,
 	dataOffset int64,
@@ -397,9 +453,11 @@ func statInWindowReader(
 	limit uint32,
 	key []byte,
 ) (LookupStat, error) {
+	// Scan ordered entry headers until the key is found or passed.
 	off := start
 	var header [4]byte
 	for off < limit {
+		// Read the next entry key through bounded requests.
 		if limit-off < 2 {
 			break
 		}
@@ -420,6 +478,7 @@ func statInWindowReader(
 		}
 		off += keyLen
 
+		// Read the value marker and length.
 		if limit-off < 4 {
 			break
 		}
@@ -429,6 +488,7 @@ func statInWindowReader(
 		valLen := binary.BigEndian.Uint32(header[:4])
 		off += 4
 
+		// Return metadata for the matching live value or tombstone.
 		cmp := bytes.Compare(entryKey, key)
 		if cmp == 0 {
 			if valLen == TombstoneLen {
@@ -443,6 +503,7 @@ func statInWindowReader(
 			return LookupStat{}, nil
 		}
 
+		// Advance past an unmatched live value without reading it.
 		if valLen == TombstoneLen {
 			continue
 		}
@@ -457,19 +518,25 @@ func statInWindowReader(
 // LocateBatch resolves keys using cached metadata and groups keys by
 // sparse-index window.
 func (m *LookupMeta) LocateBatch(r io.ReaderAt, keys [][]byte, loadValue bool) ([]LookupResult, error) {
+	// Trace the complete batch lookup.
 	ctx := context.Background()
 	ctx, task := trace.NewTask(ctx, "hydra/opfs-segment/lookup-meta/locate-batch")
 	defer task.End()
 
+	// Preserve input order and return immediately for an empty batch.
 	out := make([]LookupResult, len(keys))
 	if len(keys) == 0 {
 		return out, nil
 	}
 
+	// Group eligible keys by sparse-index window.
 	type lookupWindow struct {
+		// start is the inclusive data offset.
 		start uint32
+		// limit is the exclusive data offset.
 		limit uint32
-		keys  []int
+		// keys indexes requested keys assigned to the window.
+		keys []int
 	}
 	var windows []lookupWindow
 	for i, key := range keys {
@@ -499,7 +566,9 @@ func (m *LookupMeta) LocateBatch(r io.ReaderAt, keys [][]byte, loadValue bool) (
 		}
 	}
 
+	// Resolve each grouped window through its bounded read strategy.
 	for _, lw := range windows {
+		// Validate the encoded window bounds.
 		if lw.limit < lw.start {
 			return nil, errors.New("invalid data window")
 		}
@@ -509,12 +578,14 @@ func (m *LookupMeta) LocateBatch(r io.ReaderAt, keys [][]byte, loadValue bool) (
 		}
 		trace.Log(ctx, "window", "size="+strconv.Itoa(windowSize))
 
+		// Map duplicate requested keys back to every result position.
 		want := make(map[string][]int, len(lw.keys))
 		for _, keyIdx := range lw.keys {
 			keyStr := string(keys[keyIdx])
 			want[keyStr] = append(want[keyStr], keyIdx)
 		}
 
+		// Resolve common windows from one buffered read.
 		if windowSize <= maxLookupWindowRead {
 			_, subtask := trace.NewTask(ctx, "hydra/opfs-segment/lookup-meta/locate-batch/read-window")
 			window := make([]byte, windowSize)
@@ -533,6 +604,7 @@ func (m *LookupMeta) LocateBatch(r io.ReaderAt, keys [][]byte, loadValue bool) (
 			continue
 		}
 
+		// Stream larger windows to bound allocation.
 		_, subtask := trace.NewTask(ctx, "hydra/opfs-segment/lookup-meta/locate-batch/scan-window-streamed")
 		if err := locateBatchInWindowReader(r, int64(m.Header.DataOffset), lw.start, lw.limit, want, out, loadValue); err != nil {
 			subtask.End()
@@ -544,14 +616,17 @@ func (m *LookupMeta) LocateBatch(r io.ReaderAt, keys [][]byte, loadValue bool) (
 	return out, nil
 }
 
+// locateBatchInWindowBytes resolves a key group in one buffered window.
 func locateBatchInWindowBytes(
 	window []byte,
 	want map[string][]int,
 	out []LookupResult,
 	loadValue bool,
 ) error {
+	// Scan ordered entries until every requested key is resolved.
 	off := 0
 	for off < len(window) && len(want) != 0 {
+		// Decode the next entry key.
 		if off+2 > len(window) {
 			break
 		}
@@ -562,12 +637,15 @@ func locateBatchInWindowBytes(
 		}
 		entryKey := string(window[off : off+keyLen])
 		off += keyLen
+
+		// Decode the value marker and length.
 		if off+4 > len(window) {
 			break
 		}
 		valLen := binary.BigEndian.Uint32(window[off : off+4])
 		off += 4
 
+		// Populate every result requested for the matching key.
 		if keyIdxs, ok := want[entryKey]; ok {
 			if valLen == TombstoneLen {
 				for _, keyIdx := range keyIdxs {
@@ -598,6 +676,7 @@ func locateBatchInWindowBytes(
 			delete(want, entryKey)
 		}
 
+		// Advance to the next entry after validating its encoded value.
 		if valLen != TombstoneLen {
 			valLenInt, err := uint32ToInt(valLen)
 			if err != nil {
@@ -612,6 +691,7 @@ func locateBatchInWindowBytes(
 	return nil
 }
 
+// locateBatchInWindowReader resolves a key group through bounded reads.
 func locateBatchInWindowReader(
 	r io.ReaderAt,
 	dataOffset int64,
@@ -621,9 +701,11 @@ func locateBatchInWindowReader(
 	out []LookupResult,
 	loadValue bool,
 ) error {
+	// Scan ordered entry headers until every requested key is resolved.
 	off := start
 	var header [4]byte
 	for off < limit && len(want) != 0 {
+		// Read the next entry key through bounded requests.
 		if limit-off < 2 {
 			break
 		}
@@ -644,6 +726,7 @@ func locateBatchInWindowReader(
 		}
 		off += keyLen
 
+		// Read the value marker and length.
 		if limit-off < 4 {
 			break
 		}
@@ -653,6 +736,7 @@ func locateBatchInWindowReader(
 		valLen := binary.BigEndian.Uint32(header[:4])
 		off += 4
 
+		// Populate every result requested for the matching key.
 		entryKeyStr := string(entryKey)
 		if keyIdxs, ok := want[entryKeyStr]; ok {
 			if valLen == TombstoneLen {
@@ -688,6 +772,7 @@ func locateBatchInWindowReader(
 			delete(want, entryKeyStr)
 		}
 
+		// Advance to the next entry after validating its encoded value.
 		if valLen == TombstoneLen {
 			continue
 		}
@@ -699,6 +784,7 @@ func locateBatchInWindowReader(
 	return nil
 }
 
+// uint32ToInt rejects encoded lengths that the host cannot represent.
 func uint32ToInt(v uint32) (int, error) {
 	if uint64(v) > uint64(int(^uint(0)>>1)) {
 		return 0, errors.New("value length exceeds maximum")

--- a/db/volume/js/opfs/segment/lookup_test.go
+++ b/db/volume/js/opfs/segment/lookup_test.go
@@ -1,0 +1,62 @@
+package segment
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestLookupMetaHasStreamsLargeExistenceWindow verifies scalar existence
+// lookups scan entry metadata instead of reading large values.
+func TestLookupMetaHasStreamsLargeExistenceWindow(t *testing.T) {
+	const (
+		entryCount = 16
+		valueSize  = 8 * 1024
+	)
+
+	// Build one sparse-index window above the existence buffering threshold.
+	w := NewWriter()
+	w.SetIndexInterval(entryCount)
+	for i := range entryCount {
+		w.Add(
+			[]byte("key-"+zeroPad(i, 4)),
+			bytes.Repeat([]byte{byte('a' + i%26)}, valueSize),
+		)
+	}
+
+	var buf bytes.Buffer
+	if _, err := w.Build(&buf); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	// Load metadata before recording data-window reads.
+	data := buf.Bytes()
+	meta, err := LoadLookupMeta(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("LoadLookupMeta: %v", err)
+	}
+
+	// Check bounded reads at the beginning, middle, and end of the window.
+	positions := []struct {
+		name string
+		key  string
+	}{
+		{name: "first", key: "key-0000"},
+		{name: "middle", key: "key-0007"},
+		{name: "last", key: "key-0015"},
+	}
+	for _, position := range positions {
+		t.Run(position.name, func(t *testing.T) {
+			reader := &recordingReaderAt{data: data}
+			found, err := meta.Has(reader, []byte(position.key))
+			if err != nil {
+				t.Fatalf("Has: %v", err)
+			}
+			if !found {
+				t.Fatal("Has: not found")
+			}
+			if reader.maxRead > len(position.key) {
+				t.Fatalf("largest ReadAt = %d, want at most key length %d", reader.maxRead, len(position.key))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Scalar existence checks copied entire sparse-index windows, including values they never returned. Stream windows above 64 KiB through the existing entry scanner while retaining buffered small-window reads and the 256 KiB value-lookup limit.

The Chromium/WASM replay covers small point workloads and the first, middle, and last records in larger windows. For 64 repeated lookups in a window of 12 KiB values, cumulative Go allocation falls from about 13.5 MB to between 0.17 and 0.30 MB, with fewer fetched bytes. Small-window read behavior is preserved. Timing measurements varied with host load.

Validation: the new first/middle/last regression fails before the change with a 131,296-byte read and passes with key-sized reads. The native segment suite and extended Chromium OPFS replay pass.
