### PR TITLE
feat(sobject): verify configuration suffixes from held checkpoints

### DIFF
--- a/core/sobject/config-chain.go
+++ b/core/sobject/config-chain.go
@@ -14,12 +14,15 @@ import (
 // HashSOConfigChange computes the SHA-256 hash of a serialized SOConfigChange.
 // The signature field is excluded from the hash by zeroing it before marshaling.
 func HashSOConfigChange(entry *SOConfigChange) ([]byte, error) {
+	// Exclude the signature from the content-addressed chain entry.
 	clone := entry.CloneVT()
 	clone.Signature = nil
 	data, err := clone.MarshalVT()
 	if err != nil {
 		return nil, errors.Wrap(err, "marshal config change for hash")
 	}
+
+	// Hash the canonical generated encoding.
 	h := sha256.Sum256(data)
 	return h[:], nil
 }
@@ -30,6 +33,7 @@ func HashSOConfigChange(entry *SOConfigChange) ([]byte, error) {
 // 2. previous_hash matching the hash of the prior entry (genesis has zero previous_hash)
 // 3. Valid authorization according to the change type
 func VerifyConfigChain(entries []*SOConfigChange) error {
+	// Require a chain before validating its bootstrap entry.
 	if len(entries) == 0 {
 		return errors.New("config chain is empty")
 	}
@@ -62,6 +66,7 @@ func VerifyConfigChain(entries []*SOConfigChange) error {
 		return errors.Wrap(err, "genesis entry")
 	}
 
+	// Establish the effective genesis head before verifying later transitions.
 	prevHash, err := HashSOConfigChange(genesis)
 	if err != nil {
 		return errors.Wrap(err, "hash genesis entry")
@@ -72,49 +77,108 @@ func VerifyConfigChain(entries []*SOConfigChange) error {
 		prevHash,
 	)
 
+	// Verify each transition under the preceding configuration.
 	for i := 1; i < len(entries); i++ {
-		entry := entries[i]
-
-		// Check seqno is monotonically increasing.
-		if entry.GetConfigSeqno() != uint64(i) {
-			return errors.Errorf("entry[%d]: expected seqno %d, got %d", i, i, entry.GetConfigSeqno())
-		}
-
-		// Check previous_hash matches the hash of the prior entry.
-		if !bytes.Equal(entry.GetPreviousHash(), prevHash) {
-			return errors.Errorf("entry[%d]: previous_hash does not match", i)
-		}
-
-		// Verify authorization from the current config (before this change).
-		if err := verifyConfigChangeSignature(entry, currentConfig); err != nil {
+		currentConfig, err = VerifyConfigChange(currentConfig, entries[i])
+		if err != nil {
 			return errors.Wrapf(err, "entry[%d]", i)
 		}
-
-		prevHash, err = HashSOConfigChange(entry)
-		if err != nil {
-			return errors.Wrapf(err, "hash entry[%d]", i)
-		}
-		currentConfig = configWithAppliedConfigChainHead(
-			entry.GetConfig(),
-			entry.GetConfigSeqno(),
-			prevHash,
-		)
 	}
 
 	return nil
 }
 
+// VerifyConfigChange verifies one signed transition against the held configuration
+// and returns an independent configuration with its resulting chain head.
+// An empty held head permits sequence zero for locally authorized bootstrap.
+// SELF_ENROLL_PEER requires a separate authenticated peer-to-entity binding.
+func VerifyConfigChange(current *SharedObjectConfig, entry *SOConfigChange) (*SharedObjectConfig, error) {
+	// Require both configurations before checking the chain and its authority.
+	if current == nil || entry.GetConfig() == nil {
+		return nil, errors.New("config change requires current and next configurations")
+	}
+	if !bytes.Equal(entry.GetPreviousHash(), current.GetConfigChainHash()) {
+		return nil, errors.New("config change previous_hash does not match current config_chain_hash")
+	}
+	var expected uint64
+	if len(current.GetConfigChainHash()) != 0 {
+		expected = current.GetConfigChainSeqno() + 1
+		if expected == 0 {
+			return nil, errors.New("config change sequence exhausted")
+		}
+	}
+	if entry.GetConfigSeqno() != expected {
+		return nil, errors.Errorf("config change seqno %d does not match expected %d", entry.GetConfigSeqno(), expected)
+	}
+	if err := verifyConfigChangeSignature(entry, current); err != nil {
+		return nil, errors.Wrap(err, "verify config change")
+	}
+
+	// Derive the accepted head from the signed entry without changing its input.
+	entryHash, err := HashSOConfigChange(entry)
+	if err != nil {
+		return nil, errors.Wrap(err, "hash config change entry")
+	}
+	return configWithAppliedConfigChainHead(entry.GetConfig(), entry.GetConfigSeqno(), entryHash), nil
+}
+
+// VerifyConfigChainSuffix authenticates a candidate configuration from a held,
+// nonempty checkpoint. Every transition must be authorized by its predecessor.
+// Genesis and self-enrollment are unavailable on this peer verification path.
+// Empty suffixes require the entire candidate to equal the checkpoint.
+// This verifies configuration authority only, not root or content acceptance.
+func VerifyConfigChainSuffix(current, candidate *SharedObjectConfig, entries []*SOConfigChange) error {
+	// Trust must already exist at the receiver before remote history is examined.
+	if len(current.GetConfigChainHash()) == 0 {
+		return errors.New("config suffix requires a nonempty trusted checkpoint")
+	}
+	if err := current.Validate(); err != nil {
+		return errors.Wrap(err, "trusted config")
+	}
+
+	// Advance only through owner-signed changes linked to the evolving head.
+	for i, entry := range entries {
+		switch entry.GetChangeType() {
+		case SOConfigChangeType_SO_CONFIG_CHANGE_TYPE_ADD_PARTICIPANT,
+			SOConfigChangeType_SO_CONFIG_CHANGE_TYPE_REMOVE_PARTICIPANT,
+			SOConfigChangeType_SO_CONFIG_CHANGE_TYPE_ADD_INVITE,
+			SOConfigChangeType_SO_CONFIG_CHANGE_TYPE_REVOKE_INVITE,
+			SOConfigChangeType_SO_CONFIG_CHANGE_TYPE_INCREMENT_INVITE_USES:
+		default:
+			return errors.Errorf("entry[%d]: unsupported peer config change %s", i, entry.GetChangeType())
+		}
+		next, err := VerifyConfigChange(current, entry)
+		if err != nil {
+			return errors.Wrapf(err, "entry[%d]", i)
+		}
+		if err := next.Validate(); err != nil {
+			return errors.Wrapf(err, "entry[%d] config", i)
+		}
+		current = next
+	}
+
+	// Bind both the effective configuration and the computed head to the candidate.
+	if !current.EqualVT(candidate) {
+		return errors.New("config suffix does not match candidate configuration")
+	}
+	return nil
+}
+
+// configWithAppliedConfigChainHead clones a configuration with a verified head.
 func configWithAppliedConfigChainHead(
 	cfg *SharedObjectConfig,
 	seqno uint64,
 	hash []byte,
 ) *SharedObjectConfig {
+	// Preserve an absent configuration for callers validating optional input.
 	if cfg == nil {
 		return nil
 	}
+
+	// Keep returned head metadata independent of caller-owned buffers.
 	next := cfg.CloneVT()
 	next.ConfigChainSeqno = seqno
-	next.ConfigChainHash = slices.Clone(hash)
+	next.ConfigChainHash = bytes.Clone(hash)
 	return next
 }
 
@@ -122,12 +186,15 @@ func configWithAppliedConfigChainHead(
 // emitted by cloud bootstrap. This is a compatibility carve-out only for the
 // first config-chain entry.
 func validateUnsignedGenesisConfig(cfg *SharedObjectConfig) error {
+	// Bootstrap requires a structurally valid configuration with an owner.
 	if cfg == nil {
 		return errors.New("missing config")
 	}
 	if err := cfg.Validate(); err != nil {
 		return err
 	}
+
+	// Require authority for subsequent signed changes.
 	for _, p := range cfg.GetParticipants() {
 		if IsOwner(p.GetRole()) {
 			return nil
@@ -184,6 +251,7 @@ func BuildSOConfigChange(
 // verifyConfigChangeSignature verifies that the SOConfigChange is authorized by
 // the given config.
 func verifyConfigChangeSignature(entry *SOConfigChange, cfg *SharedObjectConfig) error {
+	// Recover the signing peer from the supplied signature.
 	sig := entry.GetSignature()
 	if sig == nil {
 		return errors.New("missing signature")
@@ -200,6 +268,7 @@ func verifyConfigChangeSignature(entry *SOConfigChange, cfg *SharedObjectConfig)
 	}
 	sigPeerIDStr := sigPeerID.String()
 
+	// Check the signing peer against the preceding configuration's authority.
 	if entry.GetChangeType() == SOConfigChangeType_SO_CONFIG_CHANGE_TYPE_SELF_ENROLL_PEER {
 		if err := validateSelfEnrollPeerChange(entry, cfg, sigPeerIDStr); err != nil {
 			return err
@@ -227,6 +296,7 @@ func verifyConfigChangeSignature(entry *SOConfigChange, cfg *SharedObjectConfig)
 	return nil
 }
 
+// isOwnerPeer reports whether a peer holds owner authority in the configuration.
 func isOwnerPeer(cfg *SharedObjectConfig, peerID string) bool {
 	for _, p := range cfg.GetParticipants() {
 		if p.GetPeerId() == peerID && IsOwner(p.GetRole()) {
@@ -236,6 +306,7 @@ func isOwnerPeer(cfg *SharedObjectConfig, peerID string) bool {
 	return false
 }
 
+// participantRoleForEntity returns the strongest role granted to an entity.
 func participantRoleForEntity(cfg *SharedObjectConfig, entityID string) SOParticipantRole {
 	role := SOParticipantRole_SOParticipantRole_UNKNOWN
 	for _, p := range cfg.GetParticipants() {
@@ -249,6 +320,7 @@ func participantRoleForEntity(cfg *SharedObjectConfig, entityID string) SOPartic
 	return role
 }
 
+// sameParticipant compares participant identity, role and entity membership.
 func sameParticipant(a, b *SOParticipantConfig) bool {
 	if a == nil || b == nil {
 		return a == b
@@ -258,7 +330,10 @@ func sameParticipant(a, b *SOParticipantConfig) bool {
 		a.GetEntityId() == b.GetEntityId()
 }
 
+// validateSelfEnrollPeerChange checks enrollment shape and existing entity role bounds.
+// The caller must independently authenticate the peer-to-entity relationship.
 func validateSelfEnrollPeerChange(entry *SOConfigChange, cfg *SharedObjectConfig, signerPeerID string) error {
+	// Enrollment preserves all configuration metadata.
 	if cfg == nil {
 		return errors.New("current config is required")
 	}
@@ -272,6 +347,7 @@ func validateSelfEnrollPeerChange(entry *SOConfigChange, cfg *SharedObjectConfig
 		return errors.New("self-enroll may not mutate config metadata")
 	}
 
+	// Index the participant sets to check that exactly one peer is added.
 	prevParticipants := cfg.GetParticipants()
 	nextParticipants := nextCfg.GetParticipants()
 	if len(nextParticipants) != len(prevParticipants)+1 {
@@ -287,6 +363,7 @@ func validateSelfEnrollPeerChange(entry *SOConfigChange, cfg *SharedObjectConfig
 		nextByPeer[p.GetPeerId()] = p
 	}
 
+	// Preserve every existing participant and its authority.
 	for peerID, prevParticipant := range prevByPeer {
 		nextParticipant, ok := nextByPeer[peerID]
 		if !ok {
@@ -297,6 +374,7 @@ func validateSelfEnrollPeerChange(entry *SOConfigChange, cfg *SharedObjectConfig
 		}
 	}
 
+	// Bind the sole added participant to the signature and an existing entity.
 	if _, exists := prevByPeer[signerPeerID]; exists {
 		return errors.New("self-enroll signer is already a participant")
 	}
@@ -325,6 +403,7 @@ func validateSelfEnrollPeerChange(entry *SOConfigChange, cfg *SharedObjectConfig
 	// Any future non-cloud / P2P path must provide an equivalent peer-to-entity
 	// binding before accepting this change type.
 
+	// Bound the enrollment role by the entity's existing authority.
 	currentRole := participantRoleForEntity(cfg, addedParticipant.GetEntityId())
 	if currentRole == SOParticipantRole_SOParticipantRole_UNKNOWN {
 		return errors.New("self-enroll entity is not a current participant")

--- a/core/sobject/config-suffix_test.go
+++ b/core/sobject/config-suffix_test.go
@@ -1,0 +1,163 @@
+package sobject
+
+import (
+	"testing"
+
+	"github.com/s4wave/spacewave/net/crypto"
+)
+
+// TestVerifyConfigChainSuffix exercises trust anchored in a receiver's held state.
+func TestVerifyConfigChainSuffix(t *testing.T) {
+	// Establish a checkpoint with an owner and a reader using real signatures.
+	peers := createMockPeers(t, 3)
+	owner, err := peers[0].GetPrivKey(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader, err := peers[1].GetPrivKey(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	enrolling, err := peers[2].GetPrivKey(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	initial := &SharedObjectConfig{Participants: []*SOParticipantConfig{
+		{PeerId: peers[0].GetPeerID().String(), Role: SOParticipantRole_SOParticipantRole_OWNER},
+		{PeerId: peers[1].GetPeerID().String(), Role: SOParticipantRole_SOParticipantRole_READER, EntityId: "reader-account"},
+	}}
+	build := func(current, next *SharedObjectConfig, kind SOConfigChangeType, signer crypto.PrivKey) *SOConfigChange {
+		t.Helper()
+		entry, err := BuildSOConfigChange(current, next, kind, signer, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return entry
+	}
+	genesis := build(initial, initial, SOConfigChangeType_SO_CONFIG_CHANGE_TYPE_GENESIS, owner)
+	checkpoint, err := VerifyConfigChange(initial, genesis)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := checkpoint.CloneVT()
+
+	// Transfer authority, then remove the previous owner under the new authority.
+	promoted := checkpoint.CloneVT()
+	promoted.Participants[1].Role = SOParticipantRole_SOParticipantRole_OWNER
+	promotion := build(checkpoint, promoted, SOConfigChangeType_SO_CONFIG_CHANGE_TYPE_ADD_PARTICIPANT, owner)
+	intermediate, err := VerifyConfigChange(checkpoint, promotion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	removed := intermediate.CloneVT()
+	removed.Participants = removed.Participants[1:]
+	removal := build(intermediate, removed, SOConfigChangeType_SO_CONFIG_CHANGE_TYPE_REMOVE_PARTICIPANT, reader)
+	candidate, err := VerifyConfigChange(intermediate, removal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := VerifyConfigChainSuffix(checkpoint, candidate, []*SOConfigChange{promotion, removal}); err != nil {
+		t.Fatal(err)
+	}
+	if !checkpoint.EqualVT(before) {
+		t.Fatal("verification mutated the held checkpoint")
+	}
+
+	// A matching head authenticates the entire held configuration, not its hash alone.
+	t.Run("same head", func(t *testing.T) {
+		if err := VerifyConfigChainSuffix(checkpoint, checkpoint.CloneVT(), nil); err != nil {
+			t.Fatal(err)
+		}
+		forged := checkpoint.CloneVT()
+		forged.Participants[1].Role = SOParticipantRole_SOParticipantRole_OWNER
+		if err := VerifyConfigChainSuffix(checkpoint, forged, nil); err == nil {
+			t.Fatal("accepted forged same-head configuration")
+		}
+	})
+
+	// Reject histories that cannot prove every transition from the held checkpoint.
+	tests := []struct {
+		// name identifies the rejected history.
+		name string
+		// change produces an independently signed invalid transition.
+		change func() *SOConfigChange
+	}{
+		{"reader promotion", func() *SOConfigChange {
+			return build(checkpoint, promoted, SOConfigChangeType_SO_CONFIG_CHANGE_TYPE_ADD_PARTICIPANT, reader)
+		}},
+		{"wrong anchor", func() *SOConfigChange {
+			entry := promotion.CloneVT()
+			entry.PreviousHash[0] ^= 1
+			signConfigChange(t, entry, owner)
+			return entry
+		}},
+		{"sequence gap", func() *SOConfigChange {
+			entry := promotion.CloneVT()
+			entry.ConfigSeqno++
+			signConfigChange(t, entry, owner)
+			return entry
+		}},
+		{"self enrollment", func() *SOConfigChange {
+			entry, err := BuildSelfEnrollPeerConfigChange(checkpoint, enrolling, peers[2].GetPeerID().String(), "reader-account", SOParticipantRole_SOParticipantRole_READER)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := VerifyConfigChange(checkpoint, entry); err != nil {
+				t.Fatal(err)
+			}
+			return entry
+		}},
+		{"genesis", func() *SOConfigChange { return genesis }},
+		{"missing entry", func() *SOConfigChange { return nil }},
+		{"invalid signature", func() *SOConfigChange {
+			entry := promotion.CloneVT()
+			entry.Config.Participants[1].Role = SOParticipantRole_SOParticipantRole_WRITER
+			return entry
+		}},
+		{"duplicate participant", func() *SOConfigChange {
+			next := promoted.CloneVT()
+			next.Participants = append(next.Participants, next.Participants[0].CloneVT())
+			return build(checkpoint, next, SOConfigChangeType_SO_CONFIG_CHANGE_TYPE_ADD_PARTICIPANT, owner)
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Match the claimed target so rejection must come from transition verification.
+			entry := tt.change()
+			var claimed *SharedObjectConfig
+			if entry != nil {
+				head, err := HashSOConfigChange(entry)
+				if err != nil {
+					t.Fatal(err)
+				}
+				claimed = configWithAppliedConfigChainHead(entry.GetConfig(), entry.GetConfigSeqno(), head)
+			}
+			if err := VerifyConfigChainSuffix(checkpoint, claimed, []*SOConfigChange{entry}); err == nil {
+				t.Fatal("accepted invalid suffix")
+			}
+		})
+	}
+
+	// Replays and unsigned legacy anchors cannot establish a new trust epoch.
+	if err := VerifyConfigChainSuffix(candidate, candidate, []*SOConfigChange{removal}); err == nil {
+		t.Fatal("accepted replay")
+	}
+	if err := VerifyConfigChainSuffix(initial, checkpoint, []*SOConfigChange{genesis}); err == nil {
+		t.Fatal("accepted empty checkpoint")
+	}
+	unauthorized := build(candidate, candidate, SOConfigChangeType_SO_CONFIG_CHANGE_TYPE_ADD_INVITE, owner)
+	if _, err := VerifyConfigChange(candidate, unauthorized); err == nil {
+		t.Fatal("accepted a removed owner's signature")
+	}
+	exhausted := candidate.CloneVT()
+	exhausted.ConfigChainSeqno = ^uint64(0)
+	wrapped := build(exhausted, exhausted, SOConfigChangeType_SO_CONFIG_CHANGE_TYPE_ADD_INVITE, reader)
+	if _, err := VerifyConfigChange(exhausted, wrapped); err == nil {
+		t.Fatal("accepted wrapped configuration sequence")
+	}
+	wrongTarget := candidate.CloneVT()
+	wrongTarget.ConfigChainHash[0] ^= 1
+	if err := VerifyConfigChainSuffix(checkpoint, wrongTarget, []*SOConfigChange{promotion, removal}); err == nil {
+		t.Fatal("accepted wrong target head")
+	}
+}

--- a/core/sobject/host.go
+++ b/core/sobject/host.go
@@ -1,7 +1,6 @@
 package sobject
 
 import (
-	"bytes"
 	"context"
 
 	"github.com/aperturerobotics/util/ccontainer"
@@ -30,7 +29,7 @@ type SOHost struct {
 
 // NewSOHost constructs a new shared object host.
 //
-// ctx can be nil
+// ctx can be nil.
 func NewSOHost(ctx context.Context, watchFn SOStateWatchFunc, lockFn SOStateLockFunc, sharedObjectID string) *SOHost {
 	h := &SOHost{watchFn: watchFn, lockFn: lockFn, sharedObjectID: sharedObjectID}
 	h.soRc = refcount.NewRefCount(ctx, false, nil, nil, func(ctx context.Context, released func()) (ccontainer.Watchable[*SOState], func(), error) {
@@ -69,12 +68,14 @@ func (s *SOHost) GetSOStateCtr(ctx context.Context, released func()) (ccontainer
 
 // GetHostState returns a snapshot of the current SOState.
 func (s *SOHost) GetHostState(ctx context.Context) (*SOState, error) {
+	// Retain the watched state until its snapshot has been copied.
 	watchable, rel, err := s.soRc.Resolve(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer rel()
 
+	// Return an independent snapshot once the state becomes available.
 	st, err := watchable.WaitValue(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -94,11 +95,13 @@ func (s *SOHost) GetRootState(ctx context.Context) (*SORoot, error) {
 
 // GetRootInnerState returns a snapshot of the SORoot and unmarshals the SORootInner.
 func (s *SOHost) GetRootInnerState(ctx context.Context) (*SORootInner, *SORoot, error) {
+	// Read the signed root from the current host snapshot.
 	sr, err := s.GetRootState(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
 
+	// Decode and validate the signed root's inner value.
 	sri := &SORootInner{}
 	if err := sri.UnmarshalVT(sr.GetInner()); err != nil {
 		return nil, sr, err
@@ -109,12 +112,14 @@ func (s *SOHost) GetRootInnerState(ctx context.Context) (*SORootInner, *SORoot, 
 // UpdateSOState locks the SO state, clones it, calls the provided function
 // to mutate the clone, then writes the updated state.
 func (s *SOHost) UpdateSOState(ctx context.Context, fn func(state *SOState) error) error {
+	// Hold the provider lock through mutation and persistence.
 	lk, err := s.lockFn(ctx, s.sharedObjectID)
 	if err != nil {
 		return err
 	}
 	defer lk.Release()
 
+	// Apply the mutation to an independent state and commit on success.
 	nextState := lk.GetSOState().CloneVT()
 	if err := fn(nextState); err != nil {
 		return err
@@ -133,45 +138,47 @@ func (s *SOHost) UpdateRootState(
 	rejectedOps []*SOOperationRejection,
 	acceptedOps []*SOOperation,
 ) error {
+	// Serialize root acceptance with other host mutations.
 	lk, err := s.lockFn(ctx, s.sharedObjectID)
 	if err != nil {
 		return err
 	}
 	defer lk.Release()
 
-	// load and clone the previous state
+	// Clone the locked state before root validation.
 	prevState := lk.GetSOState()
 	nextState := prevState.CloneVT()
 
-	// apply the change to nextState
+	// Validate root authorization and the operation results together.
 	err = nextState.UpdateRootState(s.sharedObjectID, nextRootState, enforceValidatorPeerID, rejectedOps, acceptedOps)
 	if err != nil {
 		return err
 	}
 
-	// write the change
+	// Publish the accepted state through the provider's write boundary.
 	return lk.WriteSOState(ctx, nextState)
 }
 
 // ClearRejectedOperation clears a rejected operation from the state.
 // The clear operation must be signed by the peer that submitted the original operation.
 func (s *SOHost) ClearRejectedOperation(ctx context.Context, clearOp *SOClearOperationResult) error {
+	// Serialize rejection cleanup with other host mutations.
 	lk, err := s.lockFn(ctx, s.sharedObjectID)
 	if err != nil {
 		return err
 	}
 	defer lk.Release()
 
-	// load and clone the previous state
+	// Clone the locked state before changing rejection records.
 	prevState := lk.GetSOState()
 	nextState := prevState.CloneVT()
 
-	// apply the change to nextState
+	// Validate the clearing signature against the original operation.
 	if err := nextState.ClearOperationResult(s.sharedObjectID, clearOp); err != nil {
 		return err
 	}
 
-	// write the change
+	// Commit the accepted rejection cleanup.
 	return lk.WriteSOState(ctx, nextState)
 }
 
@@ -184,53 +191,29 @@ func (s *SOHost) ClearRejectedOperation(ctx context.Context, clearOp *SOClearOpe
 // If fn is non-nil it is called after the config is applied but before the
 // state is written, allowing additional atomic mutations (e.g. grant issuance).
 func (s *SOHost) ApplyConfigChange(ctx context.Context, entry *SOConfigChange, fn func(state *SOState) error) error {
+	// Reject absent input before acquiring provider resources.
 	if entry == nil {
 		return errors.New("config change entry is nil")
 	}
 
+	// Hold the provider lock through verification and persistence.
 	lk, err := s.lockFn(ctx, s.sharedObjectID)
 	if err != nil {
 		return err
 	}
 	defer lk.Release()
 
+	// Retain the prior state unchanged if verification or the callback fails.
 	prevState := lk.GetSOState()
 	nextState := prevState.CloneVT()
 
-	currentCfg := nextState.GetConfig()
-	currentHash := currentCfg.GetConfigChainHash()
-	currentSeqno := currentCfg.GetConfigChainSeqno()
-
-	// Verify previous_hash chains from the current config.
-	if !bytes.Equal(entry.GetPreviousHash(), currentHash) {
-		return errors.New("config change previous_hash does not match current config_chain_hash")
-	}
-
-	// Verify config_seqno is the expected next value.
-	var expectedSeqno uint64
-	if len(currentHash) != 0 {
-		expectedSeqno = currentSeqno + 1
-	}
-	if entry.GetConfigSeqno() != expectedSeqno {
-		return errors.Errorf("config change seqno %d does not match expected %d", entry.GetConfigSeqno(), expectedSeqno)
-	}
-
-	// Verify the signature is authorized by the current config.
-	if err := verifyConfigChangeSignature(entry, currentCfg); err != nil {
-		return errors.Wrap(err, "verify config change")
-	}
-
-	// Apply the new config from the entry (clone to avoid mutating the input).
-	nextState.Config = entry.GetConfig().CloneVT()
-
-	// Compute and store the new config_chain_hash and seqno.
-	entryHash, err := HashSOConfigChange(entry)
+	// Verify the transition against the configuration held under this lock.
+	nextState.Config, err = VerifyConfigChange(nextState.GetConfig(), entry)
 	if err != nil {
-		return errors.Wrap(err, "hash config change entry")
+		return err
 	}
-	nextState.GetConfig().ConfigChainHash = entryHash
-	nextState.GetConfig().ConfigChainSeqno = entry.GetConfigSeqno()
 
+	// Include associated state changes in the same provider write.
 	if fn != nil {
 		if err := fn(nextState); err != nil {
 			return err
@@ -250,31 +233,32 @@ func (s *SOHost) QueueOperation(
 	peerID peer.ID,
 	cb func(nonce uint64) (*SOOperation, error),
 ) error {
+	// Serialize nonce selection and operation acceptance under the provider lock.
 	lk, err := s.lockFn(ctx, s.sharedObjectID)
 	if err != nil {
 		return err
 	}
 	defer lk.Release()
 
-	// load and clone the previous state
+	// Clone the locked state before selecting an operation nonce.
 	prevState := lk.GetSOState()
 	nextState := prevState.CloneVT()
 
-	// determine the next nonce
+	// Select the next nonce for this peer's queued operation.
 	nextAccNonce := nextState.GetNextAccountNonce(peerID.String())
 
-	// call the callback
+	// Build the operation with the selected nonce.
 	op, err := cb(nextAccNonce)
 	if err != nil {
 		return err
 	}
 
-	// apply the operation to nextState
+	// Validate and queue the operation in the cloned state.
 	err = nextState.QueueOperation(s.sharedObjectID, op)
 	if err != nil {
 		return err
 	}
 
-	// write the change
+	// Commit the accepted operation.
 	return lk.WriteSOState(ctx, nextState)
 }


### PR DESCRIPTION
Add receiver-anchored configuration suffix verification with exact candidate matching, contiguous signed transitions, and rejection of unsupported peer enrollment. Reuse the single-transition verifier in host mutation and full-chain verification. This establishes configuration verification only; snapshot transport and lineage persistence remain separate work. The SharedObject package tests and commit-hook checks pass, including signed ownership transfer, reader self-promotion rejection, replay, wrong anchors, same-head forgery, and sequence exhaustion.