### PR TITLE
feat(sobject): retain local configuration history atomically

### DIFF
--- a/core/provider/local/config-history.go
+++ b/core/provider/local/config-history.go
@@ -1,0 +1,92 @@
+package provider_local
+
+import (
+	"context"
+	"encoding/hex"
+
+	"github.com/pkg/errors"
+	"github.com/s4wave/spacewave/core/sobject"
+	"github.com/s4wave/spacewave/db/kvtx"
+)
+
+// SOConfigHistoryCheckpointKey addresses the locally held configuration from
+// which retained history begins. Its value is a serialized SharedObjectConfig.
+func SOConfigHistoryCheckpointKey(sharedObjectID string) []byte {
+	return []byte("so/" + sharedObjectID + "/config-history/checkpoint")
+}
+
+// SOConfigHistoryEntryKey addresses a serialized SOConfigChange by its hash.
+func SOConfigHistoryEntryKey(sharedObjectID string, hash []byte) []byte {
+	return []byte("so/" + sharedObjectID + "/config-history/entry/" + hex.EncodeToString(hash))
+}
+
+// WriteSOConfigHistory retains verified transitions in the transaction that
+// writes their resulting SOState. The caller commits both or discards both.
+// Ordinary state writes do not establish or replace a history checkpoint.
+// Retention records held trust; it does not authenticate legacy state or admit peers.
+func WriteSOConfigHistory(
+	ctx context.Context,
+	tx kvtx.Tx,
+	sharedObjectID string,
+	current, next *sobject.SharedObjectConfig,
+	changes []*sobject.SOConfigChange,
+) error {
+	// Ordinary writes leave retained history intact, including legacy history gaps.
+	if len(changes) == 0 {
+		return nil
+	}
+	if err := current.Validate(); err != nil {
+		return errors.Wrap(err, "config history checkpoint")
+	}
+
+	// Verify every transition against the state held under the provider lock.
+	checkpoint := current.CloneVT()
+	for _, change := range changes {
+		accepted, err := sobject.VerifyConfigChange(current, change)
+		if err != nil {
+			return err
+		}
+		if err := accepted.Validate(); err != nil {
+			return errors.Wrap(err, "config history transition")
+		}
+		if len(checkpoint.GetConfigChainHash()) == 0 {
+			checkpoint = accepted.CloneVT()
+		}
+		current = accepted
+	}
+	if !current.EqualVT(next) {
+		return errors.New("config history does not match written state")
+	}
+
+	// Preserve the first locally held checkpoint across later writes and gaps.
+	checkpointKey := SOConfigHistoryCheckpointKey(sharedObjectID)
+	_, found, err := tx.Get(ctx, checkpointKey)
+	if err != nil {
+		return err
+	}
+	if !found {
+		data, err := checkpoint.MarshalVT()
+		if err != nil {
+			return err
+		}
+		if err := tx.Set(ctx, checkpointKey, data); err != nil {
+			return err
+		}
+	}
+
+	// Store entries separately so opening state does not load the full history.
+	for _, change := range changes {
+		hash, err := sobject.HashSOConfigChange(change)
+		if err != nil {
+			return err
+		}
+		data, err := change.MarshalVT()
+		if err != nil {
+			return err
+		}
+		if err := tx.Set(ctx, SOConfigHistoryEntryKey(sharedObjectID, hash), data); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/core/provider/local/config-history_test.go
+++ b/core/provider/local/config-history_test.go
@@ -1,0 +1,198 @@
+package provider_local
+
+import (
+	"context"
+	"testing"
+
+	"github.com/s4wave/spacewave/core/sobject"
+	"github.com/s4wave/spacewave/db/kvtx"
+	kvtest "github.com/s4wave/spacewave/db/kvtx/kvtest"
+	store_inmem "github.com/s4wave/spacewave/db/store/kvtx/inmem"
+	"github.com/s4wave/spacewave/net/crypto"
+	"github.com/s4wave/spacewave/net/hash"
+	"github.com/s4wave/spacewave/net/peer"
+)
+
+// configHistoryFaultStore injects the shared commit fault only in write transactions.
+type configHistoryFaultStore struct {
+	// backend serves reads without consuming the write fault.
+	backend kvtx.Store
+	// writes injects one retryable failure before committing the real transaction.
+	writes *kvtest.FaultStore
+}
+
+// NewTransaction routes writes through the fault injector and reads to the backend.
+func (s *configHistoryFaultStore) NewTransaction(ctx context.Context, write bool) (kvtx.Tx, error) {
+	if write {
+		return s.writes.NewTransaction(ctx, true)
+	}
+	return s.backend.NewTransaction(ctx, false)
+}
+
+// TestSOConfigHistoryRetainsHostChanges proves the real host persists signed
+// lineage with configuration-only changes and reopens the committed state.
+func TestSOConfigHistoryRetainsHostChanges(t *testing.T) {
+	// Seed a signed root and locally trusted configuration in the real in-memory store.
+	ctx := t.Context()
+	priv, _, err := crypto.GenerateKeyPair(crypto.KeyType_Ed25519, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pid, err := peer.IDFromPrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initial := &sobject.SOState{
+		Config: &sobject.SharedObjectConfig{Participants: []*sobject.SOParticipantConfig{{
+			PeerId: pid.String(), Role: sobject.SOParticipantRole_SOParticipantRole_OWNER,
+		}}},
+		Root: &sobject.SORoot{InnerSeqno: 1, Inner: []byte("retained-root")},
+	}
+	if err := initial.Root.SignInnerData(priv, testSharedObjectID, 1, hash.RecommendedHashType); err != nil {
+		t.Fatal(err)
+	}
+	backend := store_inmem.NewStore()
+	seed, err := backend.NewTransaction(ctx, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(seed.Discard)
+	data, err := initial.MarshalVT()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := seed.Set(ctx, SobjectObjectStoreHostStateKey(testSharedObjectID), data); err != nil {
+		t.Fatal(err)
+	}
+	if err := seed.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	seed.Discard()
+
+	// Apply a real host change through the provider transaction and its retry boundary.
+	faults := kvtest.NewFaultStore(backend, kvtest.FaultBeforeCommit)
+	store := &configHistoryFaultStore{backend: backend, writes: faults}
+	watch, lock := NewObjectStoreSOStateFuncs(ctx, store)
+	host := sobject.NewSOHost(ctx, watch, lock, testSharedObjectID)
+	t.Cleanup(host.ClearContext)
+	entry, err := sobject.BuildSOConfigChange(initial.GetConfig(), initial.GetConfig(), sobject.SOConfigChangeType_SO_CONFIG_CHANGE_TYPE_GENESIS, priv, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := host.ApplyConfigChange(ctx, entry, nil); err != nil {
+		t.Fatal(err)
+	}
+	if faults.Opened() != 2 || faults.DelegatedCommits() != 1 {
+		t.Fatalf("write attempts = %d, commits = %d", faults.Opened(), faults.DelegatedCommits())
+	}
+	accepted, err := host.GetHostState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !accepted.GetRoot().EqualVT(initial.GetRoot()) {
+		t.Fatal("configuration-only mutation changed the signed root")
+	}
+
+	// Read state and its supporting entries from one committed snapshot.
+	read, err := backend.NewTransaction(ctx, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(read.Discard)
+	checkpointData, found, err := read.Get(ctx, SOConfigHistoryCheckpointKey(testSharedObjectID))
+	if err != nil || !found {
+		t.Fatalf("checkpoint found = %v, error = %v", found, err)
+	}
+	checkpoint := &sobject.SharedObjectConfig{}
+	if err := checkpoint.UnmarshalVT(checkpointData); err != nil {
+		t.Fatal(err)
+	}
+	if !checkpoint.EqualVT(accepted.GetConfig()) {
+		t.Fatal("bootstrap checkpoint does not match accepted configuration")
+	}
+	entryData, found, err := read.Get(ctx, SOConfigHistoryEntryKey(testSharedObjectID, accepted.GetConfig().GetConfigChainHash()))
+	if err != nil || !found {
+		t.Fatalf("entry found = %v, error = %v", found, err)
+	}
+	retained := &sobject.SOConfigChange{}
+	if err := retained.UnmarshalVT(entryData); err != nil {
+		t.Fatal(err)
+	}
+	if !retained.EqualVT(entry) {
+		t.Fatal("retained entry differs from the signed mutation")
+	}
+	read.Discard()
+
+	// A fresh provider instance must recover exactly the committed host state.
+	watchAgain, lockAgain := NewObjectStoreSOStateFuncs(ctx, backend)
+	reopened := sobject.NewSOHost(ctx, watchAgain, lockAgain, testSharedObjectID)
+	t.Cleanup(reopened.ClearContext)
+	got, err := reopened.GetHostState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.EqualVT(accepted) {
+		t.Fatal("reopened state differs from committed state")
+	}
+
+	// Reject callback configuration tampering before publishing state or history.
+	next, err := sobject.BuildSOConfigChange(accepted.GetConfig(), accepted.GetConfig(), sobject.SOConfigChangeType_SO_CONFIG_CHANGE_TYPE_ADD_INVITE, priv, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := host.ApplyConfigChange(ctx, next, func(state *sobject.SOState) error {
+		state.Config.Participants[0].Role = sobject.SOParticipantRole_SOParticipantRole_READER
+		return nil
+	}); err == nil {
+		t.Fatal("accepted state that did not match signed configuration history")
+	}
+	got, err = host.GetHostState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.EqualVT(accepted) {
+		t.Fatal("failed write changed the visible host state")
+	}
+
+	// The next valid transition must extend retained history without replacing its checkpoint.
+	if err := host.ApplyConfigChange(ctx, next, nil); err != nil {
+		t.Fatal(err)
+	}
+	got, err = host.GetHostState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sobject.VerifyConfigChainSuffix(checkpoint, got.GetConfig(), []*sobject.SOConfigChange{next}); err != nil {
+		t.Fatal(err)
+	}
+	read, err = backend.NewTransaction(ctx, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(read.Discard)
+	checkpointData, found, err = read.Get(ctx, SOConfigHistoryCheckpointKey(testSharedObjectID))
+	if err != nil || !found {
+		t.Fatalf("retained checkpoint found = %v, error = %v", found, err)
+	}
+	retainedCheckpoint := &sobject.SharedObjectConfig{}
+	if err := retainedCheckpoint.UnmarshalVT(checkpointData); err != nil {
+		t.Fatal(err)
+	}
+	if !retainedCheckpoint.EqualVT(checkpoint) {
+		t.Fatal("later mutation replaced the history checkpoint")
+	}
+	entryData, found, err = read.Get(ctx, SOConfigHistoryEntryKey(testSharedObjectID, got.GetConfig().GetConfigChainHash()))
+	if err != nil || !found {
+		t.Fatalf("later entry found = %v, error = %v", found, err)
+	}
+	retained = &sobject.SOConfigChange{}
+	if err := retained.UnmarshalVT(entryData); err != nil {
+		t.Fatal(err)
+	}
+	if !retained.EqualVT(next) {
+		t.Fatal("later signed entry was not retained")
+	}
+}
+
+// _ is a type assertion
+var _ kvtx.Store = (*configHistoryFaultStore)(nil)

--- a/core/provider/local/sostate.go
+++ b/core/provider/local/sostate.go
@@ -22,13 +22,19 @@ func NewObjectStoreSOStateFuncs(rctx context.Context, objStore object.ObjectStor
 	watchFn sobject.SOStateWatchFunc,
 	lockFn sobject.SOStateLockFunc,
 ) {
+	// Keep each mounted state and its write lock under one reference-counted entry.
 	type soStateEntry struct {
+		// stateProm completes after loading the persisted state.
 		stateProm *promise.PromiseContainer[*sobject.SOState]
-		stateCtr  *ccontainer.CContainer[*sobject.SOState]
-		writeMtx  csync.Mutex
-		key       []byte
+		// stateCtr publishes only committed state snapshots.
+		stateCtr *ccontainer.CContainer[*sobject.SOState]
+		// writeMtx serializes mutations while the state entry is retained.
+		writeMtx csync.Mutex
+		// key addresses the serialized SOState in the object store.
+		key []byte
 	}
 
+	// Load one state per retained object without reading its complete history.
 	soRc := keyed.NewKeyedRefCount(
 		func(sharedObjectID string) (keyed.Routine, *soStateEntry) {
 			ent := &soStateEntry{
@@ -37,6 +43,7 @@ func NewObjectStoreSOStateFuncs(rctx context.Context, objStore object.ObjectStor
 				key:       SobjectObjectStoreHostStateKey(sharedObjectID),
 			}
 			return func(ctx context.Context) error {
+				// Read the durable state through the store transaction boundary.
 				var data []byte
 				var found bool
 				err := kvtx.RunTransaction(ctx, false,
@@ -56,6 +63,7 @@ func NewObjectStoreSOStateFuncs(rctx context.Context, objStore object.ObjectStor
 					return world.ErrObjectNotFound
 				}
 
+				// Validate the persisted state before exposing it to consumers.
 				val := &sobject.SOState{}
 				if err := val.UnmarshalVT(data); err != nil {
 					return err
@@ -64,6 +72,7 @@ func NewObjectStoreSOStateFuncs(rctx context.Context, objStore object.ObjectStor
 					return err
 				}
 
+				// Publish the validated initial state to waiters and watches.
 				ent.stateProm.SetResult(val, nil)
 				ent.stateCtr.SetValue(val)
 				return nil
@@ -77,6 +86,7 @@ func NewObjectStoreSOStateFuncs(rctx context.Context, objStore object.ObjectStor
 	)
 	soRc.SetContext(rctx, true)
 
+	// Bind watched state to the caller's reference lifetime.
 	watchFn = func(ctx context.Context, sharedObjectID string, released func()) (ccontainer.Watchable[*sobject.SOState], func(), error) {
 		ref, ent, _ := soRc.AddKeyRef(sharedObjectID)
 		_, err := ent.stateProm.Await(ctx)
@@ -88,6 +98,7 @@ func NewObjectStoreSOStateFuncs(rctx context.Context, objStore object.ObjectStor
 		return ent.stateCtr, ref.Release, nil
 	}
 
+	// Retain the state entry until the locked write has completed.
 	lockFn = func(ctx context.Context, sharedObjectID string) (sobject.SOStateLock, error) {
 		ref, ent, _ := soRc.AddKeyRef(sharedObjectID)
 		_, err := ent.stateProm.Await(ctx)
@@ -96,16 +107,19 @@ func NewObjectStoreSOStateFuncs(rctx context.Context, objStore object.ObjectStor
 			return nil, err
 		}
 
+		// Serialize writes after the initial state load succeeds.
 		relLock, err := ent.writeMtx.Lock(ctx)
 		if err != nil {
 			ref.Release()
 			return nil, err
 		}
 
+		// Commit state and supplied configuration history before updating watchers.
 		initialState := ent.stateCtr.GetValue().CloneVT()
 		return sobject.NewSOStateLock(
 			initialState,
-			func(ctx context.Context, state *sobject.SOState) error {
+			func(ctx context.Context, state *sobject.SOState, changes ...*sobject.SOConfigChange) error {
+				// Serialize an independent state snapshot for replayable transaction writes.
 				ctx, task := trace.NewTask(ctx, "alpha/local-so/write-so-state")
 				defer task.End()
 				state = state.CloneVT()
@@ -113,11 +127,16 @@ func NewObjectStoreSOStateFuncs(rctx context.Context, objStore object.ObjectStor
 				if err != nil {
 					return err
 				}
+
+				// Retain signed changes and state under the same commit boundary.
 				err = kvtx.RunTransaction(ctx, true,
 					func(ctx context.Context) (kvtx.Tx, error) {
 						return objStore.NewTransaction(ctx, true)
 					},
 					func(ctx context.Context, tx kvtx.Tx) error {
+						if err := WriteSOConfigHistory(ctx, tx, sharedObjectID, initialState.GetConfig(), state.GetConfig(), changes); err != nil {
+							return err
+						}
 						return tx.Set(ctx, ent.key, data)
 					},
 				)
@@ -125,11 +144,15 @@ func NewObjectStoreSOStateFuncs(rctx context.Context, objStore object.ObjectStor
 					return err
 				}
 
+				// Make the committed snapshot visible only after the transaction succeeds.
 				ent.stateProm.SetResult(state, nil)
 				ent.stateCtr.SetValue(state)
 				return nil
 			},
-			relLock,
+			func() {
+				relLock()
+				ref.Release()
+			},
 		), nil
 	}
 

--- a/core/provider/spacewave/cloud-sohost.go
+++ b/core/provider/spacewave/cloud-sohost.go
@@ -166,7 +166,11 @@ func newCloudSOHost(
 		}
 
 		initialState := state.CloneVT()
-		writeFn := func(ctx context.Context, state *sobject.SOState) error {
+		writeFn := func(ctx context.Context, state *sobject.SOState, changes ...*sobject.SOConfigChange) error {
+			// Cloud configuration mutations use the server's config-state transaction.
+			if len(changes) != 0 {
+				return errors.New("configuration changes require cloud config-state publication")
+			}
 			return h.writeStateWithRetry(ctx, state)
 		}
 
@@ -406,6 +410,7 @@ func decodeSOStateResponse(data []byte) (*sobject.SOState, uint64, *sobject.SOCo
 	return nil, 0, nil, errors.New("missing snapshot or delta in SOStateMessage")
 }
 
+// syncEmbeddedConfigChain verifies a response's embedded chain through the shared fetch coordinator.
 func (h *cloudSOHost) syncEmbeddedConfigChain(
 	ctx context.Context,
 	state *sobject.SOState,
@@ -566,6 +571,7 @@ func (h *cloudSOHost) handleSONotifyWithContext(ctx context.Context, payload *ap
 	}
 }
 
+// refreshBlockManifestForNonce makes referenced blocks available before publishing newer state.
 func (h *cloudSOHost) refreshBlockManifestForNonce(ctx context.Context, nonce uint64) error {
 	if nonce == 0 || h.refreshBlockManifest == nil {
 		return nil
@@ -775,6 +781,7 @@ func applyChangeLogEntry(
 	}
 }
 
+// diffSOOperationRejections returns rejections not present in the previous state.
 func diffSOOperationRejections(
 	prevState *sobject.SOState,
 	nextState *sobject.SOState,
@@ -799,6 +806,7 @@ func diffSOOperationRejections(
 	return nextRejections
 }
 
+// addSOOperationRejectionKeys indexes the state's signed rejection records.
 func addSOOperationRejectionKeys(keys map[string]struct{}, state *sobject.SOState) {
 	if state == nil {
 		return
@@ -811,6 +819,7 @@ func addSOOperationRejectionKeys(keys map[string]struct{}, state *sobject.SOStat
 	}
 }
 
+// buildSOOperationRejectionKey identifies a rejection by its signed content.
 func buildSOOperationRejectionKey(rejection *sobject.SOOperationRejection) string {
 	if rejection == nil {
 		return ""
@@ -818,6 +827,7 @@ func buildSOOperationRejectionKey(rejection *sobject.SOOperationRejection) strin
 	return string(rejection.GetInner()) + "\x00" + string(rejection.GetSignature().GetSigData())
 }
 
+// logNewOpRejections reports newly observed rejections and decrypts local error details.
 func (h *cloudSOHost) logNewOpRejections(
 	prevState *sobject.SOState,
 	nextState *sobject.SOState,
@@ -1147,6 +1157,7 @@ func (h *cloudSOHost) syncConfigChain(ctx context.Context, newHash []byte) error
 	return h.syncConfigChainResponse(ctx, resp, newHash)
 }
 
+// syncConfigChainResponse verifies pinned chain continuity and records the resulting authority.
 func (h *cloudSOHost) syncConfigChainResponse(
 	ctx context.Context,
 	resp *sobject.SOConfigChainResponse,

--- a/core/provider/spacewave/config-history_test.go
+++ b/core/provider/spacewave/config-history_test.go
@@ -1,0 +1,44 @@
+package provider_spacewave
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/s4wave/spacewave/core/sobject"
+)
+
+// TestCloudHostRejectsConfigChangesThroughRootWrite preserves the server's
+// configuration publication boundary when shared host writes carry lineage.
+func TestCloudHostRejectsConfigChangesThroughRootWrite(t *testing.T) {
+	// Count real HTTP requests so an accidental root publication cannot pass unnoticed.
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+	priv, pid := generateTestKeypair(t)
+	client := NewSessionClient(srv.Client(), srv.URL, DefaultSigningEnvPrefix, priv, pid.String())
+	host := newCloudSOHost(nil, client, testSharedObjectID, "", nil, priv, pid, nil, nil, nil, nil)
+	initial := &sobject.SOState{Config: &sobject.SharedObjectConfig{Participants: []*sobject.SOParticipantConfig{{
+		PeerId: pid.String(), Role: sobject.SOParticipantRole_SOParticipantRole_OWNER,
+	}}}}
+	host.stateCtr.SetValue(initial)
+
+	// A valid signed transition still requires the cloud config-state operation.
+	entry, err := sobject.BuildSOConfigChange(initial.GetConfig(), initial.GetConfig(), sobject.SOConfigChangeType_SO_CONFIG_CHANGE_TYPE_GENESIS, priv, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := host.soHost.ApplyConfigChange(t.Context(), entry, nil); err == nil {
+		t.Fatal("cloud root write accepted a configuration transition")
+	}
+	if requests.Load() != 0 {
+		t.Fatalf("unexpected HTTP requests = %d", requests.Load())
+	}
+	if !host.stateCtr.GetValue().EqualVT(initial) {
+		t.Fatal("rejected configuration transition changed the cloud cache")
+	}
+}

--- a/core/sobject/apply-config-change_test.go
+++ b/core/sobject/apply-config-change_test.go
@@ -51,7 +51,7 @@ func TestApplyConfigChange(t *testing.T) {
 
 		var written *SOState
 		host := NewSOHost(nil, nil, func(_ context.Context, _ string) (SOStateLock, error) {
-			return NewSOStateLock(state, func(_ context.Context, s *SOState) error {
+			return NewSOStateLock(state, func(_ context.Context, s *SOState, _ ...*SOConfigChange) error {
 				written = s
 				return nil
 			}, func() {}), nil
@@ -111,7 +111,7 @@ func TestApplyConfigChange(t *testing.T) {
 
 		var written *SOState
 		host := NewSOHost(nil, nil, func(_ context.Context, _ string) (SOStateLock, error) {
-			return NewSOStateLock(state, func(_ context.Context, s *SOState) error {
+			return NewSOStateLock(state, func(_ context.Context, s *SOState, _ ...*SOConfigChange) error {
 				written = s
 				return nil
 			}, func() {}), nil
@@ -158,7 +158,7 @@ func TestApplyConfigChange(t *testing.T) {
 		}
 
 		host := NewSOHost(nil, nil, func(_ context.Context, _ string) (SOStateLock, error) {
-			return NewSOStateLock(state, func(_ context.Context, _ *SOState) error {
+			return NewSOStateLock(state, func(_ context.Context, _ *SOState, _ ...*SOConfigChange) error {
 				t.Fatal("should not write on rejection")
 				return nil
 			}, func() {}), nil
@@ -206,7 +206,7 @@ func TestApplyConfigChange(t *testing.T) {
 		}
 
 		host := NewSOHost(nil, nil, func(_ context.Context, _ string) (SOStateLock, error) {
-			return NewSOStateLock(state, func(_ context.Context, _ *SOState) error {
+			return NewSOStateLock(state, func(_ context.Context, _ *SOState, _ ...*SOConfigChange) error {
 				t.Fatal("should not write on seqno rejection")
 				return nil
 			}, func() {}), nil
@@ -238,7 +238,7 @@ func TestApplyConfigChange(t *testing.T) {
 
 		var written *SOState
 		host := NewSOHost(nil, nil, func(_ context.Context, _ string) (SOStateLock, error) {
-			return NewSOStateLock(state, func(_ context.Context, s *SOState) error {
+			return NewSOStateLock(state, func(_ context.Context, s *SOState, _ ...*SOConfigChange) error {
 				written = s
 				state = s
 				return nil
@@ -301,7 +301,7 @@ func TestApplyConfigChange(t *testing.T) {
 		}
 
 		host := NewSOHost(nil, nil, func(_ context.Context, _ string) (SOStateLock, error) {
-			return NewSOStateLock(state, func(_ context.Context, _ *SOState) error {
+			return NewSOStateLock(state, func(_ context.Context, _ *SOState, _ ...*SOConfigChange) error {
 				t.Fatal("should not write when signer is not OWNER")
 				return nil
 			}, func() {}), nil
@@ -362,7 +362,7 @@ func TestApplyConfigChange(t *testing.T) {
 
 		var written *SOState
 		host := NewSOHost(nil, nil, func(_ context.Context, _ string) (SOStateLock, error) {
-			return NewSOStateLock(state, func(_ context.Context, s *SOState) error {
+			return NewSOStateLock(state, func(_ context.Context, s *SOState, _ ...*SOConfigChange) error {
 				written = s
 				return nil
 			}, func() {}), nil
@@ -421,7 +421,7 @@ func TestApplyConfigChange(t *testing.T) {
 		}
 
 		host := NewSOHost(nil, nil, func(_ context.Context, _ string) (SOStateLock, error) {
-			return NewSOStateLock(state, func(_ context.Context, _ *SOState) error {
+			return NewSOStateLock(state, func(_ context.Context, _ *SOState, _ ...*SOConfigChange) error {
 				t.Fatal("should not write on self-enroll escalation")
 				return nil
 			}, func() {}), nil
@@ -472,7 +472,7 @@ func TestApplyConfigChange(t *testing.T) {
 		}
 
 		host := NewSOHost(nil, nil, func(_ context.Context, _ string) (SOStateLock, error) {
-			return NewSOStateLock(state, func(_ context.Context, _ *SOState) error {
+			return NewSOStateLock(state, func(_ context.Context, _ *SOState, _ ...*SOConfigChange) error {
 				t.Fatal("should not write on cross-entity self-enroll")
 				return nil
 			}, func() {}), nil

--- a/core/sobject/host.go
+++ b/core/sobject/host.go
@@ -195,6 +195,7 @@ func (s *SOHost) ApplyConfigChange(ctx context.Context, entry *SOConfigChange, f
 	if entry == nil {
 		return errors.New("config change entry is nil")
 	}
+	entry = entry.CloneVT()
 
 	// Hold the provider lock through verification and persistence.
 	lk, err := s.lockFn(ctx, s.sharedObjectID)
@@ -220,7 +221,7 @@ func (s *SOHost) ApplyConfigChange(ctx context.Context, entry *SOConfigChange, f
 		}
 	}
 
-	return lk.WriteSOState(ctx, nextState)
+	return lk.WriteSOState(ctx, nextState, entry)
 }
 
 // QueueOperation locks the host state and applies the QueueOperation operation.

--- a/core/sobject/invite_test.go
+++ b/core/sobject/invite_test.go
@@ -19,7 +19,7 @@ func newTestSOHost(ctx context.Context, state *SOState) (*SOHost, **SOState) {
 			return ctr, func() {}, nil
 		},
 		func(_ context.Context, _ string) (SOStateLock, error) {
-			return NewSOStateLock(*statePtr, func(_ context.Context, s *SOState) error {
+			return NewSOStateLock(*statePtr, func(_ context.Context, s *SOState, _ ...*SOConfigChange) error {
 				*statePtr = s
 				ctr.SetValue(s)
 				return nil

--- a/core/sobject/lock.go
+++ b/core/sobject/lock.go
@@ -1,16 +1,21 @@
 package sobject
 
-import "context"
+import (
+	"context"
 
-// SOStateLock is a lock handle to a SOState.
+	"github.com/pkg/errors"
+)
+
+// SOStateLock is a lock handle to a SOState. The caller serializes all handle use.
 type SOStateLock interface {
 	// GetSOState returns the SOState as of when the lock was acquired.
 	GetSOState() *SOState
 
-	// WriteSOState writes an updated SOState.
+	// WriteSOState writes an updated SOState and its accepted configuration changes.
+	// Persistent providers commit the supplied lineage with the state atomically.
 	// Returns an error if the lock was released already.
 	// Only the locked handle should be able to write.
-	WriteSOState(ctx context.Context, state *SOState) error
+	WriteSOState(ctx context.Context, state *SOState, changes ...*SOConfigChange) error
 
 	// Release releases the lock.
 	Release()
@@ -18,9 +23,14 @@ type SOStateLock interface {
 
 // soStateLock implements SOStateLock.
 type soStateLock struct {
+	// initialState is the state observed while acquiring the provider lock.
 	initialState *SOState
-	writeFn      func(ctx context.Context, state *SOState) error
-	release      func()
+	// writeFn commits state and accepted lineage through the provider boundary.
+	writeFn func(ctx context.Context, state *SOState, changes ...*SOConfigChange) error
+	// release relinquishes the provider lock and its retained state reference.
+	release func()
+	// released prevents writes after relinquishing the provider lock.
+	released bool
 }
 
 // GetSOState returns the SOState as of when the lock was acquired.
@@ -31,12 +41,19 @@ func (l *soStateLock) GetSOState() *SOState {
 // WriteSOState writes an updated SOState.
 // Returns an error if the lock was released already.
 // Only the locked handle should be able to write.
-func (l *soStateLock) WriteSOState(ctx context.Context, state *SOState) error {
-	return l.writeFn(ctx, state)
+func (l *soStateLock) WriteSOState(ctx context.Context, state *SOState, changes ...*SOConfigChange) error {
+	if l.released {
+		return errors.New("shared object state lock is released")
+	}
+	return l.writeFn(ctx, state, changes...)
 }
 
 // Release releases the lock.
 func (l *soStateLock) Release() {
+	if l.released {
+		return
+	}
+	l.released = true
 	if l.release != nil {
 		l.release()
 	}
@@ -45,7 +62,7 @@ func (l *soStateLock) Release() {
 // NewSOStateLock constructs a SOStateLock with an initial value and callbacks.
 func NewSOStateLock(
 	initialState *SOState,
-	writeFn func(ctx context.Context, state *SOState) error,
+	writeFn func(ctx context.Context, state *SOState, changes ...*SOConfigChange) error,
 	release func(),
 ) SOStateLock {
 	return &soStateLock{initialState: initialState, writeFn: writeFn, release: release}

--- a/core/sobject/lock_test.go
+++ b/core/sobject/lock_test.go
@@ -1,0 +1,34 @@
+package sobject
+
+import (
+	"context"
+	"testing"
+)
+
+// TestSOStateLockRelease fences writes after releasing the provider's lock.
+func TestSOStateLockRelease(t *testing.T) {
+	// Forward state and lineage while the handle owns the provider lock.
+	state := &SOState{}
+	entry := &SOConfigChange{}
+	writes, releases := 0, 0
+	lock := NewSOStateLock(state, func(_ context.Context, got *SOState, changes ...*SOConfigChange) error {
+		writes++
+		if got != state || len(changes) != 1 || changes[0] != entry {
+			t.Fatal("write did not forward the state and lineage together")
+		}
+		return nil
+	}, func() { releases++ })
+	if err := lock.WriteSOState(t.Context(), state, entry); err != nil {
+		t.Fatal(err)
+	}
+
+	// Repeated cleanup cannot release twice or permit an unlocked write.
+	lock.Release()
+	lock.Release()
+	if err := lock.WriteSOState(t.Context(), state, entry); err == nil {
+		t.Fatal("accepted a write after releasing the provider lock")
+	}
+	if writes != 1 || releases != 1 {
+		t.Fatalf("writes = %d, releases = %d", writes, releases)
+	}
+}

--- a/core/sobject/sync/sync-gate_test.go
+++ b/core/sobject/sync/sync-gate_test.go
@@ -37,7 +37,7 @@ func newMemHost(soID string, initial *sobject.SOState) (*sobject.SOHost, *cconta
 		return ctr, func() {}, nil
 	}
 	lockFn := func(_ context.Context, _ string) (sobject.SOStateLock, error) {
-		return sobject.NewSOStateLock(ctr.GetValue(), func(_ context.Context, s *sobject.SOState) error {
+		return sobject.NewSOStateLock(ctr.GetValue(), func(_ context.Context, s *sobject.SOState, _ ...*sobject.SOConfigChange) error {
 			ctr.SetValue(s)
 			return nil
 		}, func() {}), nil


### PR DESCRIPTION
Local configuration mutations now retain their signed entries and initial checkpoint in the same transaction as the resulting object state. Watchers see only committed state, and releasing a state lock also releases its retained provider reference. Cloud hosts reject configuration changes through the root-write path.

Focused package and race tests cover transaction retry, retained history after reopen, tampering rejection, released locks, and cloud rejection without an HTTP request. Commit-hook compile and lint checks passed. Local dependency preparation required go mod vendor -e because the base prototype still imports removed OPFS packages; those imports remain unresolved. This change adds local retention only; peer history delivery and cloud lineage persistence remain separate work.