### PR TITLE
fix(sobject): authenticate snapshots against held authority

### DIFF
--- a/core/sobject/sync/snapshot-authority_test.go
+++ b/core/sobject/sync/snapshot-authority_test.go
@@ -1,0 +1,124 @@
+package sobject_sync
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/s4wave/spacewave/core/sobject"
+	"github.com/s4wave/spacewave/net/peer"
+)
+
+// TestSnapshotExchangeRequiresHeldAuthority drives the real packet exchange
+// with valid readable candidates that differ only at the authority boundary.
+func TestSnapshotExchangeRequiresHeldAuthority(t *testing.T) {
+	// Establish authority before accepting anything from the remote stream.
+	const soID = "snapshot-held-authority"
+	owner := mustKeyPair(t)
+	reader := mustKeyPair(t)
+	local := mustKeyPair(t)
+	localID, err := peer.IDFromPrivateKey(local)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initial := &sobject.SOState{
+		Config: &sobject.SharedObjectConfig{Participants: []*sobject.SOParticipantConfig{
+			participantCfg(mustPeerIDStr(t, owner), sobject.SOParticipantRole_SOParticipantRole_OWNER),
+			participantCfg(mustPeerIDStr(t, reader), sobject.SOParticipantRole_SOParticipantRole_READER),
+			participantCfg(localID.String(), sobject.SOParticipantRole_SOParticipantRole_WRITER),
+		}},
+		Root: &sobject.SORoot{InnerSeqno: 1},
+	}
+	trustSnapshotConfig(t, initial, owner)
+	signSnapshotRoot(t, soID, initial, owner)
+	initial.RootGrants = append(initial.RootGrants, buildGrant(t, soID, owner, local.GetPublic()))
+
+	// Each rejection preserves every held byte, including configuration and queue state.
+	for _, test := range []struct {
+		// name identifies the attempted authority violation.
+		name string
+		// mutate changes an otherwise valid candidate and, when needed, its held checkpoint.
+		mutate func(held, candidate *sobject.SOState)
+		// wantError names the decisive boundary rather than an unrelated earlier failure.
+		wantError string
+		// advanceHeld commits a local configuration change during the access check.
+		advanceHeld bool
+	}{
+		{name: "authorized sequence jump"},
+		{name: "configuration advances during access check", advanceHeld: true, wantError: "configuration authority"},
+		{name: "same head self promotion", mutate: func(_, candidate *sobject.SOState) {
+			candidate.Config.Participants[1].Role = sobject.SOParticipantRole_SOParticipantRole_OWNER
+			signSnapshotRoot(t, soID, candidate, reader)
+		}, wantError: "configuration authority"},
+		{name: "chainless different head", mutate: func(_, candidate *sobject.SOState) {
+			candidate.Config.ConfigChainHash[0] ^= 1
+			candidate.Config.ConfigChainSeqno++
+		}, wantError: "configuration authority"},
+		{name: "empty held checkpoint", mutate: func(held, candidate *sobject.SOState) {
+			held.Config.ConfigChainHash = nil
+			candidate.Config = held.Config.CloneVT()
+		}, wantError: "configuration authority"},
+		{name: "reader signed root", mutate: func(_, candidate *sobject.SOState) {
+			signSnapshotRoot(t, soID, candidate, reader)
+		}, wantError: "root authority"},
+		{name: "tampered root", mutate: func(_, candidate *sobject.SOState) {
+			candidate.Root.Inner[0] ^= 1
+		}, wantError: "root authority"},
+		{name: "unsigned root", mutate: func(_, candidate *sobject.SOState) {
+			candidate.Root.ValidatorSignatures = nil
+		}, wantError: "consensus"},
+		{name: "duplicate signer", mutate: func(_, candidate *sobject.SOState) {
+			candidate.Root.ValidatorSignatures = append(candidate.Root.ValidatorSignatures, candidate.Root.ValidatorSignatures[0].CloneVT())
+		}, wantError: "root authority"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			held := initial.CloneVT()
+			candidate := held.CloneVT()
+			candidate.Root.InnerSeqno = 5
+			signSnapshotRoot(t, soID, candidate, owner)
+			if test.mutate != nil {
+				test.mutate(held, candidate)
+			}
+			before := held.CloneVT()
+			host, ctr := newMemHost(soID, held)
+			t.Cleanup(host.ClearContext)
+			var accessChecks []SnapshotAccessValidator
+			if test.advanceHeld {
+				accessChecks = append(accessChecks, func(ctx context.Context, _ *sobject.SOState) error {
+					entry, err := sobject.BuildSOConfigChange(held.GetConfig(), held.GetConfig(), sobject.SOConfigChangeType_SO_CONFIG_CHANGE_TYPE_ADD_INVITE, owner, nil)
+					if err != nil {
+						return err
+					}
+					if err := host.ApplyConfigChange(ctx, entry, nil); err != nil {
+						return err
+					}
+					before = ctr.GetValue().CloneVT()
+					return nil
+				})
+			}
+			syncer := NewSOSync(gateLogger(), nil, soID, localID, host, accessChecks...)
+			data, err := candidate.MarshalVT()
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = runSnapshotExchange(t, syncer, t.Context(), &SOSyncMessage{
+				Body: &SOSyncMessage_Snapshot{Snapshot: &SOSyncSnapshot{SoState: data, RootSeqno: 5}},
+			})
+			if test.wantError == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !ctr.GetValue().EqualVT(candidate) {
+					t.Fatal("authorized sequence jump did not converge")
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("error = %v, want %q", err, test.wantError)
+			}
+			if !ctr.GetValue().EqualVT(before) {
+				t.Fatal("rejected snapshot changed held state")
+			}
+		})
+	}
+}

--- a/core/sobject/sync/sync-gate_test.go
+++ b/core/sobject/sync/sync-gate_test.go
@@ -15,6 +15,7 @@ import (
 	transform_blockenc "github.com/s4wave/spacewave/db/block/transform/blockenc"
 	"github.com/s4wave/spacewave/db/util/blockenc"
 	"github.com/s4wave/spacewave/net/crypto"
+	"github.com/s4wave/spacewave/net/hash"
 	"github.com/s4wave/spacewave/net/peer"
 	stream_packet "github.com/s4wave/spacewave/net/stream/packet"
 	"github.com/sirupsen/logrus"
@@ -45,6 +46,7 @@ func newMemHost(soID string, initial *sobject.SOState) (*sobject.SOHost, *cconta
 	return sobject.NewSOHost(context.Background(), watchFn, lockFn, soID), ctr
 }
 
+// mustKeyPair generates a real participant signing key.
 func mustKeyPair(t *testing.T) crypto.PrivKey {
 	t.Helper()
 	priv, _, err := crypto.GenerateKeyPair(crypto.KeyType_Ed25519, 0)
@@ -54,6 +56,7 @@ func mustKeyPair(t *testing.T) crypto.PrivKey {
 	return priv
 }
 
+// mustPeerIDStr encodes the identity belonging to the signing key.
 func mustPeerIDStr(t *testing.T, priv crypto.PrivKey) string {
 	t.Helper()
 	id, err := peer.IDFromPrivateKey(priv)
@@ -63,6 +66,7 @@ func mustPeerIDStr(t *testing.T, priv crypto.PrivKey) string {
 	return id.String()
 }
 
+// participantCfg constructs a participant with the requested role.
 func participantCfg(peerIDStr string, role sobject.SOParticipantRole) *sobject.SOParticipantConfig {
 	return &sobject.SOParticipantConfig{PeerId: peerIDStr, Role: role}
 }
@@ -143,8 +147,10 @@ func TestStreamOpsAppliesNewerSnapshot(t *testing.T) {
 		Config: &sobject.SharedObjectConfig{Participants: participants},
 		Root:   &sobject.SORoot{InnerSeqno: 1},
 	}
+	trustSnapshotConfig(t, initial, ownerPriv)
 	newer := initial.CloneVT()
 	newer.Root.InnerSeqno = 2
+	signSnapshotRoot(t, "stream-newer-snapshot", newer, ownerPriv)
 	newerData, err := newer.MarshalVT()
 	if err != nil {
 		t.Fatal(err)
@@ -360,6 +366,7 @@ func TestSnapshotExchangeAcceptsObjectPeerDistinctFromTransportPeer(t *testing.T
 		Root:       &sobject.SORoot{InnerSeqno: 1},
 		RootGrants: []*sobject.SOGrant{grant},
 	}
+	trustSnapshotConfig(t, localState, ownerPriv)
 	if err := localState.QueueOperation(soID, pending); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -367,10 +374,11 @@ func TestSnapshotExchangeAcceptsObjectPeerDistinctFromTransportPeer(t *testing.T
 	s := NewSOSync(gateLogger(), nil, soID, localPeer, localHost)
 
 	peerState := &sobject.SOState{
-		Config:     &sobject.SharedObjectConfig{Participants: participants},
+		Config:     localState.GetConfig().CloneVT(),
 		Root:       &sobject.SORoot{InnerSeqno: 5},
 		RootGrants: []*sobject.SOGrant{grant},
 	}
+	signSnapshotRoot(t, soID, peerState, ownerPriv)
 	snapData, err := peerState.MarshalVT()
 	if err != nil {
 		t.Fatal(err.Error())
@@ -570,5 +578,28 @@ func TestRemoteOpTamperedSignatureRejected(t *testing.T) {
 
 	if got := len(ctr.GetValue().GetOps()); got != 0 {
 		t.Fatalf("tampered op was queued (%d ops)", got)
+	}
+}
+
+// trustSnapshotConfig establishes a signed genesis checkpoint already held locally.
+func trustSnapshotConfig(t *testing.T, state *sobject.SOState, owner crypto.PrivKey) {
+	t.Helper()
+	entry, err := sobject.BuildSOConfigChange(state.GetConfig(), state.GetConfig(), sobject.SOConfigChangeType_SO_CONFIG_CHANGE_TYPE_GENESIS, owner, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state.Config, err = sobject.VerifyConfigChange(state.GetConfig(), entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// signSnapshotRoot signs the candidate sequence and content with a real participant key.
+func signSnapshotRoot(t *testing.T, soID string, state *sobject.SOState, signer crypto.PrivKey) {
+	t.Helper()
+	state.Root.Inner = []byte("snapshot-root")
+	state.Root.ValidatorSignatures = nil
+	if err := state.Root.SignInnerData(signer, soID, state.Root.GetInnerSeqno(), hash.RecommendedHashType); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/core/sobject/sync/sync.go
+++ b/core/sobject/sync/sync.go
@@ -21,19 +21,23 @@ const SyncProtocolID = protocol.ID("alpha/so-sync")
 // maxMessageSize is the max message size for SO sync messages.
 const maxMessageSize = 10 * 1024 * 1024
 
-// SOSync manages bidirectional shared object state synchronization
-// over a solicit protocol stream. Each instance syncs one SharedObject
-// with peers connected via the session transport's child bus.
 // SnapshotAccessValidator verifies that the local object identity can decode
 // an inbound snapshot before it replaces durable state.
 type SnapshotAccessValidator func(context.Context, *sobject.SOState) error
 
+// SOSync synchronizes one shared object over the session transport's child bus.
 type SOSync struct {
-	le                     *logrus.Entry
-	b                      bus.Bus
-	soID                   string
-	localObjectPeerID      peer.ID
-	soHost                 *sobject.SOHost
+	// le records synchronization errors and peer activity.
+	le *logrus.Entry
+	// b supplies the session transport's solicitation interface.
+	b bus.Bus
+	// soID identifies the object and its signature context.
+	soID string
+	// localObjectPeerID is the participant identity, independent of transport identity.
+	localObjectPeerID peer.ID
+	// soHost owns accepted state and its provider lock.
+	soHost *sobject.SOHost
+	// validateSnapshotAccess checks local decryption before acceptance.
 	validateSnapshotAccess SnapshotAccessValidator
 }
 
@@ -189,9 +193,27 @@ func (s *SOSync) applyPeerSnapshot(
 
 	var applied bool
 	if err := s.soHost.UpdateSOState(ctx, func(state *sobject.SOState) error {
+		// This protocol carries no lineage. Authenticate the entire candidate
+		// configuration against the checkpoint held under the provider lock.
+		if err := sobject.VerifyConfigChainSuffix(state.GetConfig(), peerState.GetConfig(), nil); err != nil {
+			return errors.Wrap(err, "peer snapshot configuration authority")
+		}
 		if peerSnap.GetRootSeqno() <= state.GetRoot().GetInnerSeqno() {
 			return nil
 		}
+
+		// Sequence jumps require a root authorized by the held configuration.
+		validSigs, err := peerState.GetRoot().ValidateSignatures(s.soID, state.GetConfig().GetParticipants())
+		if err != nil {
+			return errors.Wrap(err, "peer snapshot root authority")
+		}
+		if err := sobject.CheckConsensusAcceptance(state.GetConfig().GetConsensusMode(), validSigs); err != nil {
+			return errors.Wrap(err, "peer snapshot consensus")
+		}
+		if err := peerState.Validate(s.soID); err != nil {
+			return errors.Wrap(err, "peer snapshot state")
+		}
+
 		merged := peerState.CloneVT()
 		if err := mergePendingOperations(le, s.soID, merged, state); err != nil {
 			return errors.Wrap(err, "preserve pending local operations")
@@ -244,17 +266,9 @@ func mergePendingOperations(le *logrus.Entry, sharedObjectID string, authoritati
 	return nil
 }
 
-// validateSnapshotElements checks an inbound snapshot before it may replace
-// local shared-object state. The sending peer may have self-authored the
-// received config: nothing here verifies who wrote it or its lineage. The
-// checks only require the local session peer to keep readable membership in
-// the resulting config, and the grants and ops carried in the snapshot to
-// carry internally valid signatures against that untrusted config.
-//
-// Full config-head authorization requires VerifyConfigChain over the
-// sender's SOConfigChange entries. Neither SOSyncMessage nor any p2p-side
-// store carries those entries today; closing that chain-lineage gap is a
-// separate prerequisite.
+// validateSnapshotElements checks local readability and element signatures before
+// expensive access checks. Configuration and root authority are checked again
+// against the held state under the provider lock before accepting a snapshot.
 func (s *SOSync) validateSnapshotElements(peerState *sobject.SOState) error {
 	cfg := peerState.GetConfig()
 	if cfg == nil || len(cfg.GetParticipants()) == 0 {


### PR DESCRIPTION
Snapshot acceptance now checks the complete received configuration against the nonempty checkpoint held under the provider lock. This chainless protocol rejects changed configurations. Newer roots must pass signature, consensus, and state validation before replacing local state.

The packet-exchange regression rejects self-promotion, changed or empty heads, unauthorized and tampered roots, unsigned roots, duplicate signers, and a local configuration change during the access check. All eight invalid cases were accepted by the prior implementation. The legitimate signed sequence jump and pending-operation preservation still pass. Package tests, race tests, and commit-hook compile and lint checks passed.

This closes snapshot adoption through self-declared authority. Authentication before outbound disclosure and signed history transport remain unfinished. Dependency preparation required go mod vendor -e because the base prototype imports removed OPFS packages.