### PR TITLE
perf(packfile): preserve content locality and bulk read-ahead

### DIFF
--- a/bldr/manifest/pack/locality_test.go
+++ b/bldr/manifest/pack/locality_test.go
@@ -1,0 +1,49 @@
+package bldr_manifest_pack
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/aperturerobotics/go-kvfile"
+	"github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
+	"github.com/s4wave/spacewave/net/peer"
+	"github.com/sirupsen/logrus"
+)
+
+// TestManifestPackStartsAtBundleRoot verifies physical layout and deterministic
+// output through the real manifest pack writer, including a filesystem tree.
+func TestManifestPackStartsAtBundleRoot(t *testing.T) {
+	ctx := t.Context()
+	ws := newTestWorld(t, ctx, logrus.NewEntry(logrus.New()))
+	tuple := testManifestPackTuple()
+	manifest := storeTestManifest(t, ctx, ws, tuple, false, true)
+	_, bundle, err := StoreManifestBundle(ctx, ws, peer.ID("sender"), tuple, manifest, timestamppb.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var first []byte
+	for range 4 {
+		var out bytes.Buffer
+		_, _, err := PackManifestBundle(ctx, ws, "locality", bundle, &out)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if first != nil && !bytes.Equal(first, out.Bytes()) {
+			t.Fatal("unchanged manifest produced a different physical pack order")
+		}
+		first = bytes.Clone(out.Bytes())
+	}
+
+	reader, err := kvfile.BuildReader(bytes.NewReader(first), uint64(len(first)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pos, _, _, _, err := reader.GetValuePosition([]byte(bundle.GetRootRef().GetHash().MarshalString()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pos != 0 {
+		t.Fatalf("bundle root starts at %d, want the first payload at 0", pos)
+	}
+}

--- a/bldr/manifest/pack/pack.go
+++ b/bldr/manifest/pack/pack.go
@@ -1,16 +1,16 @@
 package bldr_manifest_pack
 
 import (
+	"bytes"
 	"context"
 	"io"
-	"slices"
-	"strings"
 
 	"github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
 	"github.com/pkg/errors"
 	bldr_manifest "github.com/s4wave/spacewave/bldr/manifest"
 	packfile "github.com/s4wave/spacewave/core/provider/spacewave/packfile"
 	"github.com/s4wave/spacewave/core/provider/spacewave/packfile/identity"
+	"github.com/s4wave/spacewave/core/provider/spacewave/packfile/order"
 	"github.com/s4wave/spacewave/core/provider/spacewave/packfile/writer"
 	"github.com/s4wave/spacewave/db/block"
 	block_transform "github.com/s4wave/spacewave/db/block/transform"
@@ -28,15 +28,21 @@ func PackManifestBundle(
 	bundleRef *bucket.ObjectRef,
 	w io.Writer,
 ) (*packfile.PackfileEntry, []byte, error) {
+	// Pack only standalone references with fully specified source ownership.
 	if err := ValidateCleanObjectRef("manifest_bundle_ref", bundleRef); err != nil {
 		return nil, nil, err
 	}
-	var blocks []packBlock
-	seen := make(map[string]struct{})
+
+	// Retain structural edges while collecting encoded bytes. The walker may
+	// visit siblings before descendants; physical output follows each subtree.
+	blocks := make(map[string]packBlock)
+	graph := order.NewGraph()
+	var roots []*block.BlockRef
 	appendBlocks := func(rootRef *bucket.ObjectRef, ctor func() block.Block) error {
 		if err := ValidateCleanObjectRef("manifest_pack_root", rootRef); err != nil {
 			return err
 		}
+		roots = append(roots, rootRef.GetRootRef())
 		return ws.AccessWorldState(ctx, rootRef, func(bls *bucket_lookup.Cursor) error {
 			readXfrm := bls.GetTransformer()
 			if readXfrm == nil {
@@ -52,16 +58,21 @@ func PackManifestBundle(
 					if entry.Ref == nil || entry.Ref.GetEmpty() || !entry.Found || entry.IsSubBlock || len(entry.Data) == 0 {
 						return true, nil
 					}
-					key := entry.Ref.MarshalString()
-					if _, ok := seen[key]; ok {
+
+					// Capture each encoded payload and its structural edges once.
+					key := entry.Ref.GetHash().MarshalString()
+					if _, ok := blocks[key]; ok {
 						return true, nil
 					}
-					seen[key] = struct{}{}
-					blocks = append(blocks, packBlock{
-						key:  key,
-						hash: entry.Ref.GetHash().Clone(),
-						data: append([]byte(nil), entry.Data...),
-					})
+					children, err := block.ExtractBlockRefs(entry.Blk)
+					if err != nil {
+						return false, err
+					}
+					graph.Add(entry.Ref, children)
+					blocks[key] = packBlock{
+						hash: entry.Ref.GetHash().CloneVT(),
+						data: bytes.Clone(entry.Data),
+					}
 					return true, nil
 				},
 				bls.GetBucket(),
@@ -71,6 +82,8 @@ func PackManifestBundle(
 			)
 		})
 	}
+
+	// Include the bundle and every manifest filesystem reachable through it.
 	if err := appendBlocks(bundleRef, bldr_manifest.NewManifestBundleBlock); err != nil {
 		return nil, nil, err
 	}
@@ -83,15 +96,18 @@ func PackManifestBundle(
 			return nil, nil, errors.Wrapf(err, "manifest_refs[%d]", i)
 		}
 	}
-	slices.SortFunc(blocks, func(a, b packBlock) int {
-		return strings.Compare(a.key, b.key)
-	})
+
+	// Order before writing so related values remain adjacent in the pack.
+	refs, err := graph.Order(ctx, roots)
+	if err != nil {
+		return nil, nil, err
+	}
 	idx := 0
 	res, err := writer.PackBlocks(w, func() (*hash.Hash, []byte, error) {
-		if idx >= len(blocks) {
+		if idx >= len(refs) {
 			return nil, nil, nil
 		}
-		blk := blocks[idx]
+		blk := blocks[refs[idx].GetHash().MarshalString()]
 		idx++
 		return blk.hash, blk.data, nil
 	})
@@ -101,6 +117,8 @@ func PackManifestBundle(
 	if res.BlockCount == 0 {
 		return nil, nil, errors.New("manifest bundle pack contains no blocks")
 	}
+
+	// Derive immutable identity and metadata from the encoded physical bytes.
 	packID, err := identity.BuildPackID(resourceID, res)
 	if err != nil {
 		return nil, nil, err
@@ -128,6 +146,7 @@ func NewMetadata(
 	entry *packfile.PackfileEntry,
 	packSHA256 []byte,
 ) (*ManifestPackMetadata, error) {
+	// Own copies of all mutable artifact and manifest metadata.
 	meta := &ManifestPackMetadata{
 		FormatVersion:     MetadataFormatVersion,
 		GitSha:            gitSHA,
@@ -135,9 +154,9 @@ func NewMetadata(
 		ProducerTarget:    producerTarget,
 		ReactDev:          reactDev,
 		CacheSchema:       cacheSchema,
-		ManifestBundleRef: bundleRef.Clone(),
+		ManifestBundleRef: bundleRef.CloneVT(),
 		Pack:              entry.CloneVT(),
-		PackSha256:        append([]byte(nil), packSHA256...),
+		PackSha256:        bytes.Clone(packSHA256),
 	}
 	if len(tuples) != 0 {
 		meta.Manifests = make([]*ManifestTuple, len(tuples))
@@ -145,6 +164,8 @@ func NewMetadata(
 			meta.Manifests[i] = tuple.CloneVT()
 		}
 	}
+
+	// Return only metadata that satisfies the import contract.
 	if err := meta.Validate(); err != nil {
 		return nil, err
 	}
@@ -153,7 +174,8 @@ func NewMetadata(
 
 // packBlock is one block queued for the pack writer.
 type packBlock struct {
-	key  string
+	// hash identifies the encoded payload.
 	hash *hash.Hash
+	// data is the encoded payload copied from the source store.
 	data []byte
 }

--- a/bldr/plugin/host/scheduler/download-manifest.go
+++ b/bldr/plugin/host/scheduler/download-manifest.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	bldr_manifest "github.com/s4wave/spacewave/bldr/manifest"
 	bldr_manifest_world "github.com/s4wave/spacewave/bldr/manifest/world"
+	"github.com/s4wave/spacewave/db/block"
 	bucket "github.com/s4wave/spacewave/db/bucket"
 	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	trace "github.com/s4wave/spacewave/db/traceutil"
@@ -17,42 +18,63 @@ import (
 type manifestCopyClass string
 
 const (
-	manifestCopyClassImmediate              manifestCopyClass = "immediate"
-	manifestCopyClassAfterExecuteReady      manifestCopyClass = "after-execute-ready"
+	// manifestCopyClassImmediate permits copying without a readiness wait.
+	manifestCopyClassImmediate manifestCopyClass = "immediate"
+	// manifestCopyClassAfterExecuteReady waits for this plugin to start.
+	manifestCopyClassAfterExecuteReady manifestCopyClass = "after-execute-ready"
+	// manifestCopyClassAfterStartupGroupReady waits for the startup group.
 	manifestCopyClassAfterStartupGroupReady manifestCopyClass = "after-startup-group-ready"
-	manifestCopyClassSuppressed             manifestCopyClass = "suppressed"
+	// manifestCopyClassSuppressed excludes the source bucket from local copying.
+	manifestCopyClassSuppressed manifestCopyClass = "suppressed"
 )
 
 // manifestCopyPhase is the lifecycle phase of one manifest copy.
 type manifestCopyPhase string
 
 const (
-	manifestCopyPhaseSelected               manifestCopyPhase = "selected"
-	manifestCopyPhaseWaiting                manifestCopyPhase = "waiting-for-running"
+	// manifestCopyPhaseSelected identifies an accepted copy candidate.
+	manifestCopyPhaseSelected manifestCopyPhase = "selected"
+	// manifestCopyPhaseWaiting waits for the plugin's running capability.
+	manifestCopyPhaseWaiting manifestCopyPhase = "waiting-for-running"
+	// manifestCopyPhaseWaitingForStartupGroup waits for startup demand to settle.
 	manifestCopyPhaseWaitingForStartupGroup manifestCopyPhase = "waiting-for-startup-group"
-	manifestCopyPhaseWaitingForAdmission    manifestCopyPhase = "waiting-for-admission"
-	manifestCopyPhaseCopying                manifestCopyPhase = "copying"
-	manifestCopyPhaseDone                   manifestCopyPhase = "done"
-	manifestCopyPhaseFailed                 manifestCopyPhase = "failed"
-	manifestCopyPhaseSuppressed             manifestCopyPhase = "suppressed"
+	// manifestCopyPhaseWaitingForAdmission waits for the aggregate copy permit.
+	manifestCopyPhaseWaitingForAdmission manifestCopyPhase = "waiting-for-admission"
+	// manifestCopyPhaseCopying owns an active materialization attempt.
+	manifestCopyPhaseCopying manifestCopyPhase = "copying"
+	// manifestCopyPhaseDone reports completed copying and publication.
+	manifestCopyPhaseDone manifestCopyPhase = "done"
+	// manifestCopyPhaseFailed reports a failed attempt to the retry owner.
+	manifestCopyPhaseFailed manifestCopyPhase = "failed"
+	// manifestCopyPhaseSuppressed reports a configured copy exclusion.
+	manifestCopyPhaseSuppressed manifestCopyPhase = "suppressed"
 )
 
 // manifestCopyStatus tracks the copy state and identities for one
 // manifest.
 type manifestCopyStatus struct {
-	phase               manifestCopyPhase
-	class               manifestCopyClass
-	manifestRef         string
-	sourceBucketID      string
+	// phase describes the current copy attempt.
+	phase manifestCopyPhase
+	// class records the readiness or exclusion policy used for selection.
+	class manifestCopyClass
+	// manifestRef identifies the selected manifest snapshot.
+	manifestRef string
+	// sourceBucketID identifies the bucket supplying encoded source blocks.
+	sourceBucketID string
+	// destinationBucketID identifies the local copy destination.
 	destinationBucketID string
-	sourceIdentity      manifestCopyIdentity
+	// sourceIdentity distinguishes source account and storage ownership.
+	sourceIdentity manifestCopyIdentity
+	// destinationIdentity distinguishes destination account and ownership.
 	destinationIdentity manifestCopyIdentity
-	stats               bucket_lookup.ObjectCopyStats
+	// stats captures the most recently observed copy accounting.
+	stats bucket_lookup.ObjectCopyStats
 }
 
 // classifyManifestCopy decides the startup-copy class for a manifest
 // snapshot.
 func (t *pluginInstance) classifyManifestCopy(manifestSnapshot *bldr_manifest.ManifestSnapshot) manifestCopyClass {
+	// Honor explicit bucket exclusions before considering readiness gates.
 	if t == nil || manifestSnapshot == nil {
 		return manifestCopyClassImmediate
 	}
@@ -64,10 +86,14 @@ func (t *pluginInstance) classifyManifestCopy(manifestSnapshot *bldr_manifest.Ma
 			return manifestCopyClassSuppressed
 		}
 	}
+
+	// Startup-group readiness precedes the selected plugin's running state.
 	gate := t.c.getManifestCopyGate()
 	if gate != nil && !gate.IsReady() {
 		return manifestCopyClassAfterStartupGroupReady
 	}
+
+	// Wait only when this exact executable is selected but not running yet.
 	if t.executePluginRoutine == nil || t.runningPluginCtr == nil {
 		return manifestCopyClassImmediate
 	}
@@ -92,12 +118,15 @@ func (t *pluginInstance) setManifestCopyStatus(
 	accounting *manifestCopyAccounting,
 	stats bucket_lookup.ObjectCopyStats,
 ) {
+	// Discard observations belonging to a superseded accounting selection.
 	if t == nil ||
 		t.manifestCopyStatus == nil ||
 		accounting == nil ||
 		t.manifestCopyAccounting.Load() != accounting {
 		return
 	}
+
+	// Publish one immutable snapshot of identity and observed progress.
 	var ref string
 	if manifestSnapshot != nil && manifestSnapshot.GetManifestRef() != nil {
 		ref = manifestSnapshot.GetManifestRef().MarshalString()
@@ -121,6 +150,7 @@ func (t *pluginInstance) setDownloadManifestState(
 	manifestSnapshot *bldr_manifest.ManifestSnapshot,
 	destinationBucketID string,
 ) bool {
+	// Select the requested snapshot unless local copying is disabled.
 	if t.c.conf.GetDisableCopyManifest() {
 		return false
 	}
@@ -129,6 +159,7 @@ func (t *pluginInstance) setDownloadManifestState(
 		return changed
 	}
 
+	// A suppressed request clears demand and publishes its exclusion reason.
 	_, changed, _, _ := t.downloadManifestRoutine.SetState(nil)
 	ref := manifestSnapshot.GetManifestRef()
 	accounting := t.setManifestCopySelection(
@@ -214,6 +245,7 @@ func (t *pluginInstance) execDownloadManifest(
 	ctx context.Context,
 	manifestSnapshot *bldr_manifest.ManifestSnapshot,
 ) (rerr error) {
+	// Report every attempt's terminal error through the plugin status owner.
 	defer func() {
 		if rerr != nil {
 			trace.Log(ctx, "manifest-copy-phase", "error")
@@ -221,6 +253,7 @@ func (t *pluginInstance) execDownloadManifest(
 		t.c.recordPluginStatusError(t.pluginID, t.instanceKey, "download plugin manifest", rerr)
 	}()
 
+	// Ignore absent requests and configured exclusions without touching storage.
 	if t.c.conf.GetDisableCopyManifest() ||
 		manifestSnapshot == nil ||
 		manifestSnapshot.GetManifestRef() == nil ||
@@ -228,6 +261,7 @@ func (t *pluginInstance) execDownloadManifest(
 		return nil
 	}
 
+	// Validate the selected snapshot before acquiring copy resources.
 	ctx, task := trace.NewTask(ctx, "bldr/plugin-host-scheduler/download-manifest")
 	defer task.End()
 	le := t.le
@@ -243,6 +277,8 @@ func (t *pluginInstance) execDownloadManifest(
 			return errors.Wrap(err, "manifest snapshot metadata")
 		}
 	}
+
+	// Keep selection and failure accounting tied to this manifest generation.
 	class := t.classifyManifestCopy(manifestSnapshot)
 	accounting := t.manifestCopyAccountingForExecution(ctx, manifestSnapshot)
 	trace.Log(ctx, "manifest-copy-phase", "selection")
@@ -258,6 +294,7 @@ func (t *pluginInstance) execDownloadManifest(
 	trace.Log(ctx, "startup-fetch-kind", "background-manifest-dag-copy")
 	trace.Log(ctx, "manifest-copy-class", string(class))
 
+	// Preserve foreground startup priority before entering the copy queue.
 	if err := t.waitForManifestCopyReady(ctx, class, manifestSnapshot, accounting); err != nil {
 		return err
 	}
@@ -280,6 +317,7 @@ func (t *pluginInstance) execDownloadManifest(
 		return err
 	}
 
+	// Mark the admitted attempt and resolve its World storage owner.
 	materializerCtx, materializerTask := trace.NewTask(ctx, "bldr/plugin-host-scheduler/materializer")
 	trace.Log(materializerCtx, "materializer-phase", "start")
 	defer func() {
@@ -315,6 +353,7 @@ func (t *pluginInstance) execDownloadManifest(
 	// otherwise with the in-process copy engine. A failed RPC must not fall
 	// back to native copying; the scheduler routine owns retry.
 	copyCtx, copyTask := trace.NewTask(ctx, "bldr/plugin-host-scheduler/download-manifest/copy-dag")
+	copyCtx = block.WithReadAhead(copyCtx, materializerReadAhead)
 	trace.Log(copyCtx, "accounting-phase", "decode-verify-deserialize-block-publish")
 	var localRef *bucket.ObjectRef
 	var stats bucket_lookup.ObjectCopyStats
@@ -363,6 +402,7 @@ func (t *pluginInstance) execDownloadManifest(
 		storeTask.End()
 	}
 
+	// Fence copied blocks and the new manifest reference before reporting done.
 	syncCtx, syncTask := trace.NewTask(ctx, "bldr/plugin-host-scheduler/download-manifest/sync")
 	trace.Log(syncCtx, "accounting-phase", "world-sync-block-barrier-and-head-commit")
 	synced, syncErr := ws.Sync(syncCtx)
@@ -379,6 +419,7 @@ func (t *pluginInstance) execDownloadManifest(
 	trace.Log(syncCtx, "manifest-copy-phase", "sync-complete")
 	syncTask.End()
 
+	// Publish terminal accounting only after the storage fence succeeds.
 	copyStats = accounting.apply(copyStats)
 	t.setManifestCopyStatus(manifestCopyPhaseDone, class, manifestSnapshot, accounting, copyStats)
 	t.emitManifestCopyStartupMark(manifestCopyPhaseDone, copyStats, accounting)

--- a/bldr/plugin/host/scheduler/materialize-manifest.go
+++ b/bldr/plugin/host/scheduler/materialize-manifest.go
@@ -18,6 +18,10 @@ import (
 	"github.com/s4wave/spacewave/net/util/randstring"
 )
 
+// materializerReadAhead amortizes bulk copying over 10 MiB range fetches.
+// The source store retains its cache, transport caps, and foreground policy.
+const materializerReadAhead = 10 << 20
+
 // materializeManifest copies the selected manifest from src to dest through
 // the materializer plugin's typed streaming service.
 //
@@ -53,7 +57,7 @@ func (c *Controller) materializeManifest(
 	sourceID := randstring.RandomIdentifier(16)
 	sourceMux := srpc.NewMux()
 	if err := sourceMux.Register(block_rpc.NewSRPCBlockStoreHandler(
-		block_rpc_server.NewBlockStore(src.GetBucket()),
+		block_rpc_server.NewBlockStoreWithReadAhead(src.GetBucket(), materializerReadAhead),
 		sourceID,
 	)); err != nil {
 		return nil, stats, errors.Wrap(err, "register source block store rpc handler")

--- a/core/provider/spacewave/packfile/order/access-order-replay.go
+++ b/core/provider/spacewave/packfile/order/access-order-replay.go
@@ -16,10 +16,45 @@ func ReplayAccessOrderRecord(
 	refs []*block.BlockRef,
 	resolver AccessOrderPathResolver,
 ) (*AccessOrderReplayResult, error) {
+	// Establish structural fallback before applying any access profile.
 	fallback, err := BlockRefs(ctx, graph, refs)
 	if err != nil {
 		return nil, err
 	}
+	return ReplayAccessOrderRecordWithFallback(ctx, identity, record, fallback, resolver)
+}
+
+// ReplayAccessOrderRecordWithFallback puts recorded reads first and retains
+// the caller's structural order for all other blocks. Each nonempty identity
+// is emitted once; the input order is also used when the record is stale.
+func ReplayAccessOrderRecordWithFallback(
+	ctx context.Context,
+	identity AccessOrderManifestIdentity,
+	record *AccessOrderRecord,
+	refs []*block.BlockRef,
+	resolver AccessOrderPathResolver,
+) (*AccessOrderReplayResult, error) {
+	// Honor cancellation before constructing a potentially large ordering.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	// Normalize the supplied fallback without sorting away its locality.
+	fallback := make([]*block.BlockRef, 0, len(refs))
+	candidates := make(map[string]*block.BlockRef, len(refs))
+	for _, ref := range refs {
+		key := refKey(ref)
+		if key == "" {
+			continue
+		}
+		if _, ok := candidates[key]; ok {
+			continue
+		}
+		candidates[key] = ref
+		fallback = append(fallback, ref)
+	}
+
+	// A missing or mismatched profile cannot override producer locality.
 	res := &AccessOrderReplayResult{}
 	if record == nil || !identity.MatchesRecord(record) {
 		res.Refs = fallback
@@ -27,15 +62,7 @@ func ReplayAccessOrderRecord(
 		return res, nil
 	}
 
-	candidates := make(map[string]*block.BlockRef, len(refs))
-	for _, ref := range refs {
-		key := refKey(ref)
-		if key == "" {
-			continue
-		}
-		candidates[key] = ref
-	}
-
+	// Resolve hot entries first, then append every remaining subtree in order.
 	seen := make(map[string]struct{}, len(refs))
 	ordered := make([]*block.BlockRef, 0, len(refs))
 	for _, entry := range record.GetEntries() {
@@ -71,6 +98,7 @@ func ReplayAccessOrderRecord(
 		}
 	}
 
+	// Preserve all remaining blocks in the supplied structural order.
 	for _, ref := range fallback {
 		key := refKey(ref)
 		if key == "" {
@@ -85,6 +113,7 @@ func ReplayAccessOrderRecord(
 	return res, nil
 }
 
+// accessOrderEntryRefs resolves one file path or its captured block references.
 func accessOrderEntryRefs(ctx context.Context, entry *AccessOrderEntry, resolver AccessOrderPathResolver) ([]*block.BlockRef, bool, error) {
 	if entry == nil {
 		return nil, false, nil

--- a/core/provider/spacewave/packfile/order/graph.go
+++ b/core/provider/spacewave/packfile/order/graph.go
@@ -1,0 +1,113 @@
+package order
+
+import (
+	"context"
+	"slices"
+
+	"github.com/s4wave/spacewave/db/block"
+)
+
+// Graph orders a pack's available blocks by their structural relationships.
+// Child order is supplied by the producer; unavailable children are ignored.
+// It holds references, not block data, and is not concurrency safe.
+type Graph struct {
+	// nodes contains the available blocks and their ordered outgoing edges.
+	nodes map[string]graphNode
+}
+
+// graphNode retains one block's identity and intrinsic child order.
+type graphNode struct {
+	// ref identifies the available block.
+	ref *block.BlockRef
+	// children lists child identities in producer-supplied order.
+	children []string
+}
+
+// NewGraph constructs an empty pack ordering graph.
+func NewGraph() *Graph {
+	return &Graph{nodes: make(map[string]graphNode)}
+}
+
+// Add records a block and replaces its outgoing edges with the supplied order.
+// Empty references are ignored. The graph owns copies of retained references.
+func (g *Graph) Add(ref *block.BlockRef, children []*block.BlockRef) {
+	// Retain only addressable blocks.
+	key := refKey(ref)
+	if key == "" {
+		return
+	}
+	if g.nodes == nil {
+		g.nodes = make(map[string]graphNode)
+	}
+
+	// Preserve child order independently of later caller mutations.
+	node := graphNode{ref: ref.CloneVT()}
+	for _, child := range children {
+		if childKey := refKey(child); childKey != "" {
+			node.children = append(node.children, childKey)
+		}
+	}
+	g.nodes[key] = node
+}
+
+// Order emits each available block once in depth-first child order. Explicit
+// roots take precedence, followed by roots in the available graph. Unconnected
+// roots and remaining cycles use stable hash order. Missing external parents
+// do not prevent their available subtrees from being grouped.
+func (g *Graph) Order(ctx context.Context, roots []*block.BlockRef) ([]*block.BlockRef, error) {
+	// Find roots within the available graph, without loading absent blocks.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	keys := make([]string, 0, len(g.nodes))
+	referenced := make(map[string]struct{}, len(g.nodes))
+	for key, node := range g.nodes {
+		keys = append(keys, key)
+		for _, child := range node.children {
+			referenced[child] = struct{}{}
+		}
+	}
+	slices.Sort(keys)
+
+	// Visit explicit roots, then natural roots, then any cyclic components.
+	starts := make([]string, 0, len(roots)+len(keys))
+	for _, root := range roots {
+		starts = append(starts, refKey(root))
+	}
+	for _, key := range keys {
+		if _, ok := referenced[key]; !ok {
+			starts = append(starts, key)
+		}
+	}
+	starts = append(starts, keys...)
+
+	// An explicit stack bounds call depth and suppresses shared descendants.
+	seen := make(map[string]struct{}, len(g.nodes))
+	out := make([]*block.BlockRef, 0, len(g.nodes))
+	var stack []string
+	for _, start := range starts {
+		stack = append(stack, start)
+		for len(stack) != 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			key := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			node, ok := g.nodes[key]
+			if !ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, node.ref.CloneVT())
+
+			// Push in reverse so each subtree retains the supplied child order.
+			for _, v := range slices.Backward(node.children) {
+				stack = append(stack, v)
+			}
+		}
+	}
+	return out, nil
+}

--- a/core/provider/spacewave/packfile/order/graph_test.go
+++ b/core/provider/spacewave/packfile/order/graph_test.go
@@ -1,0 +1,73 @@
+package order
+
+import (
+	"testing"
+
+	"github.com/s4wave/spacewave/db/block"
+	block_gc "github.com/s4wave/spacewave/db/block/gc"
+)
+
+// TestGraphPreservesSubtrees proves intrinsic child order survives unordered
+// insertion, shared children, a cycle, and a missing external reference.
+func TestGraphPreservesSubtrees(t *testing.T) {
+	root := testRef(t, "root")
+	left := testRef(t, "left")
+	right := testRef(t, "right")
+	leaf := testRef(t, "leaf")
+	missing := testRef(t, "missing")
+	graph := NewGraph()
+	graph.Add(leaf, []*block.BlockRef{root})
+	graph.Add(right, []*block.BlockRef{leaf})
+	graph.Add(root, []*block.BlockRef{left, missing, right})
+	graph.Add(left, []*block.BlockRef{leaf})
+
+	refs, err := graph.Order(t.Context(), []*block.BlockRef{root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertRefOrder(t, refs, []*block.BlockRef{root, left, leaf, right})
+}
+
+// TestBlockRefsGroupsPartialGraph proves uploads retain available subtrees
+// even when the named object root is outside the candidate set.
+func TestBlockRefsGroupsPartialGraph(t *testing.T) {
+	parent := testRef(t, "unavailable-parent")
+	root := testRef(t, "partial-root")
+	child := testRef(t, "partial-child")
+	graph := newTestRefGraph()
+	graph.add(block_gc.ObjectIRI("object"), block_gc.BlockIRI(parent))
+	graph.add(block_gc.BlockIRI(parent), block_gc.BlockIRI(root))
+	graph.add(block_gc.BlockIRI(root), block_gc.BlockIRI(child))
+
+	refs, err := BlockRefs(t.Context(), graph, []*block.BlockRef{child, root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertRefOrder(t, refs, []*block.BlockRef{root, child})
+}
+
+// TestReplayKeepsStructuralFallback verifies access profiles retain producer
+// locality for unprofiled blocks and when the profile identity is stale.
+func TestReplayKeepsStructuralFallback(t *testing.T) {
+	root := testRef(t, "root")
+	child := testRef(t, "child")
+	hot := testRef(t, "hot")
+	refs := []*block.BlockRef{root, child, hot, root}
+	record := testAccessOrderRecord(t, []*AccessOrderEntry{{
+		Filesystem: AccessOrderFilesystem_ACCESS_ORDER_FILESYSTEM_DIST,
+		Path:       "entrypoint.mjs", ResolvedRefs: []*block.BlockRef{hot},
+	}})
+	identity := AccessOrderManifestIdentityFromRecord(record)
+	result, err := ReplayAccessOrderRecordWithFallback(t.Context(), identity, record, refs, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertRefOrder(t, result.Refs, []*block.BlockRef{hot, root, child})
+
+	identity.ManifestRev++
+	result, err = ReplayAccessOrderRecordWithFallback(t.Context(), identity, record, refs, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertRefOrder(t, result.Refs, []*block.BlockRef{root, child, hot})
+}

--- a/core/provider/spacewave/packfile/order/order.go
+++ b/core/provider/spacewave/packfile/order/order.go
@@ -1,4 +1,4 @@
-// Package order contains packfile block ordering helpers.
+// Package order groups related blocks for physical packfile locality.
 package order
 
 import (
@@ -12,6 +12,7 @@ import (
 	block_gc "github.com/s4wave/spacewave/db/block/gc"
 )
 
+// objectIRIPrefix identifies object roots in the GC graph.
 const objectIRIPrefix = "object:"
 
 // RefGraph is the GC graph surface required for pack locality ordering.
@@ -22,153 +23,82 @@ type RefGraph interface {
 	GetIncomingRefs(ctx context.Context, node string) ([]string, error)
 }
 
-// BlockRefs orders refs by walking GC object roots and then appending remaining
-// refs in stable hash order.
-func BlockRefs(ctx context.Context, graph RefGraph, refs []*block.BlockRef) ([]*block.BlockRef, error) {
-	candidates := make(map[string]*block.BlockRef, len(refs))
-	for _, ref := range refs {
-		key := refKey(ref)
-		if key == "" {
-			continue
-		}
-		if _, ok := candidates[key]; !ok {
-			candidates[key] = ref
-		}
-	}
-	if len(candidates) == 0 {
-		return nil, nil
-	}
-
-	keys := sortedKeys(candidates)
-	if graph == nil {
-		return refsForKeys(keys, candidates), nil
-	}
-
-	roots, err := objectRootedRefs(ctx, graph, keys, candidates)
-	if err != nil {
-		return nil, err
-	}
-
-	seen := make(map[string]struct{}, len(candidates))
-	ordered := make([]*block.BlockRef, 0, len(candidates))
-	for _, root := range roots {
-		if err := visitRef(ctx, graph, root.ref, candidates, seen, &ordered); err != nil {
-			return nil, err
-		}
-	}
-	for _, key := range keys {
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		ordered = append(ordered, candidates[key])
-	}
-	return ordered, nil
-}
-
+// rootedRef associates an available block with a named object root.
 type rootedRef struct {
+	// root identifies the object that retains the block.
 	root string
-	key  string
-	ref  *block.BlockRef
+	// key provides a stable tie-breaker within one object.
+	key string
+	// ref identifies the available root block.
+	ref *block.BlockRef
 }
 
-func objectRootedRefs(
-	ctx context.Context,
-	graph RefGraph,
-	keys []string,
-	candidates map[string]*block.BlockRef,
-) ([]rootedRef, error) {
+// BlockRefs groups refs by available subtrees, preferring named GC object roots.
+// GC edges have no intrinsic order, so siblings use stable hash order. With no
+// graph, all refs use stable hash order. Only candidate blocks are queried.
+func BlockRefs(ctx context.Context, graph RefGraph, refs []*block.BlockRef) ([]*block.BlockRef, error) {
+	// Deduplicate candidate identities before querying the graph.
+	ordered := NewGraph()
+	for _, ref := range refs {
+		ordered.Add(ref, nil)
+	}
+	if graph == nil {
+		return ordered.Order(ctx, nil)
+	}
+	keys := make([]string, 0, len(ordered.nodes))
+	for key := range ordered.nodes {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	// Capture relationships even when no object root is present in this upload.
 	var roots []rootedRef
 	for _, key := range keys {
-		ref := candidates[key]
-		incoming, err := graph.GetIncomingRefs(ctx, block_gc.BlockIRI(ref))
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		ref := ordered.nodes[key].ref
+		iri := block_gc.BlockIRI(ref)
+		outgoing, err := graph.GetOutgoingRefs(ctx, iri)
+		if err != nil {
+			return nil, errors.Wrap(err, "get outgoing gc refs")
+		}
+		slices.Sort(outgoing)
+		var children []*block.BlockRef
+		for _, target := range outgoing {
+			if child, ok := block_gc.ParseBlockIRI(target); ok {
+				children = append(children, child)
+			}
+		}
+		ordered.Add(ref, children)
+
+		// Named roots retain their existing object-key precedence.
+		incoming, err := graph.GetIncomingRefs(ctx, iri)
 		if err != nil {
 			return nil, errors.Wrap(err, "get incoming gc refs")
 		}
 		for _, source := range incoming {
-			if !strings.HasPrefix(source, objectIRIPrefix) {
-				continue
+			if strings.HasPrefix(source, objectIRIPrefix) {
+				roots = append(roots, rootedRef{root: source, key: key, ref: ref})
 			}
-			roots = append(roots, rootedRef{
-				root: source,
-				key:  key,
-				ref:  ref,
-			})
 		}
 	}
 	slices.SortFunc(roots, func(a, b rootedRef) int {
-		return cmp.Or(
-			cmp.Compare(a.root, b.root),
-			cmp.Compare(a.key, b.key),
-		)
+		return cmp.Or(cmp.Compare(a.root, b.root), cmp.Compare(a.key, b.key))
 	})
-	return roots, nil
+
+	// Use the same structural ordering as producers with intrinsic child order.
+	rootRefs := make([]*block.BlockRef, 0, len(roots))
+	for _, root := range roots {
+		rootRefs = append(rootRefs, root.ref)
+	}
+	return ordered.Order(ctx, rootRefs)
 }
 
-func visitRef(
-	ctx context.Context,
-	graph RefGraph,
-	ref *block.BlockRef,
-	candidates map[string]*block.BlockRef,
-	seen map[string]struct{},
-	ordered *[]*block.BlockRef,
-) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	key := refKey(ref)
-	if key == "" {
-		return nil
-	}
-	if _, ok := candidates[key]; !ok {
-		return nil
-	}
-	if _, ok := seen[key]; ok {
-		return nil
-	}
-	seen[key] = struct{}{}
-	*ordered = append(*ordered, candidates[key])
-
-	outgoing, err := graph.GetOutgoingRefs(ctx, block_gc.BlockIRI(ref))
-	if err != nil {
-		return errors.Wrap(err, "get outgoing gc refs")
-	}
-	slices.Sort(outgoing)
-	for _, iri := range outgoing {
-		child, ok := block_gc.ParseBlockIRI(iri)
-		if !ok {
-			continue
-		}
-		if err := visitRef(ctx, graph, child, candidates, seen, ordered); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func sortedKeys(candidates map[string]*block.BlockRef) []string {
-	keys := make([]string, 0, len(candidates))
-	for key := range candidates {
-		keys = append(keys, key)
-	}
-	slices.Sort(keys)
-	return keys
-}
-
-func refsForKeys(keys []string, candidates map[string]*block.BlockRef) []*block.BlockRef {
-	out := make([]*block.BlockRef, 0, len(keys))
-	for _, key := range keys {
-		out = append(out, candidates[key])
-	}
-	return out
-}
-
+// refKey identifies a nonempty block by its content hash.
 func refKey(ref *block.BlockRef) string {
-	if ref == nil || ref.GetEmpty() {
+	if ref == nil || ref.GetEmpty() || ref.GetHash() == nil {
 		return ""
 	}
-	h := ref.GetHash()
-	if h == nil {
-		return ""
-	}
-	return h.MarshalString()
+	return ref.GetHash().MarshalString()
 }

--- a/core/provider/spacewave/packfile/store/http-transport_test.go
+++ b/core/provider/spacewave/packfile/store/http-transport_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/s4wave/spacewave/net/hash"
 )
 
+// TestHTTPRangeReaderDefaults verifies default and explicit transport sizing.
 func TestHTTPRangeReaderDefaults(t *testing.T) {
 	rd := NewHTTPRangeReader(nil, "https://example.com/pack", 1024, 0, 0, nil, nil)
 	if rd.maxBytes != defaultResidentBudget {
@@ -53,6 +54,7 @@ func TestHTTPRangeReaderDefaults(t *testing.T) {
 	}
 }
 
+// TestPackReaderPlanFetchLeftShiftsWithinGap preserves coverage near a gap end.
 func TestPackReaderPlanFetchLeftShiftsWithinGap(t *testing.T) {
 	eng := NewPackReader("shift-pack", 8<<20, TransportFunc(func(context.Context, int64, int) ([]byte, error) {
 		return nil, nil
@@ -64,12 +66,13 @@ func TestPackReaderPlanFetchLeftShiftsWithinGap(t *testing.T) {
 	eng.sparseReads = false
 	eng.spans = []*span{{off: 3 << 20, size: 1 << 20}}
 
-	key := eng.planFetchLocked(5<<19, (5<<19)+1)
+	key := eng.planFetchLocked(5<<19, (5<<19)+1, 0)
 	if key.off != 1<<20 || key.size != 2<<20 {
 		t.Fatalf("planFetchLocked() = [%d,%d), want [%d,%d)", key.off, key.end(), int64(1<<20), int64(3<<20))
 	}
 }
 
+// TestPackReaderSparsePlanCapsColdBackshift bounds speculative sparse reads.
 func TestPackReaderSparsePlanCapsColdBackshift(t *testing.T) {
 	eng := NewPackReader("sparse-shift-pack", 10<<20, TransportFunc(func(context.Context, int64, int) ([]byte, error) {
 		return nil, nil
@@ -83,12 +86,13 @@ func TestPackReaderSparsePlanCapsColdBackshift(t *testing.T) {
 	eng.sparseLocalityDistance = 512 << 10
 	eng.spans = []*span{{off: 8 << 20, size: 256 << 10}}
 
-	key := eng.planFetchLocked(5<<20, (5<<20)+1)
+	key := eng.planFetchLocked(5<<20, (5<<20)+1, 0)
 	if key.off != 5<<20 || key.size != 256<<10 {
 		t.Fatalf("sparse planFetchLocked() = [%d,%d), want [%d,%d)", key.off, key.end(), int64(5<<20), int64((5<<20)+(256<<10)))
 	}
 }
 
+// TestPackReaderSparsePlanPromotesNearbyReads verifies locality grows read-ahead.
 func TestPackReaderSparsePlanPromotesNearbyReads(t *testing.T) {
 	eng := NewPackReader("sparse-local-pack", 10<<20, TransportFunc(func(context.Context, int64, int) ([]byte, error) {
 		return nil, nil
@@ -101,16 +105,17 @@ func TestPackReaderSparsePlanPromotesNearbyReads(t *testing.T) {
 	eng.sparseColdWindow = 256 << 10
 	eng.sparseLocalityDistance = 512 << 10
 
-	first := eng.planFetchLocked(1<<20, (1<<20)+1)
+	first := eng.planFetchLocked(1<<20, (1<<20)+1, 0)
 	if first.size != 256<<10 {
 		t.Fatalf("first sparse fetch size = %d, want %d", first.size, 256<<10)
 	}
-	second := eng.planFetchLocked((1<<20)+(128<<10), (1<<20)+(128<<10)+1)
+	second := eng.planFetchLocked((1<<20)+(128<<10), (1<<20)+(128<<10)+1, 0)
 	if second.size <= first.size {
 		t.Fatalf("nearby sparse fetch size = %d, want promotion above %d", second.size, first.size)
 	}
 }
 
+// TestPackReaderPlanFetchShrinksWhenCoveredOnBothSides prevents resident overlap.
 func TestPackReaderPlanFetchShrinksWhenCoveredOnBothSides(t *testing.T) {
 	eng := NewPackReader("shrink-pack", 8<<20, TransportFunc(func(context.Context, int64, int) ([]byte, error) {
 		return nil, nil
@@ -124,12 +129,13 @@ func TestPackReaderPlanFetchShrinksWhenCoveredOnBothSides(t *testing.T) {
 		{off: 2 << 20, size: 1 << 20},
 	}
 
-	key := eng.planFetchLocked(3<<19, (3<<19)+1)
+	key := eng.planFetchLocked(3<<19, (3<<19)+1, 0)
 	if key.off != 1<<20 || key.size != 1<<20 {
 		t.Fatalf("planFetchLocked() = [%d,%d), want [%d,%d)", key.off, key.end(), int64(1<<20), int64(2<<20))
 	}
 }
 
+// TestPackReaderSnapshotStats verifies public cache and I/O accounting.
 func TestPackReaderSnapshotStats(t *testing.T) {
 	eng := NewPackReader("stats-pack", 1024, TransportFunc(func(context.Context, int64, int) ([]byte, error) {
 		return nil, nil
@@ -179,6 +185,7 @@ func TestPackReaderSnapshotStats(t *testing.T) {
 	}
 }
 
+// TestPackfileStoreAppliesTuningOverrides verifies newly opened readers inherit store policy.
 func TestPackfileStoreAppliesTuningOverrides(t *testing.T) {
 	store := NewPackfileStore(func(packID string, size int64) (*PackReader, error) {
 		return NewPackReader(packID, size, TransportFunc(func(context.Context, int64, int) ([]byte, error) {
@@ -209,6 +216,7 @@ func TestPackfileStoreAppliesTuningOverrides(t *testing.T) {
 	}
 }
 
+// TestPackReaderTransportFetchMaxBytesClampsTuning preserves platform fetch caps.
 func TestPackReaderTransportFetchMaxBytesClampsTuning(t *testing.T) {
 	eng := NewPackReader("cap-pack", 16<<20, TransportFunc(func(context.Context, int64, int) ([]byte, error) {
 		return nil, nil
@@ -231,12 +239,13 @@ func TestPackReaderTransportFetchMaxBytesClampsTuning(t *testing.T) {
 	if tuning.TransportFetchMaxBytes != 2<<20 {
 		t.Fatalf("transport fetch cap = %d, want %d", tuning.TransportFetchMaxBytes, 2<<20)
 	}
-	key := eng.planFetchLocked(0, 1)
+	key := eng.planFetchLocked(0, 1, 0)
 	if key.size > 2<<20 {
 		t.Fatalf("planned fetch size = %d, want <= %d", key.size, 2<<20)
 	}
 }
 
+// TestHTTPRangeReaderDedupesConcurrentFetch verifies readers share one HTTP request.
 func TestHTTPRangeReaderDedupesConcurrentFetch(t *testing.T) {
 	data := []byte("abcdefghijklmnopqrstuvwxyz")
 	var reqCount atomic.Int32
@@ -296,17 +305,23 @@ func TestHTTPRangeReaderDedupesConcurrentFetch(t *testing.T) {
 	}
 }
 
+// observedDoneContext signals when a reader starts observing cancellation.
 type observedDoneContext struct {
+	// Context supplies the underlying lifetime.
 	context.Context
+	// done closes on the first observation of Done.
 	done chan struct{}
+	// once serializes the observation signal across readers.
 	once sync.Once
 }
 
+// Done exposes cancellation and records that the caller can now wait on it.
 func (c *observedDoneContext) Done() <-chan struct{} {
 	c.once.Do(func() { close(c.done) })
 	return c.Context.Done()
 }
 
+// TestPackReaderCanceledLeaderDoesNotPoisonWaiter verifies shared transport survives caller cancellation.
 func TestPackReaderCanceledLeaderDoesNotPoisonWaiter(t *testing.T) {
 	data := []byte("abcdefgh")
 	started := make(chan struct{})
@@ -372,6 +387,7 @@ func TestPackReaderCanceledLeaderDoesNotPoisonWaiter(t *testing.T) {
 	}
 }
 
+// TestPackReaderCloseCancelsTransport verifies owner shutdown releases reads.
 func TestPackReaderCloseCancelsTransport(t *testing.T) {
 	started := make(chan struct{})
 	transportDone := make(chan struct{})
@@ -403,6 +419,7 @@ func TestPackReaderCloseCancelsTransport(t *testing.T) {
 	}
 }
 
+// TestHTTPRangeReaderRetainsMultipleRanges verifies nonadjacent cache reuse.
 func TestHTTPRangeReaderRetainsMultipleRanges(t *testing.T) {
 	data := bytes.Repeat([]byte("0123456789abcdef"), 8192)
 	var reqs int
@@ -446,6 +463,7 @@ func TestHTTPRangeReaderRetainsMultipleRanges(t *testing.T) {
 	}
 }
 
+// TestHTTPRangeReaderFullResponseFallbackStats accounts for servers that ignore Range.
 func TestHTTPRangeReaderFullResponseFallbackStats(t *testing.T) {
 	data := []byte("abcdefghijklmnopqrstuvwxyz")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -485,6 +503,7 @@ func TestHTTPRangeReaderFullResponseFallbackStats(t *testing.T) {
 	}
 }
 
+// TestPackReaderRetriesIndexLoadAfterFailure verifies trailer errors do not poison the index.
 func TestPackReaderRetriesIndexLoadAfterFailure(t *testing.T) {
 	ctx := t.Context()
 	packBytes, _ := buildTestPackOrdered(t, []struct{ Name, Data string }{{"a", "alpha"}})
@@ -531,6 +550,7 @@ func TestPackReaderRetriesIndexLoadAfterFailure(t *testing.T) {
 	}
 }
 
+// TestBinarySearchEntriesByKeyUsesByteOrder preserves KVFile key ordering.
 func TestBinarySearchEntriesByKeyUsesByteOrder(t *testing.T) {
 	entries := []*kvfile.IndexEntry{
 		{Key: []byte("11")},
@@ -544,6 +564,7 @@ func TestBinarySearchEntriesByKeyUsesByteOrder(t *testing.T) {
 	}
 }
 
+// parseHTTPTestRangeHeader bounds a valid single HTTP range to the fixture.
 func parseHTTPTestRangeHeader(h string, size int64) (start, end int64, ok bool) {
 	var reqStart, reqEnd int64
 	if _, err := fmt.Sscanf(h, "bytes=%d-%d", &reqStart, &reqEnd); err != nil {
@@ -561,6 +582,7 @@ func parseHTTPTestRangeHeader(h string, size int64) (start, end int64, ok bool) 
 // TransportFunc adapts a function to Transport for tests.
 type TransportFunc func(ctx context.Context, off int64, length int) ([]byte, error)
 
+// Fetch invokes the fixture's transport operation with the caller's lifetime.
 func (f TransportFunc) Fetch(ctx context.Context, off int64, length int) ([]byte, error) {
 	return f(ctx, off, length)
 }

--- a/core/provider/spacewave/packfile/store/read-ahead_test.go
+++ b/core/provider/spacewave/packfile/store/read-ahead_test.go
@@ -1,0 +1,244 @@
+//go:build !tinygo
+
+package store
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"testing"
+
+	packfile "github.com/s4wave/spacewave/core/provider/spacewave/packfile"
+	packfile_order "github.com/s4wave/spacewave/core/provider/spacewave/packfile/order"
+	"github.com/s4wave/spacewave/db/block"
+	block_rpc "github.com/s4wave/spacewave/db/block/rpc"
+	block_rpc_server "github.com/s4wave/spacewave/db/block/rpc/server"
+	"github.com/s4wave/spacewave/net/hash"
+)
+
+// TestMaterializerReadAheadSharesForegroundCache verifies the source RPC
+// service's bulk policy reaches the real pack reader and benefits later reads.
+func TestMaterializerReadAheadSharesForegroundCache(t *testing.T) {
+	// Build a 16 MiB pack with independently addressable, adjacent blocks.
+	items := make([]packItem, 64)
+	for i := range items {
+		data := bytes.Repeat([]byte{byte(i)}, 256<<10)
+		h, err := hash.Sum(hash.RecommendedHashType, data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		items[i] = packItem{h: h, data: data}
+	}
+	data, bloom := packItems(t, items)
+	transport := &bytesTransport{data: data}
+	store := NewPackfileStore(func(id string, size int64) (*PackReader, error) {
+		return NewPackReader(id, size, transport, hash.RecommendedHashType), nil
+	}, newMemIndexCache())
+	t.Cleanup(store.Close)
+	store.SetIndexPromotionEnabled(false)
+	store.UpdateManifest([]*packfile.PackfileEntry{{
+		Id: "bulk", BloomFilter: bloom, BlockCount: uint64(len(items)), SizeBytes: uint64(len(data)),
+	}})
+
+	// Index discovery remains exact and is independent of payload read-ahead.
+	if exists, err := store.GetBlockExists(t.Context(), block.NewBlockRef(items[0].h)); err != nil || !exists {
+		t.Fatalf("load index: exists=%v err=%v", exists, err)
+	}
+	before := transport.callCount()
+	bulk := block_rpc_server.NewBlockStoreWithReadAhead(store, 10<<20)
+	resp, err := bulk.GetBlock(t.Context(), &block_rpc.GetBlockRequest{Ref: block.NewBlockRef(items[0].h)})
+	if err != nil || resp.GetError() != "" || !resp.GetExists() || !bytes.Equal(resp.GetData(), items[0].data) {
+		t.Fatalf("bulk read failed: err=%v response error=%s", err, resp.GetError())
+	}
+	if got := transport.callCount() - before; got != 1 {
+		t.Fatalf("bulk payload requests = %d, want 1", got)
+	}
+	if got := transport.callAt(before).length; got != 10<<20 {
+		t.Fatalf("bulk payload range = %d, want 10 MiB", got)
+	}
+
+	// A different service reads several MiB ahead without another fetch.
+	foreground := block_rpc_server.NewBlockStore(store)
+	resp, err = foreground.GetBlock(t.Context(), &block_rpc.GetBlockRequest{Ref: block.NewBlockRef(items[16].h)})
+	if err != nil || resp.GetError() != "" || !bytes.Equal(resp.GetData(), items[16].data) {
+		t.Fatalf("cached foreground read failed: %v %s", err, resp.GetError())
+	}
+	if got := transport.callCount() - before; got != 1 {
+		t.Fatalf("foreground refetched cached bytes: %d payload requests", got)
+	}
+
+	// A distant foreground miss retains the small-read policy.
+	resp, err = foreground.GetBlock(t.Context(), &block_rpc.GetBlockRequest{Ref: block.NewBlockRef(items[52].h)})
+	if err != nil || resp.GetError() != "" || !bytes.Equal(resp.GetData(), items[52].data) {
+		t.Fatalf("distant foreground read failed: %v %s", err, resp.GetError())
+	}
+	for i := before + 1; i < transport.callCount(); i++ {
+		if got := transport.callAt(i).length; got >= 10<<20 {
+			t.Fatalf("bulk policy leaked into foreground request: %d", got)
+		}
+	}
+}
+
+// TestReadAheadRespectsUncoveredGapsAndTransportCap verifies a bulk hint never
+// refetches resident bytes or exceeds a constrained transport's payload cap.
+func TestReadAheadRespectsUncoveredGapsAndTransportCap(t *testing.T) {
+	transport := &bytesTransport{data: make([]byte, 16<<20)}
+	reader := NewPackReader("bounded-bulk", int64(len(transport.data)), transport, hash.RecommendedHashType)
+	t.Cleanup(reader.Close)
+	reader.setTransportFetchMaxBytes(2 << 20)
+	ctx := block.WithReadAhead(t.Context(), 10<<20)
+	buf := make([]byte, 1)
+	if _, err := reader.ReaderAt(ctx).ReadAt(buf, 0); err != nil {
+		t.Fatal(err)
+	}
+	if got := transport.callAt(0).length; got != 2<<20 {
+		t.Fatalf("constrained range = %d, want 2 MiB", got)
+	}
+
+	// Prefill the far side, then request the uncovered interval between them.
+	if err := reader.ensureExactRangeResident(context.Background(), 3<<20, 4<<20); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reader.ReaderAt(ctx).ReadAt(buf, 2<<20); err != nil {
+		t.Fatal(err)
+	}
+	got := transport.callAt(2)
+	if got.off != 2<<20 || got.length != 1<<20 {
+		t.Fatalf("gap request = %+v, want [2 MiB, 3 MiB)", got)
+	}
+}
+
+// TestReadAheadDoesNotOverlapInflightNeighbor verifies different starting
+// offsets cannot cause overlapping bulk and foreground network requests.
+func TestReadAheadDoesNotOverlapInflightNeighbor(t *testing.T) {
+	started := make(chan fetchCall, 2)
+	release := make(chan struct{})
+	reader := NewPackReader("shared-inflight", 16<<20, TransportFunc(func(ctx context.Context, off int64, length int) ([]byte, error) {
+		started <- fetchCall{off: off, length: length}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-release:
+			return make([]byte, length), nil
+		}
+	}), hash.RecommendedHashType)
+	t.Cleanup(reader.Close)
+	done := make(chan error, 2)
+
+	// Keep a foreground request in flight beyond the bulk caller's target.
+	go func() {
+		_, err := reader.ReaderAt(t.Context()).ReadAt(make([]byte, 1), 8<<20)
+		done <- err
+	}()
+	foreground := <-started
+	go func() {
+		ctx := block.WithReadAhead(t.Context(), 10<<20)
+		_, err := reader.ReaderAt(ctx).ReadAt(make([]byte, 1), 0)
+		done <- err
+	}()
+	bulk := <-started
+	if bulk.off != 0 || int64(bulk.length) != foreground.off {
+		t.Fatalf("bulk range %+v overlaps or leaves a gap before in-flight foreground %+v", bulk, foreground)
+	}
+
+	// Both callers complete from their disjoint requests.
+	close(release)
+	for range 2 {
+		if err := <-done; err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestReadAheadRespectsResidentBudget bounds speculative bulk windows.
+func TestReadAheadRespectsResidentBudget(t *testing.T) {
+	transport := &bytesTransport{data: make([]byte, 16<<20)}
+	reader := NewPackReader("budgeted-bulk", int64(len(transport.data)), transport, hash.RecommendedHashType)
+	t.Cleanup(reader.Close)
+	reader.maxBytes = 2 << 20
+	ctx := block.WithReadAhead(t.Context(), 10<<20)
+	if _, err := reader.ReaderAt(ctx).ReadAt(make([]byte, 1), 0); err != nil {
+		t.Fatal(err)
+	}
+	if got := transport.callAt(0).length; got != 2<<20 {
+		t.Fatalf("budgeted range = %d, want 2 MiB", got)
+	}
+}
+
+// TestPackLocalityReducesRelatedRangeReads compares identical content and
+// reader policy while changing only physical order. The workload reads one
+// eight-block file among 64 independent files, each containing 32 KiB chunks.
+func TestPackLocalityReducesRelatedRangeReads(t *testing.T) {
+	graph := packfile_order.NewGraph()
+	items := make(map[string]packItem)
+	refs := make([]*block.BlockRef, 64*8)
+	for i := range refs {
+		data := make([]byte, 32<<10)
+		binary.LittleEndian.PutUint32(data, uint32(i))
+		h, err := hash.Sum(hash.RecommendedHashType, data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		refs[i] = block.NewBlockRef(h)
+		items[h.MarshalString()] = packItem{h: h, data: data}
+	}
+	for i, ref := range refs {
+		var children []*block.BlockRef
+		if i%8 == 0 {
+			children = refs[i+1 : i+8]
+		}
+		graph.Add(ref, children)
+	}
+
+	// Preserve exact content and count only payload fetches, after index load.
+	measure := func(ordered []*block.BlockRef) (int, int64) {
+		t.Helper()
+		orderedItems := make([]packItem, 0, len(ordered))
+		for _, ref := range ordered {
+			orderedItems = append(orderedItems, items[ref.GetHash().MarshalString()])
+		}
+		data, bloom := packItems(t, orderedItems)
+		transport := &bytesTransport{data: data}
+		store := NewPackfileStore(func(id string, size int64) (*PackReader, error) {
+			return NewPackReader(id, size, transport, hash.RecommendedHashType), nil
+		}, newMemIndexCache())
+		defer store.Close()
+		store.SetTransportMinWindow(128 << 10)
+		store.SetTransportQuantum(128 << 10)
+		store.SetTransportMaxWindow(128 << 10)
+		store.SetIndexPromotionEnabled(false)
+		store.UpdateManifest([]*packfile.PackfileEntry{{
+			Id: "layout", BloomFilter: bloom, BlockCount: uint64(len(ordered)), SizeBytes: uint64(len(data)),
+		}})
+		if exists, err := store.GetBlockExists(t.Context(), refs[0]); err != nil || !exists {
+			t.Fatalf("load index: exists=%v err=%v", exists, err)
+		}
+		before := transport.callCount()
+		for _, ref := range refs[:8] {
+			got, found, err := store.GetBlock(t.Context(), ref)
+			if err != nil || !found || !bytes.Equal(got, items[ref.GetHash().MarshalString()].data) {
+				t.Fatalf("content changed: found=%v err=%v", found, err)
+			}
+		}
+		var fetched int64
+		for i := before; i < transport.callCount(); i++ {
+			fetched += int64(transport.callAt(i).length)
+		}
+		return transport.callCount() - before, fetched
+	}
+
+	hashOrder, err := packfile_order.BlockRefs(t.Context(), nil, refs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	structuralOrder, err := graph.Order(t.Context(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hashCalls, hashBytes := measure(hashOrder)
+	structuralCalls, structuralBytes := measure(structuralOrder)
+	t.Logf("hash order: %d requests, %d bytes; structural order: %d requests, %d bytes; useful content: %d bytes", hashCalls, hashBytes, structuralCalls, structuralBytes, 8*(32<<10))
+	if structuralCalls >= hashCalls || structuralBytes >= hashBytes {
+		t.Fatal("structural layout did not improve related-content range reads")
+	}
+}

--- a/core/provider/spacewave/packfile/store/span-store.go
+++ b/core/provider/spacewave/packfile/store/span-store.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/s4wave/spacewave/db/block"
 	trace "github.com/s4wave/spacewave/db/traceutil"
 )
 
@@ -45,7 +46,7 @@ func (e *PackReader) fetchMiss(ctx context.Context, off, readEnd int64) error {
 			if load != nil {
 				return
 			}
-			key = e.planFetchLocked(off, readEnd)
+			key = e.planFetchLocked(off, readEnd, block.ReadAhead(ctx))
 			if key.size == 0 {
 				return
 			}
@@ -108,6 +109,7 @@ func (e *PackReader) fetchMiss(ctx context.Context, off, readEnd int64) error {
 	}
 }
 
+// ensureExactRangeResident fills missing bytes without speculative read-ahead.
 func (e *PackReader) ensureExactRangeResident(ctx context.Context, start, end int64) error {
 	if end <= start {
 		return nil
@@ -128,6 +130,8 @@ func (e *PackReader) ensureExactRangeResident(ctx context.Context, start, end in
 	return nil
 }
 
+// fetchExact shares resident and in-flight spans while loading only requested
+// index bytes. Transport lifetime remains owned by the PackReader.
 func (e *PackReader) fetchExact(ctx context.Context, off, readEnd int64) error {
 	ctx, task := trace.NewTask(ctx, "provider/spacewave/packfile/exact-range-fetch")
 	defer task.End()
@@ -279,7 +283,7 @@ func (e *PackReader) startFetch(key fetchKey, load *fetchLoad, indexTail bool) {
 // The planner also adapts the steady-state window against the measured
 // goodput so the request rate approaches targetInterval^-1 while staying
 // clamped to [minWindow, maxWindow].
-func (e *PackReader) planFetchLocked(off, readEnd int64) fetchKey {
+func (e *PackReader) planFetchLocked(off, readEnd int64, readAhead int) fetchKey {
 	gapStart, gapEnd, ok := e.findGapLocked(off)
 	if !ok || gapEnd <= gapStart {
 		return fetchKey{}
@@ -320,6 +324,16 @@ func (e *PackReader) planFetchLocked(off, readEnd int64) fetchKey {
 	}
 	e.recordSparseTargetLocked(off, mustEnd)
 
+	// Bulk-read hints affect this miss only. Keep transport bounds and the
+	// shared resident/in-flight gap rules without raising foreground defaults.
+	if readAhead > 0 {
+		readAhead = e.clampWindow(readAhead)
+		if e.maxBytes > 0 {
+			readAhead = int(min(int64(readAhead), e.maxBytes))
+		}
+		windowSize = max(windowSize, readAhead)
+	}
+
 	quantum := int64(max(1, e.transportQuantum))
 	gapSize := gapEnd - gapStart
 	fetchSize := min(int64(windowSize), gapSize)
@@ -339,6 +353,7 @@ func (e *PackReader) planFetchLocked(off, readEnd int64) fetchKey {
 	return fetchKey{off: start, size: int(end - start)}
 }
 
+// hasSparseLocalityLocked reports proximity to the preceding payload target.
 func (e *PackReader) hasSparseLocalityLocked(off, end int64) bool {
 	if !e.lastTargetSet {
 		return false
@@ -352,6 +367,7 @@ func (e *PackReader) hasSparseLocalityLocked(off, end int64) bool {
 	return dist <= e.sparseLocalityDistance
 }
 
+// recordSparseTargetLocked retains the latest target for locality detection.
 func (e *PackReader) recordSparseTargetLocked(off, end int64) {
 	if !e.sparseReads {
 		return
@@ -361,6 +377,7 @@ func (e *PackReader) recordSparseTargetLocked(off, end int64) {
 	e.lastTargetSet = true
 }
 
+// planExactFetchLocked clips index reads to the currently uncovered gap.
 func (e *PackReader) planExactFetchLocked(off, readEnd int64) fetchKey {
 	gapStart, gapEnd, ok := e.findGapLocked(off)
 	if !ok || gapEnd <= gapStart {
@@ -390,6 +407,7 @@ func (e *PackReader) recordFetchLocked(key fetchKey, responseBytes int) func() {
 	return e.statsChanged
 }
 
+// recordIndexTailFetchLocked accounts for index I/O separately from payloads.
 func (e *PackReader) recordIndexTailFetchLocked(key fetchKey, responseBytes int) func() {
 	e.lastFetchAt = time.Now()
 	e.lastFetchBytes = key.size
@@ -402,6 +420,7 @@ func (e *PackReader) recordIndexTailFetchLocked(key fetchKey, responseBytes int)
 	return e.statsChanged
 }
 
+// readResidentRange returns an owned copy only when every byte is resident.
 func (e *PackReader) readResidentRange(start, end int64) ([]byte, bool) {
 	if end <= start {
 		return nil, true
@@ -445,7 +464,7 @@ func (e *PackReader) findLoadingLocked(off int64) *fetchLoad {
 
 // findGapLocked returns the uncovered byte interval around off.
 //
-// If off is already covered by a resident span the gap is empty. Otherwise
+// If off is already covered by a resident or in-flight span the gap is empty. Otherwise
 // the gap is the widest [prevEnd, nextStart) that contains off, where
 // prevEnd is the end of the span before off (or 0) and nextStart is the
 // start of the next span (or the pack size).
@@ -453,19 +472,35 @@ func (e *PackReader) findGapLocked(off int64) (int64, int64, bool) {
 	if off < 0 {
 		return 0, 0, false
 	}
+
+	// Find the resident gap around this offset.
 	prevEnd := int64(0)
+	end := e.size
+	if end <= 0 {
+		end = int64(1 << 62)
+	}
 	for _, s := range e.spans {
 		if off < s.off {
-			return prevEnd, s.off, off >= prevEnd
+			end = s.off
+			break
 		}
 		if off < s.end() {
 			return 0, 0, false
 		}
 		prevEnd = s.end()
 	}
-	end := e.size
-	if end <= 0 {
-		end = int64(1 << 62)
+
+	// Reserve in-flight bytes too. A larger neighboring miss must not overlap
+	// a smaller request whose starting offset lies inside its preferred window.
+	for key := range e.loading {
+		if off >= key.off && off < key.end() {
+			return 0, 0, false
+		}
+		if key.end() <= off {
+			prevEnd = max(prevEnd, key.end())
+		} else if key.off > off {
+			end = min(end, key.off)
+		}
 	}
 	return prevEnd, end, off >= prevEnd && off < end
 }

--- a/core/provider/spacewave/packfile/store/store_test.go
+++ b/core/provider/spacewave/packfile/store/store_test.go
@@ -1719,30 +1719,30 @@ func TestPackfileStoreVerifyFailureAllowsRetry(t *testing.T) {
 	store.SetWriteback(ctx, nil, 0)
 
 	alphaHash, _ := hash.Sum(hash.HashType_HashType_SHA256, []byte("alpha"))
-	// First read returns corrupted bytes (verify happens in background so
-	// the first caller sees data). The background verify will mark the
-	// block failed.
+	// Background verification may reject the first response before this read
+	// returns, allowing it to retry and return valid data immediately.
 	if _, _, err := store.GetBlock(ctx, &block.BlockRef{Hash: alphaHash}); err != nil {
 		t.Fatalf("first GetBlock: %v", err)
 	}
 
-	// Wait for the failed record to be evicted.
+	// Observe rejection rather than transient catalog absence: a valid retry
+	// may already have installed its replacement record.
 	eng, err := store.getOrOpenEngine("retry-pack", int64(len(packBytes)), 1)
 	if err != nil {
 		t.Fatalf("getOrOpenEngine: %v", err)
 	}
 	if !waitFor(t, func() (bool, <-chan struct{}) {
-		var present bool
+		var rejected bool
 		var waitCh <-chan struct{}
 		eng.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
-			_, present = eng.blocks[alphaHash.MarshalString()]
-			if present {
+			rejected = eng.verifyFailures != 0
+			if !rejected {
 				waitCh = getWaitCh()
 			}
 		})
-		return !present, waitCh
+		return rejected, waitCh
 	}) {
-		t.Fatal("expected failed block to be evicted from catalog")
+		t.Fatal("expected corrupted response to fail verification")
 	}
 
 	got, found, err := store.GetBlock(ctx, &block.BlockRef{Hash: alphaHash})

--- a/db/block/extract.go
+++ b/db/block/extract.go
@@ -1,33 +1,43 @@
 package block
 
+import (
+	"maps"
+	"slices"
+)
+
 // ExtractBlockRefs extracts all outgoing BlockRefs from a block by
 // walking BlockWithRefs and recursing into BlockWithSubBlocks.
 //
 // This captures refs at all nesting levels: direct refs on the block,
 // refs inside sub-blocks (e.g., BlockRefSlice), and refs inside
-// nested sub-blocks.
+// nested sub-blocks. References and sub-blocks are visited in field-ID order,
+// preserving sequence order independently of Go map iteration.
 func ExtractBlockRefs(blk any) ([]*BlockRef, error) {
+	// A missing block contributes no references.
 	if blk == nil {
 		return nil, nil
 	}
 
+	// Direct references retain their declared field order.
 	var refs []*BlockRef
-
 	if bwr, ok := blk.(BlockWithRefs); ok {
 		m, err := bwr.GetBlockRefs()
 		if err != nil {
 			return nil, err
 		}
-		for _, ref := range m {
+		for _, id := range slices.Sorted(maps.Keys(m)) {
+			ref := m[id]
 			if ref != nil && !ref.GetEmpty() {
 				refs = append(refs, ref)
 			}
 		}
 	}
 
+	// Inline containers contribute their nested references in field order.
 	if bws, ok := blk.(BlockWithSubBlocks); ok {
 		subs := bws.GetSubBlocks()
-		for _, sub := range subs {
+		for _, id := range slices.Sorted(maps.Keys(subs)) {
+			sub := subs[id]
 			if sub != nil && !sub.IsNil() {
 				subRefs, err := ExtractBlockRefs(sub)
 				if err != nil {

--- a/db/block/read-ahead.go
+++ b/db/block/read-ahead.go
@@ -1,0 +1,20 @@
+package block
+
+import "context"
+
+// readAheadKey identifies the operation's preferred range-fetch minimum.
+type readAheadKey struct{}
+
+// WithReadAhead requests at least bytes per remote range-cache miss for this
+// operation. Stores may limit the request to an uncovered gap, the end of a
+// file, or their transport and memory bounds. Resident reads need no fetch.
+// The hint does not change a shared store's default policy.
+func WithReadAhead(ctx context.Context, bytes int) context.Context {
+	return context.WithValue(ctx, readAheadKey{}, max(0, bytes))
+}
+
+// ReadAhead returns the requested range-fetch minimum, or zero when unset.
+func ReadAhead(ctx context.Context) int {
+	bytes, _ := ctx.Value(readAheadKey{}).(int)
+	return bytes
+}

--- a/db/block/rpc/server/block-store.go
+++ b/db/block/rpc/server/block-store.go
@@ -9,15 +9,22 @@ import (
 
 // BlockStore implements the BlockStore RPC service.
 type BlockStore struct {
-	// store is the underlying block store
+	// store owns block storage and its lifetime.
 	store block.StoreOps
+	// readAheadBytes sets the range-fetch hint on this service's reads.
+	readAheadBytes int
 }
 
 // NewBlockStore constructs a new BlockStore from a Store.
 func NewBlockStore(store block.StoreOps) *BlockStore {
-	return &BlockStore{
-		store: store,
-	}
+	return NewBlockStoreWithReadAhead(store, 0)
+}
+
+// NewBlockStoreWithReadAhead constructs a service whose reads request the
+// supplied range-fetch minimum. Configure it before publishing the service;
+// each incoming RPC retains its own cancellation and deadline.
+func NewBlockStoreWithReadAhead(store block.StoreOps, bytes int) *BlockStore {
+	return &BlockStore{store: store, readAheadBytes: max(0, bytes)}
 }
 
 // GetHashType returns the preferred hash type for the store.
@@ -57,6 +64,7 @@ func (s *BlockStore) PutBlockBatch(
 	ctx context.Context,
 	req *block_rpc.PutBlockBatchRequest,
 ) (*block_rpc.PutBlockBatchResponse, error) {
+	// Convert wire entries without dropping references or tombstones.
 	entries := make([]*block.PutBatchEntry, 0, len(req.GetEntries()))
 	for _, entry := range req.GetEntries() {
 		entries = append(entries, &block.PutBatchEntry{
@@ -67,6 +75,7 @@ func (s *BlockStore) PutBlockBatch(
 		})
 	}
 
+	// Report the store's batch result through the service response.
 	resp := &block_rpc.PutBlockBatchResponse{}
 	if err := s.store.PutBlockBatch(ctx, entries); err != nil {
 		resp.Error = err.Error()
@@ -79,6 +88,12 @@ func (s *BlockStore) GetBlock(
 	ctx context.Context,
 	req *block_rpc.GetBlockRequest,
 ) (*block_rpc.GetBlockResponse, error) {
+	// Attach this service's policy while retaining the incoming RPC lifetime.
+	if s.readAheadBytes > 0 {
+		ctx = block.WithReadAhead(ctx, s.readAheadBytes)
+	}
+
+	// Read through the underlying owner and encode its result.
 	data, existed, err := s.store.GetBlock(ctx, req.GetRef())
 	resp := &block_rpc.GetBlockResponse{}
 	if err != nil {
@@ -167,5 +182,5 @@ func (s *BlockStore) Sync(
 	return resp, nil
 }
 
-// _ is a type assertion
+// _ verifies the RPC service contract.
 var _ block_rpc.SRPCBlockStoreServer = (*BlockStore)(nil)

--- a/prototypes/opfs-browser-harness/world.go
+++ b/prototypes/opfs-browser-harness/world.go
@@ -4,7 +4,6 @@ package opfsbrowserharness
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aperturerobotics/controllerbus/bus"
 	configset_controller "github.com/aperturerobotics/controllerbus/controller/configset/controller"
@@ -13,6 +12,8 @@ import (
 	"github.com/aperturerobotics/controllerbus/controller/resolver/static"
 	cbc "github.com/aperturerobotics/controllerbus/core"
 	boilerplate_controller "github.com/aperturerobotics/controllerbus/example/boilerplate/controller"
+	"github.com/pkg/errors"
+	browser_storage "github.com/s4wave/spacewave/bldr/storage/browser"
 	block_store_inmem "github.com/s4wave/spacewave/db/block/store/inmem"
 	block_store_overlay "github.com/s4wave/spacewave/db/block/store/overlay"
 	"github.com/s4wave/spacewave/db/bucket"
@@ -20,9 +21,6 @@ import (
 	bucket_setup "github.com/s4wave/spacewave/db/bucket/setup"
 	node_controller "github.com/s4wave/spacewave/db/node/controller"
 	volume "github.com/s4wave/spacewave/db/volume"
-	volume_opfs "github.com/s4wave/spacewave/db/volume/js/opfs"
-	volume_opfs_blockshard "github.com/s4wave/spacewave/db/volume/js/opfs/blockshard"
-	volume_opfs_pagestore "github.com/s4wave/spacewave/db/volume/js/opfs/pagestore"
 	world "github.com/s4wave/spacewave/db/world"
 	world_block_engine "github.com/s4wave/spacewave/db/world/block/engine"
 	"github.com/sirupsen/logrus"
@@ -40,9 +38,10 @@ type World struct {
 	// WS is the writable world state handle.
 	WS world.WorldState
 
-	ctx    context.Context
+	// cancel ends the World lifecycle.
 	cancel context.CancelFunc
-	rels   []func()
+	// rels releases the controller references.
+	rels []func()
 }
 
 // Close releases every resource the world holds. The world state must not
@@ -58,17 +57,20 @@ func (w *World) Close() {
 // mirroring the browser storage wiring in bldr/storage/browser. Browser
 // targets only: OPFS handles come from navigator.storage.
 func OpenWorld(ctx context.Context) (*World, error) {
+	// Keep the standalone browser proof quiet except for failures.
 	log := logrus.New()
 	log.SetLevel(logrus.ErrorLevel)
 	le := logrus.NewEntry(log)
 
+	// Bind all resources to the World lifecycle.
 	ctx, cancel := context.WithCancel(ctx)
-	w := &World{ctx: ctx, cancel: cancel}
+	w := &World{cancel: cancel}
 	fail := func(err error) (*World, error) {
 		w.Close()
 		return nil, err
 	}
 
+	// Register the same storage and World factories used by the browser.
 	b, sr, err := cbc.NewCoreBus(ctx, le)
 	if err != nil {
 		return fail(err)
@@ -78,65 +80,70 @@ func OpenWorld(ctx context.Context) (*World, error) {
 	sr.AddFactory(bucket_setup.NewFactory(b))
 	sr.AddFactory(node_controller.NewFactory(b))
 	sr.AddFactory(lookup_concurrent.NewFactory(b))
-	sr.AddFactory(volume_opfs.NewFactory(b))
+	storage := browser_storage.NewOpfsStorage("")
+	storage.AddFactories(b, sr)
 	sr.AddFactory(block_store_inmem.NewFactory(b))
 	sr.AddFactory(block_store_overlay.NewFactory(b))
 	sr.AddFactory(boilerplate_controller.NewFactory(b))
 	sr.AddFactory(world_block_engine.NewFactory(b))
 
-	if _, _, _, err := loader.WaitExecControllerRunning(
+	// Start the config-set controller and retain its directive.
+	_, _, configRef, err := loader.WaitExecControllerRunning(
 		ctx,
 		b,
 		resolver.NewLoadControllerWithConfig(&configset_controller.Config{}),
 		nil,
-	); err != nil {
-		return fail(fmt.Errorf("configset controller: %w", err))
+	)
+	if err != nil {
+		return fail(errors.Wrap(err, "configset controller"))
 	}
-	if _, _, _, err := loader.WaitExecControllerRunning(
+	w.rels = append(w.rels, configRef.Release)
+
+	// Start the node controller and retain its directive.
+	_, _, nodeRef, err := loader.WaitExecControllerRunning(
 		ctx,
 		b,
 		resolver.NewLoadControllerWithConfig(&node_controller.Config{}),
 		nil,
-	); err != nil {
-		return fail(fmt.Errorf("node controller: %w", err))
+	)
+	if err != nil {
+		return fail(errors.Wrap(err, "node controller"))
 	}
+	w.rels = append(w.rels, nodeRef.Release)
 
+	// Use the browser storage owner to select the current volume format.
+	volumeConfig, err := storage.BuildVolumeConfig(volumeRoot, nil)
+	if err != nil {
+		return fail(errors.Wrap(err, "build volume config"))
+	}
 	dv, _, volRef, err := loader.WaitExecControllerRunning(
 		ctx,
 		b,
-		resolver.NewLoadControllerWithConfig(&volume_opfs.Config{
-			RootPath:                 volumeRoot,
-			LockPrefix:               volumeRoot,
-			BlockShardCount:          volume_opfs_blockshard.DefaultShardCount,
-			BlockCompactionTrigger:   8,
-			BlockMaxSegmentDataBytes: volume_opfs_blockshard.DefaultMaxSegmentDataBytes,
-			MetaShardCount:           1,
-			PageSize:                 volume_opfs_pagestore.DefaultPageSize,
-			DriverMode:               "auto",
-			StorageFormatVersion:     2,
-			ResetPolicy:              "automatic",
-		}),
+		resolver.NewLoadControllerWithConfig(volumeConfig),
 		nil,
 	)
 	if err != nil {
-		return fail(fmt.Errorf("opfs volume controller: %w", err))
+		return fail(errors.Wrap(err, "opfs volume controller"))
 	}
 	w.rels = append(w.rels, volRef.Release)
+
+	// Open the volume and initialize the World bucket.
 	vc := dv.(volume.Controller)
 	v, err := vc.GetVolume(ctx)
 	if err != nil {
-		return fail(fmt.Errorf("get volume: %w", err))
+		return fail(errors.Wrap(err, "get volume"))
 	}
 	if _, _, _, err := v.ApplyBucketConfig(ctx, &bucket.Config{
 		Id:  engineBucketID,
 		Rev: 1,
 	}); err != nil {
-		return fail(fmt.Errorf("apply bucket config: %w", err))
+		return fail(errors.Wrap(err, "apply bucket config"))
 	}
 
+	// Start the World engine over the browser volume.
 	transformConf, err := engineTransformConfig(engineBucketID)
 	if err != nil {
-		return fail(fmt.Errorf("build transform config: %w", err))
+		return fail(errors.Wrap(err, "build transform config"))
 	}
 	initRef := &bucket.ObjectRef{
 		BucketId:      engineBucketID,
@@ -152,10 +159,11 @@ func OpenWorld(ctx context.Context) (*World, error) {
 	)
 	_, ctrlRef, err := world_block_engine.StartEngineWithConfig(ctx, b, engConf)
 	if err != nil {
-		return fail(fmt.Errorf("start world engine: %w", err))
+		return fail(errors.Wrap(err, "start world engine"))
 	}
 	w.rels = append(w.rels, ctrlRef.Release)
 
+	// Expose the engine through the ordinary transaction owner.
 	busEngine := world.NewBusEngine(ctx, b, "opfs-harness-engine")
 	w.WS = world.NewEngineWorldState(busEngine, true)
 	return w, nil


### PR DESCRIPTION
Hash-sorted pack payloads scatter related blocks and make range read-ahead less useful. Group available subtrees before writing manifest packs, preserve producer child order, and retain structural order behind profiled reads.

Materialization requests 10 MiB windows through the existing range cache. Foreground reads reuse those bytes while retaining their own miss policy. The planner also excludes neighboring in-flight ranges, preventing overlapping bulk and foreground requests. Block identities and the KVFile format stay compatible.

Validation: focused package tests and race checks pass, including source-RPC cache reuse, transport and memory bounds, overlapping requests, deterministic pack output, and corruption retry. A controlled 256 KiB related-content workload with fixed 128 KiB windows went from 8 requests / 1 MiB to 2 requests / 256 KiB. This is a layout comparison, not a deployed startup measurement.

The browser durability harness now uses the current shared storage configuration; its GoScript-tagged WebAssembly build passes.
