### PR TITLE
fix(sobject): notify peers when live sync access ends

### DIFF
--- a/core/sobject/sync/auth_test.go
+++ b/core/sobject/sync/auth_test.go
@@ -239,6 +239,77 @@ func TestParticipantAuthenticationDeniesBeforeDisclosure(t *testing.T) {
 	}
 }
 
+// TestParticipantRevocationNotifiesConnectedPeer preserves the old replica while
+// delivering an explicit denial over the already authenticated stream.
+func TestParticipantRevocationNotifiesConnectedPeer(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+	const soID = "authentication-live-revocation"
+	owner, reader := mustKeyPair(t), mustKeyPair(t)
+	state := authenticationState(t, soID, owner, reader)
+	local := newAuthenticationPeer(t, soID, owner, state)
+	remote := newAuthenticationPeer(t, soID, reader, state)
+	denied := make(chan peer.ID, 1)
+	remote.peerAdmission = func(remoteID peer.ID, accepted bool) {
+		if !accepted {
+			denied <- remoteID
+		}
+	}
+
+	// Start the real paired exchange and remove access once object traffic has begun.
+	left, right := net.Pipe()
+	t.Cleanup(func() { left.Close(); right.Close() })
+	observed := &authenticationStream{Conn: left, messages: make(chan *SOSyncMessage, 32)}
+	done := make(chan error, 2)
+	go func() { done <- local.runStream(ctx, gateLogger(), observed, "transport-a", "transport-b") }()
+	go func() { done <- remote.runStream(ctx, gateLogger(), right, "transport-b", "transport-a") }()
+	waitAuthenticationSnapshot(t, ctx, observed.messages)
+	waitAuthenticationSnapshot(t, ctx, observed.messages)
+	removed, err := sobject.RemoveSOParticipant(ctx, local.soHost, remote.localObjectPeerID.String(), owner, nil)
+	if err != nil || !removed {
+		t.Fatalf("remove = %v, %v", removed, err)
+	}
+	select {
+	case source := <-denied:
+		if source != local.localObjectPeerID {
+			t.Fatalf("denied source = %v", source)
+		}
+	case <-ctx.Done():
+		t.Fatal("connected peer did not receive the revocation notice")
+	}
+	for range 2 {
+		select {
+		case <-done:
+		case <-ctx.Done():
+			t.Fatal("revoked stream failed to close")
+		}
+	}
+
+	// The notice reveals neither the removed configuration nor any operation history.
+	for len(observed.messages) != 0 {
+		message := <-observed.messages
+		if message.GetOp() != nil {
+			t.Fatal("revocation disclosed new object data")
+		}
+		if snapshot := message.GetSnapshot(); snapshot != nil {
+			decoded := &sobject.SOState{}
+			if err := decoded.UnmarshalVT(snapshot.GetSoState()); err != nil {
+				t.Fatal(err)
+			}
+			if !decoded.GetConfig().EqualVT(state.GetConfig()) || snapshot.GetRootSeqno() != state.GetRoot().GetInnerSeqno() {
+				t.Fatal("revocation disclosed new configuration or history")
+			}
+		}
+	}
+	retained, err := remote.soHost.GetHostState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !retained.GetConfig().EqualVT(state.GetConfig()) {
+		t.Fatal("revocation rewrote the removed peer's retained configuration")
+	}
+}
+
 // TestParticipantRevocationClosesBlockedSnapshot proves the authority watch can
 // stop a stream whose authorized initial send is blocked in the transport.
 func TestParticipantRevocationClosesBlockedSnapshot(t *testing.T) {

--- a/core/sobject/sync/sync.go
+++ b/core/sobject/sync/sync.go
@@ -151,7 +151,8 @@ func (s *SOSync) runStream(ctx context.Context, le *logrus.Entry, strm stream.St
 		return err
 	}
 
-	// A separate watch can close a sender blocked in transport when membership is removed.
+	// A separate watch bounds revocation even while another sender is blocked.
+	sess := stream_packet.NewSession(strm, maxMessageSize)
 	watcher := routine.NewRoutineContainer()
 	watcher.SetRoutine(func(ctx context.Context) (rerr error) {
 		defer func() {
@@ -170,6 +171,10 @@ func (s *SOSync) runStream(ctx context.Context, le *logrus.Entry, strm stream.St
 				return err
 			}
 			if err := s.authorizeParticipants(current, remoteID); err != nil {
+				// A control frame exposes no state; a stalled transport still closes promptly.
+				if strm.SetWriteDeadline(time.Now().Add(250*time.Millisecond)) == nil {
+					_ = sendAccessDenied(sess)
+				}
 				return err
 			}
 			previous = current
@@ -186,7 +191,6 @@ func (s *SOSync) runStream(ctx context.Context, le *logrus.Entry, strm stream.St
 		}
 	}()
 
-	sess := stream_packet.NewSession(strm, maxMessageSize)
 	if err := s.exchangeSnapshots(ctx, le, sess, localTransport < remoteTransport, remoteID); err != nil {
 		return err
 	}
@@ -203,6 +207,7 @@ func (s *SOSync) exchangeSnapshots(ctx context.Context, le *logrus.Entry, sess *
 			return err
 		}
 		if err := s.authorizeParticipants(state, remoteID); err != nil {
+			_ = sendAccessDenied(sess)
 			return err
 		}
 		data, err := state.MarshalVT()
@@ -220,11 +225,11 @@ func (s *SOSync) exchangeSnapshots(ctx context.Context, le *logrus.Entry, sess *
 		if err := send(); err != nil {
 			return err
 		}
-		if err := sess.RecvMsg(incoming); err != nil {
+		if err := s.receiveSnapshot(ctx, sess, incoming, remoteID); err != nil {
 			return err
 		}
 	} else {
-		if err := sess.RecvMsg(incoming); err != nil {
+		if err := s.receiveSnapshot(ctx, sess, incoming, remoteID); err != nil {
 			return err
 		}
 		if err := send(); err != nil {
@@ -235,6 +240,36 @@ func (s *SOSync) exchangeSnapshots(ctx context.Context, le *logrus.Entry, sess *
 		return errors.New("expected authenticated snapshot")
 	}
 	return s.applyPeerSnapshot(ctx, le, incoming.GetSnapshot())
+}
+
+// receiveSnapshot recognizes a peer's revocation before disclosing another snapshot.
+func (s *SOSync) receiveSnapshot(ctx context.Context, sess *stream_packet.Session, incoming *SOSyncMessage, remoteID peer.ID) error {
+	if err := sess.RecvMsg(incoming); err != nil {
+		return err
+	}
+
+	// Recheck the held authority after the receive wait before observing peer decisions.
+	state, err := s.soHost.GetHostState(ctx)
+	if err != nil {
+		return err
+	}
+	if err := s.authorizeParticipants(state, remoteID); err != nil {
+		_ = sendAccessDenied(sess)
+		return err
+	}
+	if admission := incoming.GetAuthorization(); admission != nil && !admission.GetAccepted() {
+		if s.peerAdmission != nil {
+			s.peerAdmission(remoteID, false)
+		}
+		return ErrAccessDenied
+	}
+	return nil
+}
+
+// sendAccessDenied reports revocation without sending object state or history.
+// The stream's authority watch bounds this write before closing the transport.
+func sendAccessDenied(sess *stream_packet.Session) error {
+	return sess.SendMsg(&SOSyncMessage{Body: &SOSyncMessage_Authorization{Authorization: &SOSyncAuthorization{}}})
 }
 
 // applyPeerSnapshot validates and adopts a newer authoritative state.
@@ -404,10 +439,19 @@ func (s *SOSync) streamOps(ctx context.Context, le *logrus.Entry, sess *stream_p
 
 		// Recheck admission after a receive wait before processing any data.
 		current, err := s.soHost.GetHostState(ctx)
-		if err != nil || s.authorizeParticipants(current, remoteID) != nil {
+		if err != nil {
+			return
+		}
+		if s.authorizeParticipants(current, remoteID) != nil {
+			_ = sendAccessDenied(sess)
 			return
 		}
 		switch body := inMsg.GetBody().(type) {
+		case *SOSyncMessage_Authorization:
+			if !body.Authorization.GetAccepted() && s.peerAdmission != nil {
+				s.peerAdmission(remoteID, false)
+			}
+			return
 		case *SOSyncMessage_Snapshot:
 			if err := s.applyPeerSnapshot(ctx, le, body.Snapshot); err != nil {
 				return
@@ -444,6 +488,7 @@ func (s *SOSync) sendOps(ctx context.Context, le *logrus.Entry, sess *stream_pac
 		// Admit each outbound batch against current authority, not a queued older snapshot.
 		next := stateCtr.GetValue()
 		if err := s.authorizeParticipants(next, remoteID); err != nil {
+			_ = sendAccessDenied(sess)
 			return
 		}
 		rootSeqno := next.GetRoot().GetInnerSeqno()


### PR DESCRIPTION
Removing a participant closed an existing synchronization stream without telling the other endpoint why. The authenticated stream now sends an explicit refusal before closing. The authority watch bounds that terminal write to 250 milliseconds, and closes immediately if the transport cannot set a deadline.

The receiver records source refusal only while its own held configuration still permits the authenticated peer. Snapshot exchange stops before replying to a refusal. The notice transfers no object configuration, snapshots, or operation history and does not rewrite the receiving replica's membership.

Validation: the complete synchronization race suite passes. A paired-stream regression removes a participant during operation streaming, observes the refusal, and verifies unchanged cached configuration and no newly disclosed configuration or operations. The blocked-snapshot regression still verifies prompt stream teardown. Compile and lint hooks pass.
