### PR TITLE
fix(net): restart solicitation offers on retained links

### DIFF
--- a/.protoc-manifest.json
+++ b/.protoc-manifest.json
@@ -2877,7 +2877,7 @@
       ]
     },
     "github.com/s4wave/spacewave/net/link/solicit": {
-      "hash": "78e9d5dcabd1de669bf8ab750e79af172016e20a2eb591469c78408ad39aba28",
+      "hash": "fe81e2810ab6b3b7154fed17dcc5357d8eb60626fa78460888943832e96d4366",
       "generatedFiles": [
         "net/link/solicit/solicit.pb.go",
         "net/link/solicit/solicit.pb.ts"

--- a/net/link/solicit/controller/controller.go
+++ b/net/link/solicit/controller/controller.go
@@ -3,7 +3,9 @@ package link_solicit_controller
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"encoding/hex"
+	"math"
 	"slices"
 	"strings"
 
@@ -11,6 +13,7 @@ import (
 	"github.com/aperturerobotics/controllerbus/directive"
 	"github.com/aperturerobotics/util/broadcast"
 	"github.com/aperturerobotics/util/keyed"
+	"github.com/pkg/errors"
 	"github.com/s4wave/spacewave/net/link"
 	link_solicit "github.com/s4wave/spacewave/net/link/solicit"
 	"github.com/s4wave/spacewave/net/protocol"
@@ -31,8 +34,17 @@ const ControlProtocolID = protocol.ID("bifrost/solicit")
 // SolicitStreamPrefix is the protocol ID prefix for solicited streams.
 const SolicitStreamPrefix = "solicit:"
 
-// maxMessageSize is the max message size for packet session.
-const maxMessageSize = 256 * 32 * 2 // ~16KB, enough for 256 hashes
+// solicitationIncarnationSize is the number of random bytes in an offer incarnation.
+const solicitationIncarnationSize = 16
+
+const (
+	// encodedProtocolHashSize bounds one repeated 32-byte hash field.
+	encodedProtocolHashSize = 34
+	// encodedOfferSize bounds one repeated offer with hash and incarnation.
+	encodedOfferSize = 54
+	// exchangeMetadataSize bounds capability and generation fields.
+	exchangeMetadataSize = 32
+)
 
 // Controller is the solicitation controller.
 type Controller struct {
@@ -44,18 +56,29 @@ type Controller struct {
 	bcast broadcast.Broadcast
 	// linkRoutines manages per-link control stream goroutines.
 	linkRoutines *keyed.Keyed[uint64, struct{}]
+	// openRoutines manages solicited stream openings outside control loops.
+	openRoutines *keyed.Keyed[solicitationOpenKey, struct{}]
 	// solicitations tracks active SolicitProtocol directives.
 	// guarded by bcast
 	solicitations map[*solicitState]struct{}
 	// links tracks active link states.
 	// guarded by bcast
 	links map[uint64]*linkState // key: link UUID
+	// opens owns pending solicited stream openings.
+	// guarded by bcast
+	opens map[solicitationOpenKey]solicitationOpen
 }
 
 // solicitState tracks a single SolicitProtocol directive resolver.
 type solicitState struct {
-	dir     link_solicit.SolicitProtocol
+	// dir is the continuous solicitation directive represented by this state.
+	dir link_solicit.SolicitProtocol
+	// handler receives the stream produced for each bilateral incarnation.
 	handler directive.ResolverHandler
+	// incarnation distinguishes this lifetime from equivalent successors.
+	incarnation []byte
+	// disposed prevents publication after directive disposal.
+	disposed bool // guarded by Controller.bcast
 }
 
 // linkState tracks per-link solicitation state.
@@ -72,13 +95,72 @@ type linkState struct {
 	refCount int
 
 	// guarded by Controller.bcast
-	remoteHashes [][]byte
-	matched      map[string]struct{} // hex hash -> already matched
+	// remoteExchange is the peer's most recently advertised offer generation.
+	remoteExchange *solicitationExchange
+	// matched suppresses duplicate streams for each bilateral incarnation pair.
+	matched map[string]struct{}
 }
 
+// controlStreamLocalSnapshot captures one local offer-set observation.
 type controlStreamLocalSnapshot struct {
+	// linkRemoved indicates that this link state no longer owns its UUID.
 	linkRemoved bool
-	entries     []link_solicit.SolicitEntry
+	// offers contains the current local directive incarnations for the link.
+	offers []solicitationOffer
+}
+
+// solicitationOffer binds stable discovery identity to one directive lifetime.
+type solicitationOffer struct {
+	// protocolID identifies the requested application protocol.
+	protocolID protocol.ID
+	// context distinguishes independent uses of the same protocol.
+	context []byte
+	// hash is the stable link-scoped discovery identity.
+	hash []byte
+	// incarnation distinguishes equivalent offers across directive lifetimes.
+	incarnation []byte
+}
+
+// solicitationExchange is one complete control-stream offer generation.
+type solicitationExchange struct {
+	// hashes carries stable discovery identities for legacy peers.
+	hashes [][]byte
+	// offers carries incarnation-bound identities for upgraded peers.
+	offers []solicitationOffer
+	// supportsOfferIncarnations selects the incarnation-aware match contract.
+	supportsOfferIncarnations bool
+	// generation changes whenever this side's offer set changes.
+	generation uint64
+	// acknowledgedGeneration is the latest remote generation observed.
+	acknowledgedGeneration uint64
+}
+
+// solicitationMatch binds a stable hash to both participating offer lifetimes.
+type solicitationMatch struct {
+	// hash is the stable discovery identity shared by both peers.
+	hash []byte
+	// localIncarnation identifies the local offer lifetime.
+	localIncarnation []byte
+	// remoteIncarnation identifies the remote offer lifetime.
+	remoteIncarnation []byte
+	// incarnated distinguishes upgraded matches from legacy hash-only matches.
+	incarnated bool
+}
+
+// solicitationOpenKey identifies one pending open on one physical link.
+type solicitationOpenKey struct {
+	// linkUUID identifies the physical link that owns the pending open.
+	linkUUID uint64
+	// match is the canonical bilateral incarnation key.
+	match string
+}
+
+// solicitationOpen contains the state needed by a one-shot keyed open routine.
+type solicitationOpen struct {
+	// ls owns the physical link used to open the stream.
+	ls *linkState
+	// match binds the stream to the current bilateral offer lifetimes.
+	match solicitationMatch
 }
 
 // NewController constructs a new solicitation controller.
@@ -88,11 +170,38 @@ func NewController(le *logrus.Entry, conf *Config) (*Controller, error) {
 		maxHashes:     conf.GetMaxHashesOrDefault(),
 		solicitations: make(map[*solicitState]struct{}),
 		links:         make(map[uint64]*linkState),
+		opens:         make(map[solicitationOpenKey]solicitationOpen),
 	}
 	c.linkRoutines = keyed.NewKeyed(c.buildLinkRoutine,
 		keyed.WithExitLogger[uint64, struct{}](le),
 	)
+	c.openRoutines = keyed.NewKeyed(
+		c.buildOpenRoutine,
+		keyed.WithExitLogger[solicitationOpenKey, struct{}](le),
+		keyed.WithExitCb(func(
+			key solicitationOpenKey,
+			_ keyed.Routine,
+			_ struct{},
+			_ error,
+		) {
+			c.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+				delete(c.opens, key)
+			})
+			c.openRoutines.RemoveKey(key)
+		}),
+	)
 	return c, nil
+}
+
+// maxExchangeMessageSize returns a packet bound for the configured maximum
+// stable hashes and incarnated offers, including exchange metadata.
+func maxExchangeMessageSize(maxHashes uint32) uint32 {
+	entrySize := max(encodedOfferSize, encodedProtocolHashSize)
+	size := uint64(maxHashes)*uint64(entrySize) + exchangeMetadataSize
+	if size > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(size)
 }
 
 // buildLinkRoutine constructs the keyed routine for a link UUID.
@@ -112,10 +221,26 @@ func (c *Controller) buildLinkRoutine(uuid uint64) (keyed.Routine, struct{}) {
 	}, struct{}{}
 }
 
+// buildOpenRoutine constructs a one-shot solicited stream opening routine.
+func (c *Controller) buildOpenRoutine(key solicitationOpenKey) (keyed.Routine, struct{}) {
+	var open solicitationOpen
+	c.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		open = c.opens[key]
+	})
+	if open.ls == nil {
+		return nil, struct{}{}
+	}
+	return func(ctx context.Context) error {
+		c.openSolicitedStream(ctx, open.ls, open.match)
+		return nil
+	}, struct{}{}
+}
+
 // Execute executes the controller goroutine.
 func (c *Controller) Execute(ctx context.Context) error {
 	c.le.Debug("solicitation controller running")
 	c.linkRoutines.SetContext(ctx, true)
+	c.openRoutines.SetContext(ctx, true)
 	return nil
 }
 
@@ -139,33 +264,51 @@ func (c *Controller) HandleDirective(
 // handleSolicitProtocol returns a resolver for a SolicitProtocol directive.
 func (c *Controller) handleSolicitProtocol(
 	_ context.Context,
-	_ directive.Instance,
+	di directive.Instance,
 	d link_solicit.SolicitProtocol,
 ) ([]directive.Resolver, error) {
+	incarnation := make([]byte, solicitationIncarnationSize)
+	if _, err := rand.Read(incarnation); err != nil {
+		return nil, errors.Wrap(err, "generate solicitation incarnation")
+	}
+
+	ss := &solicitState{dir: d, incarnation: incarnation}
+	di.AddDisposeCallback(func() {
+		c.removeSolicitation(ss)
+	})
+
 	return directive.Resolvers(directive.NewFuncResolver(func(
 		rctx context.Context,
 		rh directive.ResolverHandler,
 	) error {
-		// Register the solicitation while its resolver is active.
-		ss := &solicitState{dir: d, handler: rh}
+		// Register the incarnation while its directive remains active.
 		c.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+			if ss.disposed {
+				return
+			}
+			ss.handler = rh
 			c.solicitations[ss] = struct{}{}
 			broadcast()
 		})
-
-		// Remove the solicitation when the resolver is disposed.
-		defer func() {
-			c.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
-				delete(c.solicitations, ss)
-				broadcast()
-			})
-		}()
+		defer c.removeSolicitation(ss)
 
 		// Keep the resolver idle until its context is canceled.
 		rh.MarkIdle(true)
 		<-rctx.Done()
 		return nil
 	})), nil
+}
+
+// removeSolicitation synchronously and idempotently withdraws an offer.
+func (c *Controller) removeSolicitation(ss *solicitState) {
+	c.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		ss.disposed = true
+		if _, exists := c.solicitations[ss]; !exists {
+			return
+		}
+		delete(c.solicitations, ss)
+		broadcast()
+	})
 }
 
 // handleMountedStream returns a resolver for HandleMountedStream directives
@@ -290,6 +433,29 @@ func (c *Controller) removeLink(uuid uint64) {
 	if ls != nil {
 		ls.le.Debug("link removed from solicitation")
 		c.linkRoutines.RemoveKey(uuid)
+		c.retireLinkOpens(uuid)
+	}
+}
+
+// retireLinkOpens removes pending metadata and cancels every open for a link.
+func (c *Controller) retireLinkOpens(uuid uint64) {
+	keys := make(map[solicitationOpenKey]struct{})
+	c.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		for key := range c.opens {
+			if key.linkUUID != uuid {
+				continue
+			}
+			delete(c.opens, key)
+			keys[key] = struct{}{}
+		}
+	})
+	for _, key := range c.openRoutines.GetKeys() {
+		if key.linkUUID == uuid {
+			keys[key] = struct{}{}
+		}
+	}
+	for key := range keys {
+		c.openRoutines.RemoveKey(key)
 	}
 }
 
@@ -303,19 +469,19 @@ func (c *Controller) initiateControlStream(ctx context.Context, ls *linkState) e
 		return err
 	}
 
-	sess := stream_packet.NewSession(ms.GetStream(), maxMessageSize)
+	sess := stream_packet.NewSession(ms.GetStream(), maxExchangeMessageSize(c.maxHashes))
 	c.runControlStream(ctx, ls, sess)
 	return nil
 }
 
-// getSolicitEntries returns the current set of solicit entries
-// for a given link, filtering by peer and transport constraints.
+// getSolicitationOffers returns the current offers for a link, filtering by
+// peer and transport constraints.
 // Caller must hold bcast lock.
-func (c *Controller) getSolicitEntries(ml link.MountedLink) []link_solicit.SolicitEntry {
+func (c *Controller) getSolicitationOffers(ml link.MountedLink) []solicitationOffer {
 	remotePeer := ml.GetRemotePeer()
 	transportUUID := ml.GetTransportUUID()
 
-	var entries []link_solicit.SolicitEntry
+	var offers []solicitationOffer
 	for ss := range c.solicitations {
 		if pid := ss.dir.SolicitProtocolPeerID(); len(pid) != 0 && pid != remotePeer {
 			continue
@@ -323,12 +489,13 @@ func (c *Controller) getSolicitEntries(ml link.MountedLink) []link_solicit.Solic
 		if tid := ss.dir.SolicitProtocolTransportID(); tid != 0 && tid != transportUUID {
 			continue
 		}
-		entries = append(entries, link_solicit.SolicitEntry{
-			ProtocolID: ss.dir.SolicitProtocolID(),
-			Context:    ss.dir.SolicitProtocolContext(),
+		offers = append(offers, solicitationOffer{
+			protocolID:  ss.dir.SolicitProtocolID(),
+			context:     ss.dir.SolicitProtocolContext(),
+			incarnation: ss.incarnation,
 		})
 	}
-	return entries
+	return offers
 }
 
 // watchControlStreamLocalSnapshots watches the local solicit snapshot for a
@@ -356,7 +523,7 @@ func (c *Controller) snapshotControlStreamLocalLocked(ls *linkState) *controlStr
 		return &controlStreamLocalSnapshot{linkRemoved: true}
 	}
 	return &controlStreamLocalSnapshot{
-		entries: cloneSolicitEntries(c.getSolicitEntries(ls.ml)),
+		offers: cloneSolicitationOffers(c.getSolicitationOffers(ls.ml)),
 	}
 }
 
@@ -369,28 +536,33 @@ func (c *Controller) currentControlStreamLocalSnapshot(ls *linkState) *controlSt
 	return c.snapshotControlStreamLocalLocked(ls)
 }
 
-// currentControlStreamRemoteHashes returns the remote hashes reported by a
+// currentControlStreamRemoteExchange returns the remote exchange reported by a
 // link, or true when the link is no longer active.
-func (c *Controller) currentControlStreamRemoteHashes(ls *linkState) ([][]byte, bool) {
+func (c *Controller) currentControlStreamRemoteExchange(
+	ls *linkState,
+) (*solicitationExchange, bool) {
 	locked := c.bcast.Lock()
 	defer locked.Unlock()
 
 	if !c.controlStreamLinkActiveLocked(ls) {
 		return nil, true
 	}
-	return cloneHashes(ls.remoteHashes), false
+	return cloneSolicitationExchange(ls.remoteExchange), false
 }
 
-// setControlStreamRemoteHashes stores the remote hashes reported by a link
+// setControlStreamRemoteExchange stores the remote exchange reported by a link
 // and returns false when the link is no longer active.
-func (c *Controller) setControlStreamRemoteHashes(ls *linkState, hashes [][]byte) bool {
+func (c *Controller) setControlStreamRemoteExchange(
+	ls *linkState,
+	exchange *solicitationExchange,
+) bool {
 	locked := c.bcast.Lock()
 	defer locked.Unlock()
 
 	if !c.controlStreamLinkActiveLocked(ls) {
 		return false
 	}
-	ls.remoteHashes = cloneHashes(hashes)
+	ls.remoteExchange = cloneSolicitationExchange(exchange)
 	return true
 }
 
@@ -401,7 +573,7 @@ func (c *Controller) controlStreamLinkActiveLocked(ls *linkState) bool {
 }
 
 // controlStreamLocalSnapshotsEqual returns true if two local snapshots hold
-// the same link-removed flag and solicit entries.
+// the same link-removed flag and offers.
 func controlStreamLocalSnapshotsEqual(a, b *controlStreamLocalSnapshot) bool {
 	if a == nil || b == nil {
 		return a == b
@@ -409,41 +581,66 @@ func controlStreamLocalSnapshotsEqual(a, b *controlStreamLocalSnapshot) bool {
 	if a.linkRemoved != b.linkRemoved {
 		return false
 	}
-	return solicitEntriesEqual(a.entries, b.entries)
+	return solicitationOffersEqual(a.offers, b.offers)
 }
 
-// cloneSolicitEntries deep-clones and canonically sorts solicit entries.
-func cloneSolicitEntries(entries []link_solicit.SolicitEntry) []link_solicit.SolicitEntry {
-	if len(entries) == 0 {
+// cloneSolicitationOffers deep-clones and canonically sorts offers.
+func cloneSolicitationOffers(offers []solicitationOffer) []solicitationOffer {
+	if len(offers) == 0 {
 		return nil
 	}
-	out := make([]link_solicit.SolicitEntry, len(entries))
-	for i, entry := range entries {
-		out[i] = link_solicit.SolicitEntry{
-			ProtocolID: entry.ProtocolID,
-			Context:    slices.Clone(entry.Context),
+	out := make([]solicitationOffer, len(offers))
+	for i, offer := range offers {
+		out[i] = solicitationOffer{
+			protocolID:  offer.protocolID,
+			context:     slices.Clone(offer.context),
+			hash:        slices.Clone(offer.hash),
+			incarnation: slices.Clone(offer.incarnation),
 		}
 	}
-	slices.SortFunc(out, func(a, b link_solicit.SolicitEntry) int {
-		if a.ProtocolID != b.ProtocolID {
-			return strings.Compare(string(a.ProtocolID), string(b.ProtocolID))
+	slices.SortFunc(out, func(a, b solicitationOffer) int {
+		if cmp := bytes.Compare(a.hash, b.hash); cmp != 0 {
+			return cmp
 		}
-		return bytes.Compare(a.Context, b.Context)
+		if a.protocolID != b.protocolID {
+			return strings.Compare(string(a.protocolID), string(b.protocolID))
+		}
+		if cmp := bytes.Compare(a.context, b.context); cmp != 0 {
+			return cmp
+		}
+		return bytes.Compare(a.incarnation, b.incarnation)
 	})
 	return out
 }
 
-// solicitEntriesEqual returns true if two entry lists match pairwise.
-func solicitEntriesEqual(a, b []link_solicit.SolicitEntry) bool {
+// solicitationOffersEqual returns true if two offer lists match pairwise.
+func solicitationOffersEqual(a, b []solicitationOffer) bool {
 	if len(a) != len(b) {
 		return false
 	}
 	for i := range a {
-		if a[i].ProtocolID != b[i].ProtocolID || !bytes.Equal(a[i].Context, b[i].Context) {
+		if a[i].protocolID != b[i].protocolID ||
+			!bytes.Equal(a[i].context, b[i].context) ||
+			!bytes.Equal(a[i].hash, b[i].hash) ||
+			!bytes.Equal(a[i].incarnation, b[i].incarnation) {
 			return false
 		}
 	}
 	return true
+}
+
+// cloneSolicitationExchange deep-clones an exchange.
+func cloneSolicitationExchange(exchange *solicitationExchange) *solicitationExchange {
+	if exchange == nil {
+		return nil
+	}
+	return &solicitationExchange{
+		hashes:                    cloneHashes(exchange.hashes),
+		offers:                    cloneSolicitationOffers(exchange.offers),
+		supportsOfferIncarnations: exchange.supportsOfferIncarnations,
+		generation:                exchange.generation,
+		acknowledgedGeneration:    exchange.acknowledgedGeneration,
+	}
 }
 
 // cloneHashes deep-clones a hash list.
@@ -458,25 +655,47 @@ func cloneHashes(hashes [][]byte) [][]byte {
 	return out
 }
 
-// computeHashes computes sorted hashes for the given entries.
-func (c *Controller) computeHashes(ls *linkState, entries []link_solicit.SolicitEntry) [][]byte {
-	if len(entries) == 0 {
-		return nil
+// computeExchange computes the stable hashes and incarnated offers sent for a link.
+func (c *Controller) computeExchange(
+	ls *linkState,
+	offers []solicitationOffer,
+) *solicitationExchange {
+	for i := range offers {
+		offers[i].hash = link_solicit.ComputeProtocolHash(
+			ls.sessionID,
+			offers[i].protocolID,
+			offers[i].context,
+		)
 	}
-	hashes := link_solicit.ComputeProtocolHashes(ls.sessionID, entries)
-	if len(hashes) > int(c.maxHashes) {
-		hashes = hashes[:c.maxHashes]
+	offers = cloneSolicitationOffers(offers)
+	if len(offers) > int(c.maxHashes) {
+		offers = offers[:c.maxHashes]
 	}
-	return hashes
+
+	hashes := make([][]byte, len(offers))
+	for i := range offers {
+		hashes[i] = slices.Clone(offers[i].hash)
+	}
+	return &solicitationExchange{
+		hashes:                    hashes,
+		offers:                    offers,
+		supportsOfferIncarnations: true,
+	}
 }
 
-// resolveMatch finds SolicitProtocol directives that match a given hash
-// on a link and emits SolicitMountedStream values.
-func (c *Controller) resolveMatch(ls *linkState, hashBytes []byte, ms link.MountedStream) {
-	hashHex := hex.EncodeToString(hashBytes)
-
+// resolveMatch emits a stream only to the currently active local incarnation
+// bound to the current remote incarnation.
+func (c *Controller) resolveMatch(
+	ls *linkState,
+	match solicitationMatch,
+	ms link.MountedStream,
+) bool {
 	var matches []*solicitState
 	c.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		if !c.controlStreamLinkActiveLocked(ls) ||
+			!remoteExchangeContainsMatch(ls, match) {
+			return
+		}
 		for ss := range c.solicitations {
 			if pid := ss.dir.SolicitProtocolPeerID(); len(pid) != 0 && pid != ls.ml.GetRemotePeer() {
 				continue
@@ -490,46 +709,115 @@ func (c *Controller) resolveMatch(ls *linkState, hashBytes []byte, ms link.Mount
 				ss.dir.SolicitProtocolID(),
 				ss.dir.SolicitProtocolContext(),
 			)
-			if bytes.Equal(h, hashBytes) {
-				matches = append(matches, ss)
+			if !bytes.Equal(h, match.hash) {
+				continue
 			}
+			if match.incarnated && !bytes.Equal(ss.incarnation, match.localIncarnation) {
+				continue
+			}
+			matches = append(matches, ss)
 		}
 	})
 
+	var emitted bool
 	for _, ss := range matches {
 		sms := link_solicit.NewSolicitMountedStream(ms)
 		if _, ok := ss.handler.AddValue(sms); ok {
-			ls.le.WithField("hash", hashHex).Debug("emitted SolicitMountedStream value")
+			emitted = true
+			ls.le.WithField("hash", hex.EncodeToString(match.hash)).
+				Debug("emitted SolicitMountedStream value")
 		}
 	}
+	return emitted
 }
 
-// openSolicitedStream opens a solicited stream for a matched hash.
-func (c *Controller) openSolicitedStream(ctx context.Context, ls *linkState, hashBytes []byte) {
-	hashHex := hex.EncodeToString(hashBytes)
-	pid := protocol.ID(SolicitStreamPrefix + hashHex)
+// remoteExchangeContainsMatch reports whether the remote side still advertises
+// the incarnation bound into match. Caller must hold the broadcast lock.
+func remoteExchangeContainsMatch(ls *linkState, match solicitationMatch) bool {
+	if !match.incarnated {
+		return ls.remoteExchange == nil ||
+			!ls.remoteExchange.supportsOfferIncarnations
+	}
+	if ls.remoteExchange == nil || !ls.remoteExchange.supportsOfferIncarnations {
+		return false
+	}
+	for _, offer := range ls.remoteExchange.offers {
+		if bytes.Equal(offer.hash, match.hash) &&
+			bytes.Equal(offer.incarnation, match.remoteIncarnation) {
+			return true
+		}
+	}
+	return false
+}
+
+// openSolicitedStream opens a stream bound to one bilateral offer pair.
+func (c *Controller) openSolicitedStream(
+	ctx context.Context,
+	ls *linkState,
+	match solicitationMatch,
+) {
+	pid := protocol.ID(SolicitStreamPrefix + encodeSolicitationMatch(ls, match))
 
 	ms, err := ls.ml.OpenMountedStream(ctx, pid, stream.OpenOpts{})
 	if err != nil {
-		ls.le.WithError(err).WithField("hash", hashHex).Warn("failed to open solicited stream")
+		ls.le.WithError(err).WithField("hash", hex.EncodeToString(match.hash)).
+			Warn("failed to open solicited stream")
 		return
 	}
 
-	c.resolveMatch(ls, hashBytes, ms)
+	if !c.resolveMatch(ls, match, ms) {
+		ms.GetStream().Close()
+	}
+}
+
+// encodeSolicitationMatch returns the stream protocol suffix for a match.
+func encodeSolicitationMatch(ls *linkState, match solicitationMatch) string {
+	hashHex := hex.EncodeToString(match.hash)
+	if !match.incarnated {
+		return hashHex
+	}
+	lower, higher := match.localIncarnation, match.remoteIncarnation
+	if !ls.localIsLower {
+		lower, higher = higher, lower
+	}
+	return hashHex + ":" + hex.EncodeToString(lower) + ":" + hex.EncodeToString(higher)
+}
+
+// decodeSolicitationMatch parses a stream protocol suffix for the receiving side.
+func decodeSolicitationMatch(ls *linkState, encoded string) (solicitationMatch, error) {
+	parts := strings.Split(encoded, ":")
+	if len(parts) != 1 && len(parts) != 3 {
+		return solicitationMatch{}, errors.New("invalid solicitation match field count")
+	}
+	hash, err := hex.DecodeString(parts[0])
+	if err != nil || len(hash) != link_solicit.HashSize {
+		return solicitationMatch{}, errors.New("invalid solicitation protocol hash")
+	}
+	match := solicitationMatch{hash: hash}
+	if len(parts) == 1 {
+		return match, nil
+	}
+	lower, err := hex.DecodeString(parts[1])
+	if err != nil || len(lower) != solicitationIncarnationSize {
+		return solicitationMatch{}, errors.New("invalid lower solicitation incarnation")
+	}
+	higher, err := hex.DecodeString(parts[2])
+	if err != nil || len(higher) != solicitationIncarnationSize {
+		return solicitationMatch{}, errors.New("invalid higher solicitation incarnation")
+	}
+	match.incarnated = true
+	match.localIncarnation, match.remoteIncarnation = higher, lower
+	if ls.localIsLower {
+		match.localIncarnation, match.remoteIncarnation = lower, higher
+	}
+	return match, nil
 }
 
 // handleIncomingSolicitedStream routes an incoming solicited stream.
 func (c *Controller) handleIncomingSolicitedStream(
-	hashHex string,
+	encodedMatch string,
 	ms link.MountedStream,
 ) {
-	hashBytes, err := hex.DecodeString(hashHex)
-	if err != nil {
-		c.le.WithError(err).Warn("invalid solicited stream hash")
-		ms.GetStream().Close()
-		return
-	}
-
 	lnk := ms.GetLink()
 	uuid := lnk.GetLinkUUID()
 
@@ -544,7 +832,15 @@ func (c *Controller) handleIncomingSolicitedStream(
 		return
 	}
 
-	c.resolveMatch(ls, hashBytes, ms)
+	match, err := decodeSolicitationMatch(ls, encodedMatch)
+	if err != nil {
+		c.le.WithError(err).Warn("invalid solicited stream match")
+		ms.GetStream().Close()
+		return
+	}
+	if !c.resolveMatch(ls, match, ms) {
+		ms.GetStream().Close()
+	}
 }
 
 // runControlStream manages the control stream exchange for a link.
@@ -564,7 +860,7 @@ func (c *Controller) runControlStream(
 	defer cancelWatch()
 
 	// Read incoming exchanges in a goroutine.
-	remoteCh := make(chan [][]byte, 1)
+	remoteCh := make(chan *solicitationExchange, 1)
 	go func() {
 		defer close(remoteCh)
 		for {
@@ -573,12 +869,9 @@ func (c *Controller) runControlStream(
 				le.WithError(err).Debug("control stream read ended")
 				return
 			}
-			hashes := msg.GetProtocolHashes()
-			if len(hashes) > int(c.maxHashes) {
-				hashes = hashes[:c.maxHashes]
-			}
+			exchange := c.decodeExchange(&msg)
 			select {
-			case remoteCh <- hashes:
+			case remoteCh <- exchange:
 			case <-watchCtx.Done():
 				return
 			}
@@ -606,27 +899,43 @@ func (c *Controller) runControlStream(
 		}
 	}()
 
-	var localHashes [][]byte
+	var localExchange *solicitationExchange
+	var peerSupportsOfferIncarnations bool
+	sendLocalExchange := func(exchange *solicitationExchange) bool {
+		le.WithField("hash-count", len(exchange.hashes)).Debug("sending exchange")
+		if err := c.sendExchange(sess, exchange, peerSupportsOfferIncarnations); err != nil {
+			le.WithError(err).Debug("failed to send exchange")
+			return false
+		}
+		localExchange = exchange
+		return true
+	}
 	handleLocalWake := func() bool {
 		snap := c.currentControlStreamLocalSnapshot(ls)
 		if snap.linkRemoved {
 			return false
 		}
-		remoteHashes, linkRemoved := c.currentControlStreamRemoteHashes(ls)
+		remoteExchange, linkRemoved := c.currentControlStreamRemoteExchange(ls)
 		if linkRemoved {
 			return false
 		}
-		newHashes := c.computeHashes(ls, snap.entries)
-		if !slices.EqualFunc(localHashes, newHashes, bytes.Equal) {
-			le.WithField("hash-count", len(newHashes)).Debug("sending exchange")
-			localHashes = newHashes
-			if err := c.sendExchange(sess, localHashes); err != nil {
-				le.WithError(err).Debug("failed to send exchange")
+		newExchange := c.computeExchange(ls, snap.offers)
+		newExchange.generation = 1
+		if localExchange != nil {
+			newExchange.generation = localExchange.generation
+			newExchange.acknowledgedGeneration = localExchange.acknowledgedGeneration
+			if !solicitationOfferSetsEqual(localExchange, newExchange) {
+				newExchange.generation++
+			}
+		}
+		c.pruneRetiredMatches(ls, newExchange, remoteExchange)
+		if !solicitationExchangesEqual(localExchange, newExchange) {
+			if !sendLocalExchange(newExchange) {
 				return false
 			}
 		}
-		if remoteHashes != nil {
-			c.evaluateMatches(ctx, ls, localHashes, remoteHashes)
+		if remoteExchange != nil {
+			c.evaluateMatches(ctx, ls, localExchange, remoteExchange)
 		}
 		return true
 	}
@@ -659,55 +968,254 @@ func (c *Controller) runControlStream(
 			if !handleLocalWake() {
 				return
 			}
-		case remoteHashes, ok := <-remoteCh:
+		case remoteExchange, ok := <-remoteCh:
 			if !ok {
 				return
 			}
-			le.WithField("remote-hash-count", len(remoteHashes)).Debug("received remote exchange")
-			if !c.setControlStreamRemoteHashes(ls, remoteHashes) {
+			le.WithField("remote-hash-count", len(remoteExchange.hashes)).
+				Debug("received remote exchange")
+			if !c.setControlStreamRemoteExchange(ls, remoteExchange) {
 				return
 			}
-			c.evaluateMatches(ctx, ls, localHashes, remoteHashes)
+			c.pruneRetiredMatches(ls, localExchange, remoteExchange)
+			peerSupportsOfferIncarnations = remoteExchange.supportsOfferIncarnations
+			if remoteExchange.supportsOfferIncarnations &&
+				localExchange.supportsOfferIncarnations &&
+				localExchange.acknowledgedGeneration != remoteExchange.generation {
+				acknowledged := cloneSolicitationExchange(localExchange)
+				acknowledged.acknowledgedGeneration = remoteExchange.generation
+				if !sendLocalExchange(acknowledged) {
+					return
+				}
+			}
+			c.evaluateMatches(ctx, ls, localExchange, remoteExchange)
 		}
 	}
 }
 
-// evaluateMatches finds the intersection and opens streams for new matches.
+// pruneRetiredMatches removes incarnated suppression and pending opens after
+// either offer leaves the current bilateral set. Legacy hash suppression stays
+// for the lifetime of the physical link.
+func (c *Controller) pruneRetiredMatches(
+	ls *linkState,
+	local, remote *solicitationExchange,
+) {
+	active := make(map[string]struct{})
+	if local != nil && remote != nil &&
+		local.supportsOfferIncarnations && remote.supportsOfferIncarnations {
+		for _, match := range findOfferPairs(local.offers, remote.offers) {
+			active[encodeSolicitationMatch(ls, match)] = struct{}{}
+		}
+	}
+
+	var retired []solicitationOpenKey
+	c.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		for matchKey := range ls.matched {
+			if strings.Count(matchKey, ":") != 2 {
+				continue
+			}
+			if _, exists := active[matchKey]; exists {
+				continue
+			}
+			delete(ls.matched, matchKey)
+			openKey := solicitationOpenKey{
+				linkUUID: ls.ml.GetLinkUUID(),
+				match:    matchKey,
+			}
+			if _, exists := c.opens[openKey]; exists {
+				delete(c.opens, openKey)
+				retired = append(retired, openKey)
+			}
+		}
+	})
+	for _, key := range retired {
+		c.openRoutines.RemoveKey(key)
+	}
+}
+
+// evaluateMatches finds the intersection and opens each bilateral incarnation once.
 func (c *Controller) evaluateMatches(
 	ctx context.Context,
 	ls *linkState,
-	localHashes, remoteHashes [][]byte,
+	local, remote *solicitationExchange,
 ) {
-	matches := link_solicit.FindMatchingHashes(localHashes, remoteHashes)
-	ls.le.WithField("local-count", len(localHashes)).
-		WithField("remote-count", len(remoteHashes)).
+	if local == nil || remote == nil {
+		return
+	}
+	matches := findSolicitationMatches(local, remote)
+	ls.le.WithField("local-count", len(local.hashes)).
+		WithField("remote-count", len(remote.hashes)).
 		WithField("match-count", len(matches)).
 		Debug("evaluated matches")
-	for _, h := range matches {
-		hashHex := hex.EncodeToString(h)
-		var exists bool
+	for _, match := range matches {
+		matchKey := encodeSolicitationMatch(ls, match)
+		var exists, linkActive bool
 		c.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
-			_, exists = ls.matched[hashHex]
+			linkActive = c.controlStreamLinkActiveLocked(ls)
+			if !linkActive {
+				return
+			}
+			_, exists = ls.matched[matchKey]
 			if !exists {
-				ls.matched[hashHex] = struct{}{}
+				ls.matched[matchKey] = struct{}{}
+				if ls.localIsLower {
+					key := solicitationOpenKey{
+						linkUUID: ls.ml.GetLinkUUID(),
+						match:    matchKey,
+					}
+					c.opens[key] = solicitationOpen{ls: ls, match: match}
+				}
 			}
 		})
-		if exists {
+		if !linkActive || exists {
 			continue
 		}
 
 		if ls.localIsLower {
-			go c.openSolicitedStream(ctx, ls, h)
+			key := solicitationOpenKey{
+				linkUUID: ls.ml.GetLinkUUID(),
+				match:    matchKey,
+			}
+			c.startOpenRoutine(key)
 		}
 	}
 }
 
+// startOpenRoutine registers an opening and removes the keyed entry if its
+// metadata or link was retired before registration completed.
+func (c *Controller) startOpenRoutine(key solicitationOpenKey) {
+	c.openRoutines.SetKey(key, true)
+
+	var retained bool
+	c.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		open, exists := c.opens[key]
+		retained = exists && c.links[key.linkUUID] == open.ls
+	})
+	if !retained {
+		c.openRoutines.RemoveKey(key)
+	}
+}
+
 // sendExchange sends a SolicitationExchange message.
-func (c *Controller) sendExchange(sess *stream_packet.Session, hashes [][]byte) error {
+func (c *Controller) sendExchange(
+	sess *stream_packet.Session,
+	exchange *solicitationExchange,
+	sendOffers bool,
+) error {
 	msg := &link_solicit.SolicitationExchange{
-		ProtocolHashes: hashes,
+		ProtocolHashes:            exchange.hashes,
+		SupportsOfferIncarnations: true,
+		Generation:                exchange.generation,
+		AcknowledgedGeneration:    exchange.acknowledgedGeneration,
+	}
+	if sendOffers {
+		msg.ProtocolHashes = nil
+		msg.Offers = make([]*link_solicit.SolicitationOffer, len(exchange.offers))
+		for i, offer := range exchange.offers {
+			msg.Offers[i] = &link_solicit.SolicitationOffer{
+				ProtocolHash: slices.Clone(offer.hash),
+				Incarnation:  slices.Clone(offer.incarnation),
+			}
+		}
 	}
 	return sess.SendMsg(msg)
+}
+
+// decodeExchange validates and normalizes a received exchange.
+func (c *Controller) decodeExchange(
+	msg *link_solicit.SolicitationExchange,
+) *solicitationExchange {
+	hashes := cloneHashes(msg.GetProtocolHashes())
+	if len(hashes) > int(c.maxHashes) {
+		hashes = hashes[:c.maxHashes]
+	}
+	link_solicit.SortHashes(hashes)
+
+	offers := make([]solicitationOffer, 0, len(msg.GetOffers()))
+	for _, wireOffer := range msg.GetOffers() {
+		if len(wireOffer.GetProtocolHash()) != link_solicit.HashSize ||
+			len(wireOffer.GetIncarnation()) != solicitationIncarnationSize {
+			continue
+		}
+		offers = append(offers, solicitationOffer{
+			hash:        slices.Clone(wireOffer.GetProtocolHash()),
+			incarnation: slices.Clone(wireOffer.GetIncarnation()),
+		})
+	}
+	offers = cloneSolicitationOffers(offers)
+	if len(offers) > int(c.maxHashes) {
+		offers = offers[:c.maxHashes]
+	}
+	if len(hashes) == 0 && msg.GetSupportsOfferIncarnations() {
+		hashes = make([][]byte, len(offers))
+		for i := range offers {
+			hashes[i] = slices.Clone(offers[i].hash)
+		}
+	}
+	return &solicitationExchange{
+		hashes:                    hashes,
+		offers:                    offers,
+		supportsOfferIncarnations: msg.GetSupportsOfferIncarnations(),
+		generation:                msg.GetGeneration(),
+		acknowledgedGeneration:    msg.GetAcknowledgedGeneration(),
+	}
+}
+
+// solicitationExchangesEqual reports whether exchanges advertise identical state.
+func solicitationExchangesEqual(a, b *solicitationExchange) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.supportsOfferIncarnations == b.supportsOfferIncarnations &&
+		a.generation == b.generation &&
+		a.acknowledgedGeneration == b.acknowledgedGeneration &&
+		slices.EqualFunc(a.hashes, b.hashes, bytes.Equal) &&
+		solicitationOffersEqual(a.offers, b.offers)
+}
+
+// solicitationOfferSetsEqual reports whether exchanges advertise the same offers.
+func solicitationOfferSetsEqual(a, b *solicitationExchange) bool {
+	return slices.EqualFunc(a.hashes, b.hashes, bytes.Equal) &&
+		solicitationOffersEqual(a.offers, b.offers)
+}
+
+// findSolicitationMatches returns incarnated matches when both peers support
+// them and stable-hash matches for legacy peers.
+func findSolicitationMatches(
+	local, remote *solicitationExchange,
+) []solicitationMatch {
+	if !local.supportsOfferIncarnations || !remote.supportsOfferIncarnations {
+		hashes := link_solicit.FindMatchingHashes(local.hashes, remote.hashes)
+		matches := make([]solicitationMatch, len(hashes))
+		for i, hash := range hashes {
+			matches[i] = solicitationMatch{hash: hash}
+		}
+		return matches
+	}
+	if local.acknowledgedGeneration != remote.generation ||
+		remote.acknowledgedGeneration != local.generation {
+		return nil
+	}
+	return findOfferPairs(local.offers, remote.offers)
+}
+
+// findOfferPairs returns every matching stable hash bound to both incarnations.
+func findOfferPairs(local, remote []solicitationOffer) []solicitationMatch {
+	var matches []solicitationMatch
+	for _, localOffer := range local {
+		for _, remoteOffer := range remote {
+			if !bytes.Equal(localOffer.hash, remoteOffer.hash) {
+				continue
+			}
+			matches = append(matches, solicitationMatch{
+				hash:              slices.Clone(localOffer.hash),
+				localIncarnation:  slices.Clone(localOffer.incarnation),
+				remoteIncarnation: slices.Clone(remoteOffer.incarnation),
+				incarnated:        true,
+			})
+		}
+	}
+	return matches
 }
 
 // GetControllerInfo returns information about the controller.

--- a/net/link/solicit/controller/controller_test.go
+++ b/net/link/solicit/controller/controller_test.go
@@ -3,8 +3,11 @@ package link_solicit_controller
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
+	"io"
 	"net"
 	"slices"
+	"strconv"
 	"testing"
 	"time"
 
@@ -128,6 +131,28 @@ func newTestResolverHandler() *testResolverHandler {
 	return &testResolverHandler{values: make(chan directive.Value, 8)}
 }
 
+// legacySolicitationExchange constructs a stable-hash exchange from an old peer.
+func legacySolicitationExchange(hashes [][]byte) *solicitationExchange {
+	return &solicitationExchange{hashes: cloneHashes(hashes)}
+}
+
+// incarnatedSolicitationExchange constructs one synchronized upgraded offer.
+func incarnatedSolicitationExchange(
+	hash, incarnation []byte,
+	generation, acknowledgedGeneration uint64,
+) *solicitationExchange {
+	return &solicitationExchange{
+		hashes: [][]byte{slices.Clone(hash)},
+		offers: []solicitationOffer{{
+			hash:        slices.Clone(hash),
+			incarnation: slices.Clone(incarnation),
+		}},
+		supportsOfferIncarnations: true,
+		generation:                generation,
+		acknowledgedGeneration:    acknowledgedGeneration,
+	}
+}
+
 func (h *testResolverHandler) AddValue(val directive.Value) (uint32, bool) {
 	h.values <- val
 	return uint32(len(h.values)), true
@@ -236,6 +261,8 @@ func newTestSolicitController(t *testing.T) *Controller {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
+	c.openRoutines.SetContext(t.Context(), true)
+	t.Cleanup(c.openRoutines.ClearContext)
 	return c
 }
 
@@ -322,8 +349,8 @@ func TestControlStreamLocalSnapshotWatchDynamicAddRemove(t *testing.T) {
 	}()
 
 	initial := recvLocalSnapshot(t, snapCh)
-	if initial.linkRemoved || len(initial.entries) != 0 {
-		t.Fatalf("initial snapshot removed=%v entries=%d", initial.linkRemoved, len(initial.entries))
+	if initial.linkRemoved || len(initial.offers) != 0 {
+		t.Fatalf("initial snapshot removed=%v offers=%d", initial.linkRemoved, len(initial.offers))
 	}
 
 	ss := &solicitState{
@@ -334,11 +361,11 @@ func TestControlStreamLocalSnapshotWatchDynamicAddRemove(t *testing.T) {
 		broadcast()
 	})
 	added := recvLocalSnapshot(t, snapCh)
-	if len(added.entries) != 1 || added.entries[0].ProtocolID != protocol.ID("test/dynamic") {
-		t.Fatalf("added entries = %#v", added.entries)
+	if len(added.offers) != 1 || added.offers[0].protocolID != protocol.ID("test/dynamic") {
+		t.Fatalf("added offers = %#v", added.offers)
 	}
-	if string(added.entries[0].Context) != "ctx" {
-		t.Fatalf("added context = %q", added.entries[0].Context)
+	if string(added.offers[0].context) != "ctx" {
+		t.Fatalf("added context = %q", added.offers[0].context)
 	}
 
 	c.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
@@ -346,8 +373,8 @@ func TestControlStreamLocalSnapshotWatchDynamicAddRemove(t *testing.T) {
 		broadcast()
 	})
 	removed := recvLocalSnapshot(t, snapCh)
-	if removed.linkRemoved || len(removed.entries) != 0 {
-		t.Fatalf("removed snapshot removed=%v entries=%d", removed.linkRemoved, len(removed.entries))
+	if removed.linkRemoved || len(removed.offers) != 0 {
+		t.Fatalf("removed snapshot removed=%v offers=%d", removed.linkRemoved, len(removed.offers))
 	}
 
 	cancel()
@@ -440,18 +467,19 @@ func TestControlStreamLocalSnapshotRemoteHashesRefresh(t *testing.T) {
 	c.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
 		snap = c.snapshotControlStreamLocalLocked(ls)
 	})
-	if snap.linkRemoved || len(snap.entries) != 0 {
-		t.Fatalf("local snapshot removed=%v entries=%d", snap.linkRemoved, len(snap.entries))
+	if snap.linkRemoved || len(snap.offers) != 0 {
+		t.Fatalf("local snapshot removed=%v offers=%d", snap.linkRemoved, len(snap.offers))
 	}
 
-	if !c.setControlStreamRemoteHashes(ls, hashes) {
+	remote := legacySolicitationExchange(hashes)
+	if !c.setControlStreamRemoteExchange(ls, remote) {
 		t.Fatal("link should accept remote hashes")
 	}
-	current, linkRemoved := c.currentControlStreamRemoteHashes(ls)
+	current, linkRemoved := c.currentControlStreamRemoteExchange(ls)
 	if linkRemoved {
 		t.Fatal("link should still exist")
 	}
-	if !slices.EqualFunc(current, hashes, bytes.Equal) {
+	if !slices.EqualFunc(current.hashes, hashes, bytes.Equal) {
 		t.Fatalf("current remote hashes did not refresh")
 	}
 
@@ -459,7 +487,7 @@ func TestControlStreamLocalSnapshotRemoteHashesRefresh(t *testing.T) {
 		delete(c.links, ls.ml.GetLinkUUID())
 		broadcast()
 	})
-	if c.setControlStreamRemoteHashes(ls, hashes) {
+	if c.setControlStreamRemoteExchange(ls, remote) {
 		t.Fatal("removed link accepted remote hashes")
 	}
 }
@@ -480,8 +508,8 @@ func TestControlStreamLocalSnapshotRefreshesQueuedSolicitationState(t *testing.T
 	c.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
 		queued = c.snapshotControlStreamLocalLocked(ls)
 	})
-	if len(queued.entries) != 1 {
-		t.Fatalf("queued entries = %d, want 1", len(queued.entries))
+	if len(queued.offers) != 1 {
+		t.Fatalf("queued offers = %d, want 1", len(queued.offers))
 	}
 
 	c.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
@@ -489,8 +517,8 @@ func TestControlStreamLocalSnapshotRefreshesQueuedSolicitationState(t *testing.T
 		broadcast()
 	})
 	current := c.currentControlStreamLocalSnapshot(ls)
-	if current.linkRemoved || len(current.entries) != 0 {
-		t.Fatalf("current snapshot removed=%v entries=%d", current.linkRemoved, len(current.entries))
+	if current.linkRemoved || len(current.offers) != 0 {
+		t.Fatalf("current snapshot removed=%v offers=%d", current.linkRemoved, len(current.offers))
 	}
 }
 
@@ -519,13 +547,14 @@ func TestControlStreamLocalSnapshotRejectsReplacedLink(t *testing.T) {
 		}
 	})
 
-	if _, linkRemoved := c.currentControlStreamRemoteHashes(ls); !linkRemoved {
+	if _, linkRemoved := c.currentControlStreamRemoteExchange(ls); !linkRemoved {
 		t.Fatal("replaced link should hide old remote hashes")
 	}
-	if c.setControlStreamRemoteHashes(ls, hashes) {
+	remote := legacySolicitationExchange(hashes)
+	if c.setControlStreamRemoteExchange(ls, remote) {
 		t.Fatal("replaced link accepted old remote hashes")
 	}
-	if !c.setControlStreamRemoteHashes(replacement, hashes) {
+	if !c.setControlStreamRemoteExchange(replacement, remote) {
 		t.Fatal("replacement link should accept remote hashes")
 	}
 }
@@ -551,19 +580,255 @@ func TestEvaluateMatchesSuppressesDuplicateOpens(t *testing.T) {
 		broadcast()
 	})
 
-	c.evaluateMatches(ctx, ls, hashes, hashes)
+	exchange := legacySolicitationExchange(hashes)
+	c.evaluateMatches(ctx, ls, exchange, exchange)
 	recvTestValue(t, ls.ml.(*testMountedLink).openCh, "opened protocol")
 	recvTestValue(t, handler.values, "solicit value")
 	if len(ls.matched) != 1 {
 		t.Fatalf("matched count = %d, want 1", len(ls.matched))
 	}
 
-	c.evaluateMatches(ctx, ls, hashes, hashes)
+	c.evaluateMatches(ctx, ls, exchange, exchange)
 	if len(ls.matched) != 1 {
 		t.Fatalf("matched count after duplicate = %d, want 1", len(ls.matched))
 	}
 	assertNoTestValue(t, ls.ml.(*testMountedLink).openCh, "duplicate opened protocol")
 	assertNoTestValue(t, handler.values, "duplicate solicit value")
+}
+
+// TestEvaluateMatchesStreamCloseDoesNotRearmIncarnatedPair verifies that stream
+// lifetime does not control offer-pair suppression.
+func TestEvaluateMatchesStreamCloseDoesNotRearmIncarnatedPair(t *testing.T) {
+	c := newTestSolicitController(t)
+	ls := newTestLinkState(peer.ID("a"), peer.ID("b"))
+	handler := newTestResolverHandler()
+	entry := link_solicit.SolicitEntry{
+		ProtocolID: protocol.ID("test/incarnated"),
+		Context:    []byte("ctx"),
+	}
+	hash := link_solicit.ComputeProtocolHash(ls.sessionID, entry.ProtocolID, entry.Context)
+	localIncarnation := bytes.Repeat([]byte{1}, solicitationIncarnationSize)
+	remoteIncarnation := bytes.Repeat([]byte{2}, solicitationIncarnationSize)
+	ss := &solicitState{
+		dir:         link_solicit.NewSolicitProtocol(entry.ProtocolID, entry.Context, "", 0),
+		handler:     handler,
+		incarnation: localIncarnation,
+	}
+	local := incarnatedSolicitationExchange(hash, localIncarnation, 2, 3)
+	remote := incarnatedSolicitationExchange(hash, remoteIncarnation, 3, 2)
+	c.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		c.links[ls.ml.GetLinkUUID()] = ls
+		c.solicitations[ss] = struct{}{}
+		ls.remoteExchange = remote
+		broadcast()
+	})
+
+	c.evaluateMatches(t.Context(), ls, local, remote)
+	recvTestValue(t, ls.ml.(*testMountedLink).openCh, "opened incarnated protocol")
+	value := recvTestValue(t, handler.values, "incarnated solicit value")
+	sms := value.(link_solicit.SolicitMountedStream)
+	ms, _, err := sms.AcceptMountedStream()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ms.GetStream().Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	c.evaluateMatches(t.Context(), ls, local, remote)
+	assertNoTestValue(t, ls.ml.(*testMountedLink).openCh, "reopened closed protocol")
+	assertNoTestValue(t, handler.values, "replacement for closed stream")
+}
+
+// TestRetainedLinkPrunesRetiredIncarnationPairs verifies bounded suppression
+// across repeated local and remote offer rotations.
+func TestRetainedLinkPrunesRetiredIncarnationPairs(t *testing.T) {
+	c := newTestSolicitController(t)
+	ls := newTestLinkState(peer.ID("a"), peer.ID("b"))
+	handler := newTestResolverHandler()
+	entry := link_solicit.SolicitEntry{
+		ProtocolID: protocol.ID("test/rotating-incarnations"),
+		Context:    []byte("ctx"),
+	}
+	hash := link_solicit.ComputeProtocolHash(ls.sessionID, entry.ProtocolID, entry.Context)
+	ss := &solicitState{
+		dir:     link_solicit.NewSolicitProtocol(entry.ProtocolID, entry.Context, "", 0),
+		handler: handler,
+	}
+	c.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		c.links[ls.ml.GetLinkUUID()] = ls
+		c.solicitations[ss] = struct{}{}
+		ls.matched[hex.EncodeToString(hash)] = struct{}{}
+		broadcast()
+	})
+
+	for generation := uint64(1); generation <= 8; generation++ {
+		localIncarnation := bytes.Repeat([]byte{byte(generation)}, solicitationIncarnationSize)
+		remoteIncarnation := bytes.Repeat([]byte{byte(generation + 16)}, solicitationIncarnationSize)
+		local := incarnatedSolicitationExchange(
+			hash,
+			localIncarnation,
+			generation,
+			generation,
+		)
+		remote := incarnatedSolicitationExchange(
+			hash,
+			remoteIncarnation,
+			generation,
+			generation,
+		)
+		c.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+			ss.incarnation = localIncarnation
+			broadcast()
+		})
+		if generation > 1 {
+			previousRemote, removed := c.currentControlStreamRemoteExchange(ls)
+			if removed {
+				t.Fatal("retained link was removed")
+			}
+			c.pruneRetiredMatches(ls, local, previousRemote)
+			if len(ls.matched) != 1 {
+				t.Fatalf("generation %d local rotation retained %d matches, want legacy only", generation, len(ls.matched))
+			}
+		}
+		c.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+			ls.remoteExchange = remote
+			broadcast()
+		})
+
+		c.pruneRetiredMatches(ls, local, remote)
+		c.evaluateMatches(t.Context(), ls, local, remote)
+		recvTestValue(t, ls.ml.(*testMountedLink).openCh, "rotated opened protocol")
+		recvTestValue(t, handler.values, "rotated solicitation value")
+		if len(ls.matched) != 2 {
+			t.Fatalf("generation %d matched entries = %d, want legacy plus current pair", generation, len(ls.matched))
+		}
+	}
+}
+
+// TestPruneRetiredMatchRemovesOpenBeforeRoutineStarts verifies withdrawal
+// cleanup when the keyed manager has no running context.
+func TestPruneRetiredMatchRemovesOpenBeforeRoutineStarts(t *testing.T) {
+	c, err := NewController(logrus.NewEntry(logrus.New()), &Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ls := newTestLinkState(peer.ID("a"), peer.ID("b"))
+	hash := link_solicit.ComputeProtocolHash(ls.sessionID, protocol.ID("test/pending"), nil)
+	localIncarnation := bytes.Repeat([]byte{1}, solicitationIncarnationSize)
+	remoteIncarnation := bytes.Repeat([]byte{2}, solicitationIncarnationSize)
+	match := solicitationMatch{
+		hash:              hash,
+		localIncarnation:  localIncarnation,
+		remoteIncarnation: remoteIncarnation,
+		incarnated:        true,
+	}
+	matchKey := encodeSolicitationMatch(ls, match)
+	openKey := solicitationOpenKey{linkUUID: ls.ml.GetLinkUUID(), match: matchKey}
+	c.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		c.links[ls.ml.GetLinkUUID()] = ls
+		ls.matched[matchKey] = struct{}{}
+		c.opens[openKey] = solicitationOpen{ls: ls, match: match}
+		broadcast()
+	})
+	c.openRoutines.SetKey(openKey, true)
+
+	replacement := bytes.Repeat([]byte{3}, solicitationIncarnationSize)
+	local := incarnatedSolicitationExchange(hash, replacement, 2, 2)
+	remote := incarnatedSolicitationExchange(hash, replacement, 2, 2)
+	c.pruneRetiredMatches(ls, local, remote)
+
+	if len(ls.matched) != 0 {
+		t.Fatalf("matched entries = %d, want 0", len(ls.matched))
+	}
+	c.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		if _, exists := c.opens[openKey]; exists {
+			t.Fatal("retired open metadata remains")
+		}
+	})
+	if _, exists := c.openRoutines.GetKey(openKey); exists {
+		t.Fatal("retired open routine remains")
+	}
+}
+
+// TestStartOpenRoutineRejectsLinkRemovedBeforeRegistration covers link removal
+// between pending-open publication and keyed registration.
+func TestStartOpenRoutineRejectsLinkRemovedBeforeRegistration(t *testing.T) {
+	c, err := NewController(logrus.NewEntry(logrus.New()), &Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ls := newTestLinkState(peer.ID("a"), peer.ID("b"))
+	match := solicitationMatch{
+		hash:              bytes.Repeat([]byte{1}, link_solicit.HashSize),
+		localIncarnation:  bytes.Repeat([]byte{2}, solicitationIncarnationSize),
+		remoteIncarnation: bytes.Repeat([]byte{3}, solicitationIncarnationSize),
+		incarnated:        true,
+	}
+	matchKey := encodeSolicitationMatch(ls, match)
+	openKey := solicitationOpenKey{linkUUID: ls.ml.GetLinkUUID(), match: matchKey}
+	c.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		ls.refCount = 1
+		c.links[ls.ml.GetLinkUUID()] = ls
+		ls.matched[matchKey] = struct{}{}
+		c.opens[openKey] = solicitationOpen{ls: ls, match: match}
+		broadcast()
+	})
+	c.removeLink(ls.ml.GetLinkUUID())
+	c.startOpenRoutine(openKey)
+
+	c.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		if _, exists := c.opens[openKey]; exists {
+			t.Fatal("removed link retained open metadata")
+		}
+	})
+	if _, exists := c.openRoutines.GetKey(openKey); exists {
+		t.Fatal("removed link retained open routine")
+	}
+}
+
+// TestIncomingSolicitedStreamRejectsStaleIncarnation verifies both stale-pair
+// and upgraded-peer downgrade rejection.
+func TestIncomingSolicitedStreamRejectsStaleIncarnation(t *testing.T) {
+	c := newTestSolicitController(t)
+	ls := newTestLinkState(peer.ID("b"), peer.ID("a"))
+	handler := newTestResolverHandler()
+	entry := link_solicit.SolicitEntry{
+		ProtocolID: protocol.ID("test/stale-incarnation"),
+		Context:    []byte("ctx"),
+	}
+	hash := link_solicit.ComputeProtocolHash(ls.sessionID, entry.ProtocolID, entry.Context)
+	lowerIncarnation := bytes.Repeat([]byte{1}, solicitationIncarnationSize)
+	higherIncarnation := bytes.Repeat([]byte{2}, solicitationIncarnationSize)
+	ss := &solicitState{
+		dir:         link_solicit.NewSolicitProtocol(entry.ProtocolID, entry.Context, "", 0),
+		handler:     handler,
+		incarnation: higherIncarnation,
+	}
+	remote := incarnatedSolicitationExchange(hash, lowerIncarnation, 3, 2)
+	c.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		c.links[ls.ml.GetLinkUUID()] = ls
+		c.solicitations[ss] = struct{}{}
+		ls.remoteExchange = remote
+		broadcast()
+	})
+	newStream := func() link.MountedStream {
+		return &testMountedStream{link: ls.ml}
+	}
+
+	staleLower := bytes.Repeat([]byte{3}, solicitationIncarnationSize)
+	stalePair := hex.EncodeToString(hash) + ":" +
+		hex.EncodeToString(staleLower) + ":" + hex.EncodeToString(higherIncarnation)
+	c.handleIncomingSolicitedStream(stalePair, newStream())
+	assertNoTestValue(t, handler.values, "stale incarnation stream")
+
+	c.handleIncomingSolicitedStream(hex.EncodeToString(hash), newStream())
+	assertNoTestValue(t, handler.values, "hash-only stream from upgraded peer")
+
+	currentPair := hex.EncodeToString(hash) + ":" +
+		hex.EncodeToString(lowerIncarnation) + ":" + hex.EncodeToString(higherIncarnation)
+	c.handleIncomingSolicitedStream(currentPair, newStream())
+	recvTestValue(t, handler.values, "current incarnation stream")
 }
 
 func TestEvaluateMatchesHigherPeerDoesNotOpenStream(t *testing.T) {
@@ -587,7 +852,8 @@ func TestEvaluateMatchesHigherPeerDoesNotOpenStream(t *testing.T) {
 		broadcast()
 	})
 
-	c.evaluateMatches(ctx, ls, hashes, hashes)
+	exchange := legacySolicitationExchange(hashes)
+	c.evaluateMatches(ctx, ls, exchange, exchange)
 	if len(ls.matched) != 1 {
 		t.Fatalf("matched count = %d, want 1", len(ls.matched))
 	}
@@ -610,6 +876,7 @@ func TestControlStreamSendsFullHashSetAfterLocalChange(t *testing.T) {
 	defer localConn.Close()
 	defer remoteConn.Close()
 
+	maxMessageSize := maxExchangeMessageSize(c.maxHashes)
 	localSess := stream_packet.NewSession(localConn, maxMessageSize)
 	remoteSess := stream_packet.NewSession(remoteConn, maxMessageSize)
 	done := make(chan struct{})
@@ -660,6 +927,48 @@ func TestControlStreamSendsFullHashSetAfterLocalChange(t *testing.T) {
 	<-done
 }
 
+// TestControlStreamMaxExchangeFitsPacketBound verifies the configured offer
+// limit fits through the upgraded packet codec.
+func TestControlStreamMaxExchangeFitsPacketBound(t *testing.T) {
+	c := newTestSolicitController(t)
+	ls := newTestLinkState(peer.ID("a"), peer.ID("b"))
+	offers := make([]solicitationOffer, c.maxHashes)
+	for i := range offers {
+		offers[i] = solicitationOffer{
+			protocolID:  protocol.ID(strconv.Itoa(i)),
+			incarnation: bytes.Repeat([]byte{byte(i)}, solicitationIncarnationSize),
+		}
+	}
+	exchange := c.computeExchange(ls, offers)
+	exchange.generation = 1
+	exchange.acknowledgedGeneration = 1
+
+	localConn, remoteConn := net.Pipe()
+	defer localConn.Close()
+	defer remoteConn.Close()
+	maxMessageSize := maxExchangeMessageSize(c.maxHashes)
+	localSess := stream_packet.NewSession(localConn, maxMessageSize)
+	remoteSess := stream_packet.NewSession(remoteConn, maxMessageSize)
+	sendErr := make(chan error, 1)
+	go func() {
+		sendErr <- c.sendExchange(localSess, exchange, true)
+	}()
+
+	var received link_solicit.SolicitationExchange
+	if err := remoteSess.RecvMsg(&received); err != nil {
+		t.Fatal(err)
+	}
+	if err := recvTestValue(t, sendErr, "max exchange send"); err != nil {
+		t.Fatal(err)
+	}
+	if len(received.GetProtocolHashes()) != 0 {
+		t.Fatalf("protocol hashes = %d, want 0 in upgraded exchange", len(received.GetProtocolHashes()))
+	}
+	if len(received.GetOffers()) != int(c.maxHashes) {
+		t.Fatalf("offers = %d, want %d", len(received.GetOffers()), c.maxHashes)
+	}
+}
+
 func recvSolicitationExchange(t *testing.T, sess *stream_packet.Session) *link_solicit.SolicitationExchange {
 	t.Helper()
 
@@ -680,10 +989,11 @@ func recvSolicitationExchange(t *testing.T, sess *stream_packet.Session) *link_s
 	return nil
 }
 
-// TestSolicitProtocolMatch tests that two peers both soliciting the same
-// protocol get a SolicitMountedStream value.
-func TestSolicitProtocolMatch(t *testing.T) {
-	ctx := t.Context()
+// TestSolicitProtocolRestartsOnRetainedLink verifies that restarting both
+// consumers establishes a fresh stream over the existing link.
+func TestSolicitProtocolRestartsOnRetainedLink(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
 
 	// Set up two testbeds with inproc transport and solicitation.
 	tb1 := buildTestbed(t, ctx)
@@ -712,7 +1022,7 @@ func TestSolicitProtocolMatch(t *testing.T) {
 
 	// Establish a link.
 	pid1 := tp1.GetPeerID()
-	_, lnkRel, err := link.EstablishLinkWithPeerEx(ctx, tb2.Bus, "", pid1, false)
+	heldLink, lnkRel, err := link.EstablishLinkWithPeerEx(ctx, tb2.Bus, "", pid1, false)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -729,75 +1039,93 @@ func TestSolicitProtocolMatch(t *testing.T) {
 		err error
 	}
 
-	ch1 := make(chan result, 1)
-	ch2 := make(chan result, 1)
+	runRound := func(marker string) (directive.Reference, directive.Reference, [2]uint64) {
+		t.Helper()
 
-	go func() {
-		sms, _, ref, err := link_solicit.ExSolicitProtocol(ctx, tb1.Bus, testProto, nil, "", 0)
-		ch1 <- result{sms, ref, err}
-	}()
-	go func() {
-		sms, _, ref, err := link_solicit.ExSolicitProtocol(ctx, tb2.Bus, testProto, nil, "", 0)
-		ch2 <- result{sms, ref, err}
-	}()
+		ch1 := make(chan result, 1)
+		ch2 := make(chan result, 1)
+		go func() {
+			sms, _, ref, err := link_solicit.ExSolicitProtocol(ctx, tb1.Bus, testProto, nil, "", 0)
+			ch1 <- result{sms, ref, err}
+		}()
+		go func() {
+			sms, _, ref, err := link_solicit.ExSolicitProtocol(ctx, tb2.Bus, testProto, nil, "", 0)
+			ch2 <- result{sms, ref, err}
+		}()
 
-	r1 := <-ch1
-	if r1.err != nil {
-		t.Fatalf("peer 1 solicit error: %v", r1.err)
-	}
-	defer r1.ref.Release()
+		await := func(ch <-chan result, peerNum int) result {
+			select {
+			case res := <-ch:
+				if res.err != nil {
+					t.Fatalf("peer %d solicit error: %v", peerNum, res.err)
+				}
+				return res
+			case <-ctx.Done():
+				t.Fatalf("peer %d solicitation did not resolve: %v", peerNum, ctx.Err())
+			}
+			return result{}
+		}
+		r1 := await(ch1, 1)
+		r2 := await(ch2, 2)
 
-	r2 := <-ch2
-	if r2.err != nil {
-		t.Fatalf("peer 2 solicit error: %v", r2.err)
-	}
-	defer r2.ref.Release()
+		accept := func(sms link_solicit.SolicitMountedStream, peerNum int) link.MountedStream {
+			ms, alreadyAccepted, err := sms.AcceptMountedStream()
+			if err != nil {
+				t.Fatalf("peer %d accept error: %v", peerNum, err)
+			}
+			if alreadyAccepted {
+				t.Fatalf("peer %d received the previously consumed stream", peerNum)
+			}
+			if ms == nil {
+				t.Fatalf("peer %d got nil MountedStream", peerNum)
+			}
+			return ms
+		}
+		ms1 := accept(r1.sms, 1)
+		defer ms1.GetStream().Close()
+		ms2 := accept(r2.sms, 2)
+		defer ms2.GetStream().Close()
 
-	sms1 := r1.sms
-	sms2 := r2.sms
+		deadline := time.Now().Add(time.Second)
+		if err := ms1.GetStream().SetDeadline(deadline); err != nil {
+			t.Fatalf("peer 1 stream deadline: %v", err)
+		}
+		if err := ms2.GetStream().SetDeadline(deadline); err != nil {
+			t.Fatalf("peer 2 stream deadline: %v", err)
+		}
 
-	// Accept both streams.
-	ms1, alreadyAccepted, err := sms1.AcceptMountedStream()
-	if err != nil {
-		t.Fatalf("peer 1 accept error: %v", err)
-	}
-	if alreadyAccepted {
-		t.Fatal("peer 1 stream already accepted")
-	}
-	if ms1 == nil {
-		t.Fatal("peer 1 got nil MountedStream")
-	}
-	defer ms1.GetStream().Close()
+		data := []byte(marker)
+		if _, err := ms1.GetStream().Write(data); err != nil {
+			t.Fatalf("write %q: %v", marker, err)
+		}
+		buf := make([]byte, len(data))
+		if _, err := io.ReadFull(ms2.GetStream(), buf); err != nil {
+			t.Fatalf("read %q: %v", marker, err)
+		}
+		if !bytes.Equal(buf, data) {
+			t.Fatalf("data mismatch: got %q, want %q", buf, data)
+		}
 
-	ms2, alreadyAccepted, err := sms2.AcceptMountedStream()
-	if err != nil {
-		t.Fatalf("peer 2 accept error: %v", err)
-	}
-	if alreadyAccepted {
-		t.Fatal("peer 2 stream already accepted")
-	}
-	if ms2 == nil {
-		t.Fatal("peer 2 got nil MountedStream")
-	}
-	defer ms2.GetStream().Close()
-
-	// Write data from one side and read on the other.
-	data := []byte("hello solicitation")
-	_, err = ms1.GetStream().Write(data)
-	if err != nil {
-		t.Fatalf("write error: %v", err)
-	}
-
-	buf := make([]byte, len(data)*2)
-	n, err := ms2.GetStream().Read(buf)
-	if err != nil {
-		t.Fatalf("read error: %v", err)
-	}
-	if string(buf[:n]) != string(data) {
-		t.Fatalf("data mismatch: got %q, want %q", buf[:n], data)
+		return r1.ref, r2.ref, [2]uint64{
+			ms1.GetLink().GetLinkUUID(),
+			ms2.GetLink().GetLinkUUID(),
+		}
 	}
 
-	t.Log("solicitation match successful, data exchanged")
+	round1Ref1, round1Ref2, round1Links := runRound("round one")
+	round1Ref1.Release()
+	round1Ref2.Release()
+
+	round2Ref1, round2Ref2, round2Links := runRound("round two")
+	defer round2Ref1.Release()
+	defer round2Ref2.Release()
+
+	if round2Links != round1Links {
+		t.Fatalf("link UUIDs changed: round 1 %v, round 2 %v", round1Links, round2Links)
+	}
+	if round2Links[1] != heldLink.GetLinkUUID() {
+		t.Fatalf("peer 2 link UUID = %d, held link UUID = %d", round2Links[1], heldLink.GetLinkUUID())
+	}
 }
 
 // TestSolicitProtocolNoMatch tests that disjoint protocol sets don't match.

--- a/net/link/solicit/controller/handler-control.go
+++ b/net/link/solicit/controller/handler-control.go
@@ -38,7 +38,10 @@ func (h *controlStreamMountedHandler) HandleMountedStream(
 		}
 	}
 
-	sess := stream_packet.NewSession(ms.GetStream(), maxMessageSize)
+	sess := stream_packet.NewSession(
+		ms.GetStream(),
+		maxExchangeMessageSize(h.c.maxHashes),
+	)
 	go h.c.runControlStream(ctx, ls, sess)
 	return nil
 }

--- a/net/link/solicit/solicit.go
+++ b/net/link/solicit/solicit.go
@@ -3,7 +3,6 @@ package link_solicit
 import (
 	"context"
 	"strconv"
-	"time"
 
 	"github.com/aperturerobotics/controllerbus/bus"
 	"github.com/aperturerobotics/controllerbus/directive"
@@ -11,9 +10,6 @@ import (
 	"github.com/s4wave/spacewave/net/peer"
 	"github.com/s4wave/spacewave/net/protocol"
 )
-
-// holdOpenDur is the default hold open duration for SolicitProtocol.
-var holdOpenDur = time.Second * 10
 
 // SolicitProtocol is a directive to solicit a protocol with peers.
 //
@@ -98,9 +94,7 @@ func (d *solicitProtocol) Validate() error {
 
 // GetValueOptions returns options relating to value handling.
 func (d *solicitProtocol) GetValueOptions() directive.ValueOptions {
-	return directive.ValueOptions{
-		UnrefDisposeDur: holdOpenDur,
-	}
+	return directive.ValueOptions{}
 }
 
 // IsEquivalent checks if the other directive is equivalent.

--- a/net/link/solicit/solicit.pb.go
+++ b/net/link/solicit/solicit.pb.go
@@ -63,6 +63,35 @@ func (x *SolicitProtocolRequest) GetTransportId() uint64 {
 	return 0
 }
 
+// SolicitationOffer binds a stable protocol hash to one directive incarnation.
+type SolicitationOffer struct {
+	unknownFields []byte
+	// ProtocolHash identifies the solicited protocol and context for this link.
+	ProtocolHash []byte `protobuf:"bytes,1,opt,name=protocol_hash,json=protocolHash,proto3" json:"protocolHash,omitempty"`
+	// Incarnation identifies the continuous lifetime of one solicitation offer.
+	Incarnation []byte `protobuf:"bytes,2,opt,name=incarnation,proto3" json:"incarnation,omitempty"`
+}
+
+func (x *SolicitationOffer) Reset() {
+	*x = SolicitationOffer{}
+}
+
+func (*SolicitationOffer) ProtoMessage() {}
+
+func (x *SolicitationOffer) GetProtocolHash() []byte {
+	if x != nil {
+		return x.ProtocolHash
+	}
+	return nil
+}
+
+func (x *SolicitationOffer) GetIncarnation() []byte {
+	if x != nil {
+		return x.Incarnation
+	}
+	return nil
+}
+
 // SolicitationExchange is sent on the control stream.
 // Full hash set, re-sent each time the local set changes.
 type SolicitationExchange struct {
@@ -71,6 +100,14 @@ type SolicitationExchange struct {
 	// Each hash is 32 bytes.
 	// Max 256 entries.
 	ProtocolHashes [][]byte `protobuf:"bytes,1,rep,name=protocol_hashes,json=protocolHashes,proto3" json:"protocolHashes,omitempty"`
+	// Offers binds each protocol hash to its current directive incarnation.
+	Offers []*SolicitationOffer `protobuf:"bytes,2,rep,name=offers,proto3" json:"offers,omitempty"`
+	// SupportsOfferIncarnations indicates that Offers governs match lifetimes.
+	SupportsOfferIncarnations bool `protobuf:"varint,3,opt,name=supports_offer_incarnations,json=supportsOfferIncarnations,proto3" json:"supportsOfferIncarnations,omitempty"`
+	// Generation identifies this side's current offer set.
+	Generation uint64 `protobuf:"varint,4,opt,name=generation,proto3" json:"generation,omitempty"`
+	// AcknowledgedGeneration is the latest remote generation this side observed.
+	AcknowledgedGeneration uint64 `protobuf:"varint,5,opt,name=acknowledged_generation,json=acknowledgedGeneration,proto3" json:"acknowledgedGeneration,omitempty"`
 }
 
 func (x *SolicitationExchange) Reset() {
@@ -84,6 +121,34 @@ func (x *SolicitationExchange) GetProtocolHashes() [][]byte {
 		return x.ProtocolHashes
 	}
 	return nil
+}
+
+func (x *SolicitationExchange) GetOffers() []*SolicitationOffer {
+	if x != nil {
+		return x.Offers
+	}
+	return nil
+}
+
+func (x *SolicitationExchange) GetSupportsOfferIncarnations() bool {
+	if x != nil {
+		return x.SupportsOfferIncarnations
+	}
+	return false
+}
+
+func (x *SolicitationExchange) GetGeneration() uint64 {
+	if x != nil {
+		return x.Generation
+	}
+	return 0
+}
+
+func (x *SolicitationExchange) GetAcknowledgedGeneration() uint64 {
+	if x != nil {
+		return x.AcknowledgedGeneration
+	}
+	return 0
 }
 
 func (m *SolicitProtocolRequest) CloneVT() *SolicitProtocolRequest {
@@ -105,12 +170,33 @@ func (m *SolicitProtocolRequest) CloneMessageVT() protobuf_go_lite.CloneMessage 
 	return m.CloneVT()
 }
 
+func (m *SolicitationOffer) CloneVT() *SolicitationOffer {
+	if m == nil {
+		return (*SolicitationOffer)(nil)
+	}
+	r := new(SolicitationOffer)
+	r.ProtocolHash = protobuf_go_lite.CloneBytes(m.ProtocolHash)
+	r.Incarnation = protobuf_go_lite.CloneBytes(m.Incarnation)
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = slices.Clone(m.unknownFields)
+	}
+	return r
+}
+
+func (m *SolicitationOffer) CloneMessageVT() protobuf_go_lite.CloneMessage {
+	return m.CloneVT()
+}
+
 func (m *SolicitationExchange) CloneVT() *SolicitationExchange {
 	if m == nil {
 		return (*SolicitationExchange)(nil)
 	}
 	r := new(SolicitationExchange)
+	r.SupportsOfferIncarnations = m.SupportsOfferIncarnations
+	r.Generation = m.Generation
+	r.AcknowledgedGeneration = m.AcknowledgedGeneration
 	r.ProtocolHashes = protobuf_go_lite.CloneBytesSlice(m.ProtocolHashes)
+	r.Offers = protobuf_go_lite.CloneVTSlice(m.Offers)
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = slices.Clone(m.unknownFields)
 	}
@@ -150,6 +236,29 @@ func (this *SolicitProtocolRequest) EqualMessageVT(thatMsg any) bool {
 	return this.EqualVT(that)
 }
 
+func (this *SolicitationOffer) EqualVT(that *SolicitationOffer) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !protobuf_go_lite.EqualBytes(this.ProtocolHash, that.ProtocolHash) {
+		return false
+	}
+	if !protobuf_go_lite.EqualBytes(this.Incarnation, that.Incarnation) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *SolicitationOffer) EqualMessageVT(thatMsg any) bool {
+	that, ok := thatMsg.(*SolicitationOffer)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+
 func (this *SolicitationExchange) EqualVT(that *SolicitationExchange) bool {
 	if this == that {
 		return true
@@ -157,6 +266,18 @@ func (this *SolicitationExchange) EqualVT(that *SolicitationExchange) bool {
 		return false
 	}
 	if !protobuf_go_lite.EqualBytesSlice(this.ProtocolHashes, that.ProtocolHashes) {
+		return false
+	}
+	if !protobuf_go_lite.EqualVTSliceImplicit(this.Offers, that.Offers, func() *SolicitationOffer { return &SolicitationOffer{} }) {
+		return false
+	}
+	if this.SupportsOfferIncarnations != that.SupportsOfferIncarnations {
+		return false
+	}
+	if this.Generation != that.Generation {
+		return false
+	}
+	if this.AcknowledgedGeneration != that.AcknowledgedGeneration {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -236,6 +357,56 @@ func (x *SolicitProtocolRequest) UnmarshalJSON(b []byte) error {
 	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
 }
 
+// MarshalProtoJSON marshals the SolicitationOffer message to JSON.
+func (x *SolicitationOffer) MarshalProtoJSON(s *json.MarshalState) {
+	if x == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteObjectStart()
+	var wroteField bool
+	if len(x.ProtocolHash) > 0 || s.HasField("protocolHash") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("protocolHash")
+		s.WriteBytes(x.ProtocolHash)
+	}
+	if len(x.Incarnation) > 0 || s.HasField("incarnation") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("incarnation")
+		s.WriteBytes(x.Incarnation)
+	}
+	s.WriteObjectEnd()
+}
+
+// MarshalJSON marshals the SolicitationOffer to JSON.
+func (x *SolicitationOffer) MarshalJSON() ([]byte, error) {
+	return json.DefaultMarshalerConfig.Marshal(x)
+}
+
+// UnmarshalProtoJSON unmarshals the SolicitationOffer message from JSON.
+func (x *SolicitationOffer) UnmarshalProtoJSON(s *json.UnmarshalState) {
+	if s.ReadNil() {
+		return
+	}
+	s.ReadObject(func(key string) {
+		switch key {
+		default:
+			s.Skip() // ignore unknown field
+		case "protocol_hash", "protocolHash":
+			s.AddField("protocol_hash")
+			x.ProtocolHash = s.ReadBytes()
+		case "incarnation":
+			s.AddField("incarnation")
+			x.Incarnation = s.ReadBytes()
+		}
+	})
+}
+
+// UnmarshalJSON unmarshals the SolicitationOffer from JSON.
+func (x *SolicitationOffer) UnmarshalJSON(b []byte) error {
+	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
+}
+
 // MarshalProtoJSON marshals the SolicitationExchange message to JSON.
 func (x *SolicitationExchange) MarshalProtoJSON(s *json.MarshalState) {
 	if x == nil {
@@ -248,6 +419,32 @@ func (x *SolicitationExchange) MarshalProtoJSON(s *json.MarshalState) {
 		s.WriteMoreIf(&wroteField)
 		s.WriteObjectField("protocolHashes")
 		s.WriteBytesArray(x.ProtocolHashes)
+	}
+	if len(x.Offers) > 0 || s.HasField("offers") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("offers")
+		s.WriteArrayStart()
+		var wroteElement bool
+		for _, element := range x.Offers {
+			s.WriteMoreIf(&wroteElement)
+			element.MarshalProtoJSON(s.WithField("offers"))
+		}
+		s.WriteArrayEnd()
+	}
+	if x.SupportsOfferIncarnations || s.HasField("supportsOfferIncarnations") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("supportsOfferIncarnations")
+		s.WriteBool(x.SupportsOfferIncarnations)
+	}
+	if x.Generation != 0 || s.HasField("generation") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("generation")
+		s.WriteUint64(x.Generation)
+	}
+	if x.AcknowledgedGeneration != 0 || s.HasField("acknowledgedGeneration") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("acknowledgedGeneration")
+		s.WriteUint64(x.AcknowledgedGeneration)
 	}
 	s.WriteObjectEnd()
 }
@@ -273,6 +470,33 @@ func (x *SolicitationExchange) UnmarshalProtoJSON(s *json.UnmarshalState) {
 				return
 			}
 			x.ProtocolHashes = s.ReadBytesArray()
+		case "offers":
+			s.AddField("offers")
+			if s.ReadNil() {
+				x.Offers = nil
+				return
+			}
+			s.ReadArray(func() {
+				if s.ReadNil() {
+					x.Offers = append(x.Offers, nil)
+					return
+				}
+				v := &SolicitationOffer{}
+				v.UnmarshalProtoJSON(s.WithField("offers", false))
+				if s.Err() != nil {
+					return
+				}
+				x.Offers = append(x.Offers, v)
+			})
+		case "supports_offer_incarnations", "supportsOfferIncarnations":
+			s.AddField("supports_offer_incarnations")
+			x.SupportsOfferIncarnations = s.ReadBool()
+		case "generation":
+			s.AddField("generation")
+			x.Generation = s.ReadUint64()
+		case "acknowledged_generation", "acknowledgedGeneration":
+			s.AddField("acknowledged_generation")
+			x.AcknowledgedGeneration = s.ReadUint64()
 		}
 	})
 }
@@ -334,6 +558,48 @@ func (m *SolicitProtocolRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error
 	return len(dAtA) - i, nil
 }
 
+func (m *SolicitationOffer) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SolicitationOffer) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *SolicitationOffer) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	if len(m.Incarnation) > 0 {
+		i = protobuf_go_lite.EncodeBytes(dAtA, i, m.Incarnation)
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.ProtocolHash) > 0 {
+		i = protobuf_go_lite.EncodeBytes(dAtA, i, m.ProtocolHash)
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *SolicitationExchange) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -363,6 +629,33 @@ func (m *SolicitationExchange) MarshalToSizedBufferVT(dAtA []byte) (int, error) 
 	if m.unknownFields != nil {
 		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
 	}
+	if m.AcknowledgedGeneration != 0 {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(m.AcknowledgedGeneration))
+		i--
+		dAtA[i] = 0x28
+	}
+	if m.Generation != 0 {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(m.Generation))
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.SupportsOfferIncarnations {
+		i = protobuf_go_lite.EncodeBool(dAtA, i, m.SupportsOfferIncarnations)
+		i--
+		dAtA[i] = 0x18
+	}
+	if len(m.Offers) > 0 {
+		for iNdEx := len(m.Offers) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.Offers[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x12
+		}
+	}
 	if len(m.ProtocolHashes) > 0 {
 		for iNdEx := len(m.ProtocolHashes) - 1; iNdEx >= 0; iNdEx-- {
 			i = protobuf_go_lite.EncodeBytes(dAtA, i, m.ProtocolHashes[iNdEx])
@@ -387,6 +680,18 @@ func (m *SolicitProtocolRequest) SizeVT() (n int) {
 	return n
 }
 
+func (m *SolicitationOffer) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	n += protobuf_go_lite.SizeBytesNonEmpty(1, m.ProtocolHash)
+	n += protobuf_go_lite.SizeBytesNonEmpty(1, m.Incarnation)
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *SolicitationExchange) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -394,6 +699,13 @@ func (m *SolicitationExchange) SizeVT() (n int) {
 	var l int
 	_ = l
 	n += protobuf_go_lite.SizeBytesSlice(1, m.ProtocolHashes)
+	for _, e := range m.Offers {
+		l = e.SizeVT()
+		n += protobuf_go_lite.SizeMessage(1, l)
+	}
+	n += protobuf_go_lite.SizeBoolNonZero(1, m.SupportsOfferIncarnations)
+	n += protobuf_go_lite.SizeVarintNonZero(1, m.Generation)
+	n += protobuf_go_lite.SizeVarintNonZero(1, m.AcknowledgedGeneration)
 	n += len(m.unknownFields)
 	return n
 }
@@ -424,6 +736,24 @@ func (x *SolicitProtocolRequest) String() string {
 	return x.MarshalProtoText()
 }
 
+func (x *SolicitationOffer) MarshalProtoText() string {
+	var sb protobuf_go_lite.TextBuilder
+	initialLen := protobuf_go_lite.TextStartMessage(&sb, "SolicitationOffer")
+	if len(x.ProtocolHash) != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "protocol_hash")
+		protobuf_go_lite.TextWriteBytes(&sb, x.ProtocolHash)
+	}
+	if len(x.Incarnation) != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "incarnation")
+		protobuf_go_lite.TextWriteBytes(&sb, x.Incarnation)
+	}
+	return protobuf_go_lite.TextFinishMessage(&sb)
+}
+
+func (x *SolicitationOffer) String() string {
+	return x.MarshalProtoText()
+}
+
 func (x *SolicitationExchange) MarshalProtoText() string {
 	var sb protobuf_go_lite.TextBuilder
 	initialLen := protobuf_go_lite.TextStartMessage(&sb, "SolicitationExchange")
@@ -434,6 +764,30 @@ func (x *SolicitationExchange) MarshalProtoText() string {
 			protobuf_go_lite.TextWriteBytes(&sb, v)
 		}
 		protobuf_go_lite.TextWriteListEnd(&sb)
+	}
+	if len(x.Offers) > 0 {
+		protobuf_go_lite.TextWriteListStart(&sb, initialLen, "offers")
+		for i, v := range x.Offers {
+			protobuf_go_lite.TextWriteListSeparator(&sb, i)
+			if v == nil {
+				protobuf_go_lite.TextWriteTextMarshaler(&sb, &SolicitationOffer{})
+			} else {
+				protobuf_go_lite.TextWriteTextMarshaler(&sb, v)
+			}
+		}
+		protobuf_go_lite.TextWriteListEnd(&sb)
+	}
+	if x.SupportsOfferIncarnations != false {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "supports_offer_incarnations")
+		protobuf_go_lite.TextWriteBool(&sb, x.SupportsOfferIncarnations)
+	}
+	if x.Generation != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "generation")
+		protobuf_go_lite.TextWriteUint(&sb, x.Generation)
+	}
+	if x.AcknowledgedGeneration != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "acknowledged_generation")
+		protobuf_go_lite.TextWriteUint(&sb, x.AcknowledgedGeneration)
 	}
 	return protobuf_go_lite.TextFinishMessage(&sb)
 }
@@ -522,6 +876,65 @@ func (m *SolicitProtocolRequest) UnmarshalVT(dAtA []byte) error {
 	return nil
 }
 
+func (m *SolicitationOffer) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	var err error
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		wire, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+		if err != nil {
+			return err
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SolicitationOffer: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SolicitationOffer: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ProtocolHash", wireType)
+			}
+			m.ProtocolHash, iNdEx, err = protobuf_go_lite.DecodeBytesAppend(m.ProtocolHash, dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Incarnation", wireType)
+			}
+			m.Incarnation, iNdEx, err = protobuf_go_lite.DecodeBytesAppend(m.Incarnation, dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protobuf_go_lite.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+
 func (m *SolicitationExchange) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -552,6 +965,47 @@ func (m *SolicitationExchange) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			m.ProtocolHashes = append(m.ProtocolHashes, v)
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Offers", wireType)
+			}
+			msgStart, postIndex, err := protobuf_go_lite.DecodeLengthDelimited(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.Offers = append(m.Offers, &SolicitationOffer{})
+			if err := m.Offers[len(m.Offers)-1].UnmarshalVT(dAtA[msgStart:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SupportsOfferIncarnations", wireType)
+			}
+			var v bool
+			v, iNdEx, err = protobuf_go_lite.DecodeVarintBool(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.SupportsOfferIncarnations = bool(v)
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Generation", wireType)
+			}
+			m.Generation = 0
+			m.Generation, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AcknowledgedGeneration", wireType)
+			}
+			m.AcknowledgedGeneration = 0
+			m.AcknowledgedGeneration, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])

--- a/net/link/solicit/solicit.pb.ts
+++ b/net/link/solicit/solicit.pb.ts
@@ -57,6 +57,36 @@ export const SolicitProtocolRequest: MessageType<SolicitProtocolRequest> =
   })
 
 /**
+ * SolicitationOffer binds a stable protocol hash to one directive incarnation.
+ *
+ * @generated from message link.solicit.SolicitationOffer
+ */
+export interface SolicitationOffer {
+  /**
+   * ProtocolHash identifies the solicited protocol and context for this link.
+   *
+   * @generated from field: bytes protocol_hash = 1;
+   */
+  protocolHash?: Uint8Array
+  /**
+   * Incarnation identifies the continuous lifetime of one solicitation offer.
+   *
+   * @generated from field: bytes incarnation = 2;
+   */
+  incarnation?: Uint8Array
+}
+
+export const SolicitationOffer: MessageType<SolicitationOffer> =
+  /* @__PURE__ */ createMessageType({
+    typeName: 'link.solicit.SolicitationOffer',
+    fields: [
+      { no: 1, name: 'protocol_hash', kind: 'scalar', T: ScalarType.BYTES },
+      { no: 2, name: 'incarnation', kind: 'scalar', T: ScalarType.BYTES },
+    ] satisfies readonly PartialFieldInfo[],
+    packedByDefault: true,
+  })
+
+/**
  * SolicitationExchange is sent on the control stream.
  * Full hash set, re-sent each time the local set changes.
  *
@@ -71,6 +101,30 @@ export interface SolicitationExchange {
    * @generated from field: repeated bytes protocol_hashes = 1;
    */
   protocolHashes?: Uint8Array[]
+  /**
+   * Offers binds each protocol hash to its current directive incarnation.
+   *
+   * @generated from field: repeated link.solicit.SolicitationOffer offers = 2;
+   */
+  offers?: SolicitationOffer[]
+  /**
+   * SupportsOfferIncarnations indicates that Offers governs match lifetimes.
+   *
+   * @generated from field: bool supports_offer_incarnations = 3;
+   */
+  supportsOfferIncarnations?: boolean
+  /**
+   * Generation identifies this side's current offer set.
+   *
+   * @generated from field: uint64 generation = 4;
+   */
+  generation?: bigint
+  /**
+   * AcknowledgedGeneration is the latest remote generation this side observed.
+   *
+   * @generated from field: uint64 acknowledged_generation = 5;
+   */
+  acknowledgedGeneration?: bigint
 }
 
 export const SolicitationExchange: MessageType<SolicitationExchange> =
@@ -83,6 +137,26 @@ export const SolicitationExchange: MessageType<SolicitationExchange> =
         kind: 'scalar',
         T: ScalarType.BYTES,
         repeated: true,
+      },
+      {
+        no: 2,
+        name: 'offers',
+        kind: 'message',
+        T: () => SolicitationOffer,
+        repeated: true,
+      },
+      {
+        no: 3,
+        name: 'supports_offer_incarnations',
+        kind: 'scalar',
+        T: ScalarType.BOOL,
+      },
+      { no: 4, name: 'generation', kind: 'scalar', T: ScalarType.UINT64 },
+      {
+        no: 5,
+        name: 'acknowledged_generation',
+        kind: 'scalar',
+        T: ScalarType.UINT64,
       },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,

--- a/net/link/solicit/solicit.proto
+++ b/net/link/solicit/solicit.proto
@@ -16,6 +16,15 @@ message SolicitProtocolRequest {
   uint64 transport_id = 4;
 }
 
+// SolicitationOffer binds a stable protocol hash to one directive incarnation.
+message SolicitationOffer {
+  // ProtocolHash identifies the solicited protocol and context for this link.
+  bytes protocol_hash = 1;
+
+  // Incarnation identifies the continuous lifetime of one solicitation offer.
+  bytes incarnation = 2;
+}
+
 // SolicitationExchange is sent on the control stream.
 // Full hash set, re-sent each time the local set changes.
 message SolicitationExchange {
@@ -23,4 +32,16 @@ message SolicitationExchange {
   // Each hash is 32 bytes.
   // Max 256 entries.
   repeated bytes protocol_hashes = 1;
+
+  // Offers binds each protocol hash to its current directive incarnation.
+  repeated SolicitationOffer offers = 2;
+
+  // SupportsOfferIncarnations indicates that Offers governs match lifetimes.
+  bool supports_offer_incarnations = 3;
+
+  // Generation identifies this side's current offer set.
+  uint64 generation = 4;
+
+  // AcknowledgedGeneration is the latest remote generation this side observed.
+  uint64 acknowledged_generation = 5;
 }


### PR DESCRIPTION
Stopping and restarting protocol consumers over an existing peer link could reuse an already-consumed stream or never match again. Give each solicitation a distinct incarnation and require peers to acknowledge the current offer generations before opening a stream. Reject retired stream identities, withdraw the offer when its last reference is released, and retain duplicate suppression only while the corresponding incarnations remain active.

Peers initially exchange the existing protocol hashes. Upgraded peers then exchange incarnation offers within the configured packet bound; mixed-version peers retain initial matching. Stream closure alone does not trigger a retry.

Validation: the two-round in-process test exchanges data over the same link UUIDs. Focused tests cover stale streams, legacy matching, closed-stream suppression, the maximum offer set, repeated rotations, and pending-open cleanup. Generation and the solicitation package race suite pass.
