### PR TITLE
fix(provider): retry object sync after accepting an invite

### DIFF
--- a/core/provider/local/invite-join.go
+++ b/core/provider/local/invite-join.go
@@ -118,6 +118,10 @@ func (a *ProviderAccount) JoinViaInvite(
 	// account and stops with the account, not with the enrollment request.
 	if err := a.StartPersistentP2PSync(ctx, st); err != nil {
 		a.le.WithError(err).Warn("failed to start P2P sync after invite join")
+	} else {
+		// Freshen a cached SO's solicitation after installing its new grant. A
+		// newly listed SO may still be waiting for normal list reconciliation.
+		a.RetrySharedObjectSync(result.SharedObjectID)
 	}
 	if err := a.RetainP2PPeer(ctx, ownerPeerID); err != nil {
 		return nil, errors.Wrap(err, "retain invite owner link")

--- a/core/provider/local/p2p-sync-lifecycle_test.go
+++ b/core/provider/local/p2p-sync-lifecycle_test.go
@@ -3,9 +3,162 @@ package provider_local
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/aperturerobotics/util/routine"
 )
+
+// TestRetrySharedObjectSyncRestartsOnlySelectedSO verifies that retry replaces
+// one SO routine serially without disturbing its generation or sibling SOs.
+func TestRetrySharedObjectSyncRestartsOnlySelectedSO(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	newSyncRoutine := func(started chan<- struct{}, running *atomic.Int32) *routine.RoutineContainer {
+		rc := routine.NewRoutineContainer()
+		rc.SetRoutine(func(ctx context.Context) error {
+			if active := running.Add(1); active != 1 {
+				t.Errorf("SO sync overlapped %d executions", active)
+			}
+			started <- struct{}{}
+			<-ctx.Done()
+			running.Add(-1)
+			return ctx.Err()
+		})
+		rc.SetContext(ctx, false)
+		t.Cleanup(func() {
+			exitedCh, _ := rc.SetRoutine(nil)
+			if exitedCh != nil {
+				<-exitedCh
+			}
+		})
+		return rc
+	}
+
+	targetStarted := make(chan struct{}, 2)
+	otherStarted := make(chan struct{}, 2)
+	var targetRunning atomic.Int32
+	var otherRunning atomic.Int32
+	targetRoutine := newSyncRoutine(targetStarted, &targetRunning)
+	otherRoutine := newSyncRoutine(otherStarted, &otherRunning)
+	state := &p2pSyncState{
+		ctx:     ctx,
+		started: true,
+		soSync: map[string]*routine.RoutineContainer{
+			"target": targetRoutine,
+			"other":  otherRoutine,
+		},
+	}
+	account := &ProviderAccount{}
+	account.p2pSyncBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		account.p2pSync = state
+	})
+
+	<-targetStarted
+	<-otherStarted
+	if !account.RetrySharedObjectSync("target") {
+		t.Fatal("target SO sync was not restarted")
+	}
+	<-targetStarted
+
+	select {
+	case <-otherStarted:
+		t.Fatal("retry restarted an unrelated SO sync")
+	default:
+	}
+	if targetRunning.Load() != 1 || otherRunning.Load() != 1 {
+		t.Fatalf("unexpected active routines: target=%d other=%d", targetRunning.Load(), otherRunning.Load())
+	}
+	if account.p2pSync != state {
+		t.Fatal("retry replaced the P2P transport generation")
+	}
+}
+
+// TestRetrySharedObjectSyncRejectsUnknownSOWithoutRestart verifies that list
+// reconciliation can still own initial startup when no routine exists yet.
+func TestRetrySharedObjectSyncRejectsUnknownSOWithoutRestart(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	started := make(chan struct{}, 2)
+	rc := routine.NewRoutineContainer()
+	rc.SetRoutine(func(ctx context.Context) error {
+		started <- struct{}{}
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	rc.SetContext(ctx, false)
+	t.Cleanup(func() {
+		exitedCh, _ := rc.SetRoutine(nil)
+		if exitedCh != nil {
+			<-exitedCh
+		}
+	})
+	state := &p2pSyncState{
+		ctx:     ctx,
+		started: true,
+		soSync:  map[string]*routine.RoutineContainer{"known": rc},
+	}
+	account := &ProviderAccount{p2pSync: state}
+
+	<-started
+	if account.RetrySharedObjectSync("missing") {
+		t.Fatal("unknown SO sync was restarted")
+	}
+	select {
+	case <-started:
+		t.Fatal("failed retry restarted an existing SO sync")
+	default:
+	}
+}
+
+// TestRetireP2PSyncStateWaitsForSOSyncRoutine verifies that retirement joins
+// SO routines before completing generation cleanup.
+func TestRetireP2PSyncStateWaitsForSOSyncRoutine(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	routineStarted := make(chan struct{})
+	routineCanceled := make(chan struct{})
+	allowRoutineExit := make(chan struct{})
+	var routineExited atomic.Bool
+	rc := routine.NewRoutineContainer()
+	rc.SetRoutine(func(ctx context.Context) error {
+		close(routineStarted)
+		<-ctx.Done()
+		close(routineCanceled)
+		<-allowRoutineExit
+		routineExited.Store(true)
+		return ctx.Err()
+	})
+	rc.SetContext(ctx, false)
+	state := &p2pSyncState{
+		ctx:           ctx,
+		cancel:        cancel,
+		started:       true,
+		startComplete: true,
+		startupExited: true,
+		soSync:        map[string]*routine.RoutineContainer{"target": rc},
+	}
+	account := &ProviderAccount{p2pSync: state}
+
+	<-routineStarted
+	retired := make(chan struct{})
+	go func() {
+		account.retireP2PSyncState(nil)
+		close(retired)
+	}()
+	<-routineCanceled
+	select {
+	case <-retired:
+		t.Fatal("retirement completed before SO sync exited")
+	default:
+	}
+	close(allowRoutineExit)
+	<-retired
+	if !routineExited.Load() {
+		t.Fatal("retirement released resources before SO sync exited")
+	}
+}
 
 func TestP2PSyncStateFinishStartPublishesStableState(t *testing.T) {
 	ctx := t.Context()

--- a/core/provider/local/p2p-sync.go
+++ b/core/provider/local/p2p-sync.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aperturerobotics/controllerbus/controller/resolver"
 	"github.com/aperturerobotics/controllerbus/directive"
 	"github.com/aperturerobotics/util/broadcast"
+	"github.com/aperturerobotics/util/routine"
 	"github.com/pkg/errors"
 	"github.com/s4wave/spacewave/core/sobject"
 	sobject_invite "github.com/s4wave/spacewave/core/sobject/invite"
@@ -65,8 +66,8 @@ type p2pSyncState struct {
 	relFns []func()
 	// stores indexes DEX stores by bucket ID for this generation.
 	stores map[string]block.StoreOps
-	// soIDs records shared objects whose sync controllers were started.
-	soIDs map[string]struct{}
+	// soSync indexes restartable shared-object sync routines.
+	soSync map[string]*routine.RoutineContainer
 }
 
 // retainP2PSyncStateLocked adds an owner while a.p2pSyncBcast is locked.
@@ -208,20 +209,29 @@ func (s *p2pSyncState) hasStore(bucketID string) bool {
 func (s *p2pSyncState) hasSO(soID string) bool {
 	var ok bool
 	s.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
-		_, ok = s.soIDs[soID]
+		_, ok = s.soSync[soID]
 	})
 	return ok
 }
 
-// addSO records that this generation started sync for soID.
-func (s *p2pSyncState) addSO(soID string) {
+// addSO registers the sync routine for soID while the generation is active.
+func (s *p2pSyncState) addSO(soID string, syncRoutine *routine.RoutineContainer) bool {
+	var added bool
 	s.bcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
-		if s.soIDs == nil {
-			s.soIDs = make(map[string]struct{})
+		if s.stopping || s.ctx.Err() != nil {
+			return
 		}
-		s.soIDs[soID] = struct{}{}
+		if s.soSync == nil {
+			s.soSync = make(map[string]*routine.RoutineContainer)
+		}
+		if _, exists := s.soSync[soID]; exists {
+			return
+		}
+		s.soSync[soID] = syncRoutine
+		added = true
 		bcast()
 	})
+	return added
 }
 
 // addRef retains a controllerbus reference until state cleanup.
@@ -706,7 +716,6 @@ func (a *ProviderAccount) startP2PSyncControllers(
 			a.le.WithError(err).WithField("so-id", soID).Warn("failed to start so sync")
 			continue
 		}
-		state.addSO(soID)
 	}
 
 	if !*inviteStarted {
@@ -746,6 +755,35 @@ func (a *ProviderAccount) GetP2PSyncSnapshotWithWait() (bool, <-chan struct{}) {
 func (a *ProviderAccount) IsP2PSyncRunning() bool {
 	running, _ := a.GetP2PSyncSnapshotWithWait()
 	return running
+}
+
+// RetrySharedObjectSync replaces the running SO sync directive for soID while
+// preserving the active transport generation and every other controller. It
+// reports whether an existing routine was restarted.
+func (a *ProviderAccount) RetrySharedObjectSync(soID string) bool {
+	if soID == "" {
+		return false
+	}
+
+	// Hold both lifecycle locks through the restart decision so retirement or
+	// generation replacement cannot redirect the request to a stale routine.
+	var restarted bool
+	a.p2pSyncBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		state := a.p2pSync
+		if state == nil {
+			return
+		}
+		state.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+			if !state.started || state.stopping || state.ctx.Err() != nil {
+				return
+			}
+			syncRoutine := state.soSync[soID]
+			if syncRoutine != nil {
+				restarted = syncRoutine.RestartRoutine()
+			}
+		})
+	})
+	return restarted
 }
 
 // StopP2PSync stops all P2P sync controllers, waits for goroutines
@@ -844,6 +882,22 @@ func (a *ProviderAccount) stopP2PSyncState(state *p2pSyncState) {
 			break
 		}
 		<-waitCh
+	}
+
+	// Stop and join every SO sync before releasing the mounts and controller
+	// references on which those routines depend.
+	var syncRoutines []*routine.RoutineContainer
+	state.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		syncRoutines = make([]*routine.RoutineContainer, 0, len(state.soSync))
+		for _, syncRoutine := range state.soSync {
+			syncRoutines = append(syncRoutines, syncRoutine)
+		}
+	})
+	for _, syncRoutine := range syncRoutines {
+		exitedCh, _ := syncRoutine.SetRoutine(nil)
+		if exitedCh != nil {
+			<-exitedCh
+		}
 	}
 
 	var (
@@ -966,14 +1020,26 @@ func (a *ProviderAccount) startSOSync(
 		},
 		validateSnapshotAccess,
 	)
-	state.addWorker()
-	go func() {
-		defer state.workerDone()
-		defer relSO()
-		if err := soSync.Execute(ctx); err != nil && ctx.Err() == nil {
+	// Retain the mount for this generation while allowing an explicit invite to
+	// replace only the solicitation routine. RoutineContainer serializes the
+	// replacement behind the prior execution's exit.
+	syncRoutine := routine.NewRoutineContainer()
+	syncRoutine.SetRoutine(func(runCtx context.Context) error {
+		err := soSync.Execute(runCtx)
+		if err != nil && runCtx.Err() == nil {
 			a.le.WithError(err).WithField("so-id", soID).Warn("so sync exited with error")
 		}
-	}()
+		return err
+	})
+	if !state.addSO(soID, syncRoutine) {
+		relSO()
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		return errors.Errorf("shared object sync already started: %s", soID)
+	}
+	state.addRelease(relSO)
+	syncRoutine.SetContext(ctx, false)
 
 	return nil
 }


### PR DESCRIPTION
Accepting a fresh invitation for an already-mounted object restored its authority but left the old synchronization directive active. Keep a restartable routine for each object in the existing provider generation, and request a new execution after a successful invite join. The transport, unrelated objects, and cached blocks keep their existing lifetimes.

Routine replacement waits for the previous execution to release its directive. Provider shutdown joins all object routines before releasing their mounts. Objects whose initial registration is still pending continue through the existing list watcher.

Validation: focused provider race tests cover serial replacement of only the selected object, missing-object no-op, unchanged transport generation, and shutdown waiting for a routine to exit. These are lifecycle tests with controlled callbacks; full invite-to-peer synchronization is a separate integration check.
