### PR TITLE
fix(opfs): protect root snapshots during replacement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,11 @@ a subdirectory.
   `protoc-gen-starpc-python` in `.venv`; Bun does not install Python tools. Use
   `bun run setup` only to repair stale `.bldr` exports or module resolution after
   dependencies are installed.
+- `bun install` already runs `go mod vendor` and `bun run setup`. Finish it
+  before starting builds, Go checks, or commits in that worktree. Do not run a
+  separate `go mod vendor` alongside it: vendoring replaces `vendor/` in place,
+  so concurrent writers can leave it incomplete and readers can see missing
+  files. Finish active builds and checks before repairing dependencies.
 - Keep large command output under `.tmp/` when needed, then inspect a short
   summary or tail. Do not commit `.tmp/`.
 - Do not use sleep loops for readiness, locks, files, ports, pids, or results.

--- a/db/volume/js/opfs/engine/publication.go
+++ b/db/volume/js/opfs/engine/publication.go
@@ -43,6 +43,7 @@ type outputFile struct {
 // newPublication allocates a distinct identity, including after a failed commit.
 func newPublication(e *Engine, base *Root) *publication {
 	var nonce [16]byte
+	// crypto/rand.Read fills the buffer or terminates the process.
 	_, _ = rand.Read(nonce[:])
 	root := base.CloneVT()
 	root.Format = formatVersion
@@ -78,10 +79,12 @@ func (p *publication) retire(name string) {
 
 // commit writes an intent, all immutable files, then one alternate descriptor.
 func (p *publication) commit(ctx context.Context) error {
+	// Trace the bounded publication through durable root replacement.
 	ctx, task := trace.NewTask(ctx, "hydra/opfs-engine/publish")
 	defer task.End()
 	trace.Logf(ctx, "hydra/opfs-engine/publish/shape", "files=%d bytes=%d retired=%d", len(p.output), p.bytes, len(p.retired))
 
+	// Recover any previous interrupted output before allocating new files.
 	if len(p.retired) > maxPublicationFiles {
 		return ErrLimit
 	}
@@ -120,7 +123,7 @@ func (p *publication) commit(ctx context.Context) error {
 			return err
 		}
 	}
-	if err := p.engine.writeMessage(ctx, "root-"+strconv.FormatUint(p.root.Generation%2, 10), p.root); err != nil {
+	if err := p.publishRoot(ctx); err != nil {
 		return err
 	}
 
@@ -138,6 +141,17 @@ func (p *publication) commit(ctx context.Context) error {
 	return nil
 }
 
+// publishRoot excludes root readers only while replacing the durable descriptor.
+// Callers hold reclamation protection and the publication lock before this lock.
+func (p *publication) publishRoot(ctx context.Context) error {
+	unlock, err := p.engine.backend.Lock(ctx, "root", true)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	return p.engine.writeMessage(ctx, "root-"+strconv.FormatUint(p.root.Generation%2, 10), p.root)
+}
+
 // writeMessage atomically replaces one checksummed persistent record.
 func (e *Engine) writeMessage(ctx context.Context, name string, value message) error {
 	data, err := encode(value)
@@ -150,6 +164,7 @@ func (e *Engine) writeMessage(ctx context.Context, name string, value message) e
 // cleanIntent removes only output that was never selected by a valid root.
 // The caller holds the publication lock and shared or exclusive reclamation.
 func (e *Engine) cleanIntent(ctx context.Context) error {
+	// Read the previous intent while the publication lock excludes replacement.
 	data, err := e.backend.Read(ctx, "intent", 0, readAll)
 	if errors.Is(err, fs.ErrNotExist) {
 		return nil
@@ -157,6 +172,7 @@ func (e *Engine) cleanIntent(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
 	// OPFS creates an empty entry before a writable stream commits. No output
 	// can exist until this intent is durable, so an empty entry is discardable.
 	if len(data) == 0 {
@@ -169,6 +185,8 @@ func (e *Engine) cleanIntent(ctx context.Context) error {
 	if len(intent.Names) > maxPublicationFiles+1 || intent.Publication == "" {
 		return ErrCorrupt
 	}
+
+	// Keep output selected by the current durable publication.
 	root, err := e.loadRoot(ctx)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err
@@ -195,6 +213,7 @@ func (e *Engine) cleanIntent(ctx context.Context) error {
 // Reclaim deletes at most one publication's retired files, then checkpoints.
 // It never waits for readers while holding the publication lock.
 func (e *Engine) Reclaim(ctx context.Context) (bool, error) {
+	// Exclude readers before joining the publication queue.
 	release, err := e.backend.Lock(ctx, "reclaim", true)
 	if err != nil {
 		return false, err
@@ -213,6 +232,7 @@ func (e *Engine) Reclaim(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 
+	// Advance both root slots before reclaiming the preceding generation.
 	if root.ReclaimNext >= root.Generation {
 		p := newPublication(e, root)
 		return true, p.commit(ctx)
@@ -241,6 +261,8 @@ func (e *Engine) Reclaim(ctx context.Context) (bool, error) {
 			return false, err
 		}
 	}
+
+	// Checkpoint completed reclamation through the ordinary root publication.
 	p := newPublication(e, root)
 	p.root.ReclaimNext++
 	return true, p.commit(ctx)

--- a/db/volume/js/opfs/engine/root-read_test.go
+++ b/db/volume/js/opfs/engine/root-read_test.go
@@ -1,0 +1,154 @@
+//go:build !js
+
+package engine
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// rootReadBackend pauses a retained root read at the browser byte-copy boundary.
+// Disk reads alone cannot reproduce invalidation of a retained browser File.
+type rootReadBackend struct {
+	// Backend supplies durable files and origin-wide locks.
+	Backend
+	// reading records whether the retained root still needs its bytes.
+	reading atomic.Bool
+	// started reports that the reader has retained the root.
+	started chan struct{}
+	// resume permits copying the retained root bytes.
+	resume chan struct{}
+}
+
+// Read holds the first root read until the test permits its byte copy.
+func (b *rootReadBackend) Read(ctx context.Context, name string, offset int64, length int) ([]byte, error) {
+	if name == "root-0" {
+		b.reading.Store(true)
+		close(b.started)
+		select {
+		case <-b.resume:
+		case <-ctx.Done():
+			b.reading.Store(false)
+			return nil, ctx.Err()
+		}
+		defer b.reading.Store(false)
+	}
+	return b.Backend.Read(ctx, name, offset, length)
+}
+
+// rootWriteBackend rejects replacement while the browser still needs root bytes.
+type rootWriteBackend struct {
+	// Backend supplies the same durable files and locks as the reader.
+	Backend
+	// reader exposes the retained browser-file lifetime under test.
+	reader *rootReadBackend
+	// attempted reports root lock acquisition or an unprotected root write.
+	attempted chan struct{}
+}
+
+// Lock reports publication reaching the root critical section.
+func (b *rootWriteBackend) Lock(ctx context.Context, name string, exclusive bool) (func(), error) {
+	if name == "root" && exclusive {
+		b.attempted <- struct{}{}
+	}
+	return b.Backend.Lock(ctx, name, exclusive)
+}
+
+// Write models browser invalidation when a root is replaced during its read.
+func (b *rootWriteBackend) Write(ctx context.Context, name string, data []byte) error {
+	if strings.HasPrefix(name, "root-") && b.reader.reading.Load() {
+		b.attempted <- struct{}{}
+		return errors.New("root replacement invalidated the retained browser File")
+	}
+	return b.Backend.Write(ctx, name, data)
+}
+
+// TestRootReadExcludesReplacement preserves bytes without pinning later publication.
+func TestRootReadExcludesReplacement(t *testing.T) {
+	// Seed a durable generation before installing the browser read boundary.
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	disk := newDiskBackend(t)
+	writer, err := Open(ctx, disk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := writer.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	// Leave generation three in root-1 so the next publication replaces root-0.
+	for _, value := range []string{"initial", "before"} {
+		if err := writer.Apply(ctx, nil, []*Record{{Key: []byte("key"), Value: []byte(value)}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	reader, err := Open(ctx, disk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := reader.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	reads := &rootReadBackend{Backend: disk, started: make(chan struct{}), resume: make(chan struct{})}
+	writes := &rootWriteBackend{Backend: disk, reader: reads, attempted: make(chan struct{}, 2)}
+	reader.backend = reads
+	writer.backend = writes
+
+	// Pause the root byte copy and start a publication from another engine.
+	readDone := make(chan *snapshot, 1)
+	readErr := make(chan error, 1)
+	go func() {
+		s, err := reader.snapshot(ctx)
+		readDone <- s
+		readErr <- err
+	}()
+	select {
+	case <-reads.started:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	writeDone := make(chan error, 1)
+	go func() {
+		writeDone <- writer.Apply(ctx, nil, []*Record{{Key: []byte("key"), Value: []byte("after")}})
+	}()
+	select {
+	case <-writes.attempted:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	close(reads.resume)
+
+	// Publication must finish while the reader still pins its old generation.
+	if err := <-readErr; err != nil {
+		t.Fatal(err)
+	}
+	s := <-readDone
+	defer s.release()
+	select {
+	case err := <-writeDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	value, found, err := s.get(ctx, []byte("key"))
+	if err != nil || !found || string(value) != "before" {
+		t.Fatalf("pinned generation changed: %q %t %v", value, found, err)
+	}
+}
+
+// _ is a type assertion.
+var (
+	_ Backend = (*rootReadBackend)(nil)
+	_ Backend = (*rootWriteBackend)(nil)
+)

--- a/db/volume/js/opfs/engine/snapshot.go
+++ b/db/volume/js/opfs/engine/snapshot.go
@@ -19,10 +19,21 @@ type snapshot struct {
 
 // snapshot acquires file protection before resolving the durable root.
 func (e *Engine) snapshot(ctx context.Context) (*snapshot, error) {
+	// Keep the selected generation's immutable files alive through the read.
 	release, err := e.protect(ctx)
 	if err != nil {
 		return nil, err
 	}
+
+	// A retained browser File can become unreadable when its entry is replaced.
+	// Copy both roots under a shared root lock, after reclamation protection.
+	// Payload publication remains independent of this short critical section.
+	unlock, err := e.backend.Lock(ctx, "root", false)
+	if err != nil {
+		release()
+		return nil, err
+	}
+	defer unlock()
 	root, err := e.loadRoot(ctx)
 	if err != nil {
 		release()
@@ -33,6 +44,7 @@ func (e *Engine) snapshot(ctx context.Context) (*snapshot, error) {
 
 // get resolves a full key through one partition's bounded newest-first runs.
 func (s *snapshot) get(ctx context.Context, key []byte) ([]byte, bool, error) {
+	// Descend through catalogue bounds to the partition containing the key.
 	name := s.root.Catalogue
 	for {
 		page, err := s.engine.readCatalogue(ctx, name)
@@ -47,6 +59,8 @@ func (s *snapshot) get(ctx context.Context, key []byte) ([]byte, bool, error) {
 			name = page.Children[i].File
 			continue
 		}
+
+		// Search the selected partition's runs from newest to oldest.
 		i := sort.Search(len(page.Partitions), func(i int) bool { return bytes.Compare(page.Partitions[i].Lower, key) > 0 }) - 1
 		if i < 0 {
 			return nil, false, nil
@@ -69,11 +83,14 @@ func (s *snapshot) get(ctx context.Context, key []byte) ([]byte, bool, error) {
 
 // Get returns a caller-owned value and the generation that supplied it.
 func (e *Engine) Get(ctx context.Context, key []byte) ([]byte, bool, uint64, error) {
+	// Pin one durable generation for the complete lookup.
 	s, err := e.snapshot(ctx)
 	if err != nil {
 		return nil, false, 0, err
 	}
 	defer s.release()
+
+	// Return independent bytes with the revision that supplied them.
 	value, found, err := s.get(ctx, key)
 	return bytes.Clone(value), found, s.root.Revision, err
 }


### PR DESCRIPTION
Root slots could be replaced between opening a browser File and copying its bytes, invalidating an active snapshot. Protect root reads and descriptor replacement with a shared/exclusive backend lock. Keep payload publication independent so readers can continue during uploads, and release the root lock before returning a pinned generation.

The regression pauses a root read while a second engine publishes, then verifies publication completes while the old generation remains readable. It fails on the previous implementation. Stored data and public interfaces are unchanged; all concurrent runtimes must reload to participate in the new lock.

Also clarify that `bun install` already owns vendoring and setup. Dependency preparation must finish before builds, checks, or commits read the same worktree.

Validation: OPFS engine race tests, focused failing-before/passing-after regression, normal commit hook, and concurrent block/metadata browser tests in WebKit and Chromium pass.

The full GoScript WebKit cold-browser check passes cached range reads and Drive reopening, then times out after 420 seconds waiting for the Git wizard (455.86 seconds for the test). It records no WebKitBlobResource error in this run. Offline Git startup remains unresolved. Repository CI was still running or queued at merge.
