### PR TITLE
fix(gc): retry startup replay without closing the volume

### DIFF
--- a/db/block/gc/manager.go
+++ b/db/block/gc/manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/pkg/errors"
 	trace "github.com/s4wave/spacewave/db/traceutil"
 )
 
@@ -41,8 +40,9 @@ func NewManager(cfg ManagerConfig) *Manager {
 	return &Manager{cfg: cfg}
 }
 
-// Run starts the GC manager lifecycle: startup WAL replay followed
-// by periodic sweep cycles. Blocks until the context is canceled.
+// Run replays the WAL at startup, then runs periodic sweep cycles until canceled.
+// Failed replay leaves unapplied entries for the next cycle and prevents sweeping;
+// maintenance failures must not terminate the volume serving application writes.
 func (m *Manager) Run(ctx context.Context) error {
 	ctx, task := trace.NewTask(ctx, "hydra/block-gc/manager")
 	defer task.End()
@@ -52,9 +52,11 @@ func (m *Manager) Run(ctx context.Context) error {
 	n, err := m.cfg.ReplayWAL(ctx, m.cfg.Graph)
 	replayTask.End()
 	if err != nil {
-		return errors.Wrap(err, "startup WAL replay")
-	}
-	if n > 0 {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		trace.Logf(ctx, "gc-manager", "startup WAL replay failed; retrying next cycle: %v", err)
+	} else if n > 0 {
 		trace.Logf(ctx, "gc-manager", "replayed %d WAL entries on startup", n)
 	}
 

--- a/db/block/gc/manager_test.go
+++ b/db/block/gc/manager_test.go
@@ -1,0 +1,74 @@
+package block_gc
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+	"time"
+)
+
+// TestManagerRetriesStartupReplay preserves pending ownership until replay succeeds.
+func TestManagerRetriesStartupReplay(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	graph := newMockGraph()
+	graph.addRoot("root")
+	graph.addNode(ObjectIRI("retained"))
+	graph.addNode(ObjectIRI("orphan"))
+	target := &mockSweepTarget{}
+	replays := 0
+	maintained := false
+	manager := NewManager(ManagerConfig{
+		SweepConfig: SweepConfig{
+			Graph:      graph,
+			Target:     target,
+			AcquireSTW: noopSTW,
+			ReplayWAL: func(ctx context.Context, graph CollectorGraph) (int, error) {
+				replays++
+				if replays <= 3 && len(target.deletedObjects) != 0 {
+					t.Fatal("swept objects before pending ownership was replayed")
+				}
+				if replays <= 2 {
+					return 0, errors.New("transaction attempts exhausted")
+				}
+				if replays == 3 {
+					return 1, graph.AddRef(ctx, "root", ObjectIRI("retained"))
+				}
+				return 0, nil
+			},
+		},
+		SweepInterval: time.Millisecond,
+		Maintenance: func(context.Context) error {
+			maintained = true
+			cancel()
+			return nil
+		},
+	})
+	if err := manager.Run(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("manager returned %v, want cancellation after recovery", err)
+	}
+	if replays != 4 || !maintained {
+		t.Fatalf("replays = %d, maintained = %t, want four replays and maintenance", replays, maintained)
+	}
+	if !slices.Equal(target.deletedObjects, []string{ObjectIRI("orphan")}) {
+		t.Fatalf("deleted objects = %v, want only the orphan", target.deletedObjects)
+	}
+}
+
+// TestManagerStartupReplayCancellation does not defer shutdown to the next cycle.
+func TestManagerStartupReplayCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	manager := NewManager(ManagerConfig{
+		SweepConfig: SweepConfig{
+			ReplayWAL: func(context.Context, CollectorGraph) (int, error) {
+				cancel()
+				return 0, errors.New("replay interrupted")
+			},
+		},
+	})
+	if err := manager.Run(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("manager returned %v, want cancellation", err)
+	}
+}


### PR DESCRIPTION
Startup WAL replay can exhaust its transaction attempts while application writes are active. The GC manager then terminates the ready volume, leaving offline Git Space creation retrying against a closed engine.

Keep the manager alive after failed startup replay and retry through the existing sweep cycle. Pending journal records remain durable, replay failure prevents sweeping, and cancellation still stops the manager. Storage formats and saved data are unchanged.

Validation: the GC package race suite passes. New recovery and cancellation regressions fail against the previous manager. Compile and lint hooks pass. The full GoScript WebKit offline startup check passes in 49.43 seconds, including cached range reads, cold Drive reopen with the server stopped, and Git repository creation.
