### PR TITLE
fix(opfs): retain one snapshot per transaction

### DIFF
--- a/db/volume/js/opfs/engine/engine_test.go
+++ b/db/volume/js/opfs/engine/engine_test.go
@@ -309,7 +309,7 @@ func TestStaleTransactionCannotOverwriteNewGeneration(t *testing.T) {
 	}
 }
 
-// TestTransactionCursor preserves prefix ordering, overlays, seeks, and conflicts.
+// TestTransactionCursor preserves ordering, overlays, seeks, and snapshot reads.
 func TestTransactionCursor(t *testing.T) {
 	ctx := t.Context()
 	e, err := Open(ctx, newDiskBackend(t))
@@ -382,7 +382,7 @@ func TestTransactionCursor(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Callback writes cannot deadlock on reclamation protection held by the scan.
+	// Callback writes preserve the scan snapshot and can reuse its protection.
 	read, err := e.NewTransaction(ctx, false)
 	if err != nil {
 		t.Fatal(err)
@@ -396,8 +396,8 @@ func TestTransactionCursor(t *testing.T) {
 		written = true
 		return e.Apply(ctx, nil, []*Record{{Key: []byte("new"), Value: []byte("generation")}})
 	})
-	if !errors.Is(err, kvtx.ErrInvalidSnapshot) {
-		t.Fatalf("scan combined generations: %v", err)
+	if err != nil {
+		t.Fatalf("scan across publication: %v", err)
 	}
 }
 

--- a/db/volume/js/opfs/engine/iterator.go
+++ b/db/volume/js/opfs/engine/iterator.go
@@ -9,7 +9,7 @@ import (
 )
 
 // iterator merges one bounded committed partition with bounded pending changes.
-// No file protection is held while the caller processes an entry.
+// Its transaction retains file protection until Commit or Discard.
 type iterator struct {
 	// ctx controls storage reads and iteration cancellation.
 	ctx context.Context
@@ -191,17 +191,13 @@ func (i *iterator) advance() bool {
 	}
 }
 
-// fill copies the next partition before releasing all file protection.
+// fill copies the next partition from the transaction's committed snapshot.
 func (i *iterator) fill() error {
 	if len(i.committed) != 0 || i.exhausted {
 		return nil
 	}
-	s, err := i.tx.engine.snapshot(i.ctx)
+	s, err := i.tx.readSnapshot(i.ctx)
 	if err != nil {
-		return err
-	}
-	defer s.release()
-	if err := i.tx.pin(i.tx.revision(s.root)); err != nil {
 		return err
 	}
 	records, err := s.seekEntries(i.ctx, i.boundary, i.exclusive, i.reverse)

--- a/db/volume/js/opfs/engine/metadata_test.go
+++ b/db/volume/js/opfs/engine/metadata_test.go
@@ -2,13 +2,7 @@
 
 package engine
 
-import (
-	"context"
-	"errors"
-	"testing"
-
-	"github.com/s4wave/spacewave/db/kvtx"
-)
+import "testing"
 
 // TestMetadataTransactionIgnoresBlockAndGCChanges preserves the metadata view.
 func TestMetadataTransactionIgnoresBlockAndGCChanges(t *testing.T) {
@@ -66,7 +60,7 @@ func TestMetadataTransactionIgnoresBlockAndGCChanges(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// A real metadata write must still invalidate the conservative read view.
+	// A later metadata publication cannot change an established read view.
 	read, err := store.NewTransaction(ctx, false)
 	if err != nil {
 		t.Fatal(err)
@@ -76,7 +70,10 @@ func TestMetadataTransactionIgnoresBlockAndGCChanges(t *testing.T) {
 		t.Fatal(err)
 	}
 	writeMetadata("other")
-	if _, _, err := read.Get(context.Background(), []byte("saved")); !errors.Is(err, kvtx.ErrInvalidSnapshot) {
-		t.Fatalf("changed metadata snapshot: %v", err)
+	if value, found, err := read.Get(ctx, []byte("saved")); err != nil || !found || string(value) != "value" {
+		t.Fatalf("retained metadata snapshot: %q, %t, %v", value, found, err)
+	}
+	if _, found, err := read.Get(ctx, []byte("other")); err != nil || found {
+		t.Fatalf("later metadata appeared in snapshot: %t, %v", found, err)
 	}
 }

--- a/db/volume/js/opfs/engine/transaction.go
+++ b/db/volume/js/opfs/engine/transaction.go
@@ -3,13 +3,13 @@ package engine
 import (
 	"bytes"
 	"context"
-	"sort"
+	"slices"
 
 	"github.com/s4wave/spacewave/db/kvtx"
 )
 
-// transaction buffers bounded mutations and pins the first observed generation.
-// Each file operation releases reclamation protection before application callbacks.
+// transaction buffers bounded mutations against one protected committed snapshot.
+// Commit or Discard releases the immutable files retained by the first read.
 type transaction struct {
 	// engine owns durable data and publication.
 	engine *Engine
@@ -19,10 +19,8 @@ type transaction struct {
 	metadata bool
 	// discarded closes the transaction and all derived iterators.
 	discarded bool
-	// pinned records whether generation has been established.
-	pinned bool
-	// generation is the complete view observed by this transaction.
-	generation uint64
+	// snapshot retains the first committed view until the transaction ends.
+	snapshot *snapshot
 	// pending provides read-your-writes within explicit memory bounds.
 	pending map[string]*Record
 	// pendingBytes charges retained mutation keys, values, and record overhead.
@@ -37,15 +35,16 @@ func (t *transaction) revision(root *Root) uint64 {
 	return root.Revision
 }
 
-// pin accepts the first observed generation and rejects all later mismatches.
-func (t *transaction) pin(generation uint64) error {
-	if !t.pinned {
-		t.generation = generation
-		t.pinned = true
-	} else if t.generation != generation {
-		return kvtx.ErrInvalidSnapshot
+// readSnapshot acquires the transaction's committed view on its first read.
+func (t *transaction) readSnapshot(ctx context.Context) (*snapshot, error) {
+	if t.snapshot == nil {
+		snapshot, err := t.engine.snapshot(ctx)
+		if err != nil {
+			return nil, err
+		}
+		t.snapshot = snapshot
 	}
-	return nil
+	return t.snapshot, nil
 }
 
 // check validates the transaction lifetime and caller cancellation.
@@ -53,7 +52,16 @@ func (t *transaction) check(ctx context.Context) error {
 	if t.discarded {
 		return kvtx.ErrDiscarded
 	}
-	return ctx.Err()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	t.engine.mtx.Lock()
+	closed := t.engine.closed
+	t.engine.mtx.Unlock()
+	if closed {
+		return ErrClosed
+	}
+	return nil
 }
 
 // Get returns a copied committed value or the transaction's pending value.
@@ -61,12 +69,8 @@ func (t *transaction) Get(ctx context.Context, key []byte) ([]byte, bool, error)
 	if err := t.check(ctx); err != nil {
 		return nil, false, err
 	}
-	snapshot, err := t.engine.snapshot(ctx)
+	snapshot, err := t.readSnapshot(ctx)
 	if err != nil {
-		return nil, false, err
-	}
-	defer snapshot.release()
-	if err := t.pin(t.revision(snapshot.root)); err != nil {
 		return nil, false, err
 	}
 	if pending := t.pending[string(key)]; pending != nil {
@@ -159,7 +163,7 @@ func (t *transaction) Iterate(ctx context.Context, prefix []byte, _ bool, revers
 			pending = append(pending, record)
 		}
 	}
-	sort.Slice(pending, func(i, j int) bool { return bytes.Compare(pending[i].Key, pending[j].Key) < 0 })
+	slices.SortFunc(pending, func(a, b *Record) int { return bytes.Compare(a.Key, b.Key) })
 	return &iterator{ctx: ctx, tx: t, prefix: bytes.Clone(prefix), reverse: reverse, pending: pending}
 }
 
@@ -176,19 +180,24 @@ func (t *transaction) Commit(ctx context.Context) error {
 	for _, record := range t.pending {
 		records = append(records, record)
 	}
-	sort.Slice(records, func(i, j int) bool { return bytes.Compare(records[i].Key, records[j].Key) < 0 })
+	slices.SortFunc(records, func(a, b *Record) int { return bytes.Compare(a.Key, b.Key) })
 	// Blind writes serialize against the current root without a stale read dependency.
 	var base *uint64
-	if t.pinned {
-		base = &t.generation
+	if t.snapshot != nil {
+		revision := t.revision(t.snapshot.root)
+		base = &revision
 	}
 	err := t.engine.apply(ctx, base, records, t.metadata)
 	t.Discard()
 	return err
 }
 
-// Discard releases retained mutations and invalidates derived iterators.
+// Discard releases the snapshot and mutations and invalidates derived iterators.
 func (t *transaction) Discard() {
+	if t.snapshot != nil {
+		t.snapshot.release()
+		t.snapshot = nil
+	}
 	t.discarded = true
 	t.pending = nil
 	t.pendingBytes = 0

--- a/db/volume/js/opfs/engine/transaction_test.go
+++ b/db/volume/js/opfs/engine/transaction_test.go
@@ -5,6 +5,7 @@ package engine
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/s4wave/spacewave/db/kvtx"
 )
@@ -123,75 +124,76 @@ func TestTransactionReadDependencyRejectsLogicalWrite(t *testing.T) {
 	}
 }
 
-// TestTransactionSurvivesPhysicalReclaim proves metadata commits use revision.
-func TestTransactionSurvivesPhysicalReclaim(t *testing.T) {
+// TestTransactionRetainsSnapshot proves reads remain stable and reclamation resumes.
+func TestTransactionRetainsSnapshot(t *testing.T) {
 	ctx := t.Context()
-	engine, err := Open(ctx, newDiskBackend(t))
+	disk := newDiskBackend(t)
+	queued := make(chan struct{}, 1)
+	backend := &queuedReclaimBackend{Backend: disk, queued: queued}
+	engine, err := Open(ctx, backend)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer engine.Close()
-
-	seed, err := engine.NewTransaction(ctx, true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := seed.Set(ctx, []byte("metadata"), []byte("before reclaim")); err != nil {
-		t.Fatal(err)
-	}
-	if err := seed.Commit(ctx); err != nil {
-		t.Fatal(err)
-	}
-	before, err := engine.loadRoot(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if before.ReclaimNext > before.RetireThrough {
-		t.Fatal("seed publication did not construct retired files")
-	}
-
-	tx, err := engine.NewTransaction(ctx, true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	value, found, err := tx.Get(ctx, []byte("metadata"))
-	if err != nil || !found || string(value) != "before reclaim" {
-		t.Fatalf("metadata read = %q, %t, %v", value, found, err)
-	}
-	if err := tx.Set(ctx, []byte("metadata"), []byte("after reclaim")); err != nil {
+	if err := engine.Apply(ctx, nil, []*Record{{Key: []byte("key"), Value: []byte("before")}}); err != nil {
 		t.Fatal(err)
 	}
 
-	for {
-		progress, err := engine.Reclaim(ctx)
+	for _, commit := range []bool{false, true} {
+		tx, err := engine.NewTransaction(ctx, false)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !progress {
-			break
+		defer tx.Discard()
+		value, found, err := tx.Get(ctx, []byte("key"))
+		if err != nil || !found {
+			t.Fatalf("initial read: %q, %t, %v", value, found, err)
 		}
-	}
-	after, err := engine.loadRoot(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if after.Generation <= before.Generation {
-		t.Fatalf("generation = %d, want greater than %d", after.Generation, before.Generation)
-	}
-	if after.Revision != before.Revision {
-		t.Fatalf("revision changed during reclaim: %d to %d", before.Revision, after.Revision)
-	}
-	if err := tx.Commit(ctx); err != nil {
-		t.Fatalf("commit after reclaim: %v", err)
-	}
+		reads := disk.reads
+		for range 100 {
+			if _, _, err := tx.Get(ctx, []byte("key")); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if disk.reads != reads {
+			t.Fatalf("repeated snapshot reads performed %d extra file reads", disk.reads-reads)
+		}
 
-	read, err := engine.NewTransaction(ctx, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer read.Discard()
-	value, found, err = read.Get(ctx, []byte("metadata"))
-	if err != nil || !found || string(value) != "after reclaim" {
-		t.Fatalf("metadata after commit = %q, %t, %v", value, found, err)
+		reclaimed := make(chan error, 1)
+		go func() {
+			_, err := engine.Reclaim(ctx)
+			reclaimed <- err
+		}()
+		select {
+		case <-queued:
+		case <-time.After(5 * time.Second):
+			t.Fatal("reclamation did not queue")
+		}
+		if err := engine.Apply(ctx, nil, []*Record{{Key: []byte("key"), Value: []byte("after")}}); err != nil {
+			t.Fatal(err)
+		}
+		if got, found, err := tx.Get(ctx, []byte("key")); err != nil || !found || string(got) != string(value) {
+			t.Fatalf("snapshot changed during publication: %q, %t, %v", got, found, err)
+		}
+		select {
+		case err := <-reclaimed:
+			t.Fatalf("reclamation bypassed live snapshot: %v", err)
+		default:
+		}
+		if commit {
+			if err := tx.Commit(ctx); err != nil {
+				t.Fatal(err)
+			}
+		} else {
+			tx.Discard()
+		}
+		select {
+		case err := <-reclaimed:
+			if err != nil {
+				t.Fatal(err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("reclamation did not resume after snapshot release")
+		}
 	}
 }


### PR DESCRIPTION
OPFS transactions now retain one immutable snapshot from their first read until commit or discard. Concurrent publication no longer invalidates read-only traversal, and repeated reads avoid reopening the durable roots. Writes still validate the observed revision before publication.

Validation: OPFS engine tests and race check passed; the compiled browser passed the Chromium landing-to-Drive scenario. A 100-read regression check performs no additional file reads. Broader browser acceptance is deferred until the startup optimization campaign is complete.
