### PR TITLE
test(e2e): serve browser startup from a local CDN

### DIFF
--- a/core/release/publisher/export.go
+++ b/core/release/publisher/export.go
@@ -1,0 +1,46 @@
+package publisher
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	packfile "github.com/s4wave/spacewave/core/provider/spacewave/packfile"
+	"github.com/s4wave/spacewave/core/provider/spacewave/packfile/delta"
+	"github.com/s4wave/spacewave/core/release"
+	"github.com/s4wave/spacewave/db/bucket"
+	"github.com/s4wave/spacewave/db/world"
+	"github.com/s4wave/spacewave/net/hash"
+)
+
+// Export emits the verified release closure as content-addressed CDN packs.
+// The caller exclusively owns the World until Export returns, retains emitted
+// packs, and publishes the returned head only after every pack is durable.
+// Export does not read credentials or contact a remote service.
+func Export(ctx context.Context, eng world.Engine, metadata *release.ReleaseMetadata, spaceID string, emit delta.ChunkEmitter) (*bucket.ObjectRef, []*packfile.PackfileEntry, error) {
+	// Verify the complete closure before emitting any artifact.
+	if eng == nil || spaceID == "" || emit == nil {
+		return nil, nil, errors.New("release World, Space ID, and pack emitter are required")
+	}
+	if err := metadata.Validate(); err != nil {
+		return nil, nil, err
+	}
+	head, blocks, err := collectBlocks(ctx, eng, metadata)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Preserve the same manifest-local ordering and pack limits as publication.
+	index := 0
+	entries, err := delta.EmitDeltaChunks(ctx, spaceID, func() (*hash.Hash, []byte, error) {
+		if index == len(blocks) {
+			return nil, nil, nil
+		}
+		entry := blocks[index]
+		index++
+		return entry.ref.GetHash(), entry.data, nil
+	}, delta.DefaultMaxChunkBytes, emit)
+	if err != nil {
+		return nil, nil, err
+	}
+	return head, entries, nil
+}

--- a/e2e/releasewasm/README.md
+++ b/e2e/releasewasm/README.md
@@ -1,0 +1,25 @@
+# Local CDN startup measurement
+
+Run the cold Chromium landing-to-Drive scenario with:
+
+```sh
+bun run test:release:web:startup
+```
+
+The harness incrementally builds unminified release artifacts, exports the
+startup plugins into real CDN KVF packs, and serves them on
+`http://127.0.0.1:30772`. The production bootstrap embeds only the launcher and
+materializer. The browser fetches a signed distribution fixture, the CDN root
+pointer, and plugin packs through the production loading path. Each run starts
+with an empty browser context and reports navigation-to-file and click-to-file
+times after reaching `getting-started.md` and checking the invitation dialog.
+
+Build and publication state live in `.bldr-startup`. Bldr checks source changes
+on every run and reuses unchanged manifests. The build keeps the release
+manifest selection rules, with JavaScript and entrypoint minification disabled.
+Build time is outside the measured browser interval.
+
+Browser proxy isolation blocks external network access while retaining normal
+HTTP caching. The optional public-content catalog is unavailable, and the local
+provider has no cloud signaling connection. This scenario measures local
+startup and storage costs; it does not measure internet delivery latency.

--- a/e2e/releasewasm/harness.go
+++ b/e2e/releasewasm/harness.go
@@ -78,16 +78,31 @@ func boot(ctx context.Context, le *logrus.Entry) (_ *harness, retErr error) {
 		return nil, errors.Wrap(err, "find repo root")
 	}
 
-	distDirs, err := prepareReleaseWasmDist(ctx, le, repoRoot)
+	// Own the listening socket before building or starting any browser consumer.
+	port := "0"
+	if os.Getenv(localCDNEnv) == "1" {
+		port = localCDNPort
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:"+port)
+	if err != nil {
+		return nil, errors.Wrap(err, "listen for release browser harness")
+	}
+	defer func() {
+		if retErr != nil {
+			listener.Close()
+		}
+	}()
+	port = strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
+	baseURL := "http://127.0.0.1:" + port
+	var distDirs releaseWasmDistDirs
+	if os.Getenv(localCDNEnv) == "1" {
+		distDirs, err = prepareLocalCDN(ctx, le, repoRoot, baseURL)
+	} else {
+		distDirs, err = prepareReleaseWasmDist(ctx, le, repoRoot)
+	}
 	if err != nil {
 		return nil, err
 	}
-
-	port, err := findFreePort()
-	if err != nil {
-		return nil, errors.Wrap(err, "find free port")
-	}
-	baseURL := "http://127.0.0.1:" + port
 	artifactDir := filepath.Join(repoRoot, ".bldr", "e2e-releasewasm", "artifacts")
 	browserName, err := releaseWasmBrowserName()
 	if err != nil {
@@ -111,19 +126,20 @@ func boot(ctx context.Context, le *logrus.Entry) (_ *harness, retErr error) {
 		}
 	}()
 
+	handler := releaseHandler(distDirs.releaseDist, distDirs.prerender, baseURL)
+	if os.Getenv(localCDNEnv) == "1" {
+		handler = localCDNHandler(handler)
+	}
 	h.server = &http.Server{
 		Addr:              "127.0.0.1:" + port,
-		Handler:           releaseHandler(distDirs.releaseDist, distDirs.prerender, baseURL),
+		Handler:           handler,
 		ReadHeaderTimeout: 30 * time.Second,
 	}
 	go func() {
-		if err := h.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := h.server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			le.WithError(err).Error("release wasm server exited")
 		}
 	}()
-	if err := h.waitForReady(ctx); err != nil {
-		return nil, errors.Wrap(err, "wait for release server")
-	}
 
 	le.WithField("browser", browserName).Info("installing playwright driver")
 	if err := playwright.Install(&playwright.RunOptions{
@@ -149,6 +165,11 @@ func boot(ctx context.Context, le *logrus.Entry) (_ *harness, retErr error) {
 		opts := playwright.BrowserTypeLaunchOptions{Headless: new(true)}
 		if browserName == "chromium" {
 			opts = e2eharness.ChromiumLaunchOptions(true, gpu)
+		}
+		if os.Getenv(localCDNEnv) == "1" {
+			// The static server rejects proxy requests; all browser network access
+			// stays local, including requests made by service and shared workers.
+			opts.Proxy = &playwright.Proxy{Server: baseURL, Bypass: new("127.0.0.1,localhost")}
 		}
 		return browserType.Launch(opts)
 	}
@@ -795,35 +816,4 @@ func runBun(ctx context.Context, dir string, args ...string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
-}
-
-func (h *harness) waitForReady(ctx context.Context) error {
-	client := &http.Client{Timeout: 2 * time.Second}
-	for {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, h.baseURL+"/browser-release.json", nil)
-		if err != nil {
-			return err
-		}
-		resp, err := client.Do(req)
-		if err == nil {
-			resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				return nil
-			}
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(200 * time.Millisecond):
-		}
-	}
-}
-
-func findFreePort() (string, error) {
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		return "", err
-	}
-	defer l.Close()
-	return strconv.Itoa(l.Addr().(*net.TCPAddr).Port), nil
 }

--- a/e2e/releasewasm/local-cdn-config.go
+++ b/e2e/releasewasm/local-cdn-config.go
@@ -1,0 +1,102 @@
+//go:build !js
+
+package releasewasm
+
+import (
+	"path/filepath"
+
+	configset_proto "github.com/aperturerobotics/controllerbus/controller/configset/proto"
+	"github.com/pkg/errors"
+	compiler "github.com/s4wave/spacewave/bldr/plugin/compiler/go"
+	project "github.com/s4wave/spacewave/bldr/project"
+	starlark "github.com/s4wave/spacewave/bldr/project/starlark"
+	cdn_world "github.com/s4wave/spacewave/core/cdn/world/controller"
+	launcher "github.com/s4wave/spacewave/core/provider/spacewave/launcher/controller"
+	volume_bolt "github.com/s4wave/spacewave/db/volume/bolt"
+)
+
+const (
+	localCDNEnv     = "E2E_RELEASE_WASM_LOCAL_CDN"
+	localCDNPort    = "30772"
+	localCDNSpaceID = "01kqjmfxd44r7ggrq78efad3d2"
+	localCDNState   = ".bldr-startup"
+)
+
+// localCDNProject composes the production bootstrap and plugin build targets
+// with localhost delivery and the existing public distribution test identity.
+func localCDNProject(repoRoot, baseURL string) (*project.ProjectConfig, string, error) {
+	// Retain production manifest selection, embedding, and host configuration.
+	result, err := starlark.Evaluate(filepath.Join(repoRoot, "bldr.star"))
+	if err != nil {
+		return nil, "", err
+	}
+	conf := result.Config
+	build := conf.Build["release-web"]
+	build.Targets = nil
+	build.PlatformIds = []string{"js"}
+	var bootstrap compiler.Config
+	if err := bootstrap.UnmarshalJSON(build.ManifestOverrides["spacewave-launcher"].Config); err != nil {
+		return nil, "", err
+	}
+	var worldConf cdn_world.Config
+	if err := worldConf.UnmarshalJSON(bootstrap.HostConfigSet["release-world"].Config); err != nil {
+		return nil, "", err
+	}
+	worldConf.CdnBaseUrl = baseURL + "/cdn"
+	worldConf.SpaceId = localCDNSpaceID
+	bootstrap.HostConfigSet["release-world"].Config, err = worldConf.MarshalJSON()
+	if err != nil {
+		return nil, "", err
+	}
+
+	// Fetch the signed test distribution through HTTP instead of embedding it.
+	var testBootstrap compiler.Config
+	if err := testBootstrap.UnmarshalJSON(conf.Build["release-web-e2e-goscript"].ManifestOverrides["spacewave-launcher"].Config); err != nil {
+		return nil, "", err
+	}
+	var dist launcher.Config
+	if err := dist.UnmarshalJSON(testBootstrap.ConfigSet["spacewave-launcher"].Config); err != nil {
+		return nil, "", err
+	}
+	packedConfig := dist.InitDistConfig
+	if packedConfig == "" {
+		return nil, "", errors.New("local CDN requires the signed distribution fixture")
+	}
+	dist.InitDistConfig = ""
+	dist.DisableEndpointFetch = false
+	dist.Endpoints = []*launcher.HttpEndpoint{{Url: baseURL + "/distribution.packedmsg"}}
+	bootstrap.ConfigSet["spacewave-launcher"].Config, err = dist.MarshalJSON()
+	if err != nil {
+		return nil, "", err
+	}
+	build.ManifestOverrides["spacewave-launcher"].Config, err = bootstrap.MarshalJSON()
+	if err != nil {
+		return nil, "", err
+	}
+
+	// Build the actual startup closure separately from its two embedded plugins.
+	// The local provider keeps foreground storage and RPC without cloud signaling.
+	core := conf.Build["release-web-e2e-goscript"].ManifestOverrides["spacewave-core"].CloneVT()
+	conf.Build["local-startup-plugins"] = &project.BuildConfig{
+		Manifests:         []string{"spacewave-core", "spacewave-web", "spacewave-app"},
+		PlatformIds:       []string{"js"},
+		ManifestOverrides: map[string]*configset_proto.ControllerConfig{"spacewave-core": core},
+	}
+	conf.Build["local-startup-web"] = &project.BuildConfig{
+		Manifests: []string{"web"}, PlatformIds: []string{"web/js/wasm"},
+	}
+
+	// Publish only this closure into a dedicated local World owned by the harness.
+	remote := conf.Remotes["spacewave-release"]
+	var volume volume_bolt.Config
+	if err := volume.UnmarshalJSON(remote.HostConfigSet["release-volume"].Config); err != nil {
+		return nil, "", err
+	}
+	volume.Path = filepath.Join(repoRoot, localCDNState, "publication", "release.bdb")
+	remote.HostConfigSet["release-volume"].Config, err = volume.MarshalJSON()
+	if err != nil {
+		return nil, "", err
+	}
+	conf.Publish["spacewave-release"].Manifests = []string{"spacewave-core", "spacewave-web", "spacewave-app", "web"}
+	return conf, packedConfig, nil
+}

--- a/e2e/releasewasm/local-cdn-startup_test.go
+++ b/e2e/releasewasm/local-cdn-startup_test.go
@@ -1,0 +1,83 @@
+//go:build !skip_e2e && !js
+
+package releasewasm
+
+import (
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	playwright "github.com/mxschmitt/playwright-go"
+	"github.com/s4wave/spacewave/core/cdn"
+)
+
+// TestLocalCDNDriveStartup measures the production landing-to-Drive operation
+// over localhost distribution metadata and KVF packs in a fresh browser context.
+func TestLocalCDNDriveStartup(t *testing.T) {
+	if os.Getenv(localCDNEnv) != "1" {
+		t.Skip("set " + localCDNEnv + "=1 to build and serve the local startup CDN")
+	}
+
+	// Observe delivery without request interception, which disables HTTP caching.
+	page := testHarness.newPage(t)
+	var mtx sync.Mutex
+	var external []string
+	var distribution, root, ranges int
+	page.Context().OnRequest(func(req playwright.Request) {
+		// The optional public-content catalog is absent from this fixture.
+		// Browser proxy isolation rejects its connection before any remote I/O.
+		if req.URL() == cdn.DefaultBaseURL+"/"+cdn.ProvisionedSpaceID+"/root.packedmsg" {
+			return
+		}
+		u, err := url.Parse(req.URL())
+		if err != nil || u.Hostname() != "127.0.0.1" {
+			mtx.Lock()
+			external = append(external, req.URL())
+			mtx.Unlock()
+			return
+		}
+		mtx.Lock()
+		switch {
+		case strings.HasSuffix(u.Path, "/distribution.packedmsg"):
+			distribution++
+		case strings.HasSuffix(u.Path, "/root.packedmsg"):
+			root++
+		case strings.HasSuffix(u.Path, ".kvf"):
+			ranges++
+		}
+		mtx.Unlock()
+	})
+
+	// Start exactly where a new visitor starts, before the runtime is booted.
+	if _, err := page.Goto(testHarness.baseURL + "/"); err != nil {
+		t.Fatal(err)
+	}
+	clickMS := browserNowMs(t, page)
+	if err := page.Locator("a").Filter(playwright.LocatorFilterOptions{HasText: "Create a Drive"}).First().Click(); err != nil {
+		t.Fatal(err)
+	}
+	waitForLiveApp(t, page)
+	waitForQuickstartAppRoute(t, page)
+	readyMS, failure := waitForQuickstartDriveContentReady(t, page)
+	if failure != "" {
+		t.Fatal(failure)
+	}
+	completeQuickstartDriveIntroIfPresent(t, page)
+	if _, failure := exerciseQuickstartDriveGoldenPath(t, page); failure != "" {
+		t.Fatal(failure)
+	}
+	logQuickstartTiming(t, page)
+
+	// A successful timing must include the remote-loading contract it measures.
+	mtx.Lock()
+	defer mtx.Unlock()
+	t.Logf("local CDN startup: navigation=%dms click-to-file=%dms distribution=%d roots=%d pack-requests=%d", *readyMS, *readyMS-clickMS, distribution, root, ranges)
+	if len(external) != 0 {
+		t.Errorf("startup attempted external requests: %v", external)
+	}
+	if distribution == 0 || root == 0 || ranges == 0 {
+		t.Error("startup did not exercise distribution, CDN root, and pack loading")
+	}
+}

--- a/e2e/releasewasm/local-cdn.go
+++ b/e2e/releasewasm/local-cdn.go
@@ -1,0 +1,161 @@
+//go:build !js
+
+package releasewasm
+
+import (
+	"context"
+	"crypto/rand"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/s4wave/spacewave/bldr/util/packedmsg"
+	"github.com/s4wave/spacewave/core/cdn"
+	packfile "github.com/s4wave/spacewave/core/provider/spacewave/packfile"
+	"github.com/s4wave/spacewave/core/release"
+	"github.com/s4wave/spacewave/core/release/publisher"
+	"github.com/s4wave/spacewave/core/sobject"
+	world_engine "github.com/s4wave/spacewave/core/sobject/world/engine"
+	"github.com/s4wave/spacewave/db/world"
+	"github.com/s4wave/spacewave/net/crypto"
+	"github.com/s4wave/spacewave/net/hash"
+	"github.com/sirupsen/logrus"
+)
+
+// prepareLocalCDN builds incrementally with release selection and unminified
+// JavaScript, then exports a complete localhost CDN before browser navigation.
+func prepareLocalCDN(ctx context.Context, le *logrus.Entry, repoRoot, baseURL string) (releaseWasmDistDirs, error) {
+	// Keep build state separate from release artifacts and shared development data.
+	stateDir := filepath.Join(repoRoot, localCDNState)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		return releaseWasmDistDirs{}, err
+	}
+	conf, distConfig, err := localCDNProject(repoRoot, baseURL)
+	if err != nil {
+		return releaseWasmDistDirs{}, err
+	}
+	configData, err := conf.MarshalJSON()
+	if err != nil {
+		return releaseWasmDistDirs{}, err
+	}
+	configPath := filepath.Join(localCDNState, "project.json")
+	if err := os.WriteFile(filepath.Join(repoRoot, configPath), configData, 0o644); err != nil {
+		return releaseWasmDistDirs{}, err
+	}
+
+	// Bldr owns source invalidation and rebuilds only changed manifests.
+	le.Info("building local CDN startup artifacts without JavaScript minification")
+	args := []string{"run", "bldr", "--", "--config=" + configPath, "--state-path=" + localCDNState,
+		"--build-type=release", "--js-minification=disable", "--minify-entrypoint=false"}
+	if err := runBun(ctx, repoRoot, append(args, "build", "-b", "local-startup-plugins,local-startup-web,release-web")...); err != nil {
+		return releaseWasmDistDirs{}, errors.Wrap(err, "build local CDN startup")
+	}
+
+	// Each publication contains only the current build, so earlier candidates
+	// cannot accumulate historical manifests and change later measurements.
+	publicationDir := filepath.Join(stateDir, "publication")
+	if err := os.RemoveAll(publicationDir); err != nil {
+		return releaseWasmDistDirs{}, err
+	}
+	if err := os.MkdirAll(publicationDir, 0o755); err != nil {
+		return releaseWasmDistDirs{}, err
+	}
+	if err := runBun(ctx, repoRoot, append(args, "publish", "-p", "spacewave-release")...); err != nil {
+		return releaseWasmDistDirs{}, errors.Wrap(err, "publish local startup World")
+	}
+	dirs := releaseWasmDistDirs{
+		releaseDist: filepath.Join(stateDir, "build", "js", "spacewave-browser", "dist"),
+		prerender:   filepath.Join(repoRoot, prerenderDistRelPath),
+	}
+	if err := exportLocalCDN(ctx, le, stateDir, dirs.releaseDist); err != nil {
+		return releaseWasmDistDirs{}, err
+	}
+	if err := os.WriteFile(filepath.Join(dirs.releaseDist, "distribution.packedmsg"), []byte(distConfig), 0o644); err != nil {
+		return releaseWasmDistDirs{}, err
+	}
+
+	// Use the same landing page and hydration composition as browser releases.
+	for _, config := range []string{"app/prerender/vite.hydrate.config.ts", "app/prerender/vite.ssr.config.ts"} {
+		if err := runBun(ctx, repoRoot, "run", "vite", "build", "--minify=false", "--config", config); err != nil {
+			return releaseWasmDistDirs{}, err
+		}
+	}
+	if err := runBun(ctx, repoRoot, "./app/prerender/ssr-dist/build.js", "--dist-dir", dirs.releaseDist); err != nil {
+		return releaseWasmDistDirs{}, err
+	}
+	return dirs, nil
+}
+
+// exportLocalCDN writes real release packs and their signed root pointer to
+// the static origin. Its temporary signing key never leaves this process.
+func exportLocalCDN(ctx context.Context, le *logrus.Entry, stateDir, distDir string) error {
+	// Mount only the dedicated fixture database and stage its current manifests.
+	w, err := publisher.OpenLocalWorld(ctx, le, filepath.Join(stateDir, "publication", "release.bdb"), "spacewave-release-world", "spacewave-release")
+	if err != nil {
+		return err
+	}
+	defer w.Release()
+	var metadata *release.ReleaseMetadata
+	err = world.ExecTransaction(ctx, w.Engine, true, func(ctx context.Context, ws world.WorldState) error {
+		var err error
+		metadata, err = publisher.StageChannel(ctx, ws, "spacewave/release/manifests", &release.ReleaseMetadata{
+			ProjectId: "spacewave", Version: "0.0.0-local", ChannelKey: "stable", Rev: 1,
+		})
+		return err
+	})
+	if err != nil {
+		return err
+	}
+
+	// The production exporter verifies every referenced block before emission.
+	cdnDir := filepath.Join(distDir, "cdn", localCDNSpaceID)
+	head, packs, err := publisher.Export(ctx, w.Engine, metadata, localCDNSpaceID,
+		func(ctx context.Context, index int, entry *packfile.PackfileEntry, data []byte) error {
+			path := filepath.Join(cdnDir, "packs", entry.Id[:2], entry.Id+".kvf")
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				return err
+			}
+			return os.WriteFile(path, data, 0o644)
+		})
+	if err != nil {
+		return errors.Wrap(err, "export local CDN packs")
+	}
+
+	// Publish the pointer only after all immutable packs are available.
+	head = head.CloneVT()
+	head.BucketId = ""
+	stateData, err := (&world_engine.InnerState{HeadRef: head}).MarshalVT()
+	if err != nil {
+		return err
+	}
+	inner, err := (&sobject.SORootInner{Seqno: 1, StateData: stateData}).MarshalVT()
+	if err != nil {
+		return err
+	}
+	key, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		return err
+	}
+	root := &sobject.SORoot{Inner: inner, InnerSeqno: 1}
+	if err := root.SignInnerData(key, localCDNSpaceID, 1, hash.RecommendedHashType); err != nil {
+		return err
+	}
+	data, err := (&cdn.CdnRootPointer{SpaceId: localCDNSpaceID, Root: root, Packs: packs}).MarshalVT()
+	if err != nil {
+		return err
+	}
+	le.WithField("packs", len(packs)).Info("exported local startup CDN")
+	return os.WriteFile(filepath.Join(cdnDir, "root.packedmsg"), []byte(packedmsg.EncodePackedMessage(data)), 0o644)
+}
+
+// localCDNHandler serves the fixture and rejects outbound proxy connections.
+func localCDNHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.Method == http.MethodConnect || req.URL.IsAbs() {
+			http.Error(rw, "external network is unavailable", http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(rw, req)
+	})
+}

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "test:browser:ui": "cross-env BROWSER_TEST_UI=1 bun run test:browser",
     "test:browser:watch": "cross-env BROWSER_TEST_WATCH=1 bun run test:browser",
     "test:release:web": "bun run test:go:e2e:release-wasm",
+    "test:release:web:startup": "cross-env ENABLE_E2E_RELEASE_WASM=true E2E_RELEASE_WASM_LOCAL_CDN=1 E2E_RELEASE_WASM_GOSCRIPT=true E2E_RELEASE_WASM_BROWSER=chromium go test -count=1 -timeout=20m -v ./e2e/releasewasm -run '^TestLocalCDNDriveStartup$'",
     "test:browser:nobackend": "vitest --config=vitest.browser.config.ts --run",
     "test:browser:nobackend:watch": "vitest --config=vitest.browser.config.ts",
     "test:browser:nobackend:ui": "cross-env BROWSER_TEST_UI=1 vitest --config=vitest.browser.config.ts --ui",


### PR DESCRIPTION
The release browser tests embed the startup plugins, so they do not measure distribution and CDN loading. Add `bun run test:release:web:startup` to build unminified release artifacts incrementally, export the verified plugin closure into local KVF packs, and run the landing-page Drive scenario against localhost.

The harness owns its listening socket before building, recreates only its dedicated publication database, and blocks external browser traffic through a local rejecting proxy. The scenario requires distribution, root-pointer, and pack requests, reaches `getting-started.md`, and exercises the invitation dialog. The optional public-content catalog and cloud signaling are outside this fixture.

Validation: the local Chromium scenario passes on the final change, including real CDN loading and foreground storage. Commit hooks pass. Timing remains slow and variable (47.4 seconds before publication isolation, 58.3 seconds on the final fixture); this change provides the local measurement loop, not a startup performance claim.
