### PR TITLE
perf(db): share concurrent OPFS root descriptor reads

### DIFF
--- a/db/volume/js/opfs/engine/engine.go
+++ b/db/volume/js/opfs/engine/engine.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/aperturerobotics/util/csync"
+	"github.com/aperturerobotics/util/promise"
 	"github.com/s4wave/spacewave/db/kvtx"
 )
 
@@ -25,8 +26,10 @@ const (
 type Engine struct {
 	// backend owns storage and cross-runtime locks for this volume.
 	backend Backend
-	// mtx protects the instance lifecycle and immutable byte cache.
+	// mtx protects the lifecycle, immutable cache, and pending root read.
 	mtx sync.Mutex
+	// rootRead shares only an in-flight descriptor read under shared root locks.
+	rootRead *promise.Promise[*Root]
 	// pin serializes acquisition of the shared cross-runtime reader lease.
 	pin csync.Mutex
 	// readers counts active local operations sharing reclamation protection.
@@ -61,6 +64,7 @@ type cacheEntry struct {
 
 // Open validates the current root or creates an empty volume.
 func Open(ctx context.Context, backend Backend) (_ *Engine, retErr error) {
+	// Keep initialization locks and failed-open cleanup with this construction.
 	defer func() {
 		if retErr != nil {
 			retErr = errors.Join(retErr, backend.Close())
@@ -82,12 +86,14 @@ func Open(ctx context.Context, backend Backend) (_ *Engine, retErr error) {
 	if err := e.cleanIntent(ctx); err != nil {
 		return nil, err
 	}
-	if _, err := e.loadRoot(ctx); err == nil {
+	_, err = e.loadRoot(ctx)
+	if err == nil {
 		if err := e.ensureIdentity(ctx); err != nil {
 			return nil, err
 		}
 		return e, nil
-	} else if !errors.Is(err, fs.ErrNotExist) {
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
 		return nil, err
 	}
 
@@ -139,6 +145,7 @@ func (e *Engine) readFile(ctx context.Context, name string) ([]byte, error) {
 
 // readCached charges one immutable file or payload window to the shared cache.
 func (e *Engine) readCached(ctx context.Context, key, name string, offset int64, length int) ([]byte, error) {
+	// Resolve resident immutable bytes while the cache remains open.
 	e.mtx.Lock()
 	if e.closed {
 		e.mtx.Unlock()
@@ -152,6 +159,7 @@ func (e *Engine) readCached(ctx context.Context, key, name string, offset int64,
 	}
 	e.mtx.Unlock()
 
+	// Read outside the cache lock, then reconcile any concurrent insertion.
 	data, err := e.backend.Read(ctx, name, offset, length)
 	if err != nil {
 		return nil, err
@@ -237,6 +245,7 @@ func (e *Engine) Apply(ctx context.Context, base *uint64, records []*Record) err
 
 // apply validates the caller's revision domain under the shared publication lock.
 func (e *Engine) apply(ctx context.Context, base *uint64, records []*Record, metadata bool) error {
+	// Serialize publication while protecting the generation's immutable files.
 	if err := validateRecords(records); err != nil {
 		return err
 	}
@@ -251,6 +260,7 @@ func (e *Engine) apply(ctx context.Context, base *uint64, records []*Record, met
 	}
 	defer unlock()
 
+	// Validate against the durable root after acquiring publication authority.
 	root, err := e.loadRoot(ctx)
 	if err != nil {
 		return err
@@ -265,6 +275,7 @@ func (e *Engine) apply(ctx context.Context, base *uint64, records []*Record, met
 	if len(records) == 0 {
 		return nil
 	}
+	// Build the next immutable generation before replacing either descriptor.
 	p := newPublication(e, root)
 	p.root.Revision++
 	for _, record := range records {

--- a/db/volume/js/opfs/engine/snapshot.go
+++ b/db/volume/js/opfs/engine/snapshot.go
@@ -3,8 +3,12 @@ package engine
 import (
 	"bytes"
 	"context"
+	"errors"
 	"slices"
 	"sort"
+
+	"github.com/aperturerobotics/util/promise"
+	"github.com/s4wave/spacewave/db/traceutil"
 )
 
 // snapshot pins immutable files across one read operation.
@@ -34,12 +38,56 @@ func (e *Engine) snapshot(ctx context.Context) (*snapshot, error) {
 		return nil, err
 	}
 	defer unlock()
-	root, err := e.loadRoot(ctx)
+	root, err := e.readSnapshotRoot(ctx)
 	if err != nil {
 		release()
 		return nil, err
 	}
 	return &snapshot{engine: e, root: root, release: release}, nil
+}
+
+// readSnapshotRoot shares overlapping descriptor reads. Every caller holds its
+// own shared root lock, preventing publication while it joins or consumes the
+// pending read. The result is removed before any of those locks are released;
+// a later operation always rereads durable state.
+func (e *Engine) readSnapshotRoot(ctx context.Context) (*Root, error) {
+	for {
+		// Join an existing read or perform it in the caller's own lifetime.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		e.mtx.Lock()
+		pending := e.rootRead
+		leader := pending == nil
+		if leader {
+			pending = promise.NewPromise[*Root]()
+			e.rootRead = pending
+		}
+		e.mtx.Unlock()
+		if leader {
+			traceutil.Log(ctx, "hydra/opfs-engine/root-read", "read")
+			root, err := e.loadRoot(ctx)
+			if ctx.Err() != nil {
+				root, err = nil, ctx.Err()
+			}
+			e.mtx.Lock()
+			e.rootRead = nil
+			e.mtx.Unlock()
+			pending.SetResult(root, err)
+			return root, err
+		}
+
+		// One caller's cancellation cannot cancel another caller's snapshot.
+		traceutil.Log(ctx, "hydra/opfs-engine/root-read", "joined")
+		root, err := pending.Await(ctx)
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			continue
+		}
+		return root, err
+	}
 }
 
 // get resolves a full key through one partition's bounded newest-first runs.

--- a/e2e/releasewasm/README.md
+++ b/e2e/releasewasm/README.md
@@ -19,6 +19,17 @@ on every run and reuses unchanged manifests. The build keeps the release
 manifest selection rules, with JavaScript and entrypoint minification disabled.
 Build time is outside the measured browser interval.
 
+Capture the root worker's runtime trace during the same scenario with:
+
+```sh
+E2E_RELEASE_WASM_MANIFEST_STARTUP_TRACE=1 bun run test:release:web:startup
+```
+
+The trace is written to
+`.bldr/e2e-releasewasm/artifacts/local-cdn-startup.trace`. Trace-enabled runs
+include instrumentation overhead and should be compared separately from timings
+without tracing.
+
 Browser proxy isolation blocks external network access while retaining normal
 HTTP caching. The optional public-content catalog is unavailable, and the local
 provider has no cloud signaling connection. This scenario measures local

--- a/e2e/releasewasm/local-cdn-startup_test.go
+++ b/e2e/releasewasm/local-cdn-startup_test.go
@@ -5,6 +5,7 @@ package releasewasm
 import (
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -69,6 +70,20 @@ func TestLocalCDNDriveStartup(t *testing.T) {
 		t.Fatal(failure)
 	}
 	logQuickstartTiming(t, page)
+	if releaseStartupTraceEnabled() {
+		data, err := captureReleaseStartupTrace(t.Context(), testHarness.browser)
+		if err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(testHarness.artifactDir, "local-cdn-startup.trace")
+		if err := os.MkdirAll(testHarness.artifactDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("startup runtime trace: %s (%d bytes)", path, len(data))
+	}
 
 	// A successful timing must include the remote-loading contract it measures.
 	mtx.Lock()


### PR DESCRIPTION
Concurrent OPFS snapshots now share an in-flight root descriptor read while each caller retains its own shared publication lock. The pending result is cleared before releasing that lock, so later snapshots reread durable state. Cancellation of the reader lets other callers retry under their own contexts.

The local Chromium startup trace recorded 7,028 joined reads and 5,958 physical descriptor loads, eliminating about 54% of snapshot descriptor loads. The golden startup case passed at 45.835 seconds without tracing and 54.280 seconds with tracing; run variability prevents attributing a precise end-to-end saving. The engine race tests passed. The same local startup command now supports optional runtime trace capture.
