### PR TITLE
fix(e2e): let Chromium select its native GPU backend

### DIFF
--- a/e2e/harness/chromium-launch.go
+++ b/e2e/harness/chromium-launch.go
@@ -65,8 +65,8 @@ func (p ChromiumGPUPreference) String() string {
 }
 
 // ChromiumLaunchOptions returns the Playwright launch options for one
-// Chromium launch mode. gpu selects the full-Chromium hardware-GPU launch;
-// otherwise the options are byte-identical to the legacy software launch.
+// Chromium launch mode. gpu requests acceleration in full Chromium using its
+// platform-selected backend; forcing Vulkan can select software on macOS.
 func ChromiumLaunchOptions(headless bool, gpu bool) playwright.BrowserTypeLaunchOptions {
 	opts := playwright.BrowserTypeLaunchOptions{
 		Headless: new(headless),
@@ -84,10 +84,8 @@ func ChromiumLaunchOptions(headless bool, gpu bool) playwright.BrowserTypeLaunch
 	opts.Args = append(opts.Args,
 		"--headless=new",
 		"--ignore-gpu-blocklist",
-		"--use-angle=vulkan",
 		"--enable-gpu-rasterization",
 		"--enable-zero-copy",
-		"--enable-features=Vulkan",
 	)
 	return opts
 }

--- a/e2e/harness/chromium-launch_test.go
+++ b/e2e/harness/chromium-launch_test.go
@@ -66,10 +66,8 @@ func TestChromiumLaunchOptions(t *testing.T) {
 	gpuArgs := append(append([]string{}, baseArgs...),
 		"--headless=new",
 		"--ignore-gpu-blocklist",
-		"--use-angle=vulkan",
 		"--enable-gpu-rasterization",
 		"--enable-zero-copy",
-		"--enable-features=Vulkan",
 	)
 	channel := "chromium"
 

--- a/e2e/releasewasm/README.md
+++ b/e2e/releasewasm/README.md
@@ -13,6 +13,8 @@ materializer. The browser fetches a signed distribution fixture, the CDN root
 pointer, and plugin packs through the production loading path. Each run starts
 with an empty browser context and reports navigation-to-file and click-to-file
 times after reaching `getting-started.md` and checking the invitation dialog.
+The output records Chromium's actual renderer so hardware-accelerated and
+software-rendered runs can be distinguished.
 
 Build and publication state live in `.bldr-startup`. Bldr checks source changes
 on every run and reuses unchanged manifests. The build keeps the release

--- a/e2e/releasewasm/local-cdn-startup_test.go
+++ b/e2e/releasewasm/local-cdn-startup_test.go
@@ -23,6 +23,20 @@ func TestLocalCDNDriveStartup(t *testing.T) {
 
 	// Observe delivery without request interception, which disables HTTP caching.
 	page := testHarness.newPage(t)
+	if testHarness.browserName == "chromium" {
+		cdp, err := testHarness.browser.NewBrowserCDPSession()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cdp.Detach()
+		info, err := cdp.Send("SystemInfo.getInfo", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		gpu := info.(map[string]any)["gpu"].(map[string]any)
+		attributes, _ := gpu["auxAttributes"].(map[string]any)
+		t.Logf("Chromium renderer: %v", attributes["glRenderer"])
+	}
 	var mtx sync.Mutex
 	var external []string
 	var distribution, root, ranges int


### PR DESCRIPTION
The accelerated Chromium harness forces Vulkan on every platform. On macOS this successfully launches with SwiftShader software rendering, despite logging GPU mode. Let Chromium select its native backend by removing the Vulkan overrides. The local startup scenario also reports the actual renderer.

With the same Chromium build on an Apple M3 Pro, SystemInfo changes from SwiftShader with software compositing to ANGLE Metal with GPU compositing and WebGL enabled. The local landing-to-Drive scenario with normal animation passes at 14.808 seconds, compared with 42.973 seconds under the old launch configuration. These are single samples; the difference corrects a measurement-environment defect rather than establishing a product optimization.
