### PR TITLE
fix(packfile): apply verification policy to repeated reads

### DIFF
--- a/core/provider/spacewave/packfile/store/publication.go
+++ b/core/provider/spacewave/packfile/store/publication.go
@@ -12,10 +12,9 @@ import (
 
 // getBlock is the top-level engine read path.
 //
-// Fast path: block catalog hit for a verified/published record returns
-// immediately from resident spans. A record still verifying causes the
-// caller to wait on its readyCh. A failed record is recoverable; the record
-// is unpublished so the caller falls through to a fresh fetch.
+// Catalog hits and misses follow the same verifyBeforeServe policy. Default
+// readers use resident bytes while background verification and writeback run.
+// Opt-in readers wait on readyCh. Failed records are removed so reads can retry.
 //
 // Slow path: load the kvfile index (via the shared ReaderAt, so trailer
 // bytes land in the span store), find the target entry, compute the
@@ -50,6 +49,12 @@ retry:
 				invalidated = true
 				failed = true
 				broadcast()
+			case blockStateVerifying:
+				if e.verifyBeforeServe {
+					readyCh = rec.readyCh
+					return
+				}
+				fallthrough
 			case blockStateVerified, blockStatePublished:
 				data, readErr = rec.readBytes()
 				if readErr != nil {

--- a/core/provider/spacewave/packfile/store/store_test.go
+++ b/core/provider/spacewave/packfile/store/store_test.go
@@ -1555,9 +1555,9 @@ func TestPackfileStoreVerifyBeforeServeWaitsForPersistence(t *testing.T) {
 	}
 }
 
-// TestPackfileStoreSecondReadWaitsForVerify verifies the second concurrent
-// caller blocks until verification completes.
-func TestPackfileStoreSecondReadWaitsForVerify(t *testing.T) {
+// TestPackfileStoreSecondReadReturnsBeforePersistence verifies repeated default
+// reads use resident bytes while the background cache write remains blocked.
+func TestPackfileStoreSecondReadReturnsBeforePersistence(t *testing.T) {
 	ctx := t.Context()
 	packBytes, bloomBytes := buildTestPackOrdered(t, []struct{ Name, Data string }{{"a", "alpha"}})
 	opener, _ := openerFromBytes(packBytes)
@@ -1599,25 +1599,24 @@ func TestPackfileStoreSecondReadWaitsForVerify(t *testing.T) {
 
 	second := make(chan error, 1)
 	go func() {
-		_, _, err := store.GetBlock(ctx, &block.BlockRef{Hash: alphaHash})
+		data, found, err := store.GetBlock(ctx, &block.BlockRef{Hash: alphaHash})
+		if err == nil && (!found || !bytes.Equal(data, []byte("alpha"))) {
+			err = errors.New("repeated read returned wrong block")
+		}
 		second <- err
 	}()
 
 	select {
-	case <-second:
-		t.Fatal("expected second caller to wait on verify")
-	case <-time.After(50 * time.Millisecond):
-	}
-
-	close(blocked)
-	select {
 	case err := <-second:
 		if err != nil {
+			close(blocked)
 			t.Fatalf("second caller returned error: %v", err)
 		}
 	case <-time.After(time.Second):
-		t.Fatal("expected second caller to resume after verify")
+		close(blocked)
+		t.Fatal("repeated read waited for background persistence")
 	}
+	close(blocked)
 }
 
 // TestPackfileStoreDedupesConcurrentFetch verifies two concurrent GetBlock


### PR DESCRIPTION
Repeated default reads now return resident block bytes while background verification and cache admission run, matching cold reads. The strict verification policy still waits for verification and admission. The existing repeated-read regression and focused verification tests pass. The Chromium fresh Drive scenario passes at 13.118 seconds; no end-to-end timing improvement was established.