### PR TITLE
perf(opfs): admit single writes without disk probes

### DIFF
--- a/db/volume/js/opfs/engine/block-store.go
+++ b/db/volume/js/opfs/engine/block-store.go
@@ -197,11 +197,8 @@ func (s *BlockStore) PutBlock(ctx context.Context, data []byte, opts *block.PutO
 		return ref, false, block.ErrBlockRefMismatch
 	}
 
-	// Report known duplicates without making admission retry unrelated writes.
-	existed, err := s.GetBlockExists(ctx, ref)
-	if err == nil && !existed {
-		existed, err = s.admit(ctx, &block.PutBatchEntry{Ref: ref, Data: data})
-	}
+	// Report pending duplicates; publication resolves durable duplicates.
+	existed, err := s.admit(ctx, &block.PutBatchEntry{Ref: ref, Data: data})
 	if err == nil && opts.GetSync() {
 		_, err = s.Sync(ctx)
 	}


### PR DESCRIPTION
Single-block writes now use the same bounded local admission path as batches. Durable duplicates are resolved during pack publication, removing the redundant disk probe before admission. Validation, read-through visibility, backpressure, and explicit Sync fences remain intact. Focused fence, reopen, cancellation, and pack-accounting tests pass. The Chromium fresh Drive scenario passes at 10.456 seconds, versus 13.118 seconds immediately before the change; these are individual samples.