### PR TITLE
fix(cli): wait for native storage shutdown

### DIFF
--- a/bldr/cli/entrypoint/bus.go
+++ b/bldr/cli/entrypoint/bus.go
@@ -37,31 +37,48 @@ var cliTransformConf = []config.Config{
 
 // CliBusImpl implements the CliBus interface for CLI binaries.
 type CliBusImpl struct {
-	ctx           context.Context
-	b             bus.Bus
-	le            *logrus.Entry
-	sr            *static.Resolver
-	storageID     string
+	// ctx is canceled when Release begins.
+	ctx context.Context
+	// b owns controller execution and cleanup.
+	b bus.Bus
+	// le reports lifecycle failures.
+	le *logrus.Entry
+	// sr provides the CLI controller factories.
+	sr *static.Resolver
+	// storageID identifies the CLI storage method.
+	storageID string
+	// worldEngineID identifies the CLI world engine.
 	worldEngineID string
-	vol           volume.Volume
-	worldEngine   world.Engine
-	worldState    world.WorldState
-	rels          []func()
-	releaseOnce   sync.Once
+	// vol stores CLI state.
+	vol volume.Volume
+	// worldEngine manages the CLI world.
+	worldEngine world.Engine
+	// worldState exposes the CLI world state.
+	worldState world.WorldState
+	// rels runs bus cleanup before caller cleanup.
+	rels []func()
+	// releaseOnce joins concurrent Release calls.
+	releaseOnce sync.Once
 }
 
-// _ is a type assertion
+// _ is a type assertion.
 var _ CliBus = (*CliBusImpl)(nil)
 
 // BuildCliBus builds a lightweight bus for CLI binaries.
 func BuildCliBus(rctx context.Context, le *logrus.Entry, stateRoot string) (*CliBusImpl, error) {
 	ctx, ctxCancel := context.WithCancel(rctx)
 	var rels []func()
+	var b bus.Bus
 	rel := func() {
+		ctxCancel()
+		if b != nil {
+			if err := b.Close(); err != nil {
+				le.WithError(err).Error("closing CLI bus")
+			}
+		}
 		for _, fn := range rels {
 			fn()
 		}
-		ctxCancel()
 	}
 
 	b, sr, err := cbc.NewCoreBus(ctx, le)
@@ -70,7 +87,7 @@ func BuildCliBus(rctx context.Context, le *logrus.Entry, stateRoot string) (*Cli
 		return nil, err
 	}
 
-	// add controller factories
+	// Add controller factories.
 	sr.AddFactory(node_controller.NewFactory(b))
 	sr.AddFactory(lookup_concurrent.NewFactory(b))
 	sr.AddFactory(bucket_setup.NewFactory(b))
@@ -78,7 +95,7 @@ func BuildCliBus(rctx context.Context, le *logrus.Entry, stateRoot string) (*Cli
 	sr.AddFactory(block_store_bucket.NewFactory(b))
 	sr.AddFactory(world_block_engine.NewFactory(b))
 
-	// add the configset controller
+	// Add the configset controller.
 	configSetCtrl, _ := configset_controller.NewController(le, b)
 	relConfigSetCtrl, err := b.AddController(ctx, configSetCtrl, nil)
 	if err != nil {
@@ -87,7 +104,7 @@ func BuildCliBus(rctx context.Context, le *logrus.Entry, stateRoot string) (*Cli
 	}
 	rels = append(rels, relConfigSetCtrl)
 
-	// attach the default storage controller
+	// Attach the default storage controller.
 	storageID := default_storage.StorageID
 	storageCtrl := default_storage.NewController(storageID, b, stateRoot)
 	relStorageCtrl, err := b.AddController(ctx, storageCtrl, nil)
@@ -97,19 +114,19 @@ func BuildCliBus(rctx context.Context, le *logrus.Entry, stateRoot string) (*Cli
 	}
 	rels = append(rels, relStorageCtrl)
 
-	// ensure there is at least one storage method
+	// Ensure there is at least one storage method.
 	storageMethods := storageCtrl.GetStorage()
 	if len(storageMethods) == 0 {
 		rel()
 		return nil, errors.New("no available storage methods")
 	}
 
-	// add the storage method factories
+	// Add the storage method factories.
 	for _, storageMethod := range storageMethods {
 		storageMethod.AddFactories(b, sr)
 	}
 
-	// start the storage volume
+	// Start the storage volume.
 	volCtrl, volCtrlRef, err := storage_volume.ExecVolumeController(ctx, b, &storage_volume.Config{
 		StorageId:       storageID,
 		StorageVolumeId: "cli",
@@ -129,7 +146,7 @@ func BuildCliBus(rctx context.Context, le *logrus.Entry, stateRoot string) (*Cli
 		return nil, err
 	}
 
-	// start the node controller
+	// Start the node controller.
 	dir := resolver.NewLoadControllerWithConfig(&node_controller.Config{})
 	_, _, nodeCtrlRef, err := bus.ExecOneOff(ctx, b, dir, nil, nil)
 	if err != nil {
@@ -138,7 +155,7 @@ func BuildCliBus(rctx context.Context, le *logrus.Entry, stateRoot string) (*Cli
 	}
 	rels = append(rels, nodeCtrlRef.Release)
 
-	// start the world engine
+	// Start the world engine.
 	engineBucketID := "bldr/cli"
 	engineObjStoreID := engineBucketID
 	engineID := "bldr/cli"
@@ -197,7 +214,7 @@ func BuildCliBus(rctx context.Context, le *logrus.Entry, stateRoot string) (*Cli
 		vol:           vol,
 		worldEngine:   eng,
 		worldState:    worldState,
-		rels:          rels,
+		rels:          []func(){rel},
 	}, nil
 }
 
@@ -254,7 +271,7 @@ func (c *CliBusImpl) AddRelease(release func()) {
 	}
 }
 
-// Release releases all resources held by the bus.
+// Release cancels and joins the bus before running caller cleanup.
 func (c *CliBusImpl) Release() {
 	c.releaseOnce.Do(func() {
 		for _, rel := range c.rels {

--- a/bldr/cli/entrypoint/bus_test.go
+++ b/bldr/cli/entrypoint/bus_test.go
@@ -1,0 +1,52 @@
+//go:build !js
+
+package cli_entrypoint
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	bbolt_errors "github.com/aperturerobotics/bbolt/errors"
+	volume_bolt "github.com/s4wave/spacewave/db/volume/bolt"
+	"github.com/sirupsen/logrus"
+)
+
+// TestReleaseClosesStorage checks that caller cleanup runs after storage closes.
+func TestReleaseClosesStorage(t *testing.T) {
+	for _, cancelParent := range []bool{false, true} {
+		name := "active parent"
+		if cancelParent {
+			name = "canceled parent"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			b, err := BuildCliBus(ctx, logrus.NewEntry(logrus.New()), t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer b.Release()
+			db := volume_bolt.GetBoltDB(b.GetVolume())
+			if db == nil {
+				t.Fatal("CLI storage did not provide a Bolt database")
+			}
+			b.AddRelease(func() {
+				if b.GetContext().Err() == nil {
+					t.Error("caller cleanup ran before bus cancellation")
+				}
+				tx, err := db.Begin(false)
+				if tx != nil {
+					_ = tx.Rollback()
+				}
+				if !errors.Is(err, bbolt_errors.ErrDatabaseNotOpen) {
+					t.Errorf("caller cleanup ran before database close: %v", err)
+				}
+			})
+			if cancelParent {
+				cancel()
+			}
+			b.Release()
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/aperturerobotics/cayley v0.15.1-0.20260824110931-e6b102492e31 // master
 	github.com/aperturerobotics/cli v1.1.0 // v1.1.0
 	github.com/aperturerobotics/common v0.35.4 // master
-	github.com/aperturerobotics/controllerbus v0.53.5-0.20260824183849-02413eacc3de // master
+	github.com/aperturerobotics/controllerbus v0.53.5-0.20260908122836-c1afcdc3351c // master
 	github.com/aperturerobotics/cpp-yamux v0.0.0-20260223122921-58339cfd0e5d
 	github.com/aperturerobotics/esbuild v0.24.1-0.20260219011422-6d4b923e2023 // https://github.com/evanw/esbuild/pull/3413 [rejected]
 	github.com/aperturerobotics/fastjson v0.1.2-0.20260705010846-94f343f5bb34
@@ -100,7 +100,7 @@ require (
 	go.starlark.net v0.0.0-20260904161901-6ecada49e42f
 	golang.org/x/crypto v0.56.0
 	golang.org/x/exp v0.0.0-20260824195058-e88cd73687aa
-	golang.org/x/mod v0.40.0 // latest
+	golang.org/x/mod v0.41.0 // latest
 	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,10 @@ github.com/aperturerobotics/common v0.35.4 h1:MQgSHHIad71KIwV0pFqNTKm47QW93/kWJ4
 github.com/aperturerobotics/common v0.35.4/go.mod h1:eqVzmvTuSCoS31uwheXjILMcfx+jhl3VClGCT5ZxruI=
 github.com/aperturerobotics/controllerbus v0.53.5-0.20260824183849-02413eacc3de h1:FsRiEw05cnzDsNdejdIBZSmoheio7EcY0iubWbQkXpM=
 github.com/aperturerobotics/controllerbus v0.53.5-0.20260824183849-02413eacc3de/go.mod h1:rWdcZCKa8cT7kJAHERzrIq2D/qmBCAGGYkbvBKfjjH0=
+github.com/aperturerobotics/controllerbus v0.53.5-0.20260908122515-93b13ce4474b h1:Yl3CmrfjRCVKDz4KClE+Nu2E3RA0iQHUkjHOq/EwWTo=
+github.com/aperturerobotics/controllerbus v0.53.5-0.20260908122515-93b13ce4474b/go.mod h1:rWdcZCKa8cT7kJAHERzrIq2D/qmBCAGGYkbvBKfjjH0=
+github.com/aperturerobotics/controllerbus v0.53.5-0.20260908122836-c1afcdc3351c h1:LMdjiJSGcJH0kgF1+crg3BDz3BF2cIP6yecY54nGSRk=
+github.com/aperturerobotics/controllerbus v0.53.5-0.20260908122836-c1afcdc3351c/go.mod h1:rWdcZCKa8cT7kJAHERzrIq2D/qmBCAGGYkbvBKfjjH0=
 github.com/aperturerobotics/cpp-yamux v0.0.0-20260223122921-58339cfd0e5d h1:TVae+YDmMmtutvNKC5d64yXx5Woa3QIq3Ndn11J1IPQ=
 github.com/aperturerobotics/cpp-yamux v0.0.0-20260223122921-58339cfd0e5d/go.mod h1:z43wdjwvCS9HJwxnqEtWgedAqWpeK6c5vozJoGXtUug=
 github.com/aperturerobotics/esbuild v0.24.1-0.20260219011422-6d4b923e2023 h1:OFfw+2XQglhiej7liQM/YQneJTkJvENZLfR/H4zmZ8Q=
@@ -385,6 +389,8 @@ golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvx
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.40.0 h1:hUv+3cXcdRHz08UmSiOob7sadHig73uo5bkXxQ/tvUs=
 golang.org/x/mod v0.40.0/go.mod h1:0/weTWkPWGBikyTWAX3dkjVztMmBA5hM0DH6BElSupE=
+golang.org/x/mod v0.41.0 h1:qJmnOUb4YB+FsEuM3HcWucdZASCPGhsX6uljO6pog0c=
+golang.org/x/mod v0.41.0/go.mod h1:Ek9pY8RKWXwsWvd3rQiHYtMqkjSUV+s1Rj7j4H5Ur6o=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
Native CLI shutdown could exit while a detached storage controller was still closing, leaving a writer entry in copied storage. Retain the complete startup cleanup closure, cancel and close the controller bus, then run caller cleanup.

Update ControllerBus for its joined shutdown API and refresh the annotated module reference required by the commit hook. Existing storage formats are unchanged.

Validation: the real CLI storage race test passes with active and canceled parent contexts. A Linux container clears its writer count on shutdown, and an image committed from that stopped container restarts healthy. Focused lint and compilation pass through the commit hook.
