### PR TITLE
chore(deps): update GoScript binary string map keys

### DIFF
--- a/bldr/web/plugin/controller/controller_test.go
+++ b/bldr/web/plugin/controller/controller_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAddControllerSendReadyAndWaitIgnoresNilControllerExit(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	bus := &nilExitBus{released: make(chan struct{})}
@@ -85,6 +85,10 @@ func (b *nilExitBus) AddController(ctx context.Context, ctrl controller.Controll
 }
 
 type noopBus struct{}
+
+func (noopBus) Close() error {
+	return nil
+}
 
 func (noopBus) GetControllers() []controller.Controller {
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/quic-go/quic-go v0.62.0
 	github.com/restic/chunker v0.5.0
-	github.com/s4wave/goscript v0.2.32-0.20260908112817-fcca83a8b87a
+	github.com/s4wave/goscript v0.2.32-0.20260908122638-6b25246d6975
 	github.com/sasha-s/go-deadlock v0.3.9
 	github.com/satori/go.uuid v1.2.0
 	github.com/sergi/go-diff v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -321,6 +321,8 @@ github.com/s4wave/goscript v0.2.32-0.20260908073932-9f5f25f43337 h1:OUddcu8PqYQJ
 github.com/s4wave/goscript v0.2.32-0.20260908073932-9f5f25f43337/go.mod h1:2PkLvl4v5IXRzAh+HpOQymrS7Z6mNmAOKY89EoAhv8A=
 github.com/s4wave/goscript v0.2.32-0.20260908112817-fcca83a8b87a h1:6cP0P4CLjfr5Lrnd3fcuU+A0Z2WcbYCb9WVHKiv4fK0=
 github.com/s4wave/goscript v0.2.32-0.20260908112817-fcca83a8b87a/go.mod h1:2PkLvl4v5IXRzAh+HpOQymrS7Z6mNmAOKY89EoAhv8A=
+github.com/s4wave/goscript v0.2.32-0.20260908122638-6b25246d6975 h1:DxWcftNJ9NUwjbmRA0KFmEKKUCxFjo7NcdC7WEosKCc=
+github.com/s4wave/goscript v0.2.32-0.20260908122638-6b25246d6975/go.mod h1:2PkLvl4v5IXRzAh+HpOQymrS7Z6mNmAOKY89EoAhv8A=
 github.com/sasha-s/go-deadlock v0.3.9 h1:fiaT9rB7g5sr5ddNZvlwheclN9IP86eFW9WgqlEQV+w=
 github.com/sasha-s/go-deadlock v0.3.9/go.mod h1:KuZj51ZFmx42q/mPaYbRk0P1xcwe697zsJKE03vD4/Y=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=


### PR DESCRIPTION
Update GoScript to reuse canonical binary string map keys. Complete the existing web-plugin bus fixture for the current Close contract. The 41 map and slice tests and two focused web-plugin lifecycle tests pass. The fresh Chromium Drive scenario passes; CPU profiling removes stringMapKey from the samples, but no end-to-end startup improvement is established.