### PR TITLE
perf(quickstart): initialize Drive metadata in one transaction

### DIFF
--- a/app/quickstart/create.test.ts
+++ b/app/quickstart/create.test.ts
@@ -196,10 +196,19 @@ function buildQuickstartWorld(
       },
     ),
   )
+  const getObject = vi.fn().mockResolvedValue(null)
+  const createRef = vi.fn((resourceId: number) => ({ resourceId, client: {} }))
+  const newTransaction = vi.fn().mockResolvedValue({
+    applyWorldOp,
+    getObject,
+    commit: vi.fn().mockResolvedValue(undefined),
+    discard: vi.fn().mockResolvedValue(undefined),
+  })
   return {
     world: {
+      getEngine: vi.fn(() => ({ newTransaction })),
       applyWorldOp,
-      getObject: vi.fn().mockResolvedValue(null),
+      getObject,
       lookupGraphQuads: vi.fn().mockResolvedValue({ quads: [] }),
       deleteGraphQuad: vi.fn().mockResolvedValue(undefined),
       setGraphQuad,
@@ -215,13 +224,11 @@ function buildQuickstartWorld(
       createObject,
       accessTypedObject,
       getResourceRef: vi.fn(() => ({
-        createRef: vi.fn((resourceId: number) => ({
-          resourceId,
-          client: {},
-        })),
+        createRef,
       })),
     },
     applyWorldOp,
+    createRef,
     accessTypedObject,
     blockCursorSetBlock,
     createObject,
@@ -1027,39 +1034,11 @@ describe('quickstart create', () => {
   })
 
   it('creates Drive storage and indexes the Space at the files object', async () => {
-    const createRef = vi.fn((resourceId: number) => ({
-      resourceId,
-      client: {},
-    }))
-    const putBlock = vi.fn((_arg: { data: Uint8Array }) =>
-      Promise.resolve({ ref: {} }),
-    )
-    const getRef = vi.fn().mockResolvedValue({ ref: {} })
-    const releaseCursor = vi.fn()
-    const applyWorldOp = vi.fn<ApplyWorldOp>().mockResolvedValue({
-      seqno: 1n,
-      sysErr: false,
-    })
-    const spaceWorld = {
-      getObject: vi.fn(() => Promise.resolve(null)),
-      buildStorageCursor: vi.fn(() =>
-        Promise.resolve({
-          putBlock,
-          getRef,
-          release: releaseCursor,
-          [Symbol.dispose]: releaseCursor,
-        }),
-      ),
-      createObject: vi.fn().mockResolvedValue({}),
-      lookupGraphQuads: vi.fn().mockResolvedValue({ quads: [] }),
-      setGraphQuad: vi.fn().mockResolvedValue(undefined),
-      accessTypedObject: vi.fn().mockResolvedValue({
-        resourceId: 71,
-        typeId: 'unixfs/fs-node',
-      }),
-      getResourceRef: vi.fn(() => ({ createRef })),
+    const {
+      world: spaceWorld,
       applyWorldOp,
-    }
+      createRef,
+    } = buildQuickstartWorld()
 
     await createDrive(spaceWorld as never)
 
@@ -1248,6 +1227,7 @@ to try first.
     const discard = vi.fn().mockResolvedValue(undefined)
     const newTransaction = vi.fn().mockResolvedValue({
       applyWorldOp: txApplyWorldOp,
+      getObject: vi.fn().mockResolvedValue(null),
       commit,
       discard,
     })
@@ -1281,7 +1261,7 @@ to try first.
 
     await createDrive(spaceWorld as never, undefined, timing)
 
-    expect(newTransaction).toHaveBeenCalledTimes(2)
+    expect(newTransaction).toHaveBeenCalledTimes(1)
     expect(newTransaction).toHaveBeenCalledWith(true, undefined)
     expect(txApplyWorldOp).toHaveBeenNthCalledWith(
       1,
@@ -1297,24 +1277,22 @@ to try first.
       '',
       undefined,
     )
-    expect(commit).toHaveBeenCalledTimes(2)
-    expect(discard).toHaveBeenCalledTimes(2)
+    expect(commit).toHaveBeenCalledTimes(1)
+    expect(discard).toHaveBeenCalledTimes(1)
     expect(applyWorldOp).not.toHaveBeenCalled()
     expect(timing.phases.map((phase) => phase.name)).toEqual([
+      'init-drive-new-transaction',
       'init-drive-unixfs',
-      'init-drive-unixfs-new-transaction',
-      'init-drive-unixfs-apply-op',
-      'init-drive-unixfs-commit',
-      'init-drive-unixfs-discard',
-      'write-drive-starter-guide-access',
-      'write-drive-starter-guide-upload',
       'create-drive-settings',
       'create-drive-settings-get-object',
-      'create-drive-settings-new-transaction',
-      'create-drive-settings-apply-op',
-      'create-drive-settings-commit',
-      'create-drive-settings-discard',
+      'init-drive-commit',
+      'init-drive-discard',
+      'write-drive-starter-guide-access',
+      'write-drive-starter-guide-upload',
     ])
+    expect(commit.mock.invocationCallOrder[0]).toBeLessThan(
+      fsHandleMocks.uploadFile.mock.invocationCallOrder[0] ?? 0,
+    )
   })
 
   it('seeds the KV quickstart with examples and indexes the store', async () => {

--- a/app/quickstart/create.ts
+++ b/app/quickstart/create.ts
@@ -986,7 +986,7 @@ async function waitForQuickstartRegistration(
 
 // initUnixFS initializes an empty UnixFS filesystem.
 export async function initUnixFS(
-  spaceWorld: EngineWorldState,
+  spaceWorld: IWorldState,
   abortSignal?: AbortSignal,
   timing?: QuickstartSetupTiming,
 ): Promise<void> {
@@ -1314,26 +1314,33 @@ export async function createDrive(
   abortSignal?: AbortSignal,
   timing?: QuickstartSetupTiming,
 ): Promise<void> {
-  await timeQuickstartPhase(timing, 'init-drive-unixfs', () =>
-    initUnixFS(spaceWorld, abortSignal, timing),
+  // Publish the filesystem and its index together before opening file storage.
+  const tx = await timeQuickstartPhase(
+    timing,
+    'init-drive-new-transaction',
+    () => spaceWorld.getEngine().newTransaction(true, abortSignal),
   )
+  try {
+    await timeQuickstartPhase(timing, 'init-drive-unixfs', () =>
+      initUnixFS(tx, abortSignal, timing),
+    )
+    await timeQuickstartPhase(timing, 'create-drive-settings', () =>
+      createSpaceSettingsObject(
+        tx,
+        abortSignal,
+        UNIXFS_OBJECT_KEY,
+        undefined,
+        timing,
+        'create-drive-settings',
+      ),
+    )
+    await timeQuickstartPhase(timing, 'init-drive-commit', () =>
+      tx.commit(abortSignal),
+    )
+  } finally {
+    await timeQuickstartPhase(timing, 'init-drive-discard', () => tx.discard())
+  }
   await writeDriveStarterGuide(spaceWorld, abortSignal, timing)
-  // Index the Space directly at the UnixFS files object. The new-user intro
-  // renders as a non-blocking overlay on first run instead of owning the
-  // index, so the seeded Drive is visible without finishing a wizard first.
-  // Older spaces whose index still points at a wizard object keep the
-  // existing finish flow (IntroWizardViewer only replaces the index while it
-  // still points at the wizard).
-  await timeQuickstartPhase(timing, 'create-drive-settings', () =>
-    createSpaceSettingsObject(
-      spaceWorld,
-      abortSignal,
-      UNIXFS_OBJECT_KEY,
-      undefined,
-      timing,
-      'create-drive-settings',
-    ),
-  )
 }
 
 async function applyQuickstartWorldOp(


### PR DESCRIPTION
Create the UnixFS object and Space index in one World transaction, then upload the starter guide through the existing filesystem API. This removes one metadata transaction while retaining seeded-file readiness and cancellation cleanup. The fresh Chromium Drive scenario passes at 10.933 seconds, and the 25 existing Quickstart tests pass. The combined commit consumes most of the previous two commits’ time, so no large end-to-end gain is claimed.