### PR TITLE
perf(opfs): cache newly published immutable metadata

### DIFF
--- a/db/volume/js/opfs/engine/cache.go
+++ b/db/volume/js/opfs/engine/cache.go
@@ -47,3 +47,23 @@ func (e *Engine) cacheMessage(name string, parsed message, decodedCharge int) {
 	entry.charge += decodedCharge
 	e.cacheBytes += decodedCharge
 }
+
+// cacheBytesLocked retains immutable bytes under the shared byte and entry budgets.
+// The caller holds mtx and has checked that the engine remains open.
+func (e *Engine) cacheBytesLocked(key string, data []byte) []byte {
+	if elem := e.cache[key]; elem != nil {
+		e.recency.MoveToFront(elem)
+		return elem.Value.(*cacheEntry).data
+	}
+	charge := len(data) + len(key) + 192
+	for e.cacheBytes+charge > cacheByteLimit || len(e.cache) >= cacheFileLimit {
+		elem := e.recency.Back()
+		entry := elem.Value.(*cacheEntry)
+		delete(e.cache, entry.name)
+		e.cacheBytes -= entry.charge
+		e.recency.Remove(elem)
+	}
+	e.cache[key] = e.recency.PushFront(&cacheEntry{name: key, data: data, charge: charge})
+	e.cacheBytes += charge
+	return data
+}

--- a/db/volume/js/opfs/engine/engine.go
+++ b/db/volume/js/opfs/engine/engine.go
@@ -172,21 +172,7 @@ func (e *Engine) readCached(ctx context.Context, key, name string, offset int64,
 	if e.closed {
 		return nil, ErrClosed
 	}
-	if elem := e.cache[key]; elem != nil {
-		e.recency.MoveToFront(elem)
-		return elem.Value.(*cacheEntry).data, nil
-	}
-	charge := len(data) + len(key) + 192
-	for e.cacheBytes+charge > cacheByteLimit || len(e.cache) >= cacheFileLimit {
-		elem := e.recency.Back()
-		entry := elem.Value.(*cacheEntry)
-		delete(e.cache, entry.name)
-		e.cacheBytes -= entry.charge
-		e.recency.Remove(elem)
-	}
-	e.cache[key] = e.recency.PushFront(&cacheEntry{name: key, data: data, charge: charge})
-	e.cacheBytes += charge
-	return data, nil
+	return e.cacheBytesLocked(key, data), nil
 }
 
 // loadRoot validates both fixed descriptors and each candidate's immediate page.

--- a/db/volume/js/opfs/engine/publication.go
+++ b/db/volume/js/opfs/engine/publication.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"runtime/trace"
 	"strconv"
+	"strings"
 )
 
 const (
@@ -127,6 +128,17 @@ func (p *publication) commit(ctx context.Context) error {
 		return err
 	}
 
+	// Keep newly durable metadata in the existing bounded immutable-file cache.
+	// Packs use range-window keys and remain demand-cached at the payload reader.
+	p.engine.mtx.Lock()
+	if !p.engine.closed {
+		for _, output := range p.output {
+			if !strings.HasPrefix(output.name, "pack-") {
+				p.engine.cacheBytesLocked(output.name, output.data)
+			}
+		}
+	}
+	p.engine.mtx.Unlock()
 	p.engine.backend.Notify(p.root.Generation)
 
 	// A leftover committed intent is harmless and resolved before the next write.


### PR DESCRIPTION
Retain newly published immutable index and catalogue bytes in the existing bounded OPFS cache. Reads still resolve the durable root, and payload packs continue using demand-loaded range windows.

The Chromium fresh-Drive scenario passes at 10.012 seconds. OPFS reads fall from 4,735 to 4,012 in the recorded startup traces; the overlapping read durations are not end-to-end savings. Existing durable-reopen, publication-crash-recovery, and transaction-snapshot checks pass.
