### PR TITLE
fix(bldr): separate package release mode from minification

### DIFF
--- a/bldr/web/entrypoint/browser/bundle/bundle.go
+++ b/bldr/web/entrypoint/browser/bundle/bundle.go
@@ -1171,6 +1171,7 @@ func BuildBrowserBundle(
 }
 
 // BuildWebPkgsBundle builds the web pkg bundle files.
+// devMode selects the package environment independently of minification.
 //
 // stateDir is the directory where bun will be downloaded if not found in PATH.
 // pathPrefix is the prefix to prepend to /pkgs/ for pkg paths
@@ -1209,7 +1210,7 @@ func BuildWebPkgsBundle(ctx context.Context, le *logrus.Entry, stateDir string, 
 			refs,
 			outDir,
 			pathPrefix+"/pkgs/",
-			minify,
+			!devMode,
 			minify,
 			sourcemaps,
 			client,


### PR DESCRIPTION
Use the browser entrypoint development-mode setting to select the web package environment. Disabling minification on a release build now keeps production React; enabling minification on a development build no longer switches package behavior.

Verified the unminified release contains react-dom-client.production.js and passes the Chromium fresh-Drive scenario at 9.853 seconds.
