### PR TITLE
perf(bucket): use metadata for individual existence probes

### DIFF
--- a/db/bucket/lookup/lookup-handle.go
+++ b/db/bucket/lookup/lookup-handle.go
@@ -14,11 +14,13 @@ var ErrNotImplemented = errors.New("operation not implemented by lookup controll
 
 // lookupBucket implements bucket.Bucket with a lookup handle.
 type lookupBucket struct {
-	h         Handle
+	// h resolves the bucket's lookup service.
+	h Handle
+	// localOnly excludes remote discovery from payload reads.
 	localOnly bool
 }
 
-// NewBucketFromHandle implements the Bucket api with a Lookup handle.
+// NewBucketFromHandle exposes the bucket API through a lookup handle.
 func NewBucketFromHandle(h Handle) bucket.Bucket {
 	return &lookupBucket{h: h}
 }
@@ -116,15 +118,11 @@ func (l *lookupBucket) GetBlock(ctx context.Context, ref *block.BlockRef) ([]byt
 // GetBlockExists checks if a block exists with a cid reference.
 // Note: the block may not be in the specified bucket.
 func (l *lookupBucket) GetBlockExists(ctx context.Context, ref *block.BlockRef) (bool, error) {
-	lb, err := l.h.GetLookup(ctx)
+	found, err := l.GetBlockExistsBatch(ctx, []*block.BlockRef{ref})
 	if err != nil {
 		return false, err
 	}
-	if lb == nil {
-		return false, bucket.ErrBucketNotFound
-	}
-	_, ok, err := lb.LookupBlock(ctx, ref, WithLocalOnly())
-	return ok, err
+	return found[0], nil
 }
 
 // GetBlockExistsBatch checks whether refs exist through the lookup controller.
@@ -161,5 +159,5 @@ func (l *lookupBucket) Sync(context.Context) (bool, error) {
 	return true, nil
 }
 
-// _ is a type assertion
+// _ verifies the bucket contract.
 var _ bucket.Bucket = (*lookupBucket)(nil)

--- a/db/bucket/lookup/lookup-handle_test.go
+++ b/db/bucket/lookup/lookup-handle_test.go
@@ -8,7 +8,8 @@ import (
 	"github.com/s4wave/spacewave/db/bucket"
 )
 
-func TestLookupBucketGetBlockExistsBatchUsesLookupBatch(t *testing.T) {
+// TestLookupBucketExistenceUsesLookupBatch rejects payload reads for existence probes.
+func TestLookupBucketExistenceUsesLookupBatch(t *testing.T) {
 	refs := []*block.BlockRef{
 		mustLookupTestBlockRef(t, "first"),
 		mustLookupTestBlockRef(t, "second"),
@@ -16,15 +17,26 @@ func TestLookupBucketGetBlockExistsBatchUsesLookupBatch(t *testing.T) {
 	lk := &batchLookupTestLookup{found: []bool{true, false}}
 	bkt := NewBucketFromHandle(&batchLookupTestHandle{lookup: lk})
 
-	found, err := bkt.GetBlockExistsBatch(context.Background(), refs)
+	found, err := bkt.GetBlockExistsBatch(t.Context(), refs)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(found) != 2 || !found[0] || found[1] {
 		t.Fatalf("found = %v, want [true false]", found)
 	}
-	if lk.existsBatchCalls != 1 {
-		t.Fatalf("exists batch calls = %d, want 1", lk.existsBatchCalls)
+	// Single-block probes use the same metadata-only lookup for hits and misses.
+	for _, expected := range []bool{true, false} {
+		lk.found = []bool{expected}
+		found, err := bkt.GetBlockExists(t.Context(), refs[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if found != expected {
+			t.Fatalf("single block found = %t, want %t", found, expected)
+		}
+	}
+	if lk.existsBatchCalls != 3 {
+		t.Fatalf("exists batch calls = %d, want 3", lk.existsBatchCalls)
 	}
 	if lk.lookupBlockCalls != 0 {
 		t.Fatalf("payload lookup calls = %d, want 0", lk.lookupBlockCalls)
@@ -34,6 +46,7 @@ func TestLookupBucketGetBlockExistsBatchUsesLookupBatch(t *testing.T) {
 	}
 }
 
+// mustLookupTestBlockRef builds a valid reference for a fixture payload.
 func mustLookupTestBlockRef(t *testing.T, data string) *block.BlockRef {
 	t.Helper()
 	ref, err := block.BuildBlockRef([]byte(data), nil)
@@ -43,29 +56,40 @@ func mustLookupTestBlockRef(t *testing.T, data string) *block.BlockRef {
 	return ref
 }
 
+// batchLookupTestHandle exposes one lookup service to the bucket adapter.
 type batchLookupTestHandle struct {
+	// lookup supplies the fixture lookup operations.
 	lookup Lookup
 }
 
+// GetDisposed keeps the fixture handle available.
 func (h *batchLookupTestHandle) GetDisposed() bool {
 	return false
 }
 
+// GetBucketConfig omits configuration unused by the existence probes.
 func (h *batchLookupTestHandle) GetBucketConfig() *bucket.Config {
 	return nil
 }
 
+// GetLookup returns the fixture service.
 func (h *batchLookupTestHandle) GetLookup(context.Context) (Lookup, error) {
 	return h.lookup, nil
 }
 
+// batchLookupTestLookup records whether the adapter reads metadata or payloads.
 type batchLookupTestLookup struct {
-	found            []bool
-	localOnly        bool
+	// found supplies the configured existence results.
+	found []bool
+	// localOnly records the lookup's discovery policy.
+	localOnly bool
+	// lookupBlockCalls counts payload reads.
 	lookupBlockCalls int
+	// existsBatchCalls counts metadata probes.
 	existsBatchCalls int
 }
 
+// LookupBlock records an unwanted payload read.
 func (l *batchLookupTestLookup) LookupBlock(
 	context.Context,
 	*block.BlockRef,
@@ -75,6 +99,7 @@ func (l *batchLookupTestLookup) LookupBlock(
 	return nil, false, nil
 }
 
+// LookupBlockExistsBatch returns configured metadata results in input order.
 func (l *batchLookupTestLookup) LookupBlockExistsBatch(
 	_ context.Context,
 	refs []*block.BlockRef,
@@ -87,6 +112,7 @@ func (l *batchLookupTestLookup) LookupBlockExistsBatch(
 	return out, nil
 }
 
+// PutBlock satisfies the unused write contract.
 func (l *batchLookupTestLookup) PutBlock(
 	context.Context,
 	[]byte,


### PR DESCRIPTION
Route individual bucket existence probes through the existing batched metadata lookup. The lookup adapter no longer reads a block payload solely to answer whether it exists, and keeps local-only discovery semantics.

The existing adapter test now covers individual hits and misses as well as batching and verifies zero payload lookups. It passes, along with the Chromium fresh-Drive scenario at 9.911 seconds; no end-to-end gain is established.
