### PR TITLE
feat(transport): connect native provider sessions locally

### DIFF
--- a/core/provider/local/account-transport.go
+++ b/core/provider/local/account-transport.go
@@ -21,6 +21,7 @@ type sessionTransportConfig struct {
 	signingEnvPrefix string
 }
 
+// matches compares the peer identity and signaling configuration.
 func (c sessionTransportConfig) matches(peerID peer.ID, signalingURL, signingEnvPrefix string) bool {
 	return c.peerID == peerID &&
 		c.signalingURL == signalingURL &&
@@ -41,6 +42,7 @@ type sessionTransportState struct {
 	err      error
 }
 
+// setReady publishes readiness only while this transport still owns startup.
 func (s *sessionTransportState) setReady() bool {
 	committed := false
 	s.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
@@ -54,6 +56,7 @@ func (s *sessionTransportState) setReady() bool {
 	return committed
 }
 
+// setReplaced prevents a replaced startup attempt from publishing readiness.
 func (s *sessionTransportState) setReplaced() {
 	s.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
 		if s.replaced {
@@ -64,6 +67,7 @@ func (s *sessionTransportState) setReplaced() {
 	})
 }
 
+// setExited publishes terminal state while preserving a substantive exit error.
 func (s *sessionTransportState) setExited(err error) {
 	s.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
 		if s.exited {
@@ -105,6 +109,7 @@ func sessionTransportReplacementContext(ctx context.Context) (context.Context, c
 	return context.WithCancel(replacementCtx)
 }
 
+// sessionTransportCleanupContext bounds cleanup independently of an already canceled caller.
 func sessionTransportCleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -128,6 +133,7 @@ func (a *ProviderAccount) CreateSessionTransport(ctx context.Context, sessionKey
 	return err
 }
 
+// createSessionTransport starts an account-owned transport and waits for its readiness.
 func (a *ProviderAccount) createSessionTransport(ctx context.Context, sessionKey crypto.PrivKey, signalingURL string) (*sessionTransportState, error) {
 	cleanupCtx, cleanupCancel := sessionTransportReplacementContext(ctx)
 	defer cleanupCancel()
@@ -150,6 +156,7 @@ func (a *ProviderAccount) createSessionTransport(ctx context.Context, sessionKey
 	return sts, nil
 }
 
+// waitExistingSessionTransportReady waits for readiness while detecting replacement and exit.
 func (a *ProviderAccount) waitExistingSessionTransportReady(ctx context.Context, sts *sessionTransportState) error {
 	for {
 		if err := ctx.Err(); err != nil {
@@ -203,6 +210,7 @@ func (a *ProviderAccount) waitExistingSessionTransportReady(ctx context.Context,
 	}
 }
 
+// startSessionTransportLocked replaces the previous transport under the account lock.
 func (a *ProviderAccount) startSessionTransportLocked(
 	ctx context.Context,
 	cleanupCtx context.Context,
@@ -226,6 +234,7 @@ func (a *ProviderAccount) startSessionTransportLocked(
 		signalingURL,
 		signingEnvPrefix,
 		transport.WithStartupRetry(),
+		a.t.p.localNetwork,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "create session transport")
@@ -274,6 +283,7 @@ func (a *ProviderAccount) startSessionTransportLocked(
 	return sts, nil
 }
 
+// waitSessionTransportReady races startup readiness against cancellation and replacement.
 func (a *ProviderAccount) waitSessionTransportReady(ctx context.Context, sts *sessionTransportState) error {
 	cleanup := func(err error) error {
 		return a.cleanupSessionTransportReadyError(ctx, sts, err)
@@ -342,6 +352,7 @@ func (a *ProviderAccount) waitSessionTransportReady(ctx context.Context, sts *se
 	}
 }
 
+// cleanupSessionTransportReadyError stops only the startup attempt that still owns the account slot.
 func (a *ProviderAccount) cleanupSessionTransportReadyError(ctx context.Context, sts *sessionTransportState, err error) error {
 	cleanupCtx, cleanupCancel := sessionTransportCleanupContext(ctx)
 	defer cleanupCancel()
@@ -375,6 +386,7 @@ func (a *ProviderAccount) cleanupSessionTransportReadyError(ctx context.Context,
 	return err
 }
 
+// classifySessionTransportReadyError distinguishes caller cancellation from transport replacement.
 func classifySessionTransportReadyError(ctx context.Context, sts *sessionTransportState, err error, cleanup func(error) error) error {
 	var replaced bool
 	sts.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
@@ -432,6 +444,7 @@ func (a *ProviderAccount) StopSessionTransport() {
 	}
 }
 
+// stopSessionTransportState stops the specified transport under the account lock.
 func (a *ProviderAccount) stopSessionTransportState(sts *sessionTransportState) {
 	cleanupCtx, cleanupCancel := sessionTransportReplacementContext(nil)
 	defer cleanupCancel()
@@ -447,6 +460,7 @@ func (a *ProviderAccount) stopSessionTransportState(sts *sessionTransportState) 
 	}
 }
 
+// stopSessionTransportLocked stops the current transport under the account lock.
 func (a *ProviderAccount) stopSessionTransportLocked(ctx context.Context) error {
 	var sts *sessionTransportState
 	a.transportBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
@@ -455,6 +469,7 @@ func (a *ProviderAccount) stopSessionTransportLocked(ctx context.Context) error 
 	return a.stopSessionTransportStateLocked(ctx, sts)
 }
 
+// stopSessionTransportForReplacementLocked marks replacement before waiting for the previous transport to exit.
 func (a *ProviderAccount) stopSessionTransportForReplacementLocked(ctx context.Context) error {
 	var sts *sessionTransportState
 	a.transportBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
@@ -470,6 +485,7 @@ func (a *ProviderAccount) stopSessionTransportForReplacementLocked(ctx context.C
 	return nil
 }
 
+// stopSessionTransportStateLocked joins the routine before clearing its account slot.
 func (a *ProviderAccount) stopSessionTransportStateLocked(ctx context.Context, sts *sessionTransportState) error {
 	if sts == nil {
 		return nil
@@ -563,6 +579,7 @@ func (a *ProviderAccount) EnsureConfiguredSessionTransport(
 	return err
 }
 
+// ensureSessionTransport reuses matching transport configuration or replaces it.
 func (a *ProviderAccount) ensureSessionTransport(
 	ctx context.Context,
 	sessionPriv crypto.PrivKey,
@@ -572,6 +589,7 @@ func (a *ProviderAccount) ensureSessionTransport(
 	return a.ensureSessionTransportWithReplacement(ctx, sessionPriv, relayURL, signingEnvPrefix, true)
 }
 
+// ensureSessionTransportWithReplacement selects whether a configuration mismatch permits replacement.
 func (a *ProviderAccount) ensureSessionTransportWithReplacement(
 	ctx context.Context,
 	sessionPriv crypto.PrivKey,
@@ -589,6 +607,7 @@ func (a *ProviderAccount) ensureSessionTransportWithReplacement(
 	)
 }
 
+// ensureSessionTransportWithOwner reconciles transport configuration with a separate running lifetime.
 func (a *ProviderAccount) ensureSessionTransportWithOwner(
 	ctx context.Context,
 	ownerCtx context.Context,
@@ -674,12 +693,12 @@ func (a *ProviderAccount) GetOnlinePeerIDsWithWait(peerIDs []string) ([]string, 
 		decoded = append(decoded, remotePeerID)
 		peerIDStrings[remotePeerID] = pidStr
 	}
-	linked, linkCh := st.GetLinkedPeerIDsSnapshotWithWait(decoded)
+	linked, linkChs := st.GetLinkedPeerIDsSnapshotWithWait(decoded)
 	online := make([]string, 0, len(linked))
 	for _, peerID := range decoded {
 		if _, ok := linked[peerID]; ok {
 			online = append(online, peerIDStrings[peerID])
 		}
 	}
-	return online, []<-chan struct{}{transportCh, linkCh}
+	return online, append(linkChs, transportCh)
 }

--- a/core/provider/local/invite-local-network_test.go
+++ b/core/provider/local/invite-local-network_test.go
@@ -1,0 +1,104 @@
+//go:build !tinygo
+
+package provider_local_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aperturerobotics/util/broadcast"
+	"github.com/s4wave/spacewave/core/provider"
+	provider_local "github.com/s4wave/spacewave/core/provider/local"
+	"github.com/s4wave/spacewave/core/sobject"
+)
+
+// TestLocalProviderInvitationUsesNativeNetwork joins two accounts without signaling or manual transport wiring.
+func TestLocalProviderInvitationUsesNativeNetwork(t *testing.T) {
+	// Mount two independent accounts under the same real native provider.
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
+	defer cancel()
+	tb, _, owner, ownerSession, releaseOwner := setupProviderAndSession(ctx, t)
+	t.Cleanup(releaseOwner)
+	rawProvider, providerRef, err := provider.ExLookupProvider(ctx, tb.Bus, "local", false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(providerRef.Release)
+	local := rawProvider.(*provider_local.Provider)
+	readerRef, err := local.CreateLocalAccountAndSession(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawReader, releaseReader, err := local.AccessProviderAccount(ctx, readerRef.GetProviderResourceRef().GetProviderAccountId(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(releaseReader)
+	reader := rawReader.(*provider_local.ProviderAccount)
+	readerSession, releaseSession, err := reader.MountSession(ctx, readerRef, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(releaseSession)
+
+	// Publish a signed targeted invitation through the existing owner API.
+	ref, err := owner.CreateSharedObject(ctx, "local-invitation", &sobject.SharedObjectMeta{BodyType: "space"}, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	object, releaseObject, err := owner.MountSharedObject(ctx, ref, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(releaseObject)
+	host := object.(sobject.InviteHost)
+	invite, err := host.CreateSOInviteOp(ctx, host.GetPrivKey(), sobject.SOParticipantRole_SOParticipantRole_WRITER, "local", readerSession.GetPeerId().String(), 1, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := owner.PrepareDirectInvite(ctx, ownerSession.GetPrivKey(), host.GetPrivKey(), invite); err != nil {
+		t.Fatal(err)
+	}
+
+	// Complete the unchanged authenticated invitation and grant installation protocol.
+	joined, err := reader.JoinViaInvite(ctx, readerSession.GetPrivKey(), invite, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if joined.SharedObjectID != ref.GetProviderResourceRef().GetId() || joined.Grant == nil {
+		t.Fatal("native invitation did not grant the requested object")
+	}
+	found := false
+	for _, entry := range reader.GetSOListCtr().GetValue().GetSharedObjects() {
+		if entry.GetRef().GetProviderResourceRef().GetId() == joined.SharedObjectID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("joined object is absent from the reader's retained list")
+	}
+
+	// Native presence includes the local link and updates when its peer stops.
+	ownerID := ownerSession.GetPeerId().String()
+	for {
+		online, waitChs := reader.GetOnlinePeerIDsWithWait([]string{ownerID})
+		if len(online) == 1 {
+			break
+		}
+		if err := broadcast.WaitAny(ctx, waitChs...); err != nil {
+			t.Fatal(err)
+		}
+	}
+	owner.StopP2PSync()
+	owner.StopSessionTransport()
+	for {
+		online, waitChs := reader.GetOnlinePeerIDsWithWait([]string{ownerID})
+		if len(online) == 0 {
+			break
+		}
+		if err := broadcast.WaitAny(ctx, waitChs...); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/core/provider/local/local-network-tinygo.go
+++ b/core/provider/local/local-network-tinygo.go
@@ -1,0 +1,8 @@
+//go:build tinygo
+
+package provider_local
+
+import "github.com/s4wave/spacewave/core/transport"
+
+// newLocalSessionNetwork leaves browser transport to its host-owned network runtime.
+func newLocalSessionNetwork() transport.SessionTransportOption { return nil }

--- a/core/provider/local/local-network.go
+++ b/core/provider/local/local-network.go
@@ -1,0 +1,13 @@
+//go:build !tinygo
+
+package provider_local
+
+import (
+	"github.com/s4wave/spacewave/core/transport"
+	"github.com/s4wave/spacewave/net/transport/inproc"
+)
+
+// newLocalSessionNetwork gives one native provider its own authenticated packet network.
+func newLocalSessionNetwork() transport.SessionTransportOption {
+	return transport.WithInprocNetwork(inproc.NewNetwork())
+}

--- a/core/provider/local/provider.go
+++ b/core/provider/local/provider.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"slices"
 
-	csync "github.com/aperturerobotics/util/csync"
-
 	"github.com/aperturerobotics/controllerbus/bus"
 	"github.com/aperturerobotics/util/backoff"
+	csync "github.com/aperturerobotics/util/csync"
 	"github.com/aperturerobotics/util/keyed"
 	"github.com/aperturerobotics/util/ulid"
 	"github.com/pkg/errors"
 	provider "github.com/s4wave/spacewave/core/provider"
 	"github.com/s4wave/spacewave/core/session"
+	"github.com/s4wave/spacewave/core/transport"
 	block_transform "github.com/s4wave/spacewave/db/block/transform"
 	transform_blockenc "github.com/s4wave/spacewave/db/block/transform/blockenc"
 	transform_gzip "github.com/s4wave/spacewave/db/block/transform/gzip"
@@ -39,6 +39,9 @@ type Provider struct {
 	info *provider.ProviderInfo
 	// sfs is the step factory set for block transforms
 	sfs *block_transform.StepFactorySet
+
+	// localNetwork connects native sessions within this provider lifetime.
+	localNetwork transport.SessionTransportOption
 
 	// accountRc is the keyed refcount for accounts.
 	accountRc *keyed.KeyedRefCount[string, *providerAccountTracker]
@@ -101,6 +104,7 @@ func NewProvider(
 		peer:               peer,
 		handler:            handler,
 		sfs:                sfs,
+		localNetwork:       newLocalSessionNetwork(),
 	}
 	p.linkedCloudAccountLoader = defaultLinkedCloudAccountLoader
 	p.accountRc = keyed.NewKeyedRefCountWithLogger(
@@ -260,7 +264,7 @@ func (a *ProviderAccount) writeLinkedCloudAccountID(ctx context.Context, session
 
 // AccessProviderAccount accesses a provider account.
 // If accountID is empty, it will use the default or prompt the user.
-// released may be nil
+// released may be nil.
 func (p *Provider) AccessProviderAccount(ctx context.Context, accountID string, released func()) (provider.ProviderAccount, func(), error) {
 	ref, providerAccTkr, _ := p.accountRc.AddKeyRef(accountID)
 	providerAcc, err := providerAccTkr.accCtr.WaitValue(ctx, nil)

--- a/core/provider/spacewave/transport-composition.go
+++ b/core/provider/spacewave/transport-composition.go
@@ -15,26 +15,40 @@ import (
 type TransportCompositionP2PState uint8
 
 const (
+	// TransportCompositionP2PStateUnknown has no reported lifecycle state.
 	TransportCompositionP2PStateUnknown TransportCompositionP2PState = iota
+	// TransportCompositionP2PStateDisabled has direct transport disabled.
 	TransportCompositionP2PStateDisabled
+	// TransportCompositionP2PStateStarting is starting direct transport.
 	TransportCompositionP2PStateStarting
+	// TransportCompositionP2PStateNoPeers has not established a peer link.
 	TransportCompositionP2PStateNoPeers
+	// TransportCompositionP2PStateIdle has peer links without active demand.
 	TransportCompositionP2PStateIdle
+	// TransportCompositionP2PStateActive has peer links serving active demand.
 	TransportCompositionP2PStateActive
+	// TransportCompositionP2PStateFallbackNoPeer has lost its established peer links.
 	TransportCompositionP2PStateFallbackNoPeer
+	// TransportCompositionP2PStateError could not keep direct transport running.
 	TransportCompositionP2PStateError
 )
 
 // TransportCompositionSnapshot is one Session's direct transport projection.
 type TransportCompositionSnapshot struct {
+	// DirectP2PEnabled records the session policy.
 	DirectP2PEnabled bool
-	P2PState         TransportCompositionP2PState
-	ActivePeerCount  uint32
-	LastError        string
+	// P2PState reports the current direct lifecycle.
+	P2PState TransportCompositionP2PState
+	// ActivePeerCount counts active transport links.
+	ActivePeerCount uint32
+	// LastError describes the most recent transport failure.
+	LastError string
 }
 
+// transportCompositionLinkSource exposes transport-owned link state and changes.
 type transportCompositionLinkSource interface {
-	GetLinkSnapshotsWithWait() ([]transport_controller.LinkSnapshot, <-chan struct{})
+	// GetLinkSnapshotsWithWait returns links and every channel that can change them.
+	GetLinkSnapshotsWithWait() ([]transport_controller.LinkSnapshot, []<-chan struct{})
 }
 
 type transportCompositionConfig struct {
@@ -114,6 +128,7 @@ func (o *transportCompositionOwner) init(account *ProviderAccount) {
 	}
 }
 
+// newTransportCompositionSession constructs the initial direct transport projection.
 func newTransportCompositionSession() *transportCompositionSession {
 	return &transportCompositionSession{
 		snapshot: TransportCompositionSnapshot{
@@ -123,6 +138,7 @@ func newTransportCompositionSession() *transportCompositionSession {
 	}
 }
 
+// sessionForConfigure returns the shared session state, creating it on first configuration.
 func (o *transportCompositionOwner) sessionForConfigure(sessionID string) *transportCompositionSession {
 	o.mtx.Lock()
 	defer o.mtx.Unlock()
@@ -134,6 +150,7 @@ func (o *transportCompositionOwner) sessionForConfigure(sessionID string) *trans
 	return state
 }
 
+// findSession reads the current session state under the owner lock.
 func (o *transportCompositionOwner) findSession(sessionID string) *transportCompositionSession {
 	o.mtx.Lock()
 	defer o.mtx.Unlock()
@@ -170,18 +187,21 @@ func (a *ProviderAccount) GetTransportCompositionSnapshotWithWait(sessionID stri
 	return o.snapshotWithWait(sessionID)
 }
 
+// directDemandStarted records direct work for the mounted session.
 func (a *ProviderAccount) directDemandStarted(sessionID string) {
 	o := &a.transportComposition
 	o.init(a)
 	o.demandStarted(sessionID)
 }
 
+// directDemandFinished releases direct work for the mounted session.
 func (a *ProviderAccount) directDemandFinished(sessionID string) {
 	o := &a.transportComposition
 	o.init(a)
 	o.demandFinished(sessionID)
 }
 
+// configure serializes configuration against session shutdown.
 func (o *transportCompositionOwner) configure(ctx context.Context, config *transportCompositionConfig) error {
 	state := o.sessionForConfigure(config.sessionID)
 	state.mtx.Lock()
@@ -195,6 +215,7 @@ func (o *transportCompositionOwner) configure(ctx context.Context, config *trans
 	return o.configureLocked(ctx, state, config)
 }
 
+// configureLocked reconciles direct transport and its watcher under the session lock.
 func (o *transportCompositionOwner) configureLocked(ctx context.Context, state *transportCompositionSession, config *transportCompositionConfig) error {
 	if state.config != nil && state.config.enabled == config.enabled &&
 		state.snapshotState() != TransportCompositionP2PStateError {
@@ -239,6 +260,7 @@ func (o *transportCompositionOwner) configureLocked(ctx context.Context, state *
 	return nil
 }
 
+// setEnabled updates the mounted session policy under its lifecycle lock.
 func (o *transportCompositionOwner) setEnabled(ctx context.Context, sessionID string, enabled bool) error {
 	state := o.findSession(sessionID)
 	if state == nil {
@@ -257,6 +279,7 @@ func (o *transportCompositionOwner) setEnabled(ctx context.Context, sessionID st
 	return o.configureLocked(ctx, state, &config)
 }
 
+// stop stops the session composition before removing its shared state.
 func (o *transportCompositionOwner) stop(sessionID string) {
 	state := o.findSession(sessionID)
 	if state == nil {
@@ -280,6 +303,7 @@ func (o *transportCompositionOwner) stop(sessionID string) {
 	o.removeSession(sessionID, state)
 }
 
+// removeSession removes only the session state being stopped.
 func (o *transportCompositionOwner) removeSession(sessionID string, target *transportCompositionSession) {
 	o.mtx.Lock()
 	if o.sessions[sessionID] == target {
@@ -307,6 +331,7 @@ func (o *transportCompositionOwner) awaitLinkExit(state *transportCompositionSes
 	}
 }
 
+// stopLocked cancels and joins the watcher before stopping direct transport.
 func (o *transportCompositionOwner) stopLocked(state *transportCompositionSession, clearConfig bool) {
 	state.nextGeneration()
 	if state.linkCancel != nil {
@@ -323,6 +348,7 @@ func (o *transportCompositionOwner) stopLocked(state *transportCompositionSessio
 	}
 }
 
+// watchLinks projects transport-owned snapshots until cancellation or transport exit.
 func (o *transportCompositionOwner) watchLinks(ctx context.Context, sessionID string, state *transportCompositionSession, generation uint64, source transportCompositionLinkSource) {
 	for {
 		running, transportWaitCh := o.transportState(sessionID)
@@ -330,20 +356,18 @@ func (o *transportCompositionOwner) watchLinks(ctx context.Context, sessionID st
 			o.setTransportExited(state, generation)
 			return
 		}
-		links, linkWaitCh := source.GetLinkSnapshotsWithWait()
+		links, linkWaitChs := source.GetLinkSnapshotsWithWait()
 		o.setLinks(state, generation, len(links))
-		if linkWaitCh == nil && transportWaitCh == nil {
+		if len(linkWaitChs) == 0 && transportWaitCh == nil {
 			return
 		}
-		select {
-		case <-ctx.Done():
+		if err := broadcast.WaitAny(ctx, append(linkWaitChs, transportWaitCh)...); err != nil {
 			return
-		case <-linkWaitCh:
-		case <-transportWaitCh:
 		}
 	}
 }
 
+// setLinks publishes links only for the current watcher generation.
 func (o *transportCompositionOwner) setLinks(state *transportCompositionSession, generation uint64, count int) {
 	state.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
 		if generation != state.generation {
@@ -368,6 +392,7 @@ func (o *transportCompositionOwner) setLinks(state *transportCompositionSession,
 	})
 }
 
+// setTransportExited records unexpected exit only for the current watcher generation.
 func (o *transportCompositionOwner) setTransportExited(state *transportCompositionSession, generation uint64) {
 	state.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
 		if generation != state.generation {
@@ -380,6 +405,7 @@ func (o *transportCompositionOwner) setTransportExited(state *transportCompositi
 	})
 }
 
+// demandStarted counts active demand while direct peer links exist.
 func (o *transportCompositionOwner) demandStarted(sessionID string) {
 	state := o.findSession(sessionID)
 	if state == nil {
@@ -395,6 +421,7 @@ func (o *transportCompositionOwner) demandStarted(sessionID string) {
 	})
 }
 
+// demandFinished returns linked transport to idle when its final demand ends.
 func (o *transportCompositionOwner) demandFinished(sessionID string) {
 	state := o.findSession(sessionID)
 	if state == nil {
@@ -412,6 +439,7 @@ func (o *transportCompositionOwner) demandFinished(sessionID string) {
 	})
 }
 
+// nextGeneration invalidates earlier watcher updates and resets demand history.
 func (state *transportCompositionSession) nextGeneration() uint64 {
 	var generation uint64
 	state.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
@@ -424,6 +452,7 @@ func (state *transportCompositionSession) nextGeneration() uint64 {
 	return generation
 }
 
+// setSnapshot publishes replacement lifecycle state and resets demand history.
 func (state *transportCompositionSession) setSnapshot(snapshot TransportCompositionSnapshot) {
 	state.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
 		state.snapshot = snapshot
@@ -433,6 +462,7 @@ func (state *transportCompositionSession) setSnapshot(snapshot TransportComposit
 	})
 }
 
+// snapshotState reads the projected direct lifecycle under its broadcast lock.
 func (state *transportCompositionSession) snapshotState() TransportCompositionP2PState {
 	var p2pState TransportCompositionP2PState
 	state.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
@@ -441,6 +471,7 @@ func (state *transportCompositionSession) snapshotState() TransportCompositionP2
 	return p2pState
 }
 
+// snapshotWithWait returns the current projection and its matching change channel.
 func (o *transportCompositionOwner) snapshotWithWait(sessionID string) (TransportCompositionSnapshot, <-chan struct{}) {
 	state := o.findSession(sessionID)
 	if state == nil {

--- a/core/provider/spacewave/transport-composition_test.go
+++ b/core/provider/spacewave/transport-composition_test.go
@@ -16,14 +16,14 @@ type compositionTestLinkSource struct {
 	links []transport_controller.LinkSnapshot
 }
 
-func (s *compositionTestLinkSource) GetLinkSnapshotsWithWait() ([]transport_controller.LinkSnapshot, <-chan struct{}) {
+func (s *compositionTestLinkSource) GetLinkSnapshotsWithWait() ([]transport_controller.LinkSnapshot, []<-chan struct{}) {
 	var links []transport_controller.LinkSnapshot
 	var waitCh <-chan struct{}
 	s.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
 		links = append([]transport_controller.LinkSnapshot(nil), s.links...)
 		waitCh = getWaitCh()
 	})
-	return links, waitCh
+	return links, []<-chan struct{}{waitCh}
 }
 
 func (s *compositionTestLinkSource) setLinkCount(count int) {

--- a/core/resource/session/recovery-status-registry.go
+++ b/core/resource/session/recovery-status-registry.go
@@ -1,0 +1,62 @@
+package resource_session
+
+import (
+	"sync"
+
+	"github.com/aperturerobotics/util/ccontainer"
+	"github.com/s4wave/spacewave/core/session"
+	s4wave_status "github.com/s4wave/spacewave/sdk/status"
+)
+
+// RecoveryStatusRegistry owns volatile renderer-published recovery facts for
+// logical sessions. Multiple mounted SessionResources for the same SessionRef
+// share one status container through this registry.
+type RecoveryStatusRegistry struct {
+	mtx       sync.Mutex
+	bySession map[string]*ccontainer.CContainer[*s4wave_status.ReportRecoveryStatusRequest]
+}
+
+// NewRecoveryStatusRegistry creates a new recovery status registry.
+func NewRecoveryStatusRegistry() *RecoveryStatusRegistry {
+	return &RecoveryStatusRegistry{bySession: make(map[string]*ccontainer.CContainer[*s4wave_status.ReportRecoveryStatusRequest])}
+}
+
+// GetSessionRecoveryStatusCtr returns the shared volatile recovery status
+// container for sess.
+func (r *RecoveryStatusRegistry) GetSessionRecoveryStatusCtr(
+	sess session.Session,
+) *ccontainer.CContainer[*s4wave_status.ReportRecoveryStatusRequest] {
+	if r == nil || sess == nil || sess.GetSessionRef() == nil {
+		return newRendererRecoveryCtr()
+	}
+	return r.getSessionRecoveryStatusCtrForRef(sess.GetSessionRef())
+}
+
+// getSessionRecoveryStatusCtrForRef shares renderer status by the complete provider resource identity.
+func (r *RecoveryStatusRegistry) getSessionRecoveryStatusCtrForRef(
+	ref *session.SessionRef,
+) *ccontainer.CContainer[*s4wave_status.ReportRecoveryStatusRequest] {
+	if r == nil || ref == nil {
+		return newRendererRecoveryCtr()
+	}
+	key := recoveryStatusSessionKey(ref)
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	ctr := r.bySession[key]
+	if ctr == nil {
+		ctr = newRendererRecoveryCtr()
+		r.bySession[key] = ctr
+	}
+	return ctr
+}
+
+// recoveryStatusSessionKey addresses recovery status by provider, account, and session.
+func recoveryStatusSessionKey(ref *session.SessionRef) string {
+	providerRef := ref.GetProviderResourceRef()
+	return providerRef.GetProviderId() + "/" + providerRef.GetProviderAccountId() + "/" + providerRef.GetId()
+}
+
+// newRendererRecoveryCtr constructs a volatile container that notifies only on changed reports.
+func newRendererRecoveryCtr() *ccontainer.CContainer[*s4wave_status.ReportRecoveryStatusRequest] {
+	return ccontainer.NewCContainerWithEqual(nil, rendererRecoveryStatusEqual)
+}

--- a/core/resource/session/status.go
+++ b/core/resource/session/status.go
@@ -4,7 +4,6 @@ import (
 	"cmp"
 	"context"
 	"slices"
-	"sync"
 	"time"
 
 	"github.com/aperturerobotics/controllerbus/bus"
@@ -19,56 +18,6 @@ import (
 	transport_controller "github.com/s4wave/spacewave/net/transport/controller"
 	s4wave_status "github.com/s4wave/spacewave/sdk/status"
 )
-
-// RecoveryStatusRegistry owns volatile renderer-published recovery facts for
-// logical sessions. Multiple mounted SessionResources for the same SessionRef
-// share one status container through this registry.
-type RecoveryStatusRegistry struct {
-	mtx       sync.Mutex
-	bySession map[string]*ccontainer.CContainer[*s4wave_status.ReportRecoveryStatusRequest]
-}
-
-// NewRecoveryStatusRegistry creates a new recovery status registry.
-func NewRecoveryStatusRegistry() *RecoveryStatusRegistry {
-	return &RecoveryStatusRegistry{bySession: make(map[string]*ccontainer.CContainer[*s4wave_status.ReportRecoveryStatusRequest])}
-}
-
-// GetSessionRecoveryStatusCtr returns the shared volatile recovery status
-// container for sess.
-func (r *RecoveryStatusRegistry) GetSessionRecoveryStatusCtr(
-	sess session.Session,
-) *ccontainer.CContainer[*s4wave_status.ReportRecoveryStatusRequest] {
-	if r == nil || sess == nil || sess.GetSessionRef() == nil {
-		return newRendererRecoveryCtr()
-	}
-	return r.getSessionRecoveryStatusCtrForRef(sess.GetSessionRef())
-}
-
-func (r *RecoveryStatusRegistry) getSessionRecoveryStatusCtrForRef(
-	ref *session.SessionRef,
-) *ccontainer.CContainer[*s4wave_status.ReportRecoveryStatusRequest] {
-	if r == nil || ref == nil {
-		return newRendererRecoveryCtr()
-	}
-	key := recoveryStatusSessionKey(ref)
-	r.mtx.Lock()
-	defer r.mtx.Unlock()
-	ctr := r.bySession[key]
-	if ctr == nil {
-		ctr = newRendererRecoveryCtr()
-		r.bySession[key] = ctr
-	}
-	return ctr
-}
-
-func recoveryStatusSessionKey(ref *session.SessionRef) string {
-	providerRef := ref.GetProviderResourceRef()
-	return providerRef.GetProviderId() + "/" + providerRef.GetProviderAccountId() + "/" + providerRef.GetId()
-}
-
-func newRendererRecoveryCtr() *ccontainer.CContainer[*s4wave_status.ReportRecoveryStatusRequest] {
-	return ccontainer.NewCContainerWithEqual(nil, rendererRecoveryStatusEqual)
-}
 
 // StatusResource implements the SystemStatusService for a session.
 type StatusResource struct {
@@ -208,7 +157,7 @@ func (r *StatusResource) WatchNetworkStats(
 			}
 			prev = resp.CloneVT()
 		}
-		if err := waitNetworkStats(ctx, waitChs); err != nil {
+		if err := broadcast.WaitAny(ctx, waitChs...); err != nil {
 			return err
 		}
 	}
@@ -274,6 +223,7 @@ func (r *StatusResource) WatchRecoveryStatus(
 	}
 }
 
+// watchRecoveryOwnerChanges restarts owner watches when the controller set changes until cancellation.
 func (r *StatusResource) watchRecoveryOwnerChanges(ctx context.Context, notify func()) {
 	for {
 		waitCh := r.controllersWaitCh()
@@ -292,6 +242,7 @@ func (r *StatusResource) watchRecoveryOwnerChanges(ctx context.Context, notify f
 	}
 }
 
+// watchRecoveryLauncherChanges watches launcher facts for the supplied controller-watch lifetime.
 func (r *StatusResource) watchRecoveryLauncherChanges(ctx context.Context, notify func()) {
 	ctrl := spacewave_launcher_controller.FindControllerOnBus(r.b)
 	if ctrl == nil {
@@ -327,6 +278,7 @@ func (r *StatusResource) watchRecoveryLauncherChanges(ctx context.Context, notif
 	}()
 }
 
+// watchRecoveryPluginChanges watches plugin facts until its controller-watch context ends.
 func (r *StatusResource) watchRecoveryPluginChanges(ctx context.Context, notify func()) {
 	ctr := r.findPluginStatusCtr()
 	if ctr == nil {
@@ -345,6 +297,7 @@ func (r *StatusResource) watchRecoveryPluginChanges(ctx context.Context, notify 
 	)
 }
 
+// watchRecoveryRendererChanges watches volatile renderer facts until the status stream ends.
 func (r *StatusResource) watchRecoveryRendererChanges(ctx context.Context, notify func()) {
 	current := r.rendererRecoveryCtr.GetValue()
 	_ = ccontainer.WatchChanges(
@@ -359,6 +312,7 @@ func (r *StatusResource) watchRecoveryRendererChanges(ctx context.Context, notif
 	)
 }
 
+// rendererRecoveryStatusEqual compares nullable renderer snapshots by value.
 func rendererRecoveryStatusEqual(
 	a,
 	b *s4wave_status.ReportRecoveryStatusRequest,
@@ -369,6 +323,7 @@ func rendererRecoveryStatusEqual(
 	return a.EqualVT(b)
 }
 
+// waitPluginStatusCtr waits for a plugin scheduler or context cancellation.
 func (r *StatusResource) waitPluginStatusCtr(
 	ctx context.Context,
 ) (ccontainer.Watchable[*plugin_host_scheduler.PluginStatusSnapshot], error) {
@@ -385,6 +340,7 @@ func (r *StatusResource) waitPluginStatusCtr(
 	}
 }
 
+// findPluginStatusCtr locates the mounted plugin scheduler status owner.
 func (r *StatusResource) findPluginStatusCtr() ccontainer.Watchable[*plugin_host_scheduler.PluginStatusSnapshot] {
 	for _, ctrl := range r.b.GetControllers() {
 		scheduler, ok := ctrl.(*plugin_host_scheduler.Controller)
@@ -395,6 +351,7 @@ func (r *StatusResource) findPluginStatusCtr() ccontainer.Watchable[*plugin_host
 	return nil
 }
 
+// controllersWaitCh captures controller-change notification under its owning lock.
 func (r *StatusResource) controllersWaitCh() <-chan struct{} {
 	var waitCh <-chan struct{}
 	r.b.GetControllersBroadcast().HoldLock(func(
@@ -406,6 +363,7 @@ func (r *StatusResource) controllersWaitCh() <-chan struct{} {
 	return waitCh
 }
 
+// buildPluginsResponse projects the scheduler snapshot into plugin status records.
 func buildPluginsResponse(snapshot *plugin_host_scheduler.PluginStatusSnapshot) *s4wave_status.WatchPluginsResponse {
 	var infos []*s4wave_status.PluginInfo
 	if snapshot != nil {
@@ -424,11 +382,15 @@ func buildPluginsResponse(snapshot *plugin_host_scheduler.PluginStatusSnapshot) 
 	}
 }
 
+// networkStatusProvider exposes the account-owned transport and its lifecycle.
 type networkStatusProvider interface {
+	// GetSessionTransport returns the active transport, or nil.
 	GetSessionTransport() *spacewave_transport.SessionTransport
+	// GetTransportSnapshotWithWait returns running state and its change channel.
 	GetTransportSnapshotWithWait() (bool, <-chan struct{})
 }
 
+// buildNetworkStatsResponse projects live transport links into network status records.
 func (r *StatusResource) buildNetworkStatsResponse() (*s4wave_status.WatchNetworkStatsResponse, []<-chan struct{}) {
 	resp := &s4wave_status.WatchNetworkStatsResponse{}
 	if r.sess == nil || r.sess.GetProviderAccount() == nil {
@@ -440,18 +402,19 @@ func (r *StatusResource) buildNetworkStatsResponse() (*s4wave_status.WatchNetwor
 	}
 	transportRunning, transportWaitCh := provider.GetTransportSnapshotWithWait()
 	resp.TransportRunning = transportRunning
-	waitChs := appendNetworkStatsWaitCh(nil, transportWaitCh)
+	waitChs := []<-chan struct{}{transportWaitCh}
 	st := provider.GetSessionTransport()
 	if st == nil {
 		return resp, waitChs
 	}
 	resp.LocalPeerId = st.GetPeerID().String()
-	links, linkWaitCh := st.GetLinkSnapshotsWithWait()
-	waitChs = appendNetworkStatsWaitCh(waitChs, linkWaitCh)
+	links, linkWaitChs := st.GetLinkSnapshotsWithWait()
+	waitChs = append(waitChs, linkWaitChs...)
 	slices.SortFunc(links, compareNetworkLinkSnapshots)
 	return buildNetworkStatsResponse(resp, links), waitChs
 }
 
+// compareNetworkLinkSnapshots orders links by remote identity and link identifier.
 func compareNetworkLinkSnapshots(a, b transport_controller.LinkSnapshot) int {
 	if n := cmp.Compare(a.RemotePeerID.String(), b.RemotePeerID.String()); n != 0 {
 		return n
@@ -459,6 +422,7 @@ func compareNetworkLinkSnapshots(a, b transport_controller.LinkSnapshot) int {
 	return cmp.Compare(a.LinkID, b.LinkID)
 }
 
+// buildNetworkStatsResponse projects live transport links into network status records.
 func buildNetworkStatsResponse(
 	resp *s4wave_status.WatchNetworkStatsResponse,
 	links []transport_controller.LinkSnapshot,
@@ -492,21 +456,7 @@ func buildNetworkStatsResponse(
 	return resp
 }
 
-func appendNetworkStatsWaitCh(waitChs []<-chan struct{}, waitCh <-chan struct{}) []<-chan struct{} {
-	if waitCh == nil {
-		return waitChs
-	}
-	return append(waitChs, waitCh)
-}
-
-func waitNetworkStats(ctx context.Context, waitChs []<-chan struct{}) error {
-	if len(waitChs) == 0 {
-		<-ctx.Done()
-		return ctx.Err()
-	}
-	return broadcast.WaitAny(ctx, waitChs...)
-}
-
+// buildRecoveryStatus combines current owner facts with volatile renderer facts.
 func (r *StatusResource) buildRecoveryStatus() *s4wave_status.RecoveryStatus {
 	pluginSnapshot := (*plugin_host_scheduler.PluginStatusSnapshot)(nil)
 	if statusCtr := r.findPluginStatusCtr(); statusCtr != nil {
@@ -522,6 +472,7 @@ func (r *StatusResource) buildRecoveryStatus() *s4wave_status.RecoveryStatus {
 	}
 }
 
+// buildLauncherRecoveryStatus projects the current launcher metadata and update state.
 func (r *StatusResource) buildLauncherRecoveryStatus() *s4wave_status.LauncherRecoveryStatus {
 	ctrl := spacewave_launcher_controller.FindControllerOnBus(r.b)
 	if ctrl == nil {
@@ -532,6 +483,7 @@ func (r *StatusResource) buildLauncherRecoveryStatus() *s4wave_status.LauncherRe
 	return buildLauncherRecoveryStatus(info, status)
 }
 
+// buildLauncherRecoveryStatus projects the current launcher metadata and update state.
 func buildLauncherRecoveryStatus(
 	info *spacewave_launcher.LauncherInfo,
 	status *spacewave_launcher.FetchStatus,
@@ -563,6 +515,7 @@ func buildLauncherRecoveryStatus(
 	return out
 }
 
+// launcherUpdatePhaseString formats the launcher update phase for diagnostic status.
 func launcherUpdatePhaseString(phase spacewave_launcher.UpdatePhase) string {
 	switch phase {
 	case spacewave_launcher.UpdatePhase_UpdatePhase_IDLE:
@@ -580,6 +533,7 @@ func launcherUpdatePhaseString(phase spacewave_launcher.UpdatePhase) string {
 	}
 }
 
+// buildPluginManifestRecoveryStatuses projects retained plugin recovery outcomes.
 func buildPluginManifestRecoveryStatuses(
 	snapshot *plugin_host_scheduler.PluginStatusSnapshot,
 ) []*s4wave_status.PluginManifestRecoveryStatus {
@@ -607,6 +561,7 @@ func buildPluginManifestRecoveryStatuses(
 	return out
 }
 
+// buildBrowserBootRecoveryStatus copies the renderer boot report or marks it unreported.
 func buildBrowserBootRecoveryStatus(
 	renderer *s4wave_status.ReportRecoveryStatusRequest,
 ) *s4wave_status.BrowserBootRecoveryStatus {
@@ -620,6 +575,7 @@ func buildBrowserBootRecoveryStatus(
 	return status
 }
 
+// buildRuntimeAssetRecoveryStatus copies the renderer asset report or marks it unreported.
 func buildRuntimeAssetRecoveryStatus(
 	renderer *s4wave_status.ReportRecoveryStatusRequest,
 ) *s4wave_status.RuntimeAssetRecoveryStatus {
@@ -633,6 +589,7 @@ func buildRuntimeAssetRecoveryStatus(
 	return status
 }
 
+// formatRecoveryStatusTime formats a recorded recovery timestamp in UTC.
 func formatRecoveryStatusTime(ts time.Time) string {
 	if ts.IsZero() {
 		return ""
@@ -640,6 +597,7 @@ func formatRecoveryStatusTime(ts time.Time) string {
 	return ts.UTC().Format(time.RFC3339Nano)
 }
 
+// pluginStateString formats the plugin lifecycle for diagnostic status.
 func pluginStateString(state bldr_plugin.PluginState) string {
 	switch state {
 	case bldr_plugin.PluginState_PluginState_REQUESTED:

--- a/core/transport/local-network.go
+++ b/core/transport/local-network.go
@@ -1,0 +1,45 @@
+//go:build !tinygo
+
+package transport
+
+import (
+	"context"
+
+	"github.com/aperturerobotics/controllerbus/bus"
+	"github.com/pkg/errors"
+	transport_controller "github.com/s4wave/spacewave/net/transport/controller"
+	"github.com/s4wave/spacewave/net/transport/inproc"
+)
+
+// WithInprocNetwork enables authenticated links to other sessions on this native network.
+// Network membership follows Execute; separate networks never share packet routes.
+func WithInprocNetwork(network *inproc.Network) SessionTransportOption {
+	return func(t *SessionTransport) {
+		t.startLocalTransport = func(ctx context.Context, b bus.Bus) (*transport_controller.Controller, func(), error) {
+			// Construct the transport under the session's existing peer controller.
+			controller := inproc.BuildInprocController(t.le, b, t.peerID, &inproc.Config{})
+			release, err := b.AddController(ctx, controller, nil)
+			if err != nil {
+				return nil, nil, err
+			}
+			raw, err := controller.GetTransport(ctx)
+			if err != nil {
+				release()
+				return nil, nil, err
+			}
+			transport, ok := raw.(*inproc.Inproc)
+			if !ok {
+				release()
+				return nil, nil, errors.New("in-process controller returned an unexpected transport")
+			}
+
+			// Remove packet reachability before releasing the controller.
+			detach, err := network.Attach(ctx, transport)
+			if err != nil {
+				release()
+				return nil, nil, err
+			}
+			return controller, func() { detach(); release() }, nil
+		}
+	}
+}

--- a/core/transport/transport.go
+++ b/core/transport/transport.go
@@ -2,6 +2,8 @@ package transport
 
 import (
 	"context"
+	"maps"
+	"slices"
 	"time"
 
 	"github.com/aperturerobotics/controllerbus/bus"
@@ -30,6 +32,7 @@ import (
 // SessionTransport manages a session-scoped child bus with bifrost
 // transport controllers bound to the session's peer identity.
 type SessionTransport struct {
+	// le records transport and startup activity.
 	le *logrus.Entry
 	// parentBus is the parent controller bus to bridge directives to.
 	parentBus bus.Bus
@@ -37,8 +40,10 @@ type SessionTransport struct {
 	bcast broadcast.Broadcast
 	// childBus is the session-scoped child bus.
 	childBus bus.Bus
-	// linkController is the active transport controller that owns link state.
-	linkController *transport_controller.Controller
+	// linkControllers owns the links exposed by each active transport.
+	linkControllers []*transport_controller.Controller
+	// startLocalTransport optionally attaches a native process-local network.
+	startLocalTransport func(context.Context, bus.Bus) (*transport_controller.Controller, func(), error)
 	// sessionKey is the session's Ed25519 private key.
 	sessionKey bifrost_crypto.PrivKey
 	// peerID is the peer ID derived from the session key.
@@ -171,6 +176,7 @@ func (t *SessionTransport) GetPeerID() peer.ID {
 	return t.peerID
 }
 
+// GetChildBus returns the active session bus, or nil outside Execute.
 func (t *SessionTransport) GetChildBus() bus.Bus {
 	var childBus bus.Bus
 	t.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
@@ -179,30 +185,45 @@ func (t *SessionTransport) GetChildBus() bus.Bus {
 	return childBus
 }
 
-// GetLinkedPeerIDsSnapshotWithWait returns linked peer IDs and a wait channel
-// that closes when the transport link set changes.
-func (t *SessionTransport) GetLinkedPeerIDsSnapshotWithWait(peerIDs []peer.ID) (map[peer.ID]struct{}, <-chan struct{}) {
-	var linkController *transport_controller.Controller
-	t.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
-		linkController = t.linkController
+// GetLinkedPeerIDsSnapshotWithWait returns linked peer IDs and their change channels.
+// Each controller retains its link state; callers wait on all returned channels.
+func (t *SessionTransport) GetLinkedPeerIDsSnapshotWithWait(peerIDs []peer.ID) (map[peer.ID]struct{}, []<-chan struct{}) {
+	// Snapshot controller membership together with its notification channel.
+	var controllers []*transport_controller.Controller
+	var waitChs []<-chan struct{}
+	t.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
+		controllers = slices.Clone(t.linkControllers)
+		waitChs = []<-chan struct{}{getWaitCh()}
 	})
-	if linkController == nil {
-		return nil, nil
+
+	// Read current links directly from each transport owner.
+	peers := make(map[peer.ID]struct{})
+	for _, controller := range controllers {
+		linked, waitCh := controller.GetLinkedPeerIDsSnapshotWithWait(peerIDs)
+		maps.Copy(peers, linked)
+		waitChs = append(waitChs, waitCh)
 	}
-	return linkController.GetLinkedPeerIDsSnapshotWithWait(peerIDs)
+	return peers, waitChs
 }
 
-// GetLinkSnapshotsWithWait returns live link snapshots and a wait channel that
-// closes when the transport link set changes.
-func (t *SessionTransport) GetLinkSnapshotsWithWait() ([]transport_controller.LinkSnapshot, <-chan struct{}) {
-	var linkController *transport_controller.Controller
-	t.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
-		linkController = t.linkController
+// GetLinkSnapshotsWithWait returns current links and all channels that can change them.
+func (t *SessionTransport) GetLinkSnapshotsWithWait() ([]transport_controller.LinkSnapshot, []<-chan struct{}) {
+	// Snapshot controller membership together with its notification channel.
+	var controllers []*transport_controller.Controller
+	var waitChs []<-chan struct{}
+	t.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
+		controllers = slices.Clone(t.linkControllers)
+		waitChs = []<-chan struct{}{getWaitCh()}
 	})
-	if linkController == nil {
-		return nil, nil
+
+	// Preserve individual links when more than one transport reaches the same peer.
+	var links []transport_controller.LinkSnapshot
+	for _, controller := range controllers {
+		current, waitCh := controller.GetLinkSnapshotsWithWait()
+		links = append(links, current...)
+		waitChs = append(waitChs, waitCh)
 	}
-	return linkController.GetLinkSnapshotsWithWait()
+	return links, waitChs
 }
 
 // Ready returns a channel that closes when the child bus and base controllers
@@ -466,6 +487,13 @@ func (t *SessionTransport) Execute(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		cancel()
+		closeErr := b.Close()
+		if err == nil {
+			err = closeErr
+		}
+	}()
 	t.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
 		t.childBus = b
 		broadcast()
@@ -473,7 +501,7 @@ func (t *SessionTransport) Execute(ctx context.Context) (err error) {
 	defer func() {
 		t.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
 			t.childBus = nil
-			t.linkController = nil
+			t.linkControllers = nil
 			broadcast()
 		})
 	}()
@@ -546,6 +574,20 @@ func (t *SessionTransport) Execute(ctx context.Context) (err error) {
 	}
 	defer solicitRef.Release()
 
+	// Attach process-local packet routes before announcing transport readiness.
+	if t.startLocalTransport != nil {
+		t.setStartupStage("local-transport")
+		localCtrl, releaseLocal, err := t.startLocalTransport(ctx, b)
+		if err != nil {
+			return err
+		}
+		defer releaseLocal()
+		t.bcast.HoldLock(func(notify func(), _ func() <-chan struct{}) {
+			t.linkControllers = append(t.linkControllers, localCtrl)
+			notify()
+		})
+	}
+
 	t.setStartupStage("webrtc-controllers")
 	rtcCtrl, releaseRTC, err := t.startWebRTCControllers(ctx, le, b)
 	if err != nil {
@@ -556,7 +598,7 @@ func (t *SessionTransport) Execute(ctx context.Context) (err error) {
 	}
 	if rtcCtrl != nil {
 		t.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
-			t.linkController = rtcCtrl
+			t.linkControllers = append(t.linkControllers, rtcCtrl)
 			broadcast()
 		})
 	}

--- a/net/transport/inproc/inproc.go
+++ b/net/transport/inproc/inproc.go
@@ -3,11 +3,13 @@ package inproc
 import (
 	"context"
 	"net"
-	"sync"
 
 	"github.com/aperturerobotics/controllerbus/bus"
 	"github.com/aperturerobotics/controllerbus/controller"
+	"github.com/aperturerobotics/util/broadcast"
+	"github.com/pkg/errors"
 	"github.com/s4wave/spacewave/net/crypto"
+	"github.com/s4wave/spacewave/net/link"
 	"github.com/s4wave/spacewave/net/peer"
 	"github.com/s4wave/spacewave/net/transport"
 	"github.com/s4wave/spacewave/net/transport/common/dialer"
@@ -25,23 +27,22 @@ const ControllerID = "bifrost/inproc"
 // Version is the version of the inproc implementation.
 var Version = controller.MustParseVersion("0.0.1")
 
-// Inproc implements a Inproc transport.
+// Inproc carries authenticated peer links over connected in-process packet endpoints.
 type Inproc struct {
-	// Transport is the packet transport
+	// Transport owns packet encryption and authenticated peer links.
 	*pconn.Transport
 
-	// le is the logger
+	// le records transport activity.
 	le *logrus.Entry
-	// packetConn is the packet conn
+	// packetConn receives packets for this endpoint.
 	packetConn *packetConn
-	// localAddr is the local addr
+	// localAddr identifies this endpoint.
 	localAddr net.Addr
 
-	// mtx guards below
-	mtx sync.Mutex
-	// remotes are the currently known remotes
-	// map is from string (net.addr.String()) to *packetConn
-	remotes map[string]*packetConn
+	// bcast guards remote endpoints and wakes pending dialers.
+	bcast broadcast.Broadcast
+	// remotes maps connected addresses to their receiving endpoints.
+	remotes map[string]*Inproc
 }
 
 // NewInproc builds a new Inproc transport.
@@ -64,7 +65,7 @@ func NewInproc(
 	ip := &Inproc{
 		le:        le,
 		localAddr: localAddr,
-		remotes:   make(map[string]*packetConn),
+		remotes:   make(map[string]*Inproc),
 	}
 
 	// Create the packet connection that routes to known remotes.
@@ -127,40 +128,102 @@ func BuildInprocController(
 
 // MatchTransportType checks if the given transport type ID matches this transport.
 // If returns true, the transport controller will call DialPeer with that tptaddr.
-// E.x.: "udp-quic" or "ws"
+// Examples include "udp-quic" and "ws".
 func (t *Inproc) MatchTransportType(transportType string) bool {
 	return transportType == TransportType
 }
 
 // ConnectToInproc connects the inproc to a remote inproc.
-// Will overwrite any existing connection
+// It replaces the existing route for the same peer.
 func (t *Inproc) ConnectToInproc(ctx context.Context, other *Inproc) {
 	// Record the remote packet endpoint under its address.
 	oa := other.localAddr.String()
-	t.mtx.Lock()
-	t.remotes[oa] = other.packetConn
-	t.mtx.Unlock()
+	t.bcast.HoldLock(func(notify func(), _ func() <-chan struct{}) {
+		t.remotes[oa] = other
+		notify()
+	})
 }
 
 // DisconnectInproc disconnects a previously connected inproc.
 func (t *Inproc) DisconnectInproc(ctx context.Context, other *Inproc) {
 	// Remove the remote packet endpoint from the routing table.
 	oa := other.localAddr.String()
-	t.mtx.Lock()
-	delete(t.remotes, oa)
-	t.mtx.Unlock()
+	t.bcast.HoldLock(func(notify func(), _ func() <-chan struct{}) {
+		if t.remotes[oa] == other {
+			delete(t.remotes, oa)
+			notify()
+		}
+	})
+}
+
+// GetPeerDialer waits for an attached peer unless an explicit dialer is configured.
+// Connection changes wake standing link requests without a polling loop.
+func (t *Inproc) GetPeerDialer(ctx context.Context, peerID peer.ID) (*dialer.DialerOpts, error) {
+	// Preserve explicitly configured dialing options.
+	if opts, err := t.Transport.GetPeerDialer(ctx, peerID); err != nil || opts != nil {
+		return opts, err
+	}
+	address := NewAddr(peerID).String()
+	for {
+		var remote *Inproc
+		var waitCh <-chan struct{}
+		t.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
+			remote = t.remotes[address]
+			waitCh = getWaitCh()
+		})
+		if remote != nil {
+			return &dialer.DialerOpts{Address: address}, nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-waitCh:
+		}
+	}
+}
+
+// DialPeer chooses one initiator for both directions of an in-process peer pair.
+// Concurrent callers share that transport's existing address dialer, so they cannot
+// replace each other's authenticated connection while streams are opening.
+func (t *Inproc) DialPeer(ctx context.Context, peerID peer.ID, address string) (link.Link, bool, error) {
+	// Wait for the endpoint addressed by the caller's standing link request.
+	var remote *Inproc
+	for remote == nil {
+		var waitCh <-chan struct{}
+		t.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
+			remote = t.remotes[address]
+			waitCh = getWaitCh()
+		})
+		if remote != nil {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return nil, false, ctx.Err()
+		case <-waitCh:
+		}
+	}
+	if peerID != "" && remote.GetPeerID() != peerID {
+		return nil, true, errors.New("in-process address does not match requested peer")
+	}
+
+	// Both sides delegate to the lower peer's authenticated QUIC dialer.
+	if t.GetPeerID() < remote.GetPeerID() {
+		return t.Transport.DialPeer(ctx, remote.GetPeerID(), address)
+	}
+	_, fatal, err := remote.Transport.DialPeer(ctx, t.GetPeerID(), t.localAddr.String())
+	return nil, fatal, err
 }
 
 // writeToAddr routes outgoing packets.
 func (t *Inproc) writeToAddr(ctx context.Context, p []byte, addr net.Addr) (int, error) {
 	// Resolve the remote endpoint while holding the routing mutex.
 	oa := addr.String()
-	t.mtx.Lock()
-	out, outOk := t.remotes[oa]
-	t.mtx.Unlock()
+	var out *Inproc
+	t.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) { out = t.remotes[oa] })
 
 	// Reject packets for an endpoint that is not connected.
-	if !outOk {
+	if out == nil {
 		return 0, &net.AddrError{
 			Addr: oa,
 			Err:  "remote transport not connected",
@@ -168,7 +231,7 @@ func (t *Inproc) writeToAddr(ctx context.Context, p []byte, addr net.Addr) (int,
 	}
 
 	// Deliver the packet to the remote in-process connection.
-	return out.HandlePacket(ctx, p, t.localAddr)
+	return out.packetConn.HandlePacket(ctx, p, t.localAddr)
 }
 
 // _ is a type assertion.

--- a/net/transport/inproc/network.go
+++ b/net/transport/inproc/network.go
@@ -1,0 +1,59 @@
+package inproc
+
+import (
+	"context"
+	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/s4wave/spacewave/net/peer"
+)
+
+// Network connects transports in one explicitly shared process-local network.
+// It supplies packet reachability; transport handshakes still authenticate peers.
+// Each attached transport must be detached before its lifecycle ends.
+type Network struct {
+	// mtx serializes topology changes and guards peers.
+	mtx sync.Mutex
+	// peers contains the currently attached transport for each identity.
+	peers map[peer.ID]*Inproc
+}
+
+// NewNetwork constructs an isolated network with no attached transports.
+func NewNetwork() *Network { return &Network{peers: make(map[peer.ID]*Inproc)} }
+
+// Attach connects a transport to the network and returns its idempotent detach.
+// The same peer cannot be attached twice; replacement first releases its old attachment.
+func (n *Network) Attach(ctx context.Context, transport *Inproc) (func(), error) {
+	// Serialize both directions of every connection against other topology changes.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if transport == nil {
+		return nil, errors.New("in-process network requires a transport")
+	}
+	n.mtx.Lock()
+	defer n.mtx.Unlock()
+	id := transport.GetPeerID()
+	if n.peers[id] != nil {
+		return nil, errors.New("peer is already attached to the in-process network")
+	}
+	for _, other := range n.peers {
+		transport.ConnectToInproc(ctx, other)
+		other.ConnectToInproc(ctx, transport)
+	}
+	n.peers[id] = transport
+	attached := true
+	return func() {
+		n.mtx.Lock()
+		defer n.mtx.Unlock()
+		if !attached {
+			return
+		}
+		attached = false
+		delete(n.peers, id)
+		for _, other := range n.peers {
+			transport.DisconnectInproc(ctx, other)
+			other.DisconnectInproc(ctx, transport)
+		}
+	}, nil
+}

--- a/net/transport/inproc/network_test.go
+++ b/net/transport/inproc/network_test.go
@@ -1,0 +1,66 @@
+package inproc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/s4wave/spacewave/net/link"
+)
+
+// TestNetworkIsolationAndAttachmentLifetime exercises real links across scoped packet networks.
+func TestNetworkIsolationAndAttachmentLifetime(t *testing.T) {
+	// Separate network values do not make their peers reachable to each other.
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	firstBed, _ := buildTestbed(t, ctx)
+	secondBed, _ := buildTestbed(t, ctx)
+	_, first, firstRef := execPeer(ctx, t, firstBed, nil)
+	t.Cleanup(firstRef.Release)
+	_, second, secondRef := execPeer(ctx, t, secondBed, nil)
+	t.Cleanup(secondRef.Release)
+	network := NewNetwork()
+	detachFirst, err := network.Attach(ctx, first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(detachFirst)
+	other := NewNetwork()
+	detachOther, err := other.Attach(ctx, second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(detachOther)
+	isolatedCtx, cancelIsolated := context.WithTimeout(ctx, 50*time.Millisecond)
+	defer cancelIsolated()
+	if _, err := second.GetPeerDialer(isolatedCtx, first.GetPeerID()); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("separate networks resolved a peer: %v", err)
+	}
+
+	// Moving into the same network supplies automatic dialing without static peer maps.
+	detachOther()
+	detachSecond, err := network.Attach(ctx, second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(detachSecond)
+	if _, err := network.Attach(ctx, second); err == nil {
+		t.Fatal("duplicate peer attachment succeeded")
+	}
+	detachSecond()
+	currentDetach, err := network.Attach(ctx, second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(currentDetach)
+	detachSecond()
+	linked, release, err := link.EstablishLinkWithPeerEx(ctx, secondBed.Bus, second.GetPeerID(), first.GetPeerID(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(release)
+	if linked.GetRemotePeer() != first.GetPeerID() {
+		t.Fatal("link did not authenticate the requested peer")
+	}
+}


### PR DESCRIPTION
Native accounts under the same local provider can now exchange signed invitations without a cloud signaling endpoint. The provider supplies an isolated in-process packet network; the existing QUIC/TLS handshake and shared-object protocol continue to authenticate peers and install grants. Selecting one initiator per peer pair prevents simultaneous connections from replacing active invitation streams.

Session transport status includes links from every active controller. Endpoint detachment and child-bus closure follow transport shutdown. TinyGo keeps its existing host-owned networking behavior.

Validation: focused race tests pass across the five affected packages; network isolation, attachment lifetime, authenticated links, and native invitation tests pass for 20 repetitions. Repository commit hooks pass.
