### PR TITLE
perf(bldr): probe root assets only after module import fails

### DIFF
--- a/bldr/web/bldr-react/web-view-module-loader.test.ts
+++ b/bldr/web/bldr-react/web-view-module-loader.test.ts
@@ -36,26 +36,32 @@ function deferred<T>(): {
 }
 
 describe('WebView boot deadlines', () => {
-  it('fails the boot download when the root asset fetch never settles', async () => {
-    const fetchRootAsset = vi.fn(
+  it('preserves the import failure when its diagnostic probe never settles', async () => {
+    const fetchRootAsset = vi.fn<typeof fetch>(
       () => new Promise<Response>(() => undefined),
     )
-    const importModule = vi.fn(async () => ({ default: 'module' }))
+    const importFailure = new Error('module evaluation failed')
+    const importModule = vi.fn(async () => {
+      throw importFailure
+    })
 
     await expect(
       loadWebViewScriptModule('/b/pa/spacewave-app/v/app/App.mjs', {
         fetchRootAsset,
         importModule,
         fetchDeadlineMillis: 10,
+        importDeadlineMillis: 10,
       }),
-    ).rejects.toThrow('root asset fetch')
+    ).rejects.toBe(importFailure)
 
     const downloads = readBootDownloads()
     const failed = downloads.find((download) => download.state === 'error')
-    expect(failed?.error).toContain('timed out')
-    expect(
-      globalThis.__bldrWebViewModuleImportError,
-    ).toBeUndefined()
+    expect(failed?.error).toContain('module evaluation failed')
+    expect(fetchRootAsset).toHaveBeenCalledOnce()
+    expect(fetchRootAsset.mock.calls[0]?.[1]?.signal?.aborted).toBe(true)
+    expect(globalThis.__bldrWebViewModuleImportError?.message).toBe(
+      importFailure.message,
+    )
   })
 
   it('fails the boot download when the module import never settles', async () => {
@@ -65,9 +71,7 @@ describe('WebView boot deadlines', () => {
         'X-Bldr-Plugin-Asset-Fetch-Result': 'live',
       }),
     )
-    const importModule = vi.fn(
-      () => new Promise<unknown>(() => undefined),
-    )
+    const importModule = vi.fn(() => new Promise<unknown>(() => undefined))
 
     await expect(
       loadWebViewScriptModule('/b/pa/spacewave-app/v/app/App.mjs', {
@@ -102,7 +106,7 @@ describe('WebView root module loader', () => {
     expect(importModule).toHaveBeenCalledWith('/component.js')
   })
 
-  it('reports a missing root plugin asset before module import', async () => {
+  it('reports a missing root plugin asset after module import fails', async () => {
     const fetchRootAsset = vi.fn(async () =>
       pluginAssetResponse(404, 'missing plugin asset body', {
         'content-type': 'text/plain',
@@ -111,7 +115,9 @@ describe('WebView root module loader', () => {
         'X-Bldr-Plugin-Asset-Fetch-Result': 'missing',
       }),
     )
-    const importModule = vi.fn(async () => ({ default: 'module' }))
+    const importModule = vi.fn(async () => {
+      throw new TypeError('Failed to fetch dynamically imported module')
+    })
 
     await expect(
       loadWebViewScriptModule('/b/pa/spacewave-app/v/app/App-old.mjs', {
@@ -135,9 +141,12 @@ describe('WebView root module loader', () => {
 
     expect(fetchRootAsset).toHaveBeenCalledWith(
       '/b/pa/spacewave-app/v/app/App-old.mjs',
-      { cache: 'no-store' },
+      expect.objectContaining({
+        cache: 'no-store',
+        signal: expect.any(AbortSignal),
+      }),
     )
-    expect(importModule).not.toHaveBeenCalled()
+    expect(importModule).toHaveBeenCalledOnce()
   })
 
   it('preserves nested import and module evaluation failures after a live root asset', async () => {
@@ -255,11 +264,10 @@ describe('WebView root module loader', () => {
 
   it('coalesces concurrent root plugin module loads for the same retry nonce', async () => {
     const scriptPath = '/b/pa/spacewave-app/v/app/App-coalesce-success.mjs'
-    const rootAsset = deferred<Response>()
     const importedModule = { default: 'component' }
     const moduleLoad = deferred<typeof importedModule>()
     const importStarted = deferred<void>()
-    const fetchRootAsset = vi.fn(async () => await rootAsset.promise)
+    const fetchRootAsset = vi.fn<typeof fetch>()
     const importModule = vi.fn(() => {
       importStarted.resolve()
       return moduleLoad.promise
@@ -274,16 +282,9 @@ describe('WebView root module loader', () => {
       importModule,
     })
 
-    expect(fetchRootAsset).toHaveBeenCalledOnce()
-    expect(importModule).not.toHaveBeenCalled()
+    expect(fetchRootAsset).not.toHaveBeenCalled()
+    expect(importModule).toHaveBeenCalledOnce()
 
-    rootAsset.resolve(
-      pluginAssetResponse(200, 'export default function App() {}', {
-        'content-type': 'text/javascript',
-        'X-Bldr-Fetch-Source': 'plugin-assets',
-        'X-Bldr-Plugin-Asset-Fetch-Result': 'live',
-      }),
-    )
     await importStarted.promise
 
     expect(importModule).toHaveBeenCalledOnce()
@@ -336,7 +337,7 @@ describe('WebView root module loader', () => {
 
       await firstImportStarted.promise
 
-      expect(fetchRootAsset).toHaveBeenCalledOnce()
+      expect(fetchRootAsset).not.toHaveBeenCalled()
       expect(importModule).toHaveBeenCalledOnce()
       expect(importModule).toHaveBeenNthCalledWith(1, scriptPath)
 
@@ -362,7 +363,7 @@ describe('WebView root module loader', () => {
         }),
       ).resolves.toBe(retryModule)
 
-      expect(fetchRootAsset).toHaveBeenCalledTimes(2)
+      expect(fetchRootAsset).toHaveBeenCalledOnce()
       expect(importModule).toHaveBeenCalledTimes(2)
       expect(importModule).toHaveBeenNthCalledWith(
         2,
@@ -374,7 +375,7 @@ describe('WebView root module loader', () => {
     }
   })
 
-  it('imports the module after a live root plugin asset result', async () => {
+  it('imports a root plugin module without a diagnostic probe', async () => {
     const fetchRootAsset = vi.fn(async () =>
       pluginAssetResponse(200, 'export default function App() {}', {
         'content-type': 'text/javascript',
@@ -391,7 +392,12 @@ describe('WebView root module loader', () => {
       }),
     ).resolves.toEqual({ default: 'component' })
 
-    expect(fetchRootAsset).toHaveBeenCalledOnce()
+    expect(fetchRootAsset).not.toHaveBeenCalled()
+    expect(globalThis.__bldrWebViewRootAssetStatus).toMatchObject({
+      status: 0,
+      ok: true,
+      classification: 'imported',
+    })
     expect(importModule).toHaveBeenCalledWith(
       '/b/pa/spacewave-app/v/app/App-live.mjs',
     )
@@ -416,13 +422,15 @@ describe('WebView root module loader', () => {
     })
   })
 
-  it('rejects bypassed root plugin asset responses before module import', async () => {
+  it('rejects bypassed root plugin asset responses after module import fails', async () => {
     const fetchRootAsset = vi.fn(async () =>
       pluginAssetResponse(200, '<!doctype html><title>loading</title>', {
         'content-type': 'text/html',
       }),
     )
-    const importModule = vi.fn(async () => ({ default: 'module' }))
+    const importModule = vi.fn(async () => {
+      throw new TypeError('Failed to fetch dynamically imported module')
+    })
 
     await expect(
       loadWebViewScriptModule('/b/pa/spacewave-app/v/app/App-bypass.mjs', {
@@ -441,7 +449,7 @@ describe('WebView root module loader', () => {
     })
 
     expect(fetchRootAsset).toHaveBeenCalledOnce()
-    expect(importModule).not.toHaveBeenCalled()
+    expect(importModule).toHaveBeenCalledOnce()
   })
 
   it('records the latest typed root asset result for status readers', async () => {

--- a/bldr/web/bldr-react/web-view-module-loader.ts
+++ b/bldr/web/bldr-react/web-view-module-loader.ts
@@ -6,6 +6,7 @@ import {
 
 export interface WebViewRootAssetResult {
   scriptPath: string
+  // status is the observed HTTP code, or zero when only import completion is known.
   status: number
   ok: boolean
   fetchSource?: string
@@ -56,7 +57,9 @@ const moduleLoadPromiseByImportPath = new Map<string, Promise<unknown>>()
 // webViewDownloadLabel derives a readable plugin name from a root asset path
 // such as "/b/pa/spacewave-app/v/b/fe/module.mjs" -> "spacewave-app".
 function webViewDownloadLabel(scriptPath: string): string {
-  const afterPrefix = scriptPath.slice(scriptPath.indexOf(rootPluginAssetPrefix) + rootPluginAssetPrefix.length)
+  const afterPrefix = scriptPath.slice(
+    scriptPath.indexOf(rootPluginAssetPrefix) + rootPluginAssetPrefix.length,
+  )
   const pluginId = afterPrefix.split('/')[0]
   return pluginId || 'Plugin'
 }
@@ -106,7 +109,7 @@ function classifyRootAssetResponse(response: Response): string {
 
 async function readBodyPrefix(response: Response): Promise<string | undefined> {
   try {
-    return (await response.clone().text()).slice(0, 300)
+    return (await response.text()).slice(0, 300)
   } catch {
     return undefined
   }
@@ -198,16 +201,36 @@ export function getWebViewRootAssetLoadError(
   return error instanceof WebViewRootAssetLoadError ? error : undefined
 }
 
+// fetchWebViewRootAssetResult records one bounded diagnostic probe.
 export async function fetchWebViewRootAssetResult(
   scriptPath: string,
   fetchRootAsset: typeof fetch = fetch,
   fetchDeadlineMillis: number = rootAssetFetchDeadlineMillis,
 ): Promise<WebViewRootAssetResult> {
-  const response = await withDeadline(
-    fetchRootAsset(scriptPath, { cache: 'no-store' }),
-    fetchDeadlineMillis,
-    `root asset fetch ${scriptPath}`,
-  )
+  const abort = new AbortController()
+  try {
+    const result = await withDeadline(
+      readWebViewRootAssetResult(scriptPath, fetchRootAsset, abort.signal),
+      fetchDeadlineMillis,
+      `root asset fetch ${scriptPath}`,
+    )
+    recordWebViewRootAssetResult(result)
+    return result
+  } finally {
+    abort.abort()
+  }
+}
+
+// readWebViewRootAssetResult classifies the response without publishing partial results.
+async function readWebViewRootAssetResult(
+  scriptPath: string,
+  fetchRootAsset: typeof fetch,
+  signal: AbortSignal,
+): Promise<WebViewRootAssetResult> {
+  const response = await fetchRootAsset(scriptPath, {
+    cache: 'no-store',
+    signal,
+  })
   const classification = classifyRootAssetResponse(response)
   const result: WebViewRootAssetResult = {
     scriptPath,
@@ -229,7 +252,6 @@ export async function fetchWebViewRootAssetResult(
     await closeResponseBody(response)
   }
 
-  recordWebViewRootAssetResult(result)
   return result
 }
 
@@ -308,63 +330,72 @@ export function loadWebViewScriptModule<T>(
   return promise
 }
 
+// loadWebViewScriptModuleUncached imports once and probes HTTP details only on failure.
 async function loadWebViewScriptModuleUncached<T>(
   scriptPath: string,
   moduleImportPath: string,
   options: LoadWebViewScriptModuleOptions<T>,
 ): Promise<T> {
   const isRootPluginAsset = isWebViewRootPluginAssetPath(scriptPath)
-  // The browser's native dynamic import() exposes no byte progress, so a plugin
-  // module load is tracked at honest started/completed granularity (no faked
-  // percentage) rather than a smooth bar. The boot download registry owns the
-  // per-plugin accounting; the loading screen renders it.
+  // Native imports expose completion but no byte progress.
   if (isRootPluginAsset) {
     beginBootDownload(scriptPath, webViewDownloadLabel(scriptPath))
   }
-  let rootAsset: WebViewRootAssetResult | undefined
-  if (isRootPluginAsset) {
-    try {
-      rootAsset = await fetchWebViewRootAssetResult(
-        scriptPath,
-        options.fetchRootAsset,
-        options.fetchDeadlineMillis,
-      )
-    } catch (error) {
-      // A wedged or failed fetch never reaches the response classification
-      // below, so report the boot download as failed here.
-      failBootDownload(scriptPath, serializeImportError(error).message)
-      throw error
-    }
-  }
-  if (rootAsset && (!rootAsset.ok || rootAsset.classification !== 'live')) {
-    if (isRootPluginAsset) {
-      failBootDownload(scriptPath, rootAsset.classification)
-    }
-    throw new WebViewRootAssetLoadError(rootAsset)
-  }
 
   const importModule = options.importModule ?? importWebViewScriptModule<T>
+  const deadlineMillis =
+    options.importDeadlineMillis ?? moduleImportDeadlineMillis
+  const startedAt = performance.now()
   try {
     const module = await withDeadline(
       importModule(moduleImportPath),
-      options.importDeadlineMillis ?? moduleImportDeadlineMillis,
+      deadlineMillis,
       `module import ${moduleImportPath}`,
     )
     recordModuleImportSuccess(scriptPath)
     if (isRootPluginAsset) {
+      // Import completion proves usability without inventing an HTTP response.
+      recordWebViewRootAssetResult({
+        scriptPath,
+        status: 0,
+        ok: true,
+        classification: 'imported',
+      })
       completeBootDownload(scriptPath)
     }
     return module
   } catch (error) {
-    recordModuleImportFailure(scriptPath)
+    let failure = error
+    let rootAsset: WebViewRootAssetResult | undefined
     if (isRootPluginAsset) {
-      failBootDownload(scriptPath, serializeImportError(error).message)
+      failBootDownload(scriptPath, serializeImportError(failure).message)
+      // Diagnostics share the import deadline rather than extending a failed load.
+      const remaining = deadlineMillis - (performance.now() - startedAt)
+      if (remaining > 0) {
+        try {
+          rootAsset = await fetchWebViewRootAssetResult(
+            scriptPath,
+            options.fetchRootAsset,
+            Math.min(
+              options.fetchDeadlineMillis ?? rootAssetFetchDeadlineMillis,
+              remaining,
+            ),
+          )
+          if (!rootAsset.ok || rootAsset.classification !== 'live') {
+            failure = new WebViewRootAssetLoadError(rootAsset)
+          }
+        } catch {
+          // A failed diagnostic probe must preserve the original import error.
+        }
+      }
+      failBootDownload(scriptPath, serializeImportError(failure).message)
     }
+    recordModuleImportFailure(scriptPath)
     recordWebViewModuleImportError({
       scriptPath,
-      ...serializeImportError(error),
+      ...serializeImportError(failure),
       rootAsset,
     })
-    throw error
+    throw failure
   }
 }


### PR DESCRIPTION
Import a WebView root module directly, eliminating the diagnostic GET and body cancellation from successful loads. On failure, probe response details within the remaining import deadline and retain typed root-asset errors and retry behavior. Diagnostic requests now abort when their deadline expires. Successful status reports identify import completion without inventing an HTTP status.

All 14 existing loader tests pass, covering coalescing, retry, missing and bypassed roots, and deadlines. The Chromium fresh-Drive scenario passes at 9.870 seconds. A preceding 15.323-second run was followed by observed host load; no large end-to-end improvement is claimed.
