### PR TITLE
perf(opfs): write immutable publication files concurrently

### DIFF
--- a/db/volume/js/opfs/engine/engine_test.go
+++ b/db/volume/js/opfs/engine/engine_test.go
@@ -94,12 +94,16 @@ func (d *diskBackend) Write(ctx context.Context, name string, data []byte) error
 		case <-d.writeGate:
 		}
 	}
+	// Allocate failure boundaries across concurrent immutable writes.
+	d.mtx.Lock()
 	if d.failAfter == 0 {
+		d.mtx.Unlock()
 		return errors.New("injected write failure")
 	}
 	if d.failAfter > 0 {
 		d.failAfter--
 	}
+	d.mtx.Unlock()
 	f, err := os.CreateTemp(d.root, "write-")
 	if err != nil {
 		return err

--- a/db/volume/js/opfs/engine/publication.go
+++ b/db/volume/js/opfs/engine/publication.go
@@ -9,6 +9,8 @@ import (
 	"runtime/trace"
 	"strconv"
 	"strings"
+
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -108,10 +110,23 @@ func (p *publication) commit(ctx context.Context) error {
 	if err := p.engine.writeMessage(ctx, "intent", intent); err != nil {
 		return err
 	}
+	// Join bounded immutable writes before publishing or releasing protection.
+	// Failed writes cancel their siblings; the durable intent retains cleanup.
+	writes, writeCtx := errgroup.WithContext(ctx)
+	writes.SetLimit(4)
 	for _, output := range p.output {
-		if err := p.engine.backend.Write(ctx, output.name, output.data); err != nil {
-			return err
+		if writeCtx.Err() != nil {
+			break
 		}
+		writes.Go(func() error {
+			return p.engine.backend.Write(writeCtx, output.name, output.data)
+		})
+	}
+	if err := writes.Wait(); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	// Record retirement before publication so a crash cannot lose cleanup work.


### PR DESCRIPTION
Immutable publication files now write concurrently, with at most four writes in flight. The existing durable intent precedes every write; all started writes finish before root publication or error return releases protection. Failure cancels sibling writes and leaves the intent for recovery.

The existing OPFS engine race suite passes, including publication crash recovery. The fresh Chromium landing-to-Drive case passes with functioning storage at 9.023 seconds. The fixture failure counter is synchronized for concurrent writes.
