### PR TITLE
perf(lookup): retain native local read operation scopes

### DIFF
--- a/bldr/plugin/host/scheduler/fetch-world-manifest_test.go
+++ b/bldr/plugin/host/scheduler/fetch-world-manifest_test.go
@@ -4270,6 +4270,11 @@ type testSchedulerStaticLookup struct {
 	store block.StoreOps
 }
 
+// BeginReadOperation retains the fixture lookup for a bounded read.
+func (l *testSchedulerStaticLookup) BeginReadOperation(context.Context) (bucket_lookup.Lookup, func(), error) {
+	return l, func() {}, nil
+}
+
 func (l *testSchedulerStaticLookup) LookupBlock(
 	ctx context.Context,
 	ref *block.BlockRef,

--- a/db/bucket/lookup/concurrent/read-operation.go
+++ b/db/bucket/lookup/concurrent/read-operation.go
@@ -1,0 +1,61 @@
+package lookup_concurrent
+
+import (
+	"context"
+
+	"github.com/aperturerobotics/util/ccontainer"
+	"github.com/s4wave/spacewave/db/block"
+	"github.com/s4wave/spacewave/db/bucket"
+	lookup "github.com/s4wave/spacewave/db/bucket/lookup"
+)
+
+// BeginReadOperation retains the sole local bucket's read scope when available.
+// Network fallback remains live; writeback lookups keep their unscoped path.
+func (c *LookupController) BeginReadOperation(ctx context.Context) (lookup.Lookup, func(), error) {
+	handles, err := c.getBucketHandles(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Multi-bucket lookup can return while losing reads are still running.
+	// Those reads cannot safely share a caller-released storage scope.
+	if len(handles) != 1 {
+		return c, func() {}, nil
+	}
+	// A native read scope may block writes, including synchronous writeback.
+	if c.conf.GetWritebackBehavior() != WritebackBehavior_WritebackBehavior_NONE {
+		return c, func() {}, nil
+	}
+
+	original := handles[0].GetBucket()
+	read, release, err := original.BeginReadOperation(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	readBucket := &readScopeBucket{StoreOps: read, conf: original.GetBucketConfig()}
+	scopedHandles := []bucket.BucketHandle{bucket.NewBucketHandle(
+		handles[0].GetID(), readBucket,
+	)}
+
+	// Retain lookup policy and fallback ownership, replacing only the local handle.
+	scoped := *c
+	scoped.conf = c.conf.CloneVT()
+	scoped.conf.PutBlockBehavior = PutBlockBehavior_PutBlockBehavior_NONE
+	scoped.bucketHandleSetCtr = ccontainer.NewCContainer(&scopedHandles)
+	return &scoped, release, nil
+}
+
+// readScopeBucket supplies bucket metadata for an existing scoped block store.
+type readScopeBucket struct {
+	// StoreOps contains the underlying bucket's bounded read operations.
+	block.StoreOps
+	// conf identifies the bucket retained by the operation.
+	conf *bucket.Config
+}
+
+// GetBucketConfig returns the retained bucket configuration.
+func (b *readScopeBucket) GetBucketConfig() *bucket.Config {
+	return b.conf
+}
+
+// _ is a type assertion.
+var _ bucket.Bucket = (*readScopeBucket)(nil)

--- a/db/bucket/lookup/concurrent/read-operation_test.go
+++ b/db/bucket/lookup/concurrent/read-operation_test.go
@@ -1,0 +1,63 @@
+package lookup_concurrent
+
+import (
+	"testing"
+
+	block_store "github.com/s4wave/spacewave/db/block/store"
+	block_store_kvtx "github.com/s4wave/spacewave/db/block/store/kvtx"
+	"github.com/s4wave/spacewave/db/bucket"
+	"github.com/s4wave/spacewave/db/kvtx/hashmap"
+	store_kvkey "github.com/s4wave/spacewave/db/store/kvkey"
+	"github.com/sirupsen/logrus"
+)
+
+// TestReadOperationReleasesLocalTransaction checks the native scope boundary.
+func TestReadOperationReleasesLocalTransaction(t *testing.T) {
+	ctx := t.Context()
+	blocks := block_store_kvtx.NewKVTxBlock(
+		store_kvkey.NewDefaultKVKey(),
+		hashmap.NewHashmapKvtx(hashmap.NewHashmap[[]byte]()), 0, false,
+	)
+	ref, _, err := blocks.PutBlock(ctx, []byte("retained"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conf := &bucket.Config{Id: "scoped-lookup"}
+	controller := NewLookupController(logrus.NewEntry(logrus.New()), nil, &Config{
+		BucketConf:       conf,
+		PutBlockBehavior: PutBlockBehavior_PutBlockBehavior_ALL,
+	})
+	controller.PushBucketHandles(ctx, []bucket.BucketHandle{bucket.NewBucketHandle(
+		conf.Id, &readScopeBucket{StoreOps: blocks, conf: conf},
+	)})
+
+	// A real native transaction serves repeated lookups until the scope closes.
+	scoped, release, err := controller.BeginReadOperation(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+	for range 2 {
+		data, found, err := scoped.LookupBlock(ctx, ref)
+		if err != nil || !found || string(data) != "retained" {
+			t.Fatalf("scoped lookup: data=%q found=%t err=%v", data, found, err)
+		}
+	}
+	if _, _, err := scoped.PutBlock(ctx, []byte("blocked"), nil); err != block_store.ErrReadOnly {
+		t.Fatalf("scoped write: %v", err)
+	}
+	release()
+	if _, _, err := scoped.LookupBlock(ctx, ref); err != block_store_kvtx.ErrReadOperationClosed {
+		t.Fatalf("lookup after scope release: %v", err)
+	}
+
+	// Closing the read transaction leaves the original lookup writable.
+	refs, _, err := controller.PutBlock(ctx, []byte("after"), nil)
+	if err != nil || len(refs) != 1 {
+		t.Fatalf("write after scope release: refs=%v err=%v", refs, err)
+	}
+	data, found, err := controller.LookupBlock(ctx, refs[0].RootRef)
+	if err != nil || !found || string(data) != "after" {
+		t.Fatalf("original lookup: data=%q found=%t err=%v", data, found, err)
+	}
+}

--- a/db/bucket/lookup/cursor_test.go
+++ b/db/bucket/lookup/cursor_test.go
@@ -249,6 +249,11 @@ type staticBucketLookup struct {
 	bucketID string
 }
 
+// BeginReadOperation retains the fixture lookup for a bounded read.
+func (l *staticBucketLookup) BeginReadOperation(context.Context) (Lookup, func(), error) {
+	return l, func() {}, nil
+}
+
 func (l *staticBucketLookup) LookupBlock(
 	ctx context.Context,
 	ref *block.BlockRef,

--- a/db/bucket/lookup/lookup-handle.go
+++ b/db/bucket/lookup/lookup-handle.go
@@ -16,6 +16,8 @@ var ErrNotImplemented = errors.New("operation not implemented by lookup controll
 type lookupBucket struct {
 	// h resolves the bucket's lookup service.
 	h Handle
+	// lookup retains the local bucket scopes of a bounded read operation.
+	lookup Lookup
 	// localOnly excludes remote discovery from payload reads.
 	localOnly bool
 }
@@ -43,16 +45,40 @@ func (l *lookupBucket) GetSupportedFeatures() block.StoreFeature {
 	return block.StoreFeature_STORE_FEATURE_UNKNOWN
 }
 
-// BeginReadOperation returns the lookup bucket as a scoped read handle.
-func (l *lookupBucket) BeginReadOperation(context.Context) (block.StoreOps, func(), error) {
-	return l, func() {}, nil
+// BeginReadOperation retains the lookup's local bucket read scopes.
+func (l *lookupBucket) BeginReadOperation(ctx context.Context) (block.StoreOps, func(), error) {
+	if l.lookup != nil {
+		return l, func() {}, nil
+	}
+	lookup, err := l.h.GetLookup(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	if lookup == nil {
+		return nil, nil, bucket.ErrBucketNotFound
+	}
+	lookup, release, err := lookup.BeginReadOperation(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	scoped := *l
+	scoped.lookup = lookup
+	return &scoped, release, nil
+}
+
+// getLookup uses retained bucket scopes when the caller opened a read operation.
+func (l *lookupBucket) getLookup(ctx context.Context) (Lookup, error) {
+	if l.lookup != nil {
+		return l.lookup, nil
+	}
+	return l.h.GetLookup(ctx)
 }
 
 // PutBlock puts a block into the store.
 // The ref should not be modified after return.
 func (l *lookupBucket) PutBlock(ctx context.Context, data []byte, opts *block.PutOpts) (*block.BlockRef, bool, error) {
 	// Resolve the lookup handle before writing the block.
-	lb, err := l.h.GetLookup(ctx)
+	lb, err := l.getLookup(ctx)
 	if err != nil {
 		return nil, false, err
 	}
@@ -102,7 +128,7 @@ func (l *lookupBucket) PutBlockBatch(ctx context.Context, entries []*block.PutBa
 // The ref should not be modified or retained by GetBlock.
 // Note: the block may not be in the specified bucket.
 func (l *lookupBucket) GetBlock(ctx context.Context, ref *block.BlockRef) ([]byte, bool, error) {
-	lb, err := l.h.GetLookup(ctx)
+	lb, err := l.getLookup(ctx)
 	if err != nil {
 		return nil, false, err
 	}
@@ -127,7 +153,7 @@ func (l *lookupBucket) GetBlockExists(ctx context.Context, ref *block.BlockRef) 
 
 // GetBlockExistsBatch checks whether refs exist through the lookup controller.
 func (l *lookupBucket) GetBlockExistsBatch(ctx context.Context, refs []*block.BlockRef) ([]bool, error) {
-	lb, err := l.h.GetLookup(ctx)
+	lb, err := l.getLookup(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/db/bucket/lookup/lookup-handle_test.go
+++ b/db/bucket/lookup/lookup-handle_test.go
@@ -89,6 +89,11 @@ type batchLookupTestLookup struct {
 	existsBatchCalls int
 }
 
+// BeginReadOperation retains the fixture lookup for a bounded read.
+func (l *batchLookupTestLookup) BeginReadOperation(context.Context) (Lookup, func(), error) {
+	return l, func() {}, nil
+}
+
 // LookupBlock records an unwanted payload read.
 func (l *batchLookupTestLookup) LookupBlock(
 	context.Context,

--- a/db/bucket/lookup/lookup.go
+++ b/db/bucket/lookup/lookup.go
@@ -52,6 +52,9 @@ func WithTimeout(dur time.Duration, notFound bool) LookupBlockOption {
 
 // Lookup are the lookup operations.
 type Lookup interface {
+	// BeginReadOperation opens a bounded read scope where the lookup supports one.
+	// The caller completes every lookup before releasing the returned scope.
+	BeginReadOperation(ctx context.Context) (Lookup, func(), error)
 	// LookupBlock searches for a block using the bucket lookup controller.
 	// If lookup is disabled, will return an error.
 	LookupBlock(

--- a/db/dex/psecho/queue_test.go
+++ b/db/dex/psecho/queue_test.go
@@ -79,6 +79,11 @@ type queueTestLookup struct {
 	existsBatchCalls int
 }
 
+// BeginReadOperation retains the fixture lookup for a bounded read.
+func (l *queueTestLookup) BeginReadOperation(context.Context) (bucket_lookup.Lookup, func(), error) {
+	return l, func() {}, nil
+}
+
 func (l *queueTestLookup) LookupBlock(
 	context.Context,
 	*block.BlockRef,


### PR DESCRIPTION
Bounded World reads now retain the native local bucket read scope through the lookup adapter. Single-bucket lookups without writeback use the scoped view; multi-bucket races and writeback-enabled lookups keep their existing behavior. Scoped writes are rejected, and network fallback remains available.

The lookup and dependent queue race tests pass, including a native transaction lifetime regression. The scheduler fixtures compile. The fresh Chromium landing-to-Drive case passes at 8.445 seconds with functioning storage. Aggregate graph-query time fell from 4.411 to 0.723 seconds; end-to-end timing did not materially change.
