### PR TITLE
perf(block): defer buffered batch deduplication to storage

### DIFF
--- a/db/block/buffered-store.go
+++ b/db/block/buffered-store.go
@@ -91,6 +91,12 @@ func (s *BufferedStore) BeginReadOperation(context.Context) (StoreOps, func(), e
 // PutBlock buffers a block in memory and drains synchronously only when
 // backpressure requires capacity.
 func (s *BufferedStore) PutBlock(ctx context.Context, data []byte, opts *PutOpts) (*BlockRef, bool, error) {
+	return s.putBlock(ctx, data, opts, true)
+}
+
+// putBlock verifies and buffers a block, optionally resolving prior existence.
+// Batch callers discard the existence result and let storage deduplicate at drain.
+func (s *BufferedStore) putBlock(ctx context.Context, data []byte, opts *PutOpts, checkExists bool) (*BlockRef, bool, error) {
 	if len(data) == 0 {
 		return nil, false, ErrEmptyBlock
 	}
@@ -140,9 +146,12 @@ func (s *BufferedStore) PutBlock(ctx context.Context, data []byte, opts *PutOpts
 		return finish(ref, true)
 	}
 
-	exists, err := s.inner.GetBlockExists(ctx, ref)
-	if err != nil {
-		return nil, false, err
+	var exists bool
+	if checkExists {
+		exists, err = s.inner.GetBlockExists(ctx, ref)
+		if err != nil {
+			return nil, false, err
+		}
 	}
 
 	_, subtask := trace.NewTask(ctx, "hydra/block/buffered-store/enqueue")
@@ -201,7 +210,8 @@ func (s *BufferedStore) PutBlock(ctx context.Context, data []byte, opts *PutOpts
 	}
 }
 
-// PutBlockBatch loops through PutBlock and RmBlock using the buffered store.
+// PutBlockBatch buffers verified entries without per-block existence probes.
+// Pending entries deduplicate locally; durable duplicates resolve during drain.
 func (s *BufferedStore) PutBlockBatch(ctx context.Context, entries []*PutBatchEntry) error {
 	for _, entry := range entries {
 		if entry.Tombstone {
@@ -214,10 +224,10 @@ func (s *BufferedStore) PutBlockBatch(ctx context.Context, entries []*PutBatchEn
 		if entry.Ref != nil {
 			ref = entry.Ref.Clone()
 		}
-		if _, _, err := s.PutBlock(ctx, entry.Data, &PutOpts{
+		if _, _, err := s.putBlock(ctx, entry.Data, &PutOpts{
 			ForceBlockRef: ref,
 			Refs:          CloneBlockRefs(entry.Refs),
-		}); err != nil {
+		}, false); err != nil {
 			return err
 		}
 	}

--- a/db/block/buffered-store_test.go
+++ b/db/block/buffered-store_test.go
@@ -20,6 +20,7 @@ type countStore struct {
 	mtx           sync.Mutex
 	blocks        map[string][]byte
 	putCalls      int
+	existsCalls   int
 	batchCalls    int
 	batchSizes    []int
 	failPut       error
@@ -199,6 +200,7 @@ func (s *countStore) GetBlockExists(ctx context.Context, ref *BlockRef) (bool, e
 	}
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
+	s.existsCalls++
 	_, ok := s.blocks[key]
 	return ok, nil
 }
@@ -731,15 +733,18 @@ func TestBufferedStoreUnblocksOnContextCancel(t *testing.T) {
 }
 
 func TestBufferedStoreUsesBatchPut(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	inner := newCountStore(hash.HashType_HashType_BLAKE3)
 	store := NewBufferedStore(ctx, inner)
 
-	if _, _, err := store.PutBlock(ctx, []byte("a"), nil); err != nil {
-		t.Fatal(err.Error())
+	if err := store.PutBlockBatch(ctx, []*PutBatchEntry{
+		{Data: []byte("a")},
+		{Data: []byte("b")},
+	}); err != nil {
+		t.Fatal(err)
 	}
-	if _, _, err := store.PutBlock(ctx, []byte("b"), nil); err != nil {
-		t.Fatal(err.Error())
+	if inner.existsCalls != 0 {
+		t.Fatalf("batch performed %d serial existence probes", inner.existsCalls)
 	}
 
 	if _, err := store.Sync(ctx); err != nil {


### PR DESCRIPTION
Buffered batch writes now defer durable duplicate detection to the underlying batch writer, removing a serial existence probe for each input block. Payload and forced-reference verification, pending deduplication, backpressure, and single-block existence reporting are preserved.

The existing buffered-store race tests pass. The batch case now directly exercises PutBlockBatch and verifies zero serial existence probes. The fresh Chromium landing-to-Drive case passes at 8.899 seconds with functioning storage; its trace contains 4,156 OPFS reads versus 4,385 in the preceding accepted baseline, without a demonstrated end-to-end gain.
