### PR TITLE
fix(block): let buffered puts replace queued deletions

### DIFF
--- a/db/block/buffered-store.go
+++ b/db/block/buffered-store.go
@@ -147,7 +147,8 @@ func (s *BufferedStore) putBlock(ctx context.Context, data []byte, opts *PutOpts
 	}
 
 	var exists bool
-	if checkExists {
+	// A pending tombstone means this put must restore the block, even if it drains now.
+	if checkExists && existingPending == nil {
 		exists, err = s.inner.GetBlockExists(ctx, ref)
 		if err != nil {
 			return nil, false, err
@@ -176,7 +177,8 @@ func (s *BufferedStore) putBlock(ctx context.Context, data []byte, opts *PutOpts
 				done = true
 				return
 			}
-			if exists {
+			// A queued deletion takes precedence over the still-present durable block.
+			if exists && s.pending[key] == nil {
 				alreadyExists = true
 				done = true
 				return

--- a/db/block/buffered-store_test.go
+++ b/db/block/buffered-store_test.go
@@ -766,7 +766,7 @@ func TestBufferedStoreUsesBatchPut(t *testing.T) {
 }
 
 func TestBufferedStoreRemovesPendingBlockWithoutResurrection(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	inner := newCountStore(hash.HashType_HashType_BLAKE3)
 	store := NewBufferedStore(ctx, inner)
 
@@ -797,6 +797,23 @@ func TestBufferedStoreRemovesPendingBlockWithoutResurrection(t *testing.T) {
 	}
 	if found {
 		t.Fatal("expected tombstone to win over pending put")
+	}
+
+	// A later put must replace a queued deletion even while the old block exists.
+	if _, _, err := inner.PutBlock(ctx, []byte("hello"), nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.RmBlock(ctx, ref); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.PutBlock(ctx, []byte("hello"), nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if data, found, err := inner.GetBlock(ctx, ref); err != nil || !found || string(data) != "hello" {
+		t.Fatalf("put after queued deletion: data=%q found=%t err=%v", data, found, err)
 	}
 }
 


### PR DESCRIPTION
A remove followed by a put of the same durable block could leave the tombstone queued: the put saw the old durable block and skipped its replacement. Buffered puts now honor an observed or currently queued deletion, including when a flush drains it during the operation.

The existing deletion regression was extended and failed with the block absent before the fix. The buffered-store race suite passes with the fix.
