### PR TITLE
perf(app): preload the session module during quickstart

### DIFF
--- a/app/AppQuickstart.tsx
+++ b/app/AppQuickstart.tsx
@@ -1,15 +1,25 @@
-import React, { useCallback } from 'react'
+import { useCallback } from 'react'
 
 import { useNavigate, useParams } from '@s4wave/web/router/router.js'
+import { usePromise } from '@s4wave/web/hooks/usePromise.js'
 import { Quickstart } from '@s4wave/app/quickstart/Quickstart.js'
 import { QuickstartUnavailable } from '@s4wave/app/quickstart/QuickstartUnavailable.js'
 import { isQuickstartId } from '@s4wave/app/quickstart/options.js'
 
 import './AppQuickstart.css'
 
+// AppQuickstart creates a workspace while loading its destination module.
 export function AppQuickstart() {
   const quickstartId = useParams()['quickstartId']
   const navigate = useNavigate()
+  usePromise(
+    useCallback(() => {
+      if (quickstartId && isQuickstartId(quickstartId)) {
+        return import('./AppSession.js')
+      }
+      return undefined
+    }, [quickstartId]),
+  )
   const navigateHome = useCallback(() => {
     navigate({ path: '/' })
   }, [navigate])


### PR DESCRIPTION
Quickstart now preloads the session UI module while creating the workspace, using the existing promise hook and the browser module cache. Invalid quickstart routes do not preload it.

The fresh Chromium landing-to-Drive case passes with functioning storage. Resource timing confirms the session module and dependencies finish before workspace creation completes. The two runs took 8.820 and 9.399 seconds to the file; no end-to-end improvement is claimed from these samples.
