### PR TITLE
perf(web): group initial module dependencies

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const bldrDistRoot =
   process.env['BLDR_DIST_ROOT'] || resolve(__dirname, '.bldr/src')
 
+// resolveBldrSourcePath resolves generated exports and source fallbacks.
 function resolveBldrSourcePath(...segments: string[]) {
   const isPatternReplacement = segments.some((segment) => segment.includes('$'))
   const patternProbeSegments = segments
@@ -58,6 +59,9 @@ export default defineConfig({
       preserveEntrySignatures: 'strict',
       output: {
         format: 'es',
+        codeSplitting: {
+          groups: [{ name: 'initial-deps', tags: ['$initial'] }],
+        },
       },
     },
   },


### PR DESCRIPTION
Group the application's initial dependency graph into one shared chunk while preserving dynamic route imports. This reduces module requests and the delay before workspace creation.

The fresh Chromium landing-to-Drive case passes with functioning storage at 8.345 seconds from navigation. Page module requests fall from 97 to 52; the initial dependency fetch and evaluation interval falls from approximately 0.9 seconds to 0.27 seconds. The preceding unchanged bundle took 8.820–9.399 seconds in two runs. These are individual samples, not a stable end-to-end bound.
