### PR TITLE
feat(chat): retain channel state in message history

### DIFF
--- a/.protoc-manifest.json
+++ b/.protoc-manifest.json
@@ -3420,7 +3420,7 @@
       ]
     },
     "github.com/s4wave/spacewave/sdk/chat": {
-      "hash": "2908c5488e68fdfdd601974bb24a649f29aac344d85cc57f2ca30142046e871b",
+      "hash": "4f1c9ee24d3124082b107b050bf4fa83fc42915a6144876ecf3b381e9dc88b11",
       "generatedFiles": [
         "sdk/chat/chat.pb.go",
         "sdk/chat/chat.pb.ts"
@@ -3430,7 +3430,7 @@
       ]
     },
     "github.com/s4wave/spacewave/sdk/chat/content": {
-      "hash": "334c818b0c08877fb51ca863107217b43de3eb360b775e6a74a8a2e66be7e24f",
+      "hash": "134d38b184c29cec20c5d6ff75496b1f49f92fdd886366b1a2a6c509f9f82061",
       "generatedFiles": [
         "sdk/chat/content/content.pb.go",
         "sdk/chat/content/content.pb.ts"
@@ -3440,7 +3440,7 @@
       ]
     },
     "github.com/s4wave/spacewave/sdk/chat/rpc": {
-      "hash": "67cd15d9b0f479d313fa43806c18f0f0e36332a303024548386b84128b39a473",
+      "hash": "3f323f75f230964e394f161e64424aff4a3264188a26b15e14b73d1d0631b86e",
       "generatedFiles": [
         "sdk/chat/rpc/rpc.pb.go",
         "sdk/chat/rpc/rpc.pb.ts",

--- a/sdk/chat/chat-content.go
+++ b/sdk/chat/chat-content.go
@@ -22,3 +22,9 @@ type ChatAnnotation = spacewave_chat_content.ChatAnnotation
 
 // ChatMessageContent_Annotation carries a public reaction independently of message encryption.
 type ChatMessageContent_Annotation = spacewave_chat_content.ChatMessageContent_Annotation
+
+// ChatStateChange is a public channel state event.
+type ChatStateChange = spacewave_chat_content.ChatStateChange
+
+// ChatMessageContent_StateChange carries a retained channel state event.
+type ChatMessageContent_StateChange = spacewave_chat_content.ChatMessageContent_StateChange

--- a/sdk/chat/chat-resource.go
+++ b/sdk/chat/chat-resource.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"slices"
 	"strconv"
 	"strings"
 
+	"github.com/aperturerobotics/fastjson"
 	"github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
 	"github.com/aperturerobotics/starpc/srpc"
 	"github.com/pkg/errors"
@@ -110,6 +112,42 @@ func (r *ChatResource) GetChannelInfo(
 		CreatorPeerId:       channel.GetCreatorPeerId(),
 		EncryptionAlgorithm: channel.GetEncryptionAlgorithm(),
 	}, nil
+}
+
+// GetState returns the latest retained event for each channel state identity.
+func (r *ChatResource) GetState(ctx context.Context, _ *spacewave_chat_rpc.GetStateRequest) (*spacewave_chat_rpc.GetStateResponse, error) {
+	// Require an existing mounted channel even when it has no retained state.
+	if _, err := r.readChannel(ctx); err != nil {
+		return nil, err
+	}
+
+	// Resolve graph references through the same projection used by history reads.
+	edges, err := r.ws.LookupGraphQuads(ctx, world.NewGraphQuadWithKeys(r.objectKey, PredChannelState.String(), "", ""), 0)
+	if err != nil {
+		return nil, err
+	}
+	keys := make([]string, 0, len(edges))
+	for _, edge := range edges {
+		key, err := world.GraphValueToKey(edge.GetObj())
+		if err != nil {
+			return nil, err
+		}
+		keys = append(keys, key)
+	}
+	messages, err := r.readMessages(ctx, keys)
+	if err != nil {
+		return nil, err
+	}
+
+	// State order is independent of graph index ordering and history position.
+	slices.SortFunc(messages, func(a, b *spacewave_chat_rpc.ChatMessageInfo) int {
+		left, right := a.GetContent().GetStateChange(), b.GetContent().GetStateChange()
+		if order := strings.Compare(left.GetType(), right.GetType()); order != 0 {
+			return order
+		}
+		return strings.Compare(left.GetStateKey(), right.GetStateKey())
+	})
+	return &spacewave_chat_rpc.GetStateResponse{Messages: messages}, nil
 }
 
 // GetMessage reads one channel message by its channel-scoped object key.
@@ -305,6 +343,20 @@ func (r *ChatResource) commitMessage(ctx context.Context, req *spacewave_chat_rp
 		return nil, err
 	}
 	defer wtx.Discard()
+	response, err := r.appendMessage(ctx, wtx, req, timestamppb.Now())
+	if err != nil {
+		return nil, err
+	}
+	if err := wtx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// appendMessage records a message inside the caller's World transaction.
+// Channel creation uses the same append path and supplies its operation timestamp.
+func (r *ChatResource) appendMessage(ctx context.Context, wtx world.WorldState, req *spacewave_chat_rpc.SendMessageRequest, timestamp *timestamppb.Timestamp) (*spacewave_chat_rpc.SendMessageResponse, error) {
+	// Read the policy and history extent inside the caller's transaction.
 	channel, err := world.LookupObjectBody[*ChatChannel](ctx, wtx, r.objectKey, NewChatChannelBlock)
 	if err != nil {
 		return nil, err
@@ -314,11 +366,6 @@ func (r *ChatResource) commitMessage(ctx context.Context, req *spacewave_chat_rp
 	content, err := normalizeSendMessageContent(req)
 	if err != nil {
 		return nil, err
-	}
-
-	// Encryption protects message bodies; typed annotations are public routing metadata.
-	if algorithm := channel.GetEncryptionAlgorithm(); algorithm != "" && content.GetAnnotation() == nil && content.GetCiphertext().GetAlgorithm() != algorithm {
-		return nil, errors.New("chat message ciphertext algorithm does not match channel")
 	}
 
 	// Resolve every public relationship inside this transaction and channel.
@@ -357,8 +404,39 @@ func (r *ChatResource) commitMessage(ctx context.Context, req *spacewave_chat_rp
 		}
 	}
 
+	// New bodies follow current encryption policy; accepted retries retain their original result.
+	if algorithm := channel.GetEncryptionAlgorithm(); algorithm != "" && content.GetAnnotation() == nil && content.GetStateChange() == nil && content.GetCiphertext().GetAlgorithm() != algorithm {
+		return nil, errors.New("chat message ciphertext algorithm does not match channel")
+	}
+
+	// Resolve current state after retry lookup so old retries cannot replace newer state.
+	var priorState []world.GraphQuad
+	state := content.GetStateChange()
+	if state != nil {
+		priorState, err = wtx.LookupGraphQuads(ctx, NewChatStateQuad(r.objectKey, "", state.GetType(), state.GetStateKey()), 0)
+		if err != nil {
+			return nil, err
+		}
+		for _, edge := range priorState {
+			key, err := world.GraphValueToKey(edge.GetObj())
+			if err != nil {
+				return nil, err
+			}
+			prior, err := world.LookupObjectBody[*ChatMessage](ctx, wtx, key, NewChatMessageBlock)
+			if err != nil {
+				return nil, err
+			}
+			if req.GetTransactionId() == "" && prior.GetContent().EqualVT(content) {
+				return &spacewave_chat_rpc.SendMessageResponse{MessageKey: key}, nil
+			}
+			if state.GetType() == "m.room.create" && state.GetStateKey() == "" {
+				return nil, errors.New("chat creation state cannot be replaced")
+			}
+		}
+	}
+
 	// Append the accepted message and its page entry in one World transaction.
-	index, msgKey, err := r.appendChannelMessageKey(ctx, wtx, msgKey)
+	index, msgKey, err := r.appendChannelMessageKey(ctx, wtx, msgKey, state)
 	if err != nil {
 		return nil, err
 	}
@@ -366,7 +444,7 @@ func (r *ChatResource) commitMessage(ctx context.Context, req *spacewave_chat_rp
 		SenderPeerId: r.localPeerID,
 		PersonPeerId: r.personPeerID,
 		Content:      content,
-		CreatedAt:    timestamppb.Now(),
+		CreatedAt:    timestamp.CloneVT(),
 		ReplyToKey:   req.GetReplyToKey(),
 		Index:        index,
 	}
@@ -402,9 +480,16 @@ func (r *ChatResource) commitMessage(ctx context.Context, req *spacewave_chat_rp
 		}
 	}
 
-	// Publish the message and its history position together.
-	if err := wtx.Commit(ctx); err != nil {
-		return nil, err
+	// Replace only the current-state edge; earlier messages remain in history.
+	if state != nil {
+		for _, edge := range priorState {
+			if err := wtx.DeleteGraphQuad(ctx, edge); err != nil {
+				return nil, err
+			}
+		}
+		if err := wtx.SetGraphQuad(ctx, NewChatStateQuad(r.objectKey, msgKey, state.GetType(), state.GetStateKey())); err != nil {
+			return nil, err
+		}
 	}
 	return &spacewave_chat_rpc.SendMessageResponse{MessageKey: msgKey}, nil
 }
@@ -486,7 +571,7 @@ func (r *ChatResource) commitReadPosition(ctx context.Context, req *spacewave_ch
 }
 
 // appendChannelMessageKey reserves one channel position and its stable message key.
-func (r *ChatResource) appendChannelMessageKey(ctx context.Context, ws world.WorldState, msgKey string) (uint64, string, error) {
+func (r *ChatResource) appendChannelMessageKey(ctx context.Context, ws world.WorldState, msgKey string, state *ChatStateChange) (uint64, string, error) {
 	// Acquire the mutable channel inside the caller's transaction.
 	obj, found, err := ws.GetObject(ctx, r.objectKey)
 	if err != nil {
@@ -506,6 +591,9 @@ func (r *ChatResource) appendChannelMessageKey(ctx context.Context, ws world.Wor
 		}
 		if channel == nil {
 			return world.ErrObjectNotFound
+		}
+		if err := applyChannelState(channel, state); err != nil {
+			return err
 		}
 		index = channel.GetMessageCount()
 		if msgKey == "" {
@@ -642,11 +730,27 @@ func (r *ChatResource) readMessage(ctx context.Context, key string) (*spacewave_
 	if personPeerID == "" {
 		personPeerID = msg.GetSenderPeerId()
 	}
+	text := msg.GetContent().GetText()
+	if state := msg.GetContent().GetStateChange(); state != nil {
+		text = "Channel settings updated"
+		if state.GetStateKey() == "" {
+			switch state.GetType() {
+			case "m.room.create":
+				text = "Channel created"
+			case "m.room.name":
+				text = "Channel name updated"
+			case "m.room.topic":
+				text = "Channel topic updated"
+			case "m.room.encryption":
+				text = "Channel encryption enabled"
+			}
+		}
+	}
 	return &spacewave_chat_rpc.ChatMessageInfo{
 		ObjectKey:    key,
 		SenderPeerId: msg.GetSenderPeerId(),
 		PersonPeerId: personPeerID,
-		Text:         msg.GetContent().GetText(),
+		Text:         text,
 		Content:      msg.GetContent().CloneVT(),
 		CreatedAt:    msg.GetCreatedAt().CloneVT(),
 		ReplyToKey:   msg.GetReplyToKey(),
@@ -684,10 +788,59 @@ func normalizeSendMessageContent(req *spacewave_chat_rpc.SendMessageRequest) (*C
 		if value == nil || value.Annotation.GetTargetKey() == "" || len(value.Annotation.GetTargetKey()) > 4096 || value.Annotation.GetKey() == "" || len(value.Annotation.GetKey()) > 4096 {
 			return nil, errors.New("chat annotation requires a bounded target and key")
 		}
+	case *ChatMessageContent_StateChange:
+		if value == nil {
+			return nil, errors.New("chat state content is missing")
+		}
+		if err := value.StateChange.Validate(); err != nil {
+			return nil, err
+		}
 	default:
 		return nil, errors.New("chat message content is missing")
 	}
 	return content.CloneVT(), nil
+}
+
+// applyChannelState keeps native channel metadata consistent with retained state.
+func applyChannelState(channel *ChatChannel, state *ChatStateChange) error {
+	// Named state keys and extension types do not replace channel-wide metadata.
+	if state == nil || state.GetStateKey() != "" {
+		return nil
+	}
+	var field string
+	switch state.GetType() {
+	case "m.room.name":
+		field = "name"
+	case "m.room.topic":
+		field = "topic"
+	case "m.room.encryption":
+		field = "algorithm"
+	default:
+		return nil
+	}
+
+	// These known values have native meaning and require their schema's string field.
+	value, err := fastjson.Parse(state.GetContentJson())
+	if err != nil {
+		return err
+	}
+	member := value.Get(field)
+	if member == nil || member.Type() != fastjson.TypeString {
+		return errors.New("chat state requires a string " + field)
+	}
+	text := string(member.GetStringBytes())
+	switch field {
+	case "name":
+		channel.Name = text
+	case "topic":
+		channel.Topic = text
+	case "algorithm":
+		if text == "" || channel.GetEncryptionAlgorithm() != "" && channel.GetEncryptionAlgorithm() != text {
+			return errors.New("chat encryption cannot be disabled or changed")
+		}
+		channel.EncryptionAlgorithm = text
+	}
+	return nil
 }
 
 // messageKey identifies a message sent without a transaction identity.

--- a/sdk/chat/chat-state_test.go
+++ b/sdk/chat/chat-state_test.go
@@ -1,0 +1,206 @@
+package spacewave_chat
+
+import (
+	"testing"
+
+	"github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
+	"github.com/s4wave/spacewave/db/world"
+	db_world_testbed "github.com/s4wave/spacewave/db/world/testbed"
+	spacewave_chat_rpc "github.com/s4wave/spacewave/sdk/chat/rpc"
+)
+
+// TestChatStateHistory checks current state, immutable history, and retry ordering together.
+func TestChatStateHistory(t *testing.T) {
+	// Create initial state through the production World operation.
+	ctx := t.Context()
+	wtb, err := db_world_testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(wtb.Release)
+	ws := world.NewEngineWorldState(wtb.Engine, true)
+	timestamp := timestamppb.Now()
+	sender := wtb.Volume.GetPeerID()
+	_, _, err = ws.ApplyWorldOp(ctx, &CreateChatChannelOp{
+		ObjectKey: GeneralChannelKey,
+		Name:      "General",
+		Timestamp: timestamp,
+		InitialState: []*ChatStateChange{
+			{Type: "m.room.create", ContentJson: `{"room_version":"11"}`},
+			{Type: "m.room.topic", ContentJson: `{"topic":"First"}`},
+		},
+	}, sender)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource := NewChatResource(ws, wtb.Engine, GeneralChannelKey, sender.String())
+	history, err := resource.ListMessages(ctx, &spacewave_chat_rpc.ListMessagesRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(history.GetMessages()) != 2 {
+		t.Fatalf("initial history = %d messages, want 2", len(history.GetMessages()))
+	}
+	for _, message := range history.GetMessages() {
+		if !message.GetCreatedAt().EqualVT(timestamp) {
+			t.Fatal("initial event timestamp differs from channel creation")
+		}
+		if message.GetSenderPeerId() != sender.String() {
+			t.Fatal("initial event lost its authenticated author")
+		}
+		if message.GetText() == "" {
+			t.Fatal("state event has no readable native history summary")
+		}
+	}
+
+	// A later state replaces the current value while both accepted messages remain addressable.
+	request := &spacewave_chat_rpc.SendMessageRequest{
+		TransactionId: "topic-second",
+		Content: &ChatMessageContent{Content: &ChatMessageContent_StateChange{
+			StateChange: &ChatStateChange{Type: "m.room.topic", ContentJson: `{"topic":"Second"}`},
+		}},
+	}
+	second, err := resource.SendMessage(ctx, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	thirdRequest := request.CloneVT()
+	thirdRequest.TransactionId = ""
+	thirdRequest.Content.GetStateChange().ContentJson = `{"topic":"Third"}`
+	third, err := resource.SendMessage(ctx, thirdRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repeated, err := resource.SendMessage(ctx, thirdRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repeated.GetMessageKey() != third.GetMessageKey() {
+		t.Fatal("unchanged state allocated a different event identity")
+	}
+	retried, err := resource.SendMessage(ctx, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retried.GetMessageKey() != second.GetMessageKey() {
+		t.Fatal("old transaction retry lost its accepted event")
+	}
+
+	// A fresh attachment sees the latest state with the exact history event identity.
+	reader := NewChatResource(ws, nil, GeneralChannelKey, "")
+	current, err := reader.GetState(ctx, &spacewave_chat_rpc.GetStateRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(current.GetMessages()) != 2 {
+		t.Fatalf("current state = %d messages, want 2", len(current.GetMessages()))
+	}
+	if current.GetMessages()[1].GetObjectKey() != third.GetMessageKey() {
+		t.Fatal("old retry overwrote current state")
+	}
+	info, err := reader.GetChannelInfo(ctx, &spacewave_chat_rpc.GetChannelInfoRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.GetTopic() != "Third" {
+		t.Fatalf("native topic = %q, want Third", info.GetTopic())
+	}
+	if info.GetMessageCount() != 4 {
+		t.Fatalf("history count = %d, want 4", info.GetMessageCount())
+	}
+	old, err := reader.GetMessage(ctx, &spacewave_chat_rpc.GetMessageRequest{MessageKey: history.GetMessages()[1].GetObjectKey()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if old.GetMessage().GetContent().GetStateChange().GetContentJson() != `{"topic":"First"}` {
+		t.Fatal("state replacement changed historical event content")
+	}
+
+	// Invalid native metadata rolls back the whole append, including its history position.
+	thirdRequest.Content.GetStateChange().ContentJson = `{"topic":false}`
+	if _, err := resource.SendMessage(ctx, thirdRequest); err == nil {
+		t.Fatal("accepted a non-string topic")
+	}
+	after, err := reader.GetChannelInfo(ctx, &spacewave_chat_rpc.GetChannelInfoRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.EqualVT(after) {
+		t.Fatal("rejected state changed channel metadata or history extent")
+	}
+}
+
+// TestChatStateEncryptionAndCreationRollback checks policy changes and atomic initialization.
+func TestChatStateEncryptionAndCreationRollback(t *testing.T) {
+	// Reject the entire creation when one initial event violates native metadata policy.
+	ctx := t.Context()
+	wtb, err := db_world_testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(wtb.Release)
+	ws := world.NewEngineWorldState(wtb.Engine, true)
+	operation := &CreateChatChannelOp{
+		ObjectKey: GeneralChannelKey,
+		Timestamp: timestamppb.Now(),
+		InitialState: []*ChatStateChange{
+			{Type: "m.room.create", ContentJson: `{}`},
+			{Type: "m.room.topic", ContentJson: `{"topic":false}`},
+		},
+	}
+	if _, _, err := ws.ApplyWorldOp(ctx, operation, wtb.Volume.GetPeerID()); err == nil {
+		t.Fatal("accepted invalid initial metadata")
+	}
+	object, found, err := ws.GetObject(ctx, GeneralChannelKey)
+	world.ReleaseObjectState(object)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found {
+		t.Fatal("rejected initialization left a partial channel")
+	}
+
+	// Enabling encryption changes the native body policy without hiding public state.
+	operation.InitialState = operation.InitialState[:1]
+	if _, _, err := ws.ApplyWorldOp(ctx, operation, wtb.Volume.GetPeerID()); err != nil {
+		t.Fatal(err)
+	}
+	resource := NewChatResource(ws, wtb.Engine, GeneralChannelKey, wtb.Volume.GetPeerID().String())
+	plaintext := &spacewave_chat_rpc.SendMessageRequest{Text: "accepted before encryption", TransactionId: "plaintext"}
+	accepted, err := resource.SendMessage(ctx, plaintext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encryption := &spacewave_chat_rpc.SendMessageRequest{Content: &ChatMessageContent{Content: &ChatMessageContent_StateChange{
+		StateChange: &ChatStateChange{Type: "m.room.encryption", ContentJson: `{"algorithm":"m.megolm.v1.aes-sha2"}`},
+	}}}
+	if _, err := resource.SendMessage(ctx, encryption); err != nil {
+		t.Fatal(err)
+	}
+	retried, err := resource.SendMessage(ctx, plaintext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retried.GetMessageKey() != accepted.GetMessageKey() {
+		t.Fatal("encryption activation changed an already accepted send result")
+	}
+	if _, err := resource.SendMessage(ctx, &spacewave_chat_rpc.SendMessageRequest{Text: "unprotected"}); err == nil {
+		t.Fatal("encryption state did not enforce native body policy")
+	}
+	request := &spacewave_chat_rpc.SendMessageRequest{Content: &ChatMessageContent{Content: &ChatMessageContent_StateChange{
+		StateChange: &ChatStateChange{Type: "m.room.topic", ContentJson: `{"topic":"Public metadata"}`},
+	}}}
+	if _, err := resource.SendMessage(ctx, request); err != nil {
+		t.Fatal(err)
+	}
+	request.Content.GetStateChange().Type = "m.room.encryption"
+	request.Content.GetStateChange().ContentJson = `{"algorithm":"other"}`
+	if _, err := resource.SendMessage(ctx, request); err == nil {
+		t.Fatal("accepted an encryption algorithm replacement")
+	}
+	request.Content.GetStateChange().Type = "m.room.create"
+	request.Content.GetStateChange().ContentJson = `{"room_version":"12"}`
+	if _, err := resource.SendMessage(ctx, request); err == nil {
+		t.Fatal("accepted replacement creation state")
+	}
+}

--- a/sdk/chat/chat.go
+++ b/sdk/chat/chat.go
@@ -3,6 +3,7 @@ package spacewave_chat
 import (
 	"github.com/aperturerobotics/cayley/quad"
 	"github.com/s4wave/spacewave/db/block"
+	"github.com/s4wave/spacewave/db/world"
 )
 
 // ChatChannelTypeID is the type identifier for chat channel objects.
@@ -16,6 +17,15 @@ var PredChannelMessage = quad.IRI("spacewave-chat/channel-message")
 
 // PredMessageSender is the graph predicate linking a message to its sender.
 var PredMessageSender = quad.IRI("spacewave-chat/message-sender")
+
+// PredChannelState links a channel to the latest event for each state identity.
+var PredChannelState = quad.IRI("spacewave-chat/channel-state")
+
+// NewChatStateQuad links a channel state identity to its retained message.
+// Empty messageKey selects the current event for this identity in a graph query.
+func NewChatStateQuad(channelKey, messageKey, stateType, stateKey string) world.GraphQuad {
+	return world.NewGraphQuadWithKeys(channelKey, PredChannelState.String(), messageKey, quad.String(stateType+"\x00"+stateKey).String())
+}
 
 // NewChatChannelBlock constructs a new ChatChannel block.
 func NewChatChannelBlock() block.Block {

--- a/sdk/chat/chat.pb.go
+++ b/sdk/chat/chat.pb.go
@@ -33,8 +33,8 @@ type ChatChannel struct {
 	ReadPositions map[string]*state.ChatReadPosition `protobuf:"bytes,5,rep,name=read_positions,json=readPositions,proto3" json:"readPositions,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// CreatorPeerId is the peer identity that created the channel.
 	CreatorPeerId string `protobuf:"bytes,6,opt,name=creator_peer_id,json=creatorPeerId,proto3" json:"creatorPeerId,omitempty"`
-	// EncryptionAlgorithm is the immutable creation-time policy. Empty allows plaintext;
-	// otherwise message bodies require this algorithm; typed annotations remain public.
+	// EncryptionAlgorithm is the channel encryption policy. Empty allows plaintext;
+	// once enabled it cannot change. Annotations and state changes remain public.
 	EncryptionAlgorithm string `protobuf:"bytes,7,opt,name=encryption_algorithm,json=encryptionAlgorithm,proto3" json:"encryptionAlgorithm,omitempty"`
 }
 
@@ -219,9 +219,11 @@ type CreateChatChannelOp struct {
 	Topic string `protobuf:"bytes,3,opt,name=topic,proto3" json:"topic,omitempty"`
 	// Timestamp is the creation timestamp.
 	Timestamp *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
-	// EncryptionAlgorithm is the immutable creation-time policy. Empty allows plaintext;
-	// otherwise message bodies require this algorithm; typed annotations remain public.
+	// EncryptionAlgorithm initializes the channel encryption policy. Empty allows plaintext;
+	// once enabled it cannot change. Annotations and state changes remain public.
 	EncryptionAlgorithm string `protobuf:"bytes,5,opt,name=encryption_algorithm,json=encryptionAlgorithm,proto3" json:"encryptionAlgorithm,omitempty"`
+	// InitialState is appended atomically in order with the channel creation timestamp.
+	InitialState []*content.ChatStateChange `protobuf:"bytes,6,rep,name=initial_state,json=initialState,proto3" json:"initialState,omitempty"`
 }
 
 func (x *CreateChatChannelOp) Reset() {
@@ -263,6 +265,13 @@ func (x *CreateChatChannelOp) GetEncryptionAlgorithm() string {
 		return x.EncryptionAlgorithm
 	}
 	return ""
+}
+
+func (x *CreateChatChannelOp) GetInitialState() []*content.ChatStateChange {
+	if x != nil {
+		return x.InitialState
+	}
+	return nil
 }
 
 type ChatChannel_ReadPositionsEntry struct {
@@ -377,6 +386,7 @@ func (m *CreateChatChannelOp) CloneVT() *CreateChatChannelOp {
 	r.Topic = m.Topic
 	r.EncryptionAlgorithm = m.EncryptionAlgorithm
 	r.Timestamp = protobuf_go_lite.CloneVTValue(m.Timestamp)
+	r.InitialState = protobuf_go_lite.CloneVTSlice(m.InitialState)
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = slices.Clone(m.unknownFields)
 	}
@@ -522,6 +532,9 @@ func (this *CreateChatChannelOp) EqualVT(that *CreateChatChannelOp) bool {
 		return false
 	}
 	if this.EncryptionAlgorithm != that.EncryptionAlgorithm {
+		return false
+	}
+	if !protobuf_go_lite.EqualVTSliceImplicit(this.InitialState, that.InitialState, func() *content.ChatStateChange { return &content.ChatStateChange{} }) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -922,6 +935,17 @@ func (x *CreateChatChannelOp) MarshalProtoJSON(s *json.MarshalState) {
 		s.WriteObjectField("encryptionAlgorithm")
 		s.WriteString(x.EncryptionAlgorithm)
 	}
+	if len(x.InitialState) > 0 || s.HasField("initialState") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("initialState")
+		s.WriteArrayStart()
+		var wroteElement bool
+		for _, element := range x.InitialState {
+			s.WriteMoreIf(&wroteElement)
+			element.MarshalProtoJSON(s.WithField("initialState"))
+		}
+		s.WriteArrayEnd()
+	}
 	s.WriteObjectEnd()
 }
 
@@ -958,6 +982,24 @@ func (x *CreateChatChannelOp) UnmarshalProtoJSON(s *json.UnmarshalState) {
 		case "encryption_algorithm", "encryptionAlgorithm":
 			s.AddField("encryption_algorithm")
 			x.EncryptionAlgorithm = s.ReadString()
+		case "initial_state", "initialState":
+			s.AddField("initial_state")
+			if s.ReadNil() {
+				x.InitialState = nil
+				return
+			}
+			s.ReadArray(func() {
+				if s.ReadNil() {
+					x.InitialState = append(x.InitialState, nil)
+					return
+				}
+				v := &content.ChatStateChange{}
+				v.UnmarshalProtoJSON(s.WithField("initial_state", false))
+				if s.Err() != nil {
+					return
+				}
+				x.InitialState = append(x.InitialState, v)
+			})
 		}
 	})
 }
@@ -1241,6 +1283,18 @@ func (m *CreateChatChannelOp) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
 	}
+	if len(m.InitialState) > 0 {
+		for iNdEx := len(m.InitialState) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.InitialState[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x32
+		}
+	}
 	if len(m.EncryptionAlgorithm) > 0 {
 		i = protobuf_go_lite.EncodeString(dAtA, i, m.EncryptionAlgorithm)
 		i--
@@ -1365,6 +1419,10 @@ func (m *CreateChatChannelOp) SizeVT() (n int) {
 		n += protobuf_go_lite.SizeMessage(1, l)
 	}
 	n += protobuf_go_lite.SizeStringNonEmpty(1, m.EncryptionAlgorithm)
+	for _, e := range m.InitialState {
+		l = e.SizeVT()
+		n += protobuf_go_lite.SizeMessage(1, l)
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -1528,6 +1586,18 @@ func (x *CreateChatChannelOp) MarshalProtoText() string {
 	if x.EncryptionAlgorithm != "" {
 		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "encryption_algorithm")
 		protobuf_go_lite.TextWriteString(&sb, x.EncryptionAlgorithm)
+	}
+	if len(x.InitialState) > 0 {
+		protobuf_go_lite.TextWriteListStart(&sb, initialLen, "initial_state")
+		for i, v := range x.InitialState {
+			protobuf_go_lite.TextWriteListSeparator(&sb, i)
+			if v == nil {
+				protobuf_go_lite.TextWriteTextMarshaler(&sb, &content.ChatStateChange{})
+			} else {
+				protobuf_go_lite.TextWriteTextMarshaler(&sb, v)
+			}
+		}
+		protobuf_go_lite.TextWriteListEnd(&sb)
 	}
 	return protobuf_go_lite.TextFinishMessage(&sb)
 }
@@ -1998,6 +2068,19 @@ func (m *CreateChatChannelOp) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			m.EncryptionAlgorithm = v
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field InitialState", wireType)
+			}
+			msgStart, postIndex, err := protobuf_go_lite.DecodeLengthDelimited(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.InitialState = append(m.InitialState, &content.ChatStateChange{})
+			if err := m.InitialState[len(m.InitialState)-1].UnmarshalVT(dAtA[msgStart:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])

--- a/sdk/chat/chat.pb.ts
+++ b/sdk/chat/chat.pb.ts
@@ -8,7 +8,7 @@ import { createMessageType } from '@aptre/protobuf-es-lite/message'
 import { ScalarType } from '@aptre/protobuf-es-lite/scalar'
 import { Timestamp } from '@aptre/protobuf-es-lite/google/protobuf/timestamp'
 import type { PartialFieldInfo } from '@aptre/protobuf-es-lite/field'
-import { ChatMessageContent } from './content/content.pb.js'
+import { ChatMessageContent, ChatStateChange } from './content/content.pb.js'
 
 export const protobufPackage = 'spacewave.chat'
 
@@ -57,8 +57,8 @@ export interface ChatChannel {
    */
   creatorPeerId?: string
   /**
-   * EncryptionAlgorithm is the immutable creation-time policy. Empty allows plaintext;
-   * otherwise message bodies require this algorithm; typed annotations remain public.
+   * EncryptionAlgorithm is the channel encryption policy. Empty allows plaintext;
+   * once enabled it cannot change. Annotations and state changes remain public.
    *
    * @generated from field: string encryption_algorithm = 7;
    */
@@ -245,12 +245,18 @@ export interface CreateChatChannelOp {
    */
   timestamp?: Date
   /**
-   * EncryptionAlgorithm is the immutable creation-time policy. Empty allows plaintext;
-   * otherwise message bodies require this algorithm; typed annotations remain public.
+   * EncryptionAlgorithm initializes the channel encryption policy. Empty allows plaintext;
+   * once enabled it cannot change. Annotations and state changes remain public.
    *
    * @generated from field: string encryption_algorithm = 5;
    */
   encryptionAlgorithm?: string
+  /**
+   * InitialState is appended atomically in order with the channel creation timestamp.
+   *
+   * @generated from field: repeated spacewave.chat.ChatStateChange initial_state = 6;
+   */
+  initialState?: ChatStateChange[]
 }
 
 export const CreateChatChannelOp: MessageType<CreateChatChannelOp> =
@@ -266,6 +272,13 @@ export const CreateChatChannelOp: MessageType<CreateChatChannelOp> =
         name: 'encryption_algorithm',
         kind: 'scalar',
         T: ScalarType.STRING,
+      },
+      {
+        no: 6,
+        name: 'initial_state',
+        kind: 'message',
+        T: () => ChatStateChange,
+        repeated: true,
       },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,

--- a/sdk/chat/chat.proto
+++ b/sdk/chat/chat.proto
@@ -23,8 +23,8 @@ message ChatChannel {
   map<string, ChatReadPosition> read_positions = 5;
   // CreatorPeerId is the peer identity that created the channel.
   string creator_peer_id = 6;
-  // EncryptionAlgorithm is the immutable creation-time policy. Empty allows plaintext;
-  // otherwise message bodies require this algorithm; typed annotations remain public.
+  // EncryptionAlgorithm is the channel encryption policy. Empty allows plaintext;
+  // once enabled it cannot change. Annotations and state changes remain public.
   string encryption_algorithm = 7;
 }
 
@@ -69,7 +69,9 @@ message CreateChatChannelOp {
   string topic = 3;
   // Timestamp is the creation timestamp.
   .google.protobuf.Timestamp timestamp = 4;
-  // EncryptionAlgorithm is the immutable creation-time policy. Empty allows plaintext;
-  // otherwise message bodies require this algorithm; typed annotations remain public.
+  // EncryptionAlgorithm initializes the channel encryption policy. Empty allows plaintext;
+  // once enabled it cannot change. Annotations and state changes remain public.
   string encryption_algorithm = 5;
+  // InitialState is appended atomically in order with the channel creation timestamp.
+  repeated ChatStateChange initial_state = 6;
 }

--- a/sdk/chat/content/content.pb.go
+++ b/sdk/chat/content/content.pb.go
@@ -163,6 +163,45 @@ func (x *ChatAnnotation) GetKey() string {
 	return ""
 }
 
+// ChatStateChange replaces one channel state value while retaining its history.
+type ChatStateChange struct {
+	unknownFields []byte
+	// Type is an open protocol vocabulary identifying the state schema.
+	Type string `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
+	// StateKey is an external state identity within Type, not a World object key.
+	StateKey string `protobuf:"bytes,2,opt,name=state_key,json=stateKey,proto3" json:"stateKey,omitempty"`
+	// ContentJson is a complete JSON object, bounded to 64 KiB.
+	// The producing protocol validates its schema and canonicalizes its encoding.
+	ContentJson string `protobuf:"bytes,3,opt,name=content_json,json=contentJson,proto3" json:"contentJson,omitempty"`
+}
+
+func (x *ChatStateChange) Reset() {
+	*x = ChatStateChange{}
+}
+
+func (*ChatStateChange) ProtoMessage() {}
+
+func (x *ChatStateChange) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *ChatStateChange) GetStateKey() string {
+	if x != nil {
+		return x.StateKey
+	}
+	return ""
+}
+
+func (x *ChatStateChange) GetContentJson() string {
+	if x != nil {
+		return x.ContentJson
+	}
+	return ""
+}
+
 // ChatMessageContent contains the message body.
 type ChatMessageContent struct {
 	unknownFields []byte
@@ -170,6 +209,7 @@ type ChatMessageContent struct {
 	//	*ChatMessageContent_Text
 	//	*ChatMessageContent_Ciphertext
 	//	*ChatMessageContent_Annotation
+	//	*ChatMessageContent_StateChange
 	Content isChatMessageContent_Content `protobuf_oneof:"content"`
 }
 
@@ -207,6 +247,13 @@ func (x *ChatMessageContent) GetAnnotation() *ChatAnnotation {
 	return nil
 }
 
+func (x *ChatMessageContent) GetStateChange() *ChatStateChange {
+	if x, ok := x.GetContent().(*ChatMessageContent_StateChange); ok {
+		return x.StateChange
+	}
+	return nil
+}
+
 type isChatMessageContent_Content interface {
 	isChatMessageContent_Content()
 }
@@ -226,11 +273,18 @@ type ChatMessageContent_Annotation struct {
 	Annotation *ChatAnnotation `protobuf:"bytes,3,opt,name=annotation,proto3,oneof"`
 }
 
+type ChatMessageContent_StateChange struct {
+	// StateChange is public channel metadata retained in message history.
+	StateChange *ChatStateChange `protobuf:"bytes,4,opt,name=state_change,json=stateChange,proto3,oneof"`
+}
+
 func (*ChatMessageContent_Text) isChatMessageContent_Content() {}
 
 func (*ChatMessageContent_Ciphertext) isChatMessageContent_Content() {}
 
 func (*ChatMessageContent_Annotation) isChatMessageContent_Content() {}
+
+func (*ChatMessageContent_StateChange) isChatMessageContent_Content() {}
 
 func (m *ChatCiphertext) CloneVT() *ChatCiphertext {
 	if m == nil {
@@ -290,6 +344,24 @@ func (m *ChatAnnotation) CloneMessageVT() protobuf_go_lite.CloneMessage {
 	return m.CloneVT()
 }
 
+func (m *ChatStateChange) CloneVT() *ChatStateChange {
+	if m == nil {
+		return (*ChatStateChange)(nil)
+	}
+	r := new(ChatStateChange)
+	r.Type = m.Type
+	r.StateKey = m.StateKey
+	r.ContentJson = m.ContentJson
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = slices.Clone(m.unknownFields)
+	}
+	return r
+}
+
+func (m *ChatStateChange) CloneMessageVT() protobuf_go_lite.CloneMessage {
+	return m.CloneVT()
+}
+
 func (m *ChatMessageContent) CloneVT() *ChatMessageContent {
 	if m == nil {
 		return (*ChatMessageContent)(nil)
@@ -346,6 +418,19 @@ func (m *ChatMessageContent_Annotation) CloneVT() *ChatMessageContent_Annotation
 }
 
 func (m *ChatMessageContent_Annotation) CloneOneofVT() isChatMessageContent_Content {
+	return m.CloneVT()
+}
+
+func (m *ChatMessageContent_StateChange) CloneVT() *ChatMessageContent_StateChange {
+	if m == nil {
+		return (*ChatMessageContent_StateChange)(nil)
+	}
+	r := new(ChatMessageContent_StateChange)
+	r.StateChange = protobuf_go_lite.CloneVTValue(m.StateChange)
+	return r
+}
+
+func (m *ChatMessageContent_StateChange) CloneOneofVT() isChatMessageContent_Content {
 	return m.CloneVT()
 }
 
@@ -439,6 +524,32 @@ func (this *ChatAnnotation) EqualMessageVT(thatMsg any) bool {
 	return this.EqualVT(that)
 }
 
+func (this *ChatStateChange) EqualVT(that *ChatStateChange) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.Type != that.Type {
+		return false
+	}
+	if this.StateKey != that.StateKey {
+		return false
+	}
+	if this.ContentJson != that.ContentJson {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *ChatStateChange) EqualMessageVT(thatMsg any) bool {
+	that, ok := thatMsg.(*ChatStateChange)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+
 func (this *ChatMessageContent) EqualVT(that *ChatMessageContent) bool {
 	if this == that {
 		return true
@@ -514,6 +625,23 @@ func (this *ChatMessageContent_Annotation) EqualVT(thatIface isChatMessageConten
 		return false
 	}
 	if !protobuf_go_lite.EqualVTImplicit(this.Annotation, that.Annotation, func() *ChatAnnotation { return &ChatAnnotation{} }) {
+		return false
+	}
+	return true
+}
+
+func (this *ChatMessageContent_StateChange) EqualVT(thatIface isChatMessageContent_Content) bool {
+	that, ok := thatIface.(*ChatMessageContent_StateChange)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if !protobuf_go_lite.EqualVTImplicit(this.StateChange, that.StateChange, func() *ChatStateChange { return &ChatStateChange{} }) {
 		return false
 	}
 	return true
@@ -729,6 +857,64 @@ func (x *ChatAnnotation) UnmarshalJSON(b []byte) error {
 	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
 }
 
+// MarshalProtoJSON marshals the ChatStateChange message to JSON.
+func (x *ChatStateChange) MarshalProtoJSON(s *json.MarshalState) {
+	if x == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteObjectStart()
+	var wroteField bool
+	if x.Type != "" || s.HasField("type") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("type")
+		s.WriteString(x.Type)
+	}
+	if x.StateKey != "" || s.HasField("stateKey") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("stateKey")
+		s.WriteString(x.StateKey)
+	}
+	if x.ContentJson != "" || s.HasField("contentJson") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("contentJson")
+		s.WriteString(x.ContentJson)
+	}
+	s.WriteObjectEnd()
+}
+
+// MarshalJSON marshals the ChatStateChange to JSON.
+func (x *ChatStateChange) MarshalJSON() ([]byte, error) {
+	return json.DefaultMarshalerConfig.Marshal(x)
+}
+
+// UnmarshalProtoJSON unmarshals the ChatStateChange message from JSON.
+func (x *ChatStateChange) UnmarshalProtoJSON(s *json.UnmarshalState) {
+	if s.ReadNil() {
+		return
+	}
+	s.ReadObject(func(key string) {
+		switch key {
+		default:
+			s.Skip() // ignore unknown field
+		case "type":
+			s.AddField("type")
+			x.Type = s.ReadString()
+		case "state_key", "stateKey":
+			s.AddField("state_key")
+			x.StateKey = s.ReadString()
+		case "content_json", "contentJson":
+			s.AddField("content_json")
+			x.ContentJson = s.ReadString()
+		}
+	})
+}
+
+// UnmarshalJSON unmarshals the ChatStateChange from JSON.
+func (x *ChatStateChange) UnmarshalJSON(b []byte) error {
+	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
+}
+
 // MarshalProtoJSON marshals the ChatMessageContent message to JSON.
 func (x *ChatMessageContent) MarshalProtoJSON(s *json.MarshalState) {
 	if x == nil {
@@ -751,6 +937,10 @@ func (x *ChatMessageContent) MarshalProtoJSON(s *json.MarshalState) {
 			s.WriteMoreIf(&wroteField)
 			s.WriteObjectField("annotation")
 			ov.Annotation.MarshalProtoJSON(s.WithField("annotation"))
+		case *ChatMessageContent_StateChange:
+			s.WriteMoreIf(&wroteField)
+			s.WriteObjectField("stateChange")
+			ov.StateChange.MarshalProtoJSON(s.WithField("stateChange"))
 		}
 	}
 	s.WriteObjectEnd()
@@ -793,6 +983,15 @@ func (x *ChatMessageContent) UnmarshalProtoJSON(s *json.UnmarshalState) {
 			}
 			ov.Annotation = &ChatAnnotation{}
 			ov.Annotation.UnmarshalProtoJSON(s.WithField("annotation", true))
+		case "state_change", "stateChange":
+			ov := &ChatMessageContent_StateChange{}
+			x.Content = ov
+			if s.ReadNil() {
+				ov.StateChange = nil
+				return
+			}
+			ov.StateChange = &ChatStateChange{}
+			ov.StateChange.UnmarshalProtoJSON(s.WithField("state_change", true))
 		}
 	})
 }
@@ -968,6 +1167,53 @@ func (m *ChatAnnotation) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *ChatStateChange) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ChatStateChange) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *ChatStateChange) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	if len(m.ContentJson) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.ContentJson)
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.StateKey) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.StateKey)
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Type) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.Type)
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *ChatMessageContent) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -1070,6 +1316,30 @@ func (m *ChatMessageContent_Annotation) MarshalToSizedBufferVT(dAtA []byte) (int
 	return len(dAtA) - i, nil
 }
 
+func (m *ChatMessageContent_StateChange) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *ChatMessageContent_StateChange) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.StateChange != nil {
+		size, err := m.StateChange.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x22
+	} else {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, 0)
+		i--
+		dAtA[i] = 0x22
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *ChatCiphertext) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -1112,6 +1382,19 @@ func (m *ChatAnnotation) SizeVT() (n int) {
 	_ = l
 	n += protobuf_go_lite.SizeStringNonEmpty(1, m.TargetKey)
 	n += protobuf_go_lite.SizeStringNonEmpty(1, m.Key)
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *ChatStateChange) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.Type)
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.StateKey)
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.ContentJson)
 	n += len(m.unknownFields)
 	return n
 }
@@ -1162,6 +1445,21 @@ func (m *ChatMessageContent_Annotation) SizeVT() (n int) {
 	_ = l
 	if m.Annotation != nil {
 		l = m.Annotation.SizeVT()
+		n += protobuf_go_lite.SizeMessage(1, l)
+	} else {
+		n += 2
+	}
+	return n
+}
+
+func (m *ChatMessageContent_StateChange) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.StateChange != nil {
+		l = m.StateChange.SizeVT()
 		n += protobuf_go_lite.SizeMessage(1, l)
 	} else {
 		n += 2
@@ -1251,6 +1549,28 @@ func (x *ChatAnnotation) String() string {
 	return x.MarshalProtoText()
 }
 
+func (x *ChatStateChange) MarshalProtoText() string {
+	var sb protobuf_go_lite.TextBuilder
+	initialLen := protobuf_go_lite.TextStartMessage(&sb, "ChatStateChange")
+	if x.Type != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "type")
+		protobuf_go_lite.TextWriteString(&sb, x.Type)
+	}
+	if x.StateKey != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "state_key")
+		protobuf_go_lite.TextWriteString(&sb, x.StateKey)
+	}
+	if x.ContentJson != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "content_json")
+		protobuf_go_lite.TextWriteString(&sb, x.ContentJson)
+	}
+	return protobuf_go_lite.TextFinishMessage(&sb)
+}
+
+func (x *ChatStateChange) String() string {
+	return x.MarshalProtoText()
+}
+
 func (x *ChatMessageContent) MarshalProtoText() string {
 	var sb protobuf_go_lite.TextBuilder
 	initialLen := protobuf_go_lite.TextStartMessage(&sb, "ChatMessageContent")
@@ -1271,6 +1591,13 @@ func (x *ChatMessageContent) MarshalProtoText() string {
 			protobuf_go_lite.TextWriteTextMarshaler(&sb, &ChatAnnotation{})
 		} else {
 			protobuf_go_lite.TextWriteTextMarshaler(&sb, body.Annotation)
+		}
+	case *ChatMessageContent_StateChange:
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "state_change")
+		if body.StateChange == nil {
+			protobuf_go_lite.TextWriteTextMarshaler(&sb, &ChatStateChange{})
+		} else {
+			protobuf_go_lite.TextWriteTextMarshaler(&sb, body.StateChange)
 		}
 	}
 	return protobuf_go_lite.TextFinishMessage(&sb)
@@ -1544,6 +1871,79 @@ func (m *ChatAnnotation) UnmarshalVT(dAtA []byte) error {
 	return nil
 }
 
+func (m *ChatStateChange) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	var err error
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		wire, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+		if err != nil {
+			return err
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ChatStateChange: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ChatStateChange: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Type", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.Type = v
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field StateKey", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.StateKey = v
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ContentJson", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.ContentJson = v
+		default:
+			iNdEx = preIndex
+			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protobuf_go_lite.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+
 func (m *ChatMessageContent) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1612,6 +2012,26 @@ func (m *ChatMessageContent) UnmarshalVT(dAtA []byte) error {
 					return err
 				}
 				m.Content = &ChatMessageContent_Annotation{Annotation: v}
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field StateChange", wireType)
+			}
+			msgStart, postIndex, err := protobuf_go_lite.DecodeLengthDelimited(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			if oneof, ok := m.Content.(*ChatMessageContent_StateChange); ok {
+				if err := oneof.StateChange.UnmarshalVT(dAtA[msgStart:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				v := &ChatStateChange{}
+				if err := v.UnmarshalVT(dAtA[msgStart:postIndex]); err != nil {
+					return err
+				}
+				m.Content = &ChatMessageContent_StateChange{StateChange: v}
 			}
 			iNdEx = postIndex
 		default:

--- a/sdk/chat/content/content.pb.ts
+++ b/sdk/chat/content/content.pb.ts
@@ -149,6 +149,44 @@ export const ChatAnnotation: MessageType<ChatAnnotation> =
   })
 
 /**
+ * ChatStateChange replaces one channel state value while retaining its history.
+ *
+ * @generated from message spacewave.chat.ChatStateChange
+ */
+export interface ChatStateChange {
+  /**
+   * Type is an open protocol vocabulary identifying the state schema.
+   *
+   * @generated from field: string type = 1;
+   */
+  type?: string
+  /**
+   * StateKey is an external state identity within Type, not a World object key.
+   *
+   * @generated from field: string state_key = 2;
+   */
+  stateKey?: string
+  /**
+   * ContentJson is a complete JSON object, bounded to 64 KiB.
+   * The producing protocol validates its schema and canonicalizes its encoding.
+   *
+   * @generated from field: string content_json = 3;
+   */
+  contentJson?: string
+}
+
+export const ChatStateChange: MessageType<ChatStateChange> =
+  /* @__PURE__ */ createMessageType({
+    typeName: 'spacewave.chat.ChatStateChange',
+    fields: [
+      { no: 1, name: 'type', kind: 'scalar', T: ScalarType.STRING },
+      { no: 2, name: 'state_key', kind: 'scalar', T: ScalarType.STRING },
+      { no: 3, name: 'content_json', kind: 'scalar', T: ScalarType.STRING },
+    ] satisfies readonly PartialFieldInfo[],
+    packedByDefault: true,
+  })
+
+/**
  * ChatMessageContent contains the message body.
  *
  * @generated from message spacewave.chat.ChatMessageContent
@@ -189,6 +227,15 @@ export interface ChatMessageContent {
         value: ChatAnnotation
         case: 'annotation'
       }
+    | {
+        /**
+         * StateChange is public channel metadata retained in message history.
+         *
+         * @generated from field: spacewave.chat.ChatStateChange state_change = 4;
+         */
+        value: ChatStateChange
+        case: 'stateChange'
+      }
 }
 
 export const ChatMessageContent: MessageType<ChatMessageContent> =
@@ -214,6 +261,13 @@ export const ChatMessageContent: MessageType<ChatMessageContent> =
         name: 'annotation',
         kind: 'message',
         T: () => ChatAnnotation,
+        oneof: 'content',
+      },
+      {
+        no: 4,
+        name: 'state_change',
+        kind: 'message',
+        T: () => ChatStateChange,
         oneof: 'content',
       },
     ] satisfies readonly PartialFieldInfo[],

--- a/sdk/chat/content/content.proto
+++ b/sdk/chat/content/content.proto
@@ -41,6 +41,17 @@ message ChatAnnotation {
   string key = 2;
 }
 
+// ChatStateChange replaces one channel state value while retaining its history.
+message ChatStateChange {
+  // Type is an open protocol vocabulary identifying the state schema.
+  string type = 1;
+  // StateKey is an external state identity within Type, not a World object key.
+  string state_key = 2;
+  // ContentJson is a complete JSON object, bounded to 64 KiB.
+  // The producing protocol validates its schema and canonicalizes its encoding.
+  string content_json = 3;
+}
+
 // ChatMessageContent contains the message body.
 message ChatMessageContent {
   oneof content {
@@ -50,5 +61,7 @@ message ChatMessageContent {
     ChatCiphertext ciphertext = 2;
     // Annotation is public metadata even when message bodies require encryption.
     ChatAnnotation annotation = 3;
+    // StateChange is public channel metadata retained in message history.
+    ChatStateChange state_change = 4;
   }
 }

--- a/sdk/chat/content/state-change.go
+++ b/sdk/chat/content/state-change.go
@@ -1,0 +1,30 @@
+package spacewave_chat_content
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	"github.com/aperturerobotics/fastjson"
+	"github.com/pkg/errors"
+)
+
+// Validate checks the state identity and bounded external JSON object.
+func (s *ChatStateChange) Validate() error {
+	// NUL separates the two external identities in the current-state graph label.
+	if s.GetType() == "" || len(s.GetType()) > 255 || len(s.GetStateKey()) > 255 || strings.ContainsRune(s.GetType(), 0) || strings.ContainsRune(s.GetStateKey(), 0) || !utf8.ValidString(s.GetType()) || !utf8.ValidString(s.GetStateKey()) {
+		return errors.New("chat state requires a bounded type and state key")
+	}
+
+	// State payloads stay public and must be complete objects before storage.
+	if len(s.GetContentJson()) > 64*1024 || !utf8.ValidString(s.GetContentJson()) {
+		return errors.New("chat state content exceeds its bounds or is not UTF-8")
+	}
+	value, err := fastjson.Parse(s.GetContentJson())
+	if err != nil {
+		return errors.Wrap(err, "parse chat state content")
+	}
+	if value.Type() != fastjson.TypeObject {
+		return errors.New("chat state content must be a JSON object")
+	}
+	return nil
+}

--- a/sdk/chat/create-channel.go
+++ b/sdk/chat/create-channel.go
@@ -7,6 +7,7 @@ import (
 	"github.com/s4wave/spacewave/db/world"
 	world_types "github.com/s4wave/spacewave/db/world/types"
 	"github.com/s4wave/spacewave/net/peer"
+	spacewave_chat_rpc "github.com/s4wave/spacewave/sdk/chat/rpc"
 	"github.com/sirupsen/logrus"
 )
 
@@ -30,6 +31,11 @@ func (o *CreateChatChannelOp) Validate() error {
 	}
 	if err := o.GetTimestamp().Validate(false); err != nil {
 		return err
+	}
+	for _, state := range o.GetInitialState() {
+		if err := state.Validate(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -73,6 +79,17 @@ func (o *CreateChatChannelOp) ApplyWorldOp(
 
 	if err := world_types.SetObjectType(ctx, ws, objKey, ChatChannelTypeID); err != nil {
 		return false, err
+	}
+
+	// Initial events share the operation's author, timestamp, and transaction.
+	resource := NewChatResource(ws, nil, objKey, sender.String())
+	for _, state := range o.GetInitialState() {
+		request := &spacewave_chat_rpc.SendMessageRequest{
+			Content: &ChatMessageContent{Content: &ChatMessageContent_StateChange{StateChange: state}},
+		}
+		if _, err := resource.appendMessage(ctx, ws, request, o.GetTimestamp()); err != nil {
+			return false, err
+		}
 	}
 
 	return false, nil

--- a/sdk/chat/rpc/rpc.pb.go
+++ b/sdk/chat/rpc/rpc.pb.go
@@ -16,6 +16,37 @@ import (
 	state "github.com/s4wave/spacewave/sdk/chat/state"
 )
 
+// GetStateRequest selects current state for the mounted channel.
+type GetStateRequest struct {
+	unknownFields []byte
+}
+
+func (x *GetStateRequest) Reset() {
+	*x = GetStateRequest{}
+}
+
+func (*GetStateRequest) ProtoMessage() {}
+
+// GetStateResponse contains current state events with their immutable history identities.
+type GetStateResponse struct {
+	unknownFields []byte
+	// Messages is ordered by state type and state key.
+	Messages []*ChatMessageInfo `protobuf:"bytes,1,rep,name=messages,proto3" json:"messages,omitempty"`
+}
+
+func (x *GetStateResponse) Reset() {
+	*x = GetStateResponse{}
+}
+
+func (*GetStateResponse) ProtoMessage() {}
+
+func (x *GetStateResponse) GetMessages() []*ChatMessageInfo {
+	if x != nil {
+		return x.Messages
+	}
+	return nil
+}
+
 // ChatMessageInfo contains flattened message info for the client.
 type ChatMessageInfo struct {
 	unknownFields []byte
@@ -23,7 +54,8 @@ type ChatMessageInfo struct {
 	ObjectKey string `protobuf:"bytes,1,opt,name=object_key,json=objectKey,proto3" json:"objectKey,omitempty"`
 	// SenderPeerId is the sender's peer ID.
 	SenderPeerId string `protobuf:"bytes,2,opt,name=sender_peer_id,json=senderPeerId,proto3" json:"senderPeerId,omitempty"`
-	// Text is the message text content. Empty for ciphertext messages.
+	// Text is plaintext content or a readable state-change summary.
+	// Empty for ciphertext messages and annotations.
 	Text string `protobuf:"bytes,3,opt,name=text,proto3" json:"text,omitempty"`
 	// CreatedAt is the message creation timestamp.
 	CreatedAt *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=created_at,json=createdAt,proto3" json:"createdAt,omitempty"`
@@ -123,8 +155,8 @@ type GetChannelInfoResponse struct {
 	CreatedAt *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=created_at,json=createdAt,proto3" json:"createdAt,omitempty"`
 	// CreatorPeerId is the peer identity that created the channel.
 	CreatorPeerId string `protobuf:"bytes,5,opt,name=creator_peer_id,json=creatorPeerId,proto3" json:"creatorPeerId,omitempty"`
-	// EncryptionAlgorithm reports the immutable creation-time policy. Empty allows plaintext;
-	// otherwise sends require ciphertext using this algorithm.
+	// EncryptionAlgorithm reports the channel encryption policy. Empty allows plaintext;
+	// otherwise message bodies require this algorithm. State and annotations remain public.
 	EncryptionAlgorithm string `protobuf:"bytes,6,opt,name=encryption_algorithm,json=encryptionAlgorithm,proto3" json:"encryptionAlgorithm,omitempty"`
 }
 
@@ -489,6 +521,37 @@ func (x *GetReadPositionsResponse_PositionsEntry) GetValue() *state.ChatReadPosi
 	return nil
 }
 
+func (m *GetStateRequest) CloneVT() *GetStateRequest {
+	if m == nil {
+		return (*GetStateRequest)(nil)
+	}
+	r := new(GetStateRequest)
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = slices.Clone(m.unknownFields)
+	}
+	return r
+}
+
+func (m *GetStateRequest) CloneMessageVT() protobuf_go_lite.CloneMessage {
+	return m.CloneVT()
+}
+
+func (m *GetStateResponse) CloneVT() *GetStateResponse {
+	if m == nil {
+		return (*GetStateResponse)(nil)
+	}
+	r := new(GetStateResponse)
+	r.Messages = protobuf_go_lite.CloneVTSlice(m.Messages)
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = slices.Clone(m.unknownFields)
+	}
+	return r
+}
+
+func (m *GetStateResponse) CloneMessageVT() protobuf_go_lite.CloneMessage {
+	return m.CloneVT()
+}
+
 func (m *ChatMessageInfo) CloneVT() *ChatMessageInfo {
 	if m == nil {
 		return (*ChatMessageInfo)(nil)
@@ -743,6 +806,43 @@ func (m *UpdateReadPositionResponse) CloneVT() *UpdateReadPositionResponse {
 
 func (m *UpdateReadPositionResponse) CloneMessageVT() protobuf_go_lite.CloneMessage {
 	return m.CloneVT()
+}
+
+func (this *GetStateRequest) EqualVT(that *GetStateRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *GetStateRequest) EqualMessageVT(thatMsg any) bool {
+	that, ok := thatMsg.(*GetStateRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+
+func (this *GetStateResponse) EqualVT(that *GetStateResponse) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !protobuf_go_lite.EqualVTSliceImplicit(this.Messages, that.Messages, func() *ChatMessageInfo { return &ChatMessageInfo{} }) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *GetStateResponse) EqualMessageVT(thatMsg any) bool {
+	that, ok := thatMsg.(*GetStateResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
 }
 
 func (this *ChatMessageInfo) EqualVT(that *ChatMessageInfo) bool {
@@ -1091,6 +1191,99 @@ func (this *UpdateReadPositionResponse) EqualMessageVT(thatMsg any) bool {
 		return false
 	}
 	return this.EqualVT(that)
+}
+
+// MarshalProtoJSON marshals the GetStateRequest message to JSON.
+func (x *GetStateRequest) MarshalProtoJSON(s *json.MarshalState) {
+	if x == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteObjectStart()
+	s.WriteObjectEnd()
+}
+
+// MarshalJSON marshals the GetStateRequest to JSON.
+func (x *GetStateRequest) MarshalJSON() ([]byte, error) {
+	return json.DefaultMarshalerConfig.Marshal(x)
+}
+
+// UnmarshalProtoJSON unmarshals the GetStateRequest message from JSON.
+func (x *GetStateRequest) UnmarshalProtoJSON(s *json.UnmarshalState) {
+	if s.ReadNil() {
+		return
+	}
+	s.ReadObject(func(key string) {
+		// no fields
+	})
+}
+
+// UnmarshalJSON unmarshals the GetStateRequest from JSON.
+func (x *GetStateRequest) UnmarshalJSON(b []byte) error {
+	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
+}
+
+// MarshalProtoJSON marshals the GetStateResponse message to JSON.
+func (x *GetStateResponse) MarshalProtoJSON(s *json.MarshalState) {
+	if x == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteObjectStart()
+	var wroteField bool
+	if len(x.Messages) > 0 || s.HasField("messages") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("messages")
+		s.WriteArrayStart()
+		var wroteElement bool
+		for _, element := range x.Messages {
+			s.WriteMoreIf(&wroteElement)
+			element.MarshalProtoJSON(s.WithField("messages"))
+		}
+		s.WriteArrayEnd()
+	}
+	s.WriteObjectEnd()
+}
+
+// MarshalJSON marshals the GetStateResponse to JSON.
+func (x *GetStateResponse) MarshalJSON() ([]byte, error) {
+	return json.DefaultMarshalerConfig.Marshal(x)
+}
+
+// UnmarshalProtoJSON unmarshals the GetStateResponse message from JSON.
+func (x *GetStateResponse) UnmarshalProtoJSON(s *json.UnmarshalState) {
+	if s.ReadNil() {
+		return
+	}
+	s.ReadObject(func(key string) {
+		switch key {
+		default:
+			s.Skip() // ignore unknown field
+		case "messages":
+			s.AddField("messages")
+			if s.ReadNil() {
+				x.Messages = nil
+				return
+			}
+			s.ReadArray(func() {
+				if s.ReadNil() {
+					x.Messages = append(x.Messages, nil)
+					return
+				}
+				v := &ChatMessageInfo{}
+				v.UnmarshalProtoJSON(s.WithField("messages", false))
+				if s.Err() != nil {
+					return
+				}
+				x.Messages = append(x.Messages, v)
+			})
+		}
+	})
+}
+
+// UnmarshalJSON unmarshals the GetStateResponse from JSON.
+func (x *GetStateResponse) UnmarshalJSON(b []byte) error {
+	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
 }
 
 // MarshalProtoJSON marshals the ChatMessageInfo message to JSON.
@@ -1985,6 +2178,82 @@ func (x *UpdateReadPositionResponse) UnmarshalJSON(b []byte) error {
 	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
 }
 
+func (m *GetStateRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetStateRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *GetStateRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetStateResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetStateResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *GetStateResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	if len(m.Messages) > 0 {
+		for iNdEx := len(m.Messages) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.Messages[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *ChatMessageInfo) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -2679,6 +2948,30 @@ func (m *UpdateReadPositionResponse) MarshalToSizedBufferVT(dAtA []byte) (int, e
 	return len(dAtA) - i, nil
 }
 
+func (m *GetStateRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *GetStateResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	for _, e := range m.Messages {
+		l = e.SizeVT()
+		n += protobuf_go_lite.SizeMessage(1, l)
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *ChatMessageInfo) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -2891,6 +3184,38 @@ func (m *UpdateReadPositionResponse) SizeVT() (n int) {
 	}
 	n += len(m.unknownFields)
 	return n
+}
+
+func (x *GetStateRequest) MarshalProtoText() string {
+	var sb protobuf_go_lite.TextBuilder
+	protobuf_go_lite.TextStartMessage(&sb, "GetStateRequest")
+	return protobuf_go_lite.TextFinishMessage(&sb)
+}
+
+func (x *GetStateRequest) String() string {
+	return x.MarshalProtoText()
+}
+
+func (x *GetStateResponse) MarshalProtoText() string {
+	var sb protobuf_go_lite.TextBuilder
+	initialLen := protobuf_go_lite.TextStartMessage(&sb, "GetStateResponse")
+	if len(x.Messages) > 0 {
+		protobuf_go_lite.TextWriteListStart(&sb, initialLen, "messages")
+		for i, v := range x.Messages {
+			protobuf_go_lite.TextWriteListSeparator(&sb, i)
+			if v == nil {
+				protobuf_go_lite.TextWriteTextMarshaler(&sb, &ChatMessageInfo{})
+			} else {
+				protobuf_go_lite.TextWriteTextMarshaler(&sb, v)
+			}
+		}
+		protobuf_go_lite.TextWriteListEnd(&sb)
+	}
+	return protobuf_go_lite.TextFinishMessage(&sb)
+}
+
+func (x *GetStateResponse) String() string {
+	return x.MarshalProtoText()
 }
 
 func (x *ChatMessageInfo) MarshalProtoText() string {
@@ -3210,6 +3535,105 @@ func (x *UpdateReadPositionResponse) MarshalProtoText() string {
 
 func (x *UpdateReadPositionResponse) String() string {
 	return x.MarshalProtoText()
+}
+
+func (m *GetStateRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	var err error
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		wire, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+		if err != nil {
+			return err
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetStateRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetStateRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protobuf_go_lite.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+
+func (m *GetStateResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	var err error
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		wire, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+		if err != nil {
+			return err
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetStateResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetStateResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Messages", wireType)
+			}
+			msgStart, postIndex, err := protobuf_go_lite.DecodeLengthDelimited(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.Messages = append(m.Messages, &ChatMessageInfo{})
+			if err := m.Messages[len(m.Messages)-1].UnmarshalVT(dAtA[msgStart:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protobuf_go_lite.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
 }
 
 func (m *ChatMessageInfo) UnmarshalVT(dAtA []byte) error {

--- a/sdk/chat/rpc/rpc.pb.ts
+++ b/sdk/chat/rpc/rpc.pb.ts
@@ -2,18 +2,31 @@
 // @generated from file github.com/s4wave/spacewave/sdk/chat/rpc/rpc.proto (package spacewave.chat.rpc, syntax proto3)
 /* eslint-disable */
 
-import { ChatMessageContent } from '../content/content.pb.js'
 import type { MessageType } from '@aptre/protobuf-es-lite/message'
 import {
   createEmptyMessageType,
   createMessageType,
 } from '@aptre/protobuf-es-lite/message'
+import { ChatMessageContent } from '../content/content.pb.js'
 import { ScalarType } from '@aptre/protobuf-es-lite/scalar'
 import { Timestamp } from '@aptre/protobuf-es-lite/google/protobuf/timestamp'
 import type { PartialFieldInfo } from '@aptre/protobuf-es-lite/field'
 import { ChatReadPosition } from '../state/state.pb.js'
 
 export const protobufPackage = 'spacewave.chat.rpc'
+
+/**
+ * GetStateRequest selects current state for the mounted channel.
+ *
+ * @generated from message spacewave.chat.rpc.GetStateRequest
+ */
+export interface GetStateRequest {}
+
+export const GetStateRequest: MessageType<GetStateRequest> =
+  /* @__PURE__ */ createEmptyMessageType<GetStateRequest>(
+    'spacewave.chat.rpc.GetStateRequest',
+    true,
+  )
 
 /**
  * ChatMessageInfo contains flattened message info for the client.
@@ -34,7 +47,8 @@ export interface ChatMessageInfo {
    */
   senderPeerId?: string
   /**
-   * Text is the message text content. Empty for ciphertext messages.
+   * Text is plaintext content or a readable state-change summary.
+   * Empty for ciphertext messages and annotations.
    *
    * @generated from field: string text = 3;
    */
@@ -83,6 +97,35 @@ export const ChatMessageInfo: MessageType<ChatMessageInfo> =
       { no: 6, name: 'index', kind: 'scalar', T: ScalarType.UINT64 },
       { no: 7, name: 'content', kind: 'message', T: () => ChatMessageContent },
       { no: 8, name: 'person_peer_id', kind: 'scalar', T: ScalarType.STRING },
+    ] satisfies readonly PartialFieldInfo[],
+    packedByDefault: true,
+  })
+
+/**
+ * GetStateResponse contains current state events with their immutable history identities.
+ *
+ * @generated from message spacewave.chat.rpc.GetStateResponse
+ */
+export interface GetStateResponse {
+  /**
+   * Messages is ordered by state type and state key.
+   *
+   * @generated from field: repeated spacewave.chat.rpc.ChatMessageInfo messages = 1;
+   */
+  messages?: ChatMessageInfo[]
+}
+
+export const GetStateResponse: MessageType<GetStateResponse> =
+  /* @__PURE__ */ createMessageType({
+    typeName: 'spacewave.chat.rpc.GetStateResponse',
+    fields: [
+      {
+        no: 1,
+        name: 'messages',
+        kind: 'message',
+        T: () => ChatMessageInfo,
+        repeated: true,
+      },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,
   })
@@ -137,8 +180,8 @@ export interface GetChannelInfoResponse {
    */
   creatorPeerId?: string
   /**
-   * EncryptionAlgorithm reports the immutable creation-time policy. Empty allows plaintext;
-   * otherwise sends require ciphertext using this algorithm.
+   * EncryptionAlgorithm reports the channel encryption policy. Empty allows plaintext;
+   * otherwise message bodies require this algorithm. State and annotations remain public.
    *
    * @generated from field: string encryption_algorithm = 6;
    */

--- a/sdk/chat/rpc/rpc.proto
+++ b/sdk/chat/rpc/rpc.proto
@@ -11,6 +11,8 @@ option go_package = "github.com/s4wave/spacewave/sdk/chat/rpc;spacewave_chat_rpc
 service ChatResourceService {
   // GetChannelInfo returns channel metadata and its retained history extent.
   rpc GetChannelInfo(GetChannelInfoRequest) returns (GetChannelInfoResponse);
+  // GetState returns the latest retained event for each channel state identity.
+  rpc GetState(GetStateRequest) returns (GetStateResponse);
   // GetMessage returns one message from this channel by object key.
   rpc GetMessage(GetMessageRequest) returns (GetMessageResponse);
   // ListMessages returns a bounded page of channel history.
@@ -25,13 +27,24 @@ service ChatResourceService {
   rpc UpdateReadPosition(UpdateReadPositionRequest) returns (UpdateReadPositionResponse);
 }
 
+// GetStateRequest selects current state for the mounted channel.
+message GetStateRequest {
+}
+
+// GetStateResponse contains current state events with their immutable history identities.
+message GetStateResponse {
+  // Messages is ordered by state type and state key.
+  repeated ChatMessageInfo messages = 1;
+}
+
 // ChatMessageInfo contains flattened message info for the client.
 message ChatMessageInfo {
   // ObjectKey is the message world object key.
   string object_key = 1;
   // SenderPeerId is the sender's peer ID.
   string sender_peer_id = 2;
-  // Text is the message text content. Empty for ciphertext messages.
+  // Text is plaintext content or a readable state-change summary.
+  // Empty for ciphertext messages and annotations.
   string text = 3;
   // CreatedAt is the message creation timestamp.
   .google.protobuf.Timestamp created_at = 4;
@@ -61,8 +74,8 @@ message GetChannelInfoResponse {
   .google.protobuf.Timestamp created_at = 4;
   // CreatorPeerId is the peer identity that created the channel.
   string creator_peer_id = 5;
-  // EncryptionAlgorithm reports the immutable creation-time policy. Empty allows plaintext;
-  // otherwise sends require ciphertext using this algorithm.
+  // EncryptionAlgorithm reports the channel encryption policy. Empty allows plaintext;
+  // otherwise message bodies require this algorithm. State and annotations remain public.
   string encryption_algorithm = 6;
 }
 

--- a/sdk/chat/rpc/rpc_srpc.pb.go
+++ b/sdk/chat/rpc/rpc_srpc.pb.go
@@ -16,6 +16,8 @@ type SRPCChatResourceServiceClient interface {
 
 	// GetChannelInfo returns channel metadata and its retained history extent.
 	GetChannelInfo(ctx context.Context, in *GetChannelInfoRequest) (*GetChannelInfoResponse, error)
+	// GetState returns the latest retained event for each channel state identity.
+	GetState(ctx context.Context, in *GetStateRequest) (*GetStateResponse, error)
 	// GetMessage returns one message from this channel by object key.
 	GetMessage(ctx context.Context, in *GetMessageRequest) (*GetMessageResponse, error)
 	// ListMessages returns a bounded page of channel history.
@@ -51,6 +53,15 @@ func (c *srpcChatResourceServiceClient) SRPCClient() srpc.Client { return c.cc }
 func (c *srpcChatResourceServiceClient) GetChannelInfo(ctx context.Context, in *GetChannelInfoRequest) (*GetChannelInfoResponse, error) {
 	out := new(GetChannelInfoResponse)
 	err := c.cc.ExecCall(ctx, c.serviceID, "GetChannelInfo", in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *srpcChatResourceServiceClient) GetState(ctx context.Context, in *GetStateRequest) (*GetStateResponse, error) {
+	out := new(GetStateResponse)
+	err := c.cc.ExecCall(ctx, c.serviceID, "GetState", in, out)
 	if err != nil {
 		return nil, err
 	}
@@ -139,6 +150,8 @@ func (c *srpcChatResourceServiceClient) UpdateReadPosition(ctx context.Context, 
 type SRPCChatResourceServiceServer interface {
 	// GetChannelInfo returns channel metadata and its retained history extent.
 	GetChannelInfo(context.Context, *GetChannelInfoRequest) (*GetChannelInfoResponse, error)
+	// GetState returns the latest retained event for each channel state identity.
+	GetState(context.Context, *GetStateRequest) (*GetStateResponse, error)
 	// GetMessage returns one message from this channel by object key.
 	GetMessage(context.Context, *GetMessageRequest) (*GetMessageResponse, error)
 	// ListMessages returns a bounded page of channel history.
@@ -180,6 +193,7 @@ func (d *SRPCChatResourceServiceHandler) GetServiceID() string { return d.servic
 func (SRPCChatResourceServiceHandler) GetMethodIDs() []string {
 	return []string{
 		"GetChannelInfo",
+		"GetState",
 		"GetMessage",
 		"ListMessages",
 		"WatchMessages",
@@ -200,6 +214,8 @@ func (d *SRPCChatResourceServiceHandler) InvokeMethod(
 	switch methodID {
 	case "GetChannelInfo":
 		return true, d.InvokeMethod_GetChannelInfo(d.impl, strm)
+	case "GetState":
+		return true, d.InvokeMethod_GetState(d.impl, strm)
 	case "GetMessage":
 		return true, d.InvokeMethod_GetMessage(d.impl, strm)
 	case "ListMessages":
@@ -223,6 +239,18 @@ func (SRPCChatResourceServiceHandler) InvokeMethod_GetChannelInfo(impl SRPCChatR
 		return err
 	}
 	out, err := impl.GetChannelInfo(strm.Context(), req)
+	if err != nil {
+		return err
+	}
+	return strm.MsgSend(out)
+}
+
+func (SRPCChatResourceServiceHandler) InvokeMethod_GetState(impl SRPCChatResourceServiceServer, strm srpc.Stream) error {
+	req := new(GetStateRequest)
+	if err := strm.MsgRecv(req); err != nil {
+		return err
+	}
+	out, err := impl.GetState(strm.Context(), req)
 	if err != nil {
 		return err
 	}
@@ -303,6 +331,14 @@ type SRPCChatResourceService_GetChannelInfoStream interface {
 }
 
 type srpcChatResourceService_GetChannelInfoStream struct {
+	srpc.Stream
+}
+
+type SRPCChatResourceService_GetStateStream interface {
+	srpc.Stream
+}
+
+type srpcChatResourceService_GetStateStream struct {
 	srpc.Stream
 }
 

--- a/sdk/chat/rpc/rpc_srpc.pb.ts
+++ b/sdk/chat/rpc/rpc_srpc.pb.ts
@@ -9,6 +9,8 @@ import {
   GetMessageResponse,
   GetReadPositionsRequest,
   GetReadPositionsResponse,
+  GetStateRequest,
+  GetStateResponse,
   ListMessagesRequest,
   ListMessagesResponse,
   SendMessageRequest,
@@ -43,6 +45,17 @@ export const ChatResourceServiceDefinition = {
       name: 'GetChannelInfo',
       I: GetChannelInfoRequest,
       O: GetChannelInfoResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * GetState returns the latest retained event for each channel state identity.
+     *
+     * @generated from rpc spacewave.chat.rpc.ChatResourceService.GetState
+     */
+    GetState: {
+      name: 'GetState',
+      I: GetStateRequest,
+      O: GetStateResponse,
       kind: MethodKind.Unary,
     },
     /**
@@ -131,6 +144,16 @@ export interface ChatResourceService {
   ): Promise<GetChannelInfoResponse>
 
   /**
+   * GetState returns the latest retained event for each channel state identity.
+   *
+   * @generated from rpc spacewave.chat.rpc.ChatResourceService.GetState
+   */
+  GetState(
+    request: GetStateRequest,
+    abortSignal?: AbortSignal,
+  ): Promise<GetStateResponse>
+
+  /**
    * GetMessage returns one message from this channel by object key.
    *
    * @generated from rpc spacewave.chat.rpc.ChatResourceService.GetMessage
@@ -209,6 +232,17 @@ export interface ChatResourceServiceHandler {
   ): Promise<GetChannelInfoResponse>
 
   /**
+   * GetState returns the latest retained event for each channel state identity.
+   *
+   * @generated from rpc spacewave.chat.rpc.ChatResourceService.GetState
+   */
+  GetState(
+    request: GetStateRequest,
+    abortSignal: AbortSignal,
+    context: ServerContext,
+  ): Promise<GetStateResponse>
+
+  /**
    * GetMessage returns one message from this channel by object key.
    *
    * @generated from rpc spacewave.chat.rpc.ChatResourceService.GetMessage
@@ -285,6 +319,7 @@ export class ChatResourceServiceClient implements ChatResourceService {
     this.service = opts?.service || ChatResourceServiceServiceName
     this.rpc = rpc
     this.GetChannelInfo = this.GetChannelInfo.bind(this)
+    this.GetState = this.GetState.bind(this)
     this.GetMessage = this.GetMessage.bind(this)
     this.ListMessages = this.ListMessages.bind(this)
     this.WatchMessages = this.WatchMessages.bind(this)
@@ -309,6 +344,25 @@ export class ChatResourceServiceClient implements ChatResourceService {
       abortSignal || undefined,
     )
     return GetChannelInfoResponse.fromBinary(result)
+  }
+
+  /**
+   * GetState returns the latest retained event for each channel state identity.
+   *
+   * @generated from rpc spacewave.chat.rpc.ChatResourceService.GetState
+   */
+  async GetState(
+    request: GetStateRequest,
+    abortSignal?: AbortSignal,
+  ): Promise<GetStateResponse> {
+    const requestMsg = GetStateRequest.create(request)
+    const result = await this.rpc.request(
+      this.service,
+      ChatResourceServiceDefinition.methods.GetState.name,
+      GetStateRequest.toBinary(requestMsg),
+      abortSignal || undefined,
+    )
+    return GetStateResponse.fromBinary(result)
   }
 
   /**


### PR DESCRIPTION
Retain channel state changes as attributed messages with stable history identities. Current state is selected by graph edges, and channel creation appends its initial state atomically.

Name, topic, and encryption state update native channel metadata in the same transaction. Encryption can be enabled once; existing accepted sends retain their retry results. Earlier history remains readable without migration.

Validation: `go test ./sdk/chat/...`, `bun run typecheck`, generated Go/TypeScript codecs, and repository commit hooks.
