### PR TITLE
perf(app): load quickstart with the initial route table

### DIFF
--- a/app/routes/AppRoutes.tsx
+++ b/app/routes/AppRoutes.tsx
@@ -3,6 +3,9 @@ import { lazy, Suspense, type ComponentType, type ReactNode } from 'react'
 import { Routes, Route } from '@s4wave/web/router/router.js'
 import { NavigatePath } from '@s4wave/web/router/NavigatePath.js'
 
+import { AppQuickstart } from '../AppQuickstart.js'
+
+// createRouteGroup gives a deferred route table its own full-path matcher.
 function createRouteGroup(routes: ReactNode): ComponentType {
   return function LazyRouteGroup() {
     return <Routes fullPath>{routes}</Routes>
@@ -49,6 +52,7 @@ const LazyDebugRoutes = lazy(async () => {
   return { default: createRouteGroup(DebugRoutes) }
 })
 
+// LazyRoute suspends a deferred route group until its module is available.
 function LazyRoute(props: { component: ComponentType }) {
   const Component = props.component
   return (
@@ -128,8 +132,8 @@ export function AppRoutes() {
       <Route path="/display/*">
         <LazyRoute component={LazyDisplayRoutes} />
       </Route>
-      <Route path="/quickstart/*">
-        <LazyRoute component={LazySessionRoutes} />
+      <Route path="/quickstart/:quickstartId">
+        <AppQuickstart />
       </Route>
       <Route path="/u/:sessionIndex/*">
         <LazyRoute component={LazyAppSession} />

--- a/app/routes/SessionRoutes.test.tsx
+++ b/app/routes/SessionRoutes.test.tsx
@@ -50,12 +50,8 @@ vi.mock('@s4wave/web/router/NavigatePath.js', () => ({
   ),
 }))
 
-vi.mock('../AppQuickstart.js', () => ({
-  AppQuickstart: () => <div>Quickstart</div>,
-}))
-
 vi.mock('@s4wave/app/provider/spacewave/CheckoutResultPage.js', () => ({
-  CheckoutResultPage: () => null,
+  CheckoutResultPage: () => <div>Checkout result</div>,
 }))
 
 vi.mock('@s4wave/app/pair/PairCodePage.js', () => {
@@ -133,12 +129,12 @@ describe('SessionRoutes join redirect', () => {
     sessionStorage.clear()
   })
 
-  it('loads pairing only after leaving quickstart for a pairing route', async () => {
-    mockActiveRoutePath.value = '/quickstart/:quickstartId'
+  it('loads pairing only after leaving checkout for a pairing route', async () => {
+    mockActiveRoutePath.value = '/checkout/success'
 
     render(<Suspense fallback={null}>{SessionRoutes}</Suspense>)
 
-    expect(screen.getByText('Quickstart')).toBeTruthy()
+    expect(screen.getByText('Checkout result')).toBeTruthy()
     expect(mockPairModuleLoaded).not.toHaveBeenCalled()
     cleanup()
 

--- a/app/routes/SessionRoutes.tsx
+++ b/app/routes/SessionRoutes.tsx
@@ -6,7 +6,6 @@ import { useSessionList } from '@s4wave/app/hooks/useSessionList.js'
 import { NavigatePath } from '@s4wave/web/router/NavigatePath.js'
 import { LoadingCard } from '@s4wave/web/ui/loading/LoadingCard.js'
 
-import { AppQuickstart } from '../AppQuickstart.js'
 import { formatPendingJoin, storePendingJoin } from './pendingJoin.js'
 
 export { consumePendingJoin, storePendingJoin } from './pendingJoin.js'
@@ -52,10 +51,8 @@ function JoinRedirect() {
   return <NavigatePath to={target} replace />
 }
 
-// SessionRoutes contains routes for session entry: checkout, join, pair, and
-// quickstart. The mounted session surface at /u/:sessionIndex/* is owned by
-// AppRoutes (LazyAppSession) so the quickstart entry chunk stays free of the
-// AppSession bundle until a session is actually opened.
+// SessionRoutes contains checkout, join, and pairing entry routes.
+// AppRoutes owns Quickstart and the mounted session surface.
 export const SessionRoutes = (
   <>
     <Route path="/checkout/success">
@@ -75,9 +72,6 @@ export const SessionRoutes = (
     </Route>
     <Route path="/pair">
       <LazyPairCodePage />
-    </Route>
-    <Route path="/quickstart/:quickstartId">
-      <AppQuickstart />
     </Route>
   </>
 )


### PR DESCRIPTION
Put the Quickstart route in the initial app route table so creating a workspace no longer waits for the checkout, join, and pairing route bundle. Those other entry routes remain lazy, as does the mounted session UI.

The existing app/session route checks pass (7 tests), including pairing's deferred import. The fresh Chromium landing-to-Drive case passes with functioning storage at 8.994 seconds. Resource timing confirms the session-entry bundle is absent from this path; page module requests fall from 52 to 50. These samples do not establish an end-to-end latency improvement.
