### PR TITLE
fix(bldr): bind startup cache to build policy

### DIFF
--- a/bldr/manifest/builder/controller/startup-cache.go
+++ b/bldr/manifest/builder/controller/startup-cache.go
@@ -16,6 +16,7 @@ import (
 	configset_proto "github.com/aperturerobotics/controllerbus/controller/configset/proto"
 	"github.com/pkg/errors"
 	bldr_manifest "github.com/s4wave/spacewave/bldr/manifest"
+	bldr_manifest_build "github.com/s4wave/spacewave/bldr/manifest/build"
 	bldr_manifest_builder "github.com/s4wave/spacewave/bldr/manifest/builder"
 	bldr_manifest_world "github.com/s4wave/spacewave/bldr/manifest/world"
 	"github.com/s4wave/spacewave/db/block"
@@ -30,9 +31,9 @@ import (
 )
 
 // startupCacheFormatEnvKey is bumped when compiler-owned output policy changes
-// without changing a plugin source file. V11 invalidates Vite results that
-// omitted dynamically imported chunks from their source dependencies.
-const startupCacheFormatEnvKey = "BLDR_STARTUP_CACHE_FORMAT_V11"
+// without changing a plugin source file. V12 binds the effective build policy
+// to the controller configuration fingerprint.
+const startupCacheFormatEnvKey = "BLDR_STARTUP_CACHE_FORMAT_V12"
 
 // startupValidationResult contains the startup cache validation result.
 type startupValidationResult struct {
@@ -83,7 +84,7 @@ func (c *Controller) validateStartupBuilderResult(
 	if err := validateStartupFiles(c.c.GetBuilderConfig().GetSourcePath(), inputManifest); err != nil {
 		return &startupValidationResult{reason: err.Error()}, nil
 	}
-	if err := validateStartupInputs(c.c.GetControllerConfig(), inputManifest); err != nil {
+	if err := validateStartupInputs(c.c.GetControllerConfig(), c.c.GetBuilderConfig().GetBuildPolicy(), inputManifest); err != nil {
 		return &startupValidationResult{reason: err.Error()}, nil
 	}
 
@@ -306,7 +307,7 @@ func enrichBuilderResultForStartupReuse(
 	}
 
 	// Bind startup reuse to the effective controller configuration and format.
-	controllerConfigDigest, err := marshalControllerConfigDigest(controllerConfig)
+	controllerConfigDigest, err := marshalStartupConfigDigest(controllerConfig, builderConfig.GetBuildPolicy())
 	if err != nil {
 		return err
 	}
@@ -387,21 +388,23 @@ func validateStartupFiles(sourcePath string, inputManifest *bldr_manifest_builde
 // validateStartupInputs validates typed non-file startup inputs.
 func validateStartupInputs(
 	controllerConfig *configset_proto.ControllerConfig,
+	buildPolicy *bldr_manifest_build.BuildPolicy,
 	inputManifest *bldr_manifest_builder.InputManifest,
 ) error {
-	return validateStartupInputsWithControllerConfig(controllerConfig, inputManifest, true)
+	return validateStartupInputsWithControllerConfig(controllerConfig, buildPolicy, inputManifest, true)
 }
 
 // validateNestedStartupInputs validates child inputs whose effective config is
 // derived from and covered by the validated parent controller config.
 func validateNestedStartupInputs(inputManifest *bldr_manifest_builder.InputManifest) error {
-	return validateStartupInputsWithControllerConfig(nil, inputManifest, false)
+	return validateStartupInputsWithControllerConfig(nil, nil, inputManifest, false)
 }
 
 // validateStartupInputsWithControllerConfig validates the startup input
 // manifest against the controller config digest and cache format.
 func validateStartupInputsWithControllerConfig(
 	controllerConfig *configset_proto.ControllerConfig,
+	buildPolicy *bldr_manifest_build.BuildPolicy,
 	inputManifest *bldr_manifest_builder.InputManifest,
 	validateControllerConfig bool,
 ) error {
@@ -424,14 +427,14 @@ func validateStartupInputsWithControllerConfig(
 				continue
 			}
 			if len(controllerConfigDigest) == 0 {
-				digest, err := marshalControllerConfigDigest(controllerConfig)
+				digest, err := marshalStartupConfigDigest(controllerConfig, buildPolicy)
 				if err != nil {
 					return err
 				}
 				controllerConfigDigest = digest
 			}
 			if !bytes.Equal(controllerConfigDigest, input.GetBytesValue()) {
-				return errors.New("builder controller config changed")
+				return errors.New("builder controller config or build policy changed")
 			}
 		default:
 			return errors.Errorf("unsupported startup input kind: %s", input.GetKind().String())
@@ -506,19 +509,31 @@ func resolveStartupInputPath(sourcePath, inputPath string) string {
 	return filePath
 }
 
-// marshalControllerConfigDigest marshals the controller config to a digest.
-func marshalControllerConfigDigest(controllerConfig *configset_proto.ControllerConfig) ([]byte, error) {
-	// Marshal the effective configuration using its generated codec.
-	if controllerConfig == nil {
-		return nil, nil
+// marshalStartupConfigDigest fingerprints compiler configuration and build policy.
+func marshalStartupConfigDigest(
+	controllerConfig *configset_proto.ControllerConfig,
+	buildPolicy *bldr_manifest_build.BuildPolicy,
+) ([]byte, error) {
+	var controllerConfigBin []byte
+	if controllerConfig != nil {
+		var err error
+		controllerConfigBin, err = controllerConfig.MarshalVT()
+		if err != nil {
+			return nil, err
+		}
 	}
-	controllerConfigBin, err := controllerConfig.MarshalVT()
-	if err != nil {
-		return nil, err
+	var buildPolicyBin []byte
+	if buildPolicy != nil {
+		var err error
+		buildPolicyBin, err = buildPolicy.MarshalVT()
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	// Hash serialized configuration for compact startup comparison.
-	digest := sha256.Sum256(controllerConfigBin)
+	// A fixed-width policy digest separates the two serialized inputs.
+	policyDigest := sha256.Sum256(buildPolicyBin)
+	digest := sha256.Sum256(append(controllerConfigBin, policyDigest[:]...))
 	return digest[:], nil
 }
 

--- a/bldr/manifest/builder/controller/startup-cache_test.go
+++ b/bldr/manifest/builder/controller/startup-cache_test.go
@@ -17,8 +17,10 @@ import (
 	"github.com/aperturerobotics/controllerbus/controller/configset"
 	configset_proto "github.com/aperturerobotics/controllerbus/controller/configset/proto"
 	"github.com/aperturerobotics/controllerbus/directive"
+	"github.com/aperturerobotics/util/enabled"
 	"github.com/go-git/go-billy/v6/memfs"
 	bldr_manifest "github.com/s4wave/spacewave/bldr/manifest"
+	bldr_manifest_build "github.com/s4wave/spacewave/bldr/manifest/build"
 	bldr_manifest_builder "github.com/s4wave/spacewave/bldr/manifest/builder"
 	bldr_project "github.com/s4wave/spacewave/bldr/project"
 	"github.com/s4wave/spacewave/bldr/testbed"
@@ -363,7 +365,7 @@ func TestValidateStartupFilesEscapedBldrDistPath(t *testing.T) {
 func TestValidateStartupInputs(t *testing.T) {
 	t.Setenv("BLDR_TEST_ENV", "expected")
 	controllerConfig := &configset_proto.ControllerConfig{}
-	controllerConfigDigest, err := marshalControllerConfigDigest(controllerConfig)
+	controllerConfigDigest, err := marshalStartupConfigDigest(controllerConfig, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -377,19 +379,32 @@ func TestValidateStartupInputs(t *testing.T) {
 		bldr_manifest_builder.NewEnvStartupInput("BLDR_TEST_ENV", "expected"),
 	)
 
-	if err := validateStartupInputs(controllerConfig, inputManifest); err != nil {
+	if err := validateStartupInputs(controllerConfig, nil, inputManifest); err != nil {
 		t.Fatalf("validate startup inputs: %v", err)
 	}
 
+	policy := &bldr_manifest_build.BuildPolicy{JsMinification: enabled.Enabled_ENABLE}
+	if err := validateStartupInputs(controllerConfig, policy, inputManifest); err == nil {
+		t.Fatal("expected rebuild after build policy changed")
+	}
+	policyDigest, err := marshalStartupConfigDigest(controllerConfig, policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inputManifest.StartupInputs[0] = bldr_manifest_builder.NewControllerConfigDigestStartupInput(policyDigest)
+	if err := validateStartupInputs(controllerConfig, policy, inputManifest); err != nil {
+		t.Fatalf("unchanged build policy: %v", err)
+	}
+
 	t.Setenv("BLDR_TEST_ENV", "changed")
-	if err := validateStartupInputs(controllerConfig, inputManifest); err == nil {
+	if err := validateStartupInputs(controllerConfig, policy, inputManifest); err == nil {
 		t.Fatal("expected env validation error")
 	}
 }
 
 func TestValidateStartupInputsRequiresCacheFormat(t *testing.T) {
 	controllerConfig := &configset_proto.ControllerConfig{}
-	controllerConfigDigest, err := marshalControllerConfigDigest(controllerConfig)
+	controllerConfigDigest, err := marshalStartupConfigDigest(controllerConfig, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -398,14 +413,14 @@ func TestValidateStartupInputsRequiresCacheFormat(t *testing.T) {
 	inputManifest.AddStartupInput(
 		bldr_manifest_builder.NewControllerConfigDigestStartupInput(controllerConfigDigest),
 	)
-	if err := validateStartupInputs(controllerConfig, inputManifest); err == nil {
+	if err := validateStartupInputs(controllerConfig, nil, inputManifest); err == nil {
 		t.Fatal("expected missing startup cache format marker error")
 	}
 }
 
 func TestValidateStartupInputsRejectsOldCacheFormat(t *testing.T) {
 	controllerConfig := &configset_proto.ControllerConfig{}
-	controllerConfigDigest, err := marshalControllerConfigDigest(controllerConfig)
+	controllerConfigDigest, err := marshalStartupConfigDigest(controllerConfig, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -418,7 +433,7 @@ func TestValidateStartupInputsRejectsOldCacheFormat(t *testing.T) {
 		bldr_manifest_builder.NewEnvStartupInput("BLDR_STARTUP_CACHE_FORMAT_V10", ""),
 	)
 
-	err = validateStartupInputs(controllerConfig, inputManifest)
+	err = validateStartupInputs(controllerConfig, nil, inputManifest)
 	if err == nil || !strings.Contains(err.Error(), "missing startup cache format marker") {
 		t.Fatalf("validate startup inputs error = %v, want missing current cache format", err)
 	}
@@ -463,7 +478,7 @@ func TestValidateStartupHookDeclaredProvenanceInvalidation(t *testing.T) {
 	if err := validateStartupFiles(tmpDir, inputManifest); err != nil {
 		t.Fatalf("unchanged declared file validation: %v", err)
 	}
-	if err := validateStartupInputs(controllerConfig, inputManifest); err != nil {
+	if err := validateStartupInputs(controllerConfig, nil, inputManifest); err != nil {
 		t.Fatalf("unchanged declared env validation: %v", err)
 	}
 
@@ -478,7 +493,7 @@ func TestValidateStartupHookDeclaredProvenanceInvalidation(t *testing.T) {
 	// A changed declared environment variable forces a rebuild.
 	fresh := buildInputManifest()
 	t.Setenv("BLDR_TEST_HOOK_ENV", "changed-value")
-	if err := validateStartupInputs(controllerConfig, fresh); err == nil {
+	if err := validateStartupInputs(controllerConfig, nil, fresh); err == nil {
 		t.Fatal("expected rebuild after declared env var changed")
 	}
 	// An unset declared environment variable still participates in identity.
@@ -487,7 +502,7 @@ func TestValidateStartupHookDeclaredProvenanceInvalidation(t *testing.T) {
 	}
 	unset := buildInputManifest()
 	t.Setenv("BLDR_TEST_HOOK_ENV", "set-after-unset")
-	if err := validateStartupInputs(controllerConfig, unset); err == nil {
+	if err := validateStartupInputs(controllerConfig, nil, unset); err == nil {
 		t.Fatal("expected rebuild after declared env var changed from unset")
 	}
 }


### PR DESCRIPTION
Changing JavaScript minification, sourcemaps, or GoScript splitting could reuse startup manifests built with the previous policy. Include BuildPolicy in the existing configuration fingerprint and invalidate older fingerprints so changed policy recompiles the affected output.

Validation: focused startup-input, provenance, and target-identity checks pass. A release build rejects the stale manifests and produces new minified app content; the fresh Chromium Drive scenario passes at 9.019 seconds from navigation.
