### PR TITLE
fix(storage): preserve concurrent read scopes

### DIFF
--- a/db/volume/controller/bucket-handle.go
+++ b/db/volume/controller/bucket-handle.go
@@ -15,22 +15,31 @@ import (
 
 // bucketHandleTracker implements Bucket with a volume handle.
 type bucketHandleTracker struct {
-	c         *Controller
-	bucketID  string
+	// c resolves the volume and bucket configuration.
+	c *Controller
+	// bucketID identifies the tracked bucket.
+	bucketID string
+	// handleCtr publishes the current bucket handle or resolution error.
 	handleCtr *ccontainer.CContainer[*bucketHandle]
 }
 
 // bucketHandle contains state resolved by the bucket handle tracker.
 type bucketHandle struct {
-	t          *bucketHandleTracker
-	err        error
-	v          volume.Volume
+	// t tracks this bucket's configuration and lifetime.
+	t *bucketHandleTracker
+	// err records a failure resolving the bucket.
+	err error
+	// v provides the backing volume.
+	v volume.Volume
+	// bucketConf retains the resolved bucket configuration.
 	bucketConf *bucket.Config
-	gcOps      *block_gc.GCStoreOps
-	readOps    block.StoreOps
+	// gcOps tracks references for block mutations when GC is enabled.
+	gcOps *block_gc.GCStoreOps
+	// readOps confines block operations to an existing read snapshot when set.
+	readOps block.StoreOps
 }
 
-// clone copies the bucketHandle
+// clone copies the bucket handle without changing its retained dependencies.
 func (b *bucketHandle) clone() *bucketHandle {
 	if b == nil {
 		return b
@@ -53,6 +62,7 @@ func (c *Controller) newBucketHandleTracker(
 
 // execute executes the bucket handle management routine.
 func (b *bucketHandleTracker) execute(ctx context.Context) (exErr error) {
+	// Clear stale resolution and publish any new failure when this attempt ends.
 	b.handleCtr.SetValue(nil)
 	defer func() {
 		if exErr != nil {
@@ -64,16 +74,19 @@ func (b *bucketHandleTracker) execute(ctx context.Context) (exErr error) {
 		}
 	}()
 
+	// Resolve the backing volume and its current bucket configuration.
 	vol, err := b.c.GetVolume(ctx)
 	if err != nil {
 		return err
 	}
 
+	// Load the bucket configuration before constructing its handle.
 	bc, err := vol.GetBucketConfig(ctx, b.bucketID)
 	if err != nil {
 		return err
 	}
 
+	// Retain the resolved configuration independently of later updates.
 	handle := &bucketHandle{
 		t:          b,
 		v:          vol,
@@ -103,6 +116,7 @@ func (b *bucketHandleTracker) execute(ctx context.Context) (exErr error) {
 		}
 	}
 
+	// Publish the complete handle after its optional GC wrapper is ready.
 	b.handleCtr.SetValue(handle)
 
 	return nil
@@ -110,16 +124,17 @@ func (b *bucketHandleTracker) execute(ctx context.Context) (exErr error) {
 
 // updateBucketConfig overrides the bucket config in the current handle.
 //
-// if conf is nil, unsets the handle ctr and restarts the routine.
-// if there is a current handle set: returns the updated bucket handle.
-// if there is no handle set: restarts the routine and returns nil.
+// A nil configuration clears the handle and restarts resolution.
+// An existing handle receives the configuration; otherwise resolution restarts.
 func (b *bucketHandleTracker) updateBucketConfig(conf *bucket.Config) *bucketHandle {
+	// Restart resolution when the caller invalidates the configuration.
 	if conf == nil {
 		b.handleCtr.SetValue(nil)
 		b.restart()
 		return nil
 	}
 
+	// Update a resolved handle without mutating its previous snapshot.
 	conf = conf.CloneVT()
 	handle := b.handleCtr.SwapValue(func(val *bucketHandle) *bucketHandle {
 		if val == nil || val.bucketConf.EqualVT(conf) {
@@ -167,7 +182,7 @@ func (b *bucketHandle) GetExists() bool {
 
 // GetBucketConfig returns the bucket configuration.
 //
-// note: may be nil if this is the pin controller.
+// The configuration may be nil for the pin controller.
 func (b *bucketHandle) GetBucketConfig() *bucket.Config {
 	if !b.GetExists() {
 		return nil
@@ -178,6 +193,7 @@ func (b *bucketHandle) GetBucketConfig() *bucket.Config {
 // PutBlock puts a block into the store.
 // The ref should not be modified after return.
 func (b *bucketHandle) PutBlock(ctx context.Context, data []byte, opts *block.PutOpts) (*block.BlockRef, bool, error) {
+	// Trace the complete bucket write.
 	ctx, task := trace.NewTask(ctx, "hydra/volume/bucket-handle/put-block")
 	defer task.End()
 
@@ -187,8 +203,11 @@ func (b *bucketHandle) PutBlock(ctx context.Context, data []byte, opts *block.Pu
 	if b.bucketConf == nil {
 		return nil, false, bucket.ErrBucketNotFound
 	}
+	if b.readOps != nil {
+		return b.readOps.PutBlock(ctx, data, opts)
+	}
 
-	// set hash type if not set
+	// Fill the bucket's preferred hash type when the caller leaves it unset.
 	if opts.GetHashType() == 0 {
 		ht := opts.GetForceBlockRef().GetHash().GetHashType()
 		if ht == 0 {
@@ -205,7 +224,7 @@ func (b *bucketHandle) PutBlock(ctx context.Context, data []byte, opts *block.Pu
 	}
 	putOpts, syncRequested := block.PutOptsWithoutSync(opts)
 
-	// store will hash the data, route through GCStoreOps if available.
+	// Route the write through GC tracking when enabled.
 	// Bucket writes do not have a later commit hook, so bucket-level GC
 	// refs must be flushed before returning.
 	var (
@@ -248,6 +267,7 @@ func (b *bucketHandle) PutBlock(ctx context.Context, data []byte, opts *block.Pu
 // tracking is enabled, otherwise falls back to per-entry volume PutBlock.
 // FlushPending is called once for the entire batch.
 func (b *bucketHandle) PutBlockBatch(ctx context.Context, entries []*block.PutBatchEntry) error {
+	// Trace the complete bucket batch write.
 	ctx, task := trace.NewTask(ctx, "hydra/volume/bucket-handle/put-block-batch")
 	defer task.End()
 
@@ -259,6 +279,9 @@ func (b *bucketHandle) PutBlockBatch(ctx context.Context, entries []*block.PutBa
 	}
 	if len(entries) == 0 {
 		return nil
+	}
+	if b.readOps != nil {
+		return b.readOps.PutBlockBatch(ctx, entries)
 	}
 
 	if b.gcOps != nil {
@@ -310,37 +333,32 @@ func (b *bucketHandle) GetSupportedFeatures() block.StoreFeature {
 
 // BeginReadOperation opens a read scope for the bucket's volume reads.
 func (b *bucketHandle) BeginReadOperation(ctx context.Context) (block.StoreOps, func(), error) {
+	// Select the complete wrapper chain before opening its one read scope.
 	if b == nil || b.v == nil {
 		return b, func() {}, nil
 	}
-	scopedV, releaseV, err := b.v.BeginReadOperation(ctx)
+	store := block.StoreOps(b.v)
+	if b.gcOps != nil {
+		store = b.gcOps
+	}
+	if b.readOps != nil {
+		store = b.readOps
+	}
+	scopedOps, release, err := store.BeginReadOperation(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// Keep the bucket's metadata while all block operations use the scoped store.
 	scoped := b.clone()
-	scoped.readOps = scopedV
-	if v, ok := scopedV.(volume.Volume); ok {
+	scoped.readOps = scopedOps
+	if v, ok := scopedOps.(volume.Volume); ok {
 		scoped.v = v
 	}
-	var releaseGC func()
-	if b.gcOps != nil {
-		scopedGC, release, err := b.gcOps.BeginReadOperation(ctx)
-		if err != nil {
-			releaseV()
-			return nil, nil, err
-		}
-		if gcOps, ok := scopedGC.(*block_gc.GCStoreOps); ok {
-			scoped.gcOps = gcOps
-			scoped.readOps = gcOps
-		}
-		releaseGC = release
+	if gcOps, ok := scopedOps.(*block_gc.GCStoreOps); ok {
+		scoped.gcOps = gcOps
 	}
-	return scoped, func() {
-		if releaseGC != nil {
-			releaseGC()
-		}
-		releaseV()
-	}, nil
+	return scoped, release, nil
 }
 
 // GetBlock gets a block with a cid reference.
@@ -406,11 +424,14 @@ func (b *bucketHandle) RmBlock(ctx context.Context, ref *block.BlockRef) error {
 	if b.bucketConf == nil {
 		return nil
 	}
+	if b.readOps != nil {
+		return b.readOps.RmBlock(ctx, ref)
+	}
 
 	if !b.t.c.config.GetDisableEventBlockRm() {
 		ok, err := b.v.GetBlockExists(ctx, ref)
 		if err == nil && !ok {
-			// skip, does not exist.
+			// An absent block needs no removal event.
 			return nil
 		}
 	}
@@ -431,6 +452,9 @@ func (b *bucketHandle) RmBlock(ctx context.Context, ref *block.BlockRef) error {
 
 // Sync makes bucket-level GC writes durable, then fences the volume.
 func (b *bucketHandle) Sync(ctx context.Context) (bool, error) {
+	if b.readOps != nil {
+		return b.readOps.Sync(ctx)
+	}
 	if b.gcOps != nil {
 		if err := b.gcOps.FlushPending(ctx); err != nil {
 			return false, err
@@ -456,7 +480,7 @@ func (b *bucketHandle) EndDeferFlush(ctx context.Context) error {
 	return nil
 }
 
-// _ is a type assertion
+// _ asserts the bucket and deferred-flush contracts.
 var (
 	_ bucket.Bucket       = (*bucketHandle)(nil)
 	_ bucket.BucketHandle = (*bucketHandle)(nil)

--- a/db/volume/controller/bucket-read-operation_test.go
+++ b/db/volume/controller/bucket-read-operation_test.go
@@ -1,0 +1,77 @@
+//go:build !js && !wasip1
+
+package volume_controller
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/s4wave/spacewave/db/block"
+	block_gc "github.com/s4wave/spacewave/db/block/gc"
+	"github.com/s4wave/spacewave/db/bucket"
+	store_kvkey "github.com/s4wave/spacewave/db/store/kvkey"
+	store_kvtx_bolt "github.com/s4wave/spacewave/db/store/kvtx/bolt"
+	common_kvtx "github.com/s4wave/spacewave/db/volume/common/kvtx"
+)
+
+// TestBucketReadOperationUsesOneSnapshot requires the GC wrapper and volume to share a reader.
+func TestBucketReadOperationUsesOneSnapshot(t *testing.T) {
+	t.Run("plain", func(t *testing.T) { testBucketReadOperationUsesOneSnapshot(t, false) })
+	t.Run("gc", func(t *testing.T) { testBucketReadOperationUsesOneSnapshot(t, true) })
+}
+
+// testBucketReadOperationUsesOneSnapshot checks either native bucket wrapper chain.
+func testBucketReadOperationUsesOneSnapshot(t *testing.T, withGC bool) {
+	// Assemble the native Bolt-backed volume with the ordinary GC wrapper.
+	t.Helper()
+	store, err := store_kvtx_bolt.Open(filepath.Join(t.TempDir(), "bucket.db"), 0o600, nil, []byte("volume"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.GetDB().Close() })
+	vol, err := common_kvtx.NewVolume(t.Context(), "test-volume", store_kvkey.NewDefaultKVKey(), store, nil, false, false, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = vol.Close() })
+	handle := &bucketHandle{v: vol, bucketConf: &bucket.Config{Id: "test"}}
+	if withGC {
+		handle.gcOps = block_gc.NewGCStoreOps(vol, stubCollectorGraph{})
+	}
+	ref, _, err := vol.PutBlock(t.Context(), []byte("snapshot contents"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// One bucket scope opens one database transaction, including nested read scopes.
+	scoped, release, err := handle.BeginReadOperation(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(release)
+	if count := store.GetDB().Stats().OpenTxN; count != 1 {
+		t.Fatalf("bucket scope opened %d database snapshots, want one", count)
+	}
+	nested, releaseNested, err := scoped.BeginReadOperation(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(releaseNested)
+	if count := store.GetDB().Stats().OpenTxN; count != 1 {
+		t.Fatalf("nested bucket scope opened %d database snapshots, want one", count)
+	}
+
+	// Read through the nested wrapper before releasing the single underlying snapshot.
+	data, found, err := nested.GetBlock(t.Context(), ref)
+	if err != nil || !found || string(data) != "snapshot contents" {
+		t.Fatalf("nested read returned %q, found=%v, err=%v", data, found, err)
+	}
+	if _, _, err := nested.PutBlock(t.Context(), []byte("forbidden write"), &block.PutOpts{}); err == nil {
+		t.Fatal("read scope accepted a write")
+	}
+	releaseNested()
+	release()
+	if count := store.GetDB().Stats().OpenTxN; count != 0 {
+		t.Fatalf("released bucket scope retained %d database snapshots", count)
+	}
+}

--- a/db/world/block/engine/state.go
+++ b/db/world/block/engine/state.go
@@ -9,30 +9,32 @@ import (
 	"github.com/s4wave/spacewave/db/object"
 )
 
-// defaultHeadStateKey is the default key used for head state
+// defaultHeadStateKey is the default key used for head state.
 const defaultHeadStateKey = "world-head"
 
 // loadHeadState loads the head ref from the store.
 func (c *Controller) loadHeadState(ctx context.Context, store object.ObjectStore) (*HeadState, bool, error) {
-	if err := refreshHeadStoreForCoordination(store); err != nil {
-		return nil, false, err
-	}
+	// The store's read transaction observes committed metadata without a writer refresh.
+	// A coordination refresh can remap storage and wait for this caller's other readers.
 	ktx, err := store.NewTransaction(ctx, false)
 	if err != nil {
 		return nil, false, err
 	}
 	defer ktx.Discard()
 
+	// Resolve the persisted head key within this object store.
 	headKey := []byte(c.conf.GetObjectStoreHeadKey())
 	if len(headKey) == 0 {
 		headKey = []byte(defaultHeadStateKey)
 	}
 
+	// Read the current committed record through the read snapshot.
 	data, found, err := ktx.Get(ctx, headKey)
 	if err != nil || !found {
 		return nil, false, err
 	}
 
+	// Decode the configured storage transform before parsing the head.
 	if !c.conf.GetStateTransformConf().GetEmpty() {
 		var err error
 		data, err = c.stateXfrm.DecodeBlock(data)
@@ -41,6 +43,7 @@ func (c *Controller) loadHeadState(ctx context.Context, store object.ObjectStore
 		}
 	}
 
+	// Return the durable head without changing coordination or storage state.
 	s := &HeadState{}
 	if err := s.UnmarshalVT(data); err != nil {
 		return nil, true, err
@@ -51,6 +54,7 @@ func (c *Controller) loadHeadState(ctx context.Context, store object.ObjectStore
 // writeHeadState writes the head state to the store when the durable head still
 // matches the transaction base.
 func (c *Controller) writeHeadState(ctx context.Context, store object.ObjectStore, baseRef, nref *bucket.ObjectRef) error {
+	// Refresh the coordinated writer before beginning its compare-and-swap transaction.
 	if err := refreshHeadStoreForCoordination(store); err != nil {
 		return err
 	}
@@ -60,11 +64,13 @@ func (c *Controller) writeHeadState(ctx context.Context, store object.ObjectStor
 	}
 	defer ktx.Discard()
 
+	// Resolve the persisted head key within this object store.
 	headKey := []byte(c.conf.GetObjectStoreHeadKey())
 	if len(headKey) == 0 {
 		headKey = []byte(defaultHeadStateKey)
 	}
 
+	// Reject publication when another writer replaced the transaction's base.
 	data, found, err := ktx.Get(ctx, headKey)
 	if err != nil {
 		return err
@@ -87,6 +93,7 @@ func (c *Controller) writeHeadState(ctx context.Context, store object.ObjectStor
 		return coord.ErrStaleGeneration
 	}
 
+	// Encode the replacement head under the configured storage transform.
 	v := &HeadState{HeadRef: nref}
 	data, err = v.MarshalVT()
 	if err != nil {
@@ -100,13 +107,14 @@ func (c *Controller) writeHeadState(ctx context.Context, store object.ObjectStor
 		}
 	}
 
+	// Publish the validated replacement in the same transaction.
 	if err := ktx.Set(ctx, headKey, data); err != nil {
 		return err
 	}
-
 	return ktx.Commit(ctx)
 }
 
+// headRefsEqual compares optional persisted World references.
 func headRefsEqual(a, b *bucket.ObjectRef) bool {
 	if a == nil || b == nil {
 		return a == nil && b == nil
@@ -114,6 +122,7 @@ func headRefsEqual(a, b *bucket.ObjectRef) bool {
 	return a.EqualsRef(b)
 }
 
+// objectStoreHeadKeyPrefix identifies the head's key in the backing store.
 func (c *Controller) objectStoreHeadKeyPrefix() []byte {
 	headKey := []byte(c.conf.GetObjectStoreHeadKey())
 	if len(headKey) == 0 {
@@ -126,6 +135,7 @@ func (c *Controller) objectStoreHeadKeyPrefix() []byte {
 	return out
 }
 
+// refreshHeadStoreForCoordination prepares supported stores for coordinated writes.
 func refreshHeadStoreForCoordination(store object.ObjectStore) error {
 	refreshable, ok := store.(kvtx.CoordinationRefreshStore)
 	if !ok {

--- a/db/world/block/engine/state_test.go
+++ b/db/world/block/engine/state_test.go
@@ -1,0 +1,56 @@
+//go:build !js && !wasip1
+
+package world_block_engine
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/s4wave/spacewave/db/bucket"
+	store_kvtx_bolt "github.com/s4wave/spacewave/db/store/kvtx/bolt"
+)
+
+// TestLoadHeadStateWithActiveReader requires head reads to coexist with retained snapshots.
+func TestLoadHeadStateWithActiveReader(t *testing.T) {
+	// Seed the persisted head through the same Bolt store used by native controllers.
+	store, err := store_kvtx_bolt.Open(filepath.Join(t.TempDir(), "head.db"), 0o600, nil, []byte("head"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.GetDB().Close() })
+	controller := &Controller{conf: &Config{}}
+	want := &bucket.ObjectRef{BucketId: "retained"}
+	if err := controller.writeHeadState(t.Context(), store, nil, want); err != nil {
+		t.Fatal(err)
+	}
+
+	// Hold an existing read snapshot while another caller loads the current head.
+	reader, err := store.NewTransaction(t.Context(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		state, found, err := controller.loadHeadState(t.Context(), store)
+		if err == nil && (!found || !state.GetHeadRef().EqualsRef(want)) {
+			t.Error("head read did not return the persisted reference")
+		}
+		done <- err
+	}()
+
+	// Release and join on failure as well, so the regression never strands a reader.
+	select {
+	case err := <-done:
+		reader.Discard()
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		reader.Discard()
+		if err := <-done; err != nil {
+			t.Error(err)
+		}
+		t.Fatal("head read waited for an unrelated read snapshot to close")
+	}
+}


### PR DESCRIPTION
Concurrent World reads could stall behind a forced database remap. Read persisted heads through ordinary read transactions, and open bucket read scopes through the complete GC wrapper chain so each operation retains one database snapshot. Nested reads reuse that scope, and attempted writes remain confined to its read-only store.

The Bolt-backed regressions fail before the change and pass afterward. `go test -race ./db/volume/controller ./db/world/block/engine` passes. A separate-process client integration that previously timed out now completes its concurrent creation, state update, and sync checks. Stored data and coordinated write checks are unchanged.
