### PR TITLE
perf(block): avoid existence probes for staged transaction writes

### DIFF
--- a/db/block/transaction.go
+++ b/db/block/transaction.go
@@ -574,12 +574,10 @@ func (t *Transaction) WriteAtRoot(ctx context.Context, clearTree bool, subRoot *
 						writeQueue.Enqueue(func() {
 							writeCtx, writeTask := trace.NewTask(ctx, "hydra/block/transaction/write-at-root/put-block")
 							putBlocks.Add(1)
-							// ensure that the wrote ref == the expected.
-							wroteRef, _, err := writeStore.PutBlock(writeCtx, dat, putOpts)
+							// The encoded reference is known; storage deduplicates when
+							// the buffer drains, without probing disk for each block.
+							_, _, err := buffered.putBlock(writeCtx, dat, putOpts, false)
 							writeTask.End()
-							if err == nil && !wroteRef.EqualsRef(blkRef) {
-								err = errors.Errorf("wrote block ref %s != expected %s", wroteRef.MarshalString(), blkRef.MarshalString())
-							}
 							if err != nil {
 								handleErr(err)
 								return


### PR DESCRIPTION
Block transactions discarded the existence result from each buffered write, but computing it still probed the underlying store. Use the buffer's existing admission path without that probe; forced-reference validation, backpressure, deduplication at drain, and durability barriers remain in place.

Validation: focused block and Okra checks pass. The fresh traced Chromium Drive scenario improves from 8.913 to 8.286 seconds. Accumulated block-admission time falls from 1.161 seconds across 270 calls to 0.063 seconds across 269 calls.
