### PR TITLE
perf(world): reuse the published root when building handles

### DIFF
--- a/db/world/block/engine.go
+++ b/db/world/block/engine.go
@@ -1095,6 +1095,17 @@ func (e *Engine) buildWorldStateForRoot(
 	_, subtask = trace.NewTask(ctx, "hydra/world-block/engine/build-world-state/build-transaction")
 	btx, bcs := root.BuildTransactionWithStore(nil, store)
 	subtask.End()
+
+	// The published read head already holds this immutable root. Clone its
+	// decoded value so each new handle owns its mutable sub-block fields.
+	if e.head.readTx != nil && e.head.root.GetRef().EqualsRef(root.GetRef()) &&
+		e.head.readTx.state.GetRootRef().EqualsRef(root.GetRef().GetRootRef()) {
+		rootBlock, err := e.head.readTx.state.GetRoot(ctx)
+		if err != nil {
+			return nil, err
+		}
+		bcs.SetBlock(rootBlock.CloneVT(), false)
+	}
 	if readOnly {
 		btx = nil
 	}


### PR DESCRIPTION
New World handles repeatedly fetched and decoded the same root already held by the engine's published read transaction. Reuse its GetRoot result when the content reference matches, cloning the decoded block so each handle owns its mutable sub-block fields.

Validation: engine and coordinator snapshot checks pass under the race detector. The fresh traced Chromium Drive scenario passes at 7.831 seconds; accumulated World-handle construction time drops from 1.128 seconds across 221 calls to 0.229 seconds across 223 calls. An independent storage fix entered the baseline, so the whole startup improvement is not attributed to this change.
