### PR TITLE
fix(quickstart): retain new Drive route and mounted provider identity

### DIFF
--- a/app/quickstart/Quickstart.tsx
+++ b/app/quickstart/Quickstart.tsx
@@ -1,10 +1,4 @@
-/**
- * Quickstart Component
- *
- * Handles the automatic setup of a session and space for quick onboarding.
- * This component orchestrates the creation of a local provider account,
- * mounting a session, and creating a new space with a specific quickstart ID.
- */
+// Quickstart prepares a local session and opens the selected app.
 
 import { useCallback, useState } from 'react'
 
@@ -55,16 +49,7 @@ function QuickstartErrorState({ message, onRetry }: QuickstartErrorStateProps) {
   )
 }
 
-/**
- * Quickstart component that automatically sets up a session and space.
- *
- * Flow:
- * 1. Load the root resource
- * 2. Create a local provider account
- * 3. Mount a session using the account
- * 4. Create a space with the quickstart ID (unless 'local')
- * 5. Provide the session context to children
- */
+// Quickstart retains setup resources across the final route transition.
 export const Quickstart: React.FC<QuickstartProps> = ({ quickstartId }) => {
   // isCreate indicates this is an option that should call createQuickstartSetup.
   // otherwise we redirect below.
@@ -130,7 +115,8 @@ export const Quickstart: React.FC<QuickstartProps> = ({ quickstartId }) => {
             setup.sessionIndex,
             setup.session,
             spaceID,
-            getQuickstartInitialObjectRouteHandoff(quickstartId),
+            setup.initialObjectRoute ??
+              getQuickstartInitialObjectRouteHandoff(quickstartId),
           )
           if (spaceID) {
             markQuickstartStartupBoundary('quickstart.route-handoff-ready', {
@@ -202,6 +188,7 @@ export const Quickstart: React.FC<QuickstartProps> = ({ quickstartId }) => {
       to={buildQuickstartSpaceRoutePath(
         `/u/${setup.sessionIndex}/so/${spaceID}`,
         quickstartId,
+        setup.initialObjectRoute?.objectKey,
       )}
     />
   )

--- a/app/quickstart/create.test.ts
+++ b/app/quickstart/create.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { UnixFSTypeID } from '@s4wave/sdk/unixfs/type.js'
 import { TypePred, buildTypeObjectKey } from '@s4wave/sdk/world/types/types.js'
 import { keyToIRI } from '@s4wave/sdk/world/graph-utils.js'
 import { SET_SPACE_SETTINGS_OP_ID } from '@s4wave/core/space/world/ops/set-space-settings.js'
@@ -693,7 +694,7 @@ describe('quickstart create', () => {
 
     const progressEvents: QuickstartProgressState[] = []
 
-    await createQuickstartSetup(
+    const result = await createQuickstartSetup(
       root as never,
       'drive',
       abortSignal,
@@ -702,6 +703,18 @@ describe('quickstart create', () => {
         progressEvents.push(state)
       },
     )
+
+    expect(result.initialObjectRoute).toEqual({
+      objectKey: UNIXFS_OBJECT_KEY,
+      objectType: UnixFSTypeID,
+    })
+    expect(
+      buildQuickstartSpaceRoutePath(
+        '/u/3/so/space-1',
+        'drive',
+        result.initialObjectRoute?.objectKey,
+      ),
+    ).toBe('/u/3/so/space-1/-/files')
 
     const timing = globalThis.__s4waveQuickstartTiming
     expect(timing?.state).toBe('content-ready')
@@ -944,12 +957,12 @@ describe('quickstart create', () => {
                   ref: {
                     providerResourceRef: {
                       providerId: 'local',
-                      id: 'space-notebook',
+                      id: 'space-drive',
                     },
                   },
                   source: 'created',
                 },
-                spaceMeta: { name: 'My Notebook' },
+                spaceMeta: { name: 'My Drive' },
               },
             ],
           }),
@@ -966,13 +979,14 @@ describe('quickstart create', () => {
       }),
     }))
 
-    await createQuickstartSetup(
+    const result = await createQuickstartSetup(
       root as never,
-      'notebook',
+      'drive',
       new AbortController().signal,
       cleanup,
     )
 
+    expect(result.initialObjectRoute).toBeUndefined()
     expect(createSpace).not.toHaveBeenCalled()
     expect(quickstartRegistryMocks.ExecuteQuickstart).not.toHaveBeenCalled()
     expect(applyWorldOp).not.toHaveBeenCalled()

--- a/app/quickstart/create.ts
+++ b/app/quickstart/create.ts
@@ -555,6 +555,7 @@ export interface LocalSessionSetup {
   session: Session
 }
 
+// QuickstartSetup retains mounted resources and a newly seeded initial route.
 export interface QuickstartSetup {
   root?: Root
   accountResp?: CreateAccountResponse
@@ -564,6 +565,7 @@ export interface QuickstartSetup {
   space: Space
   spaceContents?: SpaceContents
   spaceWorld: EngineWorldState
+  initialObjectRoute?: { objectKey: string; objectType: string }
 }
 
 // QuickstartSetupParams contains the parameters for creating a quickstart setup.
@@ -718,8 +720,7 @@ export async function createQuickstartSetup(
       mountContents: quickstartId !== 'drive',
     })
 
-    // Construct the result
-    const result = {
+    const result: QuickstartSetup = {
       root,
       accountResp,
       sessionIndex,
@@ -741,6 +742,13 @@ export async function createQuickstartSetup(
       await timeQuickstartPhase(timing, 'populate-space', () =>
         populateSpace(quickstartId, result, abortSignal, timing),
       )
+      if (quickstartId === 'drive') {
+        // Only a newly seeded Drive has a known index; reused Spaces keep theirs.
+        result.initialObjectRoute = {
+          objectKey: UNIXFS_OBJECT_KEY,
+          objectType: UnixFSTypeID,
+        }
+      }
     }
 
     markQuickstartProgressReady(timing)
@@ -779,8 +787,8 @@ export function getQuickstartInitialObjectRouteHandoff(
 export function buildQuickstartSpaceRoutePath(
   basePath: string,
   quickstartId: QuickstartSpaceCreateId,
+  objectKey = getQuickstartInitialObjectKey(quickstartId),
 ): string {
-  const objectKey = getQuickstartInitialObjectKey(quickstartId)
   if (!objectKey) {
     return basePath
   }

--- a/app/session/SessionContainer.tsx
+++ b/app/session/SessionContainer.tsx
@@ -108,8 +108,8 @@ const LazyLinkDeviceWizard = lazy(async () => {
 // SessionRootRouter handles the root route redirect logic for a session.
 // Dispatches to SpacewaveRootRouter for cloud sessions.
 // Local sessions show the dashboard directly.
-function SessionRootRouter(props: { metadata?: SessionMetadata }) {
-  if (props.metadata?.providerId === 'spacewave') {
+function SessionRootRouter(props: { providerId?: string }) {
+  if (props.providerId === 'spacewave') {
     return <SpacewaveRootRouter />
   }
 
@@ -125,6 +125,9 @@ interface SessionContainerProps {
 // document state access, and navigation callbacks.
 function useSessionContainerController(props: SessionContainerProps) {
   const session = props.sessionResource.value
+  const providerId =
+    session?.sessionRef?.providerResourceRef?.providerId ??
+    props.metadata?.providerId
 
   // Signal to bootstrap.ts that this user has product state to return to.
   // Return visitors with hasSession see the loading screen instead of landing.
@@ -179,7 +182,7 @@ function useSessionContainerController(props: SessionContainerProps) {
 
   const spacewaveSessionResource = useMemo<Resource<Session>>(
     () =>
-      props.metadata?.providerId === 'spacewave'
+      providerId === 'spacewave'
         ? props.sessionResource
         : {
             value: null,
@@ -187,7 +190,7 @@ function useSessionContainerController(props: SessionContainerProps) {
             error: props.sessionResource.error,
             retry: props.sessionResource.retry,
           },
-    [props.metadata?.providerId, props.sessionResource],
+    [providerId, props.sessionResource],
   )
 
   const onboardingState = useStreamingResource(
@@ -271,7 +274,7 @@ function useSessionContainerController(props: SessionContainerProps) {
       })
   }, [handleRemoveSession, isDeleted, navigate, rootResource.value, sessionIdx])
 
-  const isCloudProvider = props.metadata?.providerId === 'spacewave'
+  const isCloudProvider = providerId === 'spacewave'
 
   const badgeLabel = isCloudProvider
     ? isDormant
@@ -347,6 +350,7 @@ function useSessionContainerController(props: SessionContainerProps) {
     isUnauthenticated,
     onboardingState,
     path,
+    providerId,
     session,
     sessionIdx,
     sessionStateAccessor,
@@ -378,6 +382,7 @@ export function SessionContainer(props: SessionContainerProps) {
     isUnauthenticated,
     onboardingState,
     path,
+    providerId,
     session,
     sessionIdx,
     sessionStateAccessor,
@@ -451,6 +456,7 @@ export function SessionContainer(props: SessionContainerProps) {
                   <SystemStatusButton />
                   <SessionUploadIndicator />
                   <SessionProviderContainer
+                    providerId={providerId}
                     metadata={props.metadata}
                     spacewaveOnboarding={onboardingState.value ?? null}
                   >
@@ -521,7 +527,7 @@ export function SessionContainer(props: SessionContainerProps) {
                         </SessionFlowFrame>
                       </Route>
                       <Route path="/">
-                        <SessionRootRouter metadata={props.metadata} />
+                        <SessionRootRouter providerId={providerId} />
                       </Route>
                       <Route path="/billing/:baId/cancel">
                         <BillingCancelRoute />

--- a/app/session/SessionProviderContainer.tsx
+++ b/app/session/SessionProviderContainer.tsx
@@ -9,11 +9,12 @@ import type { WatchOnboardingStatusResponse } from '@s4wave/sdk/provider/spacewa
 // based on the session's provider ID. Spacewave sessions get Onboarding Status
 // route context and lapse banner; local sessions get the setup banner.
 export function SessionProviderContainer(props: {
+  providerId?: string
   metadata?: SessionMetadata
   spacewaveOnboarding?: WatchOnboardingStatusResponse | null
   children: ReactNode
 }) {
-  switch (props.metadata?.providerId) {
+  switch (props.providerId) {
     case 'spacewave':
       return (
         <SpacewaveSessionContent onboarding={props.spacewaveOnboarding ?? null}>

--- a/sdk/root/root.ts
+++ b/sdk/root/root.ts
@@ -74,7 +74,11 @@ export class Root extends Resource {
     abortSignal?: AbortSignal,
   ): Promise<Session> {
     const resp = await this.service.MountSession(request ?? {}, abortSignal)
-    return this.resourceRef.createResource(resp.resourceId ?? 0, Session)
+    return this.resourceRef.createResource(
+      resp.resourceId ?? 0,
+      Session,
+      request?.sessionRef,
+    )
   }
 
   // mountSessionByIdx mounts a session by index.
@@ -93,7 +97,11 @@ export class Root extends Resource {
       return null
     }
     return {
-      session: this.resourceRef.createResource(resp.resourceId ?? 0, Session),
+      session: this.resourceRef.createResource(
+        resp.resourceId ?? 0,
+        Session,
+        resp.sessionRef,
+      ),
       sessionRef: resp.sessionRef,
     }
   }

--- a/sdk/session/session.ts
+++ b/sdk/session/session.ts
@@ -39,7 +39,7 @@ import {
   WatchSessionStateAtomsResponse,
   WatchTransferProgressResponse,
 } from './session.pb.js'
-import { SessionLockMode } from '../../core/session/session.pb.js'
+import { SessionLockMode, SessionRef } from '../../core/session/session.pb.js'
 import type {
   SOInviteMessage,
   SOParticipantRole,
@@ -54,7 +54,10 @@ import { StateAtom } from '@aptre/bldr-sdk/state/state.js'
 //
 // The MountSession directive will remain active until this resource is released.
 export class Session extends Resource {
-  // service is the session resource service
+  // sessionRef is the provider identity retained for this mounted resource.
+  public readonly sessionRef?: SessionRef
+
+  // service is the session resource service.
   private service: SessionResourceService
   // _spacewave is the lazy-initialized SpacewaveSession wrapper.
   private _spacewave: SpacewaveSession | null = null
@@ -63,8 +66,9 @@ export class Session extends Resource {
   // _systemStatus is the lazy-initialized SystemStatus wrapper.
   private _systemStatus: SystemStatus | null = null
 
-  constructor(resourceRef: ClientResourceRef) {
+  constructor(resourceRef: ClientResourceRef, sessionRef?: SessionRef) {
     super(resourceRef)
+    this.sessionRef = SessionRef.clone(sessionRef) ?? undefined
     this.service = new SessionResourceServiceClient(resourceRef.client)
   }
 


### PR DESCRIPTION
New Drive quickstarts now open the freshly seeded files route directly. Reused Spaces continue to use their saved index.

Retain the provider reference returned when mounting a Session and use it to select the provider wrapper immediately. Asynchronous metadata previously replaced the wrapper after content mounted, canceling and repeating the first load.

Validation: 43 focused tests and TypeScript checking pass. Fresh Chromium landing-to-Drive storage exercise passes and records one content mount instead of two. The single timing sample does not establish an end-to-end speedup.
