### PR TITLE
fix(bldr): track the Rolldown runner in cached build inputs

### DIFF
--- a/bldr/manifest/builder/controller/startup-cache.go
+++ b/bldr/manifest/builder/controller/startup-cache.go
@@ -31,9 +31,9 @@ import (
 )
 
 // startupCacheFormatEnvKey is bumped when compiler-owned output policy changes
-// without changing a plugin source file. V12 binds the effective build policy
-// to the controller configuration fingerprint.
-const startupCacheFormatEnvKey = "BLDR_STARTUP_CACHE_FORMAT_V12"
+// without changing a plugin source file. V13 requires the Rolldown runner in
+// the compiler input manifest so bundling policy edits invalidate its outputs.
+const startupCacheFormatEnvKey = "BLDR_STARTUP_CACHE_FORMAT_V13"
 
 // startupValidationResult contains the startup cache validation result.
 type startupValidationResult struct {

--- a/bldr/web/bundler/rolldown/rolldown.go
+++ b/bldr/web/bundler/rolldown/rolldown.go
@@ -195,6 +195,8 @@ func Build(ctx context.Context, le *logrus.Entry, stateDir, toolRoot string, req
 	runErr := bldr_exec.StartAndWait(ctx, le, cmd)
 	result, parseErr := readBuildResult(resultPath)
 	if result != nil {
+		// Track the runner so compiler policy edits invalidate cached bundles.
+		result.Inputs = append(result.Inputs, runnerPath)
 		sortBuildResult(result)
 	}
 	if ctxErr := ctx.Err(); ctxErr != nil {

--- a/e2e/releasewasm/README.md
+++ b/e2e/releasewasm/README.md
@@ -6,7 +6,7 @@ Run the cold Chromium landing-to-Drive scenario with:
 bun run test:release:web:startup
 ```
 
-The harness incrementally builds unminified release artifacts, exports the
+The harness incrementally builds minified release artifacts, exports the
 startup plugins into real CDN KVF packs, and serves them on
 `http://127.0.0.1:30772`. The production bootstrap embeds only the launcher and
 materializer. The browser fetches a signed distribution fixture, the CDN root
@@ -18,7 +18,7 @@ software-rendered runs can be distinguished.
 
 Build and publication state live in `.bldr-startup`. Bldr checks source changes
 on every run and reuses unchanged manifests. The build keeps the release
-manifest selection rules, with JavaScript and entrypoint minification disabled.
+manifest selection rules, with JavaScript and entrypoint minification enabled.
 Build time is outside the measured browser interval.
 
 Capture the root worker's runtime trace during the same scenario with:


### PR DESCRIPTION
Bldr now records the Rolldown runner in build inputs, so editing the bundling policy invalidates cached plugin outputs. The startup cache format advances to rebuild older entries that lack that input. The startup harness README also reflects its enabled release minification.

Focused Rolldown build and startup-cache tests pass.
