### PR TITLE
fix(e2e): select startup publication platforms explicitly

### DIFF
--- a/e2e/releasewasm/local-cdn-config.go
+++ b/e2e/releasewasm/local-cdn-config.go
@@ -97,6 +97,12 @@ func localCDNProject(repoRoot, baseURL string) (*project.ProjectConfig, string, 
 	if err != nil {
 		return nil, "", err
 	}
-	conf.Publish["spacewave-release"].Manifests = []string{"spacewave-core", "spacewave-web", "spacewave-app", "web"}
+	plugins := conf.Publish["spacewave-release"]
+	plugins.Manifests = []string{"spacewave-core", "spacewave-web", "spacewave-app"}
+	plugins.PlatformIds = []string{"js"}
+	web := plugins.CloneVT()
+	web.Manifests = []string{"web"}
+	web.PlatformIds = []string{"web/js/wasm"}
+	conf.Publish["spacewave-release-web"] = web
 	return conf, packedConfig, nil
 }

--- a/e2e/releasewasm/local-cdn.go
+++ b/e2e/releasewasm/local-cdn.go
@@ -63,8 +63,11 @@ func prepareLocalCDN(ctx context.Context, le *logrus.Entry, repoRoot, baseURL st
 	if err := os.MkdirAll(publicationDir, 0o755); err != nil {
 		return releaseWasmDistDirs{}, err
 	}
-	if err := runBun(ctx, repoRoot, append(args, "publish", "-p", "spacewave-release")...); err != nil {
-		return releaseWasmDistDirs{}, errors.Wrap(err, "publish local startup World")
+	// Publish sequentially because both selections write the same local World.
+	for _, selection := range []string{"spacewave-release", "spacewave-release-web"} {
+		if err := runBun(ctx, repoRoot, append(args, "publish", "-p", selection)...); err != nil {
+			return releaseWasmDistDirs{}, errors.Wrap(err, "publish local startup World")
+		}
 	}
 	dirs := releaseWasmDistDirs{
 		releaseDist: filepath.Join(stateDir, "build", "js", "spacewave-browser", "dist"),


### PR DESCRIPTION
The local CDN startup fixture previously published every cached platform for each selected manifest. A build left by a different compiler configuration could therefore enter a later browser comparison.

Select JavaScript plugins and the web bridge explicitly, publishing the two selections sequentially into the fixture World. The fresh Chromium Drive scenario passes, including the file storage exercise.
