### PR TITLE
feat(chat): support conditional state writes

### DIFF
--- a/.protoc-manifest.json
+++ b/.protoc-manifest.json
@@ -3440,7 +3440,7 @@
       ]
     },
     "github.com/s4wave/spacewave/sdk/chat/rpc": {
-      "hash": "3f323f75f230964e394f161e64424aff4a3264188a26b15e14b73d1d0631b86e",
+      "hash": "d168607e532b733e32a73aa05b52af4c73674da3fece54f70fb9c760da634fa6",
       "generatedFiles": [
         "sdk/chat/rpc/rpc.pb.go",
         "sdk/chat/rpc/rpc.pb.ts",

--- a/sdk/chat/chat-resource.go
+++ b/sdk/chat/chat-resource.go
@@ -32,6 +32,9 @@ const (
 // ErrChatAuthorIdentityRequired is returned when a message has no authenticated author.
 var ErrChatAuthorIdentityRequired = errors.New("chat author identity required")
 
+// ErrChatStateConflict indicates that current state no longer matches a write condition.
+var ErrChatStateConflict = errors.New("chat state write condition conflicts with current state")
+
 // ChatResource serves ChatResourceService for a single chat channel object.
 type ChatResource struct {
 	// ws serves reads within the mounted Space.
@@ -367,6 +370,9 @@ func (r *ChatResource) appendMessage(ctx context.Context, wtx world.WorldState, 
 	if err != nil {
 		return nil, err
 	}
+	if req.ExpectedStateMessageKey != nil && content.GetStateChange() == nil {
+		return nil, errors.New("chat state write condition requires a state change")
+	}
 
 	// Resolve every public relationship inside this transaction and channel.
 	relation := content.GetCiphertext().GetRelation()
@@ -416,6 +422,21 @@ func (r *ChatResource) appendMessage(ctx context.Context, wtx world.WorldState, 
 		priorState, err = wtx.LookupGraphQuads(ctx, NewChatStateQuad(r.objectKey, "", state.GetType(), state.GetStateKey()), 0)
 		if err != nil {
 			return nil, err
+		}
+		if expected := req.ExpectedStateMessageKey; expected != nil {
+			currentKey := ""
+			if len(priorState) > 1 {
+				return nil, errors.New("chat state has multiple current events")
+			}
+			if len(priorState) == 1 {
+				currentKey, err = world.GraphValueToKey(priorState[0].GetObj())
+				if err != nil {
+					return nil, err
+				}
+			}
+			if currentKey != *expected {
+				return nil, ErrChatStateConflict
+			}
 		}
 		for _, edge := range priorState {
 			key, err := world.GraphValueToKey(edge.GetObj())

--- a/sdk/chat/chat-state_test.go
+++ b/sdk/chat/chat-state_test.go
@@ -1,6 +1,7 @@
 package spacewave_chat
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
@@ -8,6 +9,97 @@ import (
 	db_world_testbed "github.com/s4wave/spacewave/db/world/testbed"
 	spacewave_chat_rpc "github.com/s4wave/spacewave/sdk/chat/rpc"
 )
+
+// TestChatStateConditionalWrite checks that stale cleanup cannot replace newer state.
+func TestChatStateConditionalWrite(t *testing.T) {
+	ctx := t.Context()
+	wtb, err := db_world_testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(wtb.Release)
+	ws := world.NewEngineWorldState(wtb.Engine, true)
+	createChatChannel(t, ctx, ws, GeneralChannelKey, "General")
+	sender := wtb.Volume.GetPeerID().String()
+	cleaner := NewChatResource(ws, wtb.Engine, GeneralChannelKey, sender)
+	writer := NewChatResource(ws, wtb.Engine, GeneralChannelKey, sender)
+
+	// An absent-state condition creates the first event exactly once.
+	empty := ""
+	request := &spacewave_chat_rpc.SendMessageRequest{
+		ExpectedStateMessageKey: &empty,
+		TransactionId:           "first-state",
+		Content: &ChatMessageContent{Content: &ChatMessageContent_StateChange{
+			StateChange: &ChatStateChange{Type: "m.room.canonical_alias", ContentJson: `{"alias":"#first:example.org"}`},
+		}},
+	}
+	first, err := cleaner.SendMessage(ctx, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newer := request.CloneVT()
+	newer.ExpectedStateMessageKey = nil
+	newer.TransactionId = ""
+	newer.Content.GetStateChange().ContentJson = `{"alias":"#newer:example.org"}`
+	second, err := writer.SendMessage(ctx, newer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A cleanup based on the first event fails, including when its body matches current state.
+	stale := newer.CloneVT()
+	stale.ExpectedStateMessageKey = &first.MessageKey
+	if _, err := cleaner.SendMessage(ctx, stale); !errors.Is(err, ErrChatStateConflict) {
+		t.Fatalf("stale identical state error = %v, want state conflict", err)
+	}
+	stale.Content.GetStateChange().ContentJson = `{}`
+	if _, err := cleaner.SendMessage(ctx, stale); !errors.Is(err, ErrChatStateConflict) {
+		t.Fatalf("stale cleanup error = %v, want state conflict", err)
+	}
+	absent := stale.CloneVT()
+	absent.ExpectedStateMessageKey = &empty
+	if _, err := cleaner.SendMessage(ctx, absent); !errors.Is(err, ErrChatStateConflict) {
+		t.Fatalf("absent-state condition error = %v, want state conflict", err)
+	}
+	current, err := writer.GetState(ctx, &spacewave_chat_rpc.GetStateRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(current.GetMessages()) != 1 || current.GetMessages()[0].GetObjectKey() != second.GetMessageKey() {
+		t.Fatal("rejected cleanup changed current state")
+	}
+	info, err := writer.GetChannelInfo(ctx, &spacewave_chat_rpc.GetChannelInfoRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.GetMessageCount() != 2 {
+		t.Fatalf("rejected writes changed history count to %d, want 2", info.GetMessageCount())
+	}
+
+	// An accepted retry keeps its identity; a fresh matching condition can clear state.
+	retried, err := cleaner.SendMessage(ctx, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retried.GetMessageKey() != first.GetMessageKey() {
+		t.Fatal("accepted conditional retry lost its original event")
+	}
+	stale.ExpectedStateMessageKey = &second.MessageKey
+	cleared, err := cleaner.SendMessage(ctx, stale)
+	if err != nil {
+		t.Fatal(err)
+	}
+	current, err = writer.GetState(ctx, &spacewave_chat_rpc.GetStateRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(current.GetMessages()) != 1 || current.GetMessages()[0].GetObjectKey() != cleared.GetMessageKey() || current.GetMessages()[0].GetContent().GetStateChange().GetContentJson() != `{}` {
+		t.Fatal("matching condition did not clear current state")
+	}
+	if _, err := cleaner.SendMessage(ctx, &spacewave_chat_rpc.SendMessageRequest{Text: "plain", ExpectedStateMessageKey: &empty}); err == nil {
+		t.Fatal("accepted a state condition on a non-state message")
+	}
+}
 
 // TestChatStateHistory checks current state, immutable history, and retry ordering together.
 func TestChatStateHistory(t *testing.T) {

--- a/sdk/chat/rpc/rpc.pb.go
+++ b/sdk/chat/rpc/rpc.pb.go
@@ -368,6 +368,11 @@ type SendMessageRequest struct {
 	// Content is the typed message content. When set, it is persisted as given
 	// and the legacy text field is rejected if also supplied.
 	Content *content.ChatMessageContent `protobuf:"bytes,4,opt,name=content,proto3" json:"content,omitempty"`
+	// ExpectedStateMessageKey requires the current state event to have this key.
+	// An empty value requires absent state; omission makes the write unconditional.
+	// Only state changes accept this condition. Accepted transaction retries retain
+	// their original result even when current state has since changed.
+	ExpectedStateMessageKey *string `protobuf:"bytes,5,opt,name=expected_state_message_key,json=expectedStateMessageKey,proto3,oneof" json:"expectedStateMessageKey,omitempty"`
 }
 
 func (x *SendMessageRequest) Reset() {
@@ -402,6 +407,13 @@ func (x *SendMessageRequest) GetContent() *content.ChatMessageContent {
 		return x.Content
 	}
 	return nil
+}
+
+func (x *SendMessageRequest) GetExpectedStateMessageKey() string {
+	if x != nil && x.ExpectedStateMessageKey != nil {
+		return *x.ExpectedStateMessageKey
+	}
+	return ""
 }
 
 // SendMessageResponse is the response after sending a message.
@@ -719,6 +731,7 @@ func (m *SendMessageRequest) CloneVT() *SendMessageRequest {
 	r.ReplyToKey = m.ReplyToKey
 	r.TransactionId = m.TransactionId
 	r.Content = protobuf_go_lite.CloneVTValue(m.Content)
+	r.ExpectedStateMessageKey = protobuf_go_lite.ClonePtr(m.ExpectedStateMessageKey)
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = slices.Clone(m.unknownFields)
 	}
@@ -1083,6 +1096,9 @@ func (this *SendMessageRequest) EqualVT(that *SendMessageRequest) bool {
 		return false
 	}
 	if !protobuf_go_lite.IsEqualVT(this.Content, that.Content) {
+		return false
+	}
+	if !protobuf_go_lite.EqualPtr(this.ExpectedStateMessageKey, that.ExpectedStateMessageKey) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -1864,6 +1880,11 @@ func (x *SendMessageRequest) MarshalProtoJSON(s *json.MarshalState) {
 		s.WriteObjectField("content")
 		x.Content.MarshalProtoJSON(s.WithField("content"))
 	}
+	if x.ExpectedStateMessageKey != nil {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("expectedStateMessageKey")
+		s.WriteString(*x.ExpectedStateMessageKey)
+	}
 	s.WriteObjectEnd()
 }
 
@@ -1897,6 +1918,14 @@ func (x *SendMessageRequest) UnmarshalProtoJSON(s *json.UnmarshalState) {
 			}
 			x.Content = &content.ChatMessageContent{}
 			x.Content.UnmarshalProtoJSON(s.WithField("content", true))
+		case "expected_state_message_key", "expectedStateMessageKey":
+			s.AddField("expected_state_message_key")
+			if s.ReadNil() {
+				x.ExpectedStateMessageKey = nil
+				return
+			}
+			t := s.ReadString()
+			x.ExpectedStateMessageKey = &t
 		}
 	})
 }
@@ -2720,6 +2749,11 @@ func (m *SendMessageRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
 	}
+	if m.ExpectedStateMessageKey != nil {
+		i = protobuf_go_lite.EncodeString(dAtA, i, *m.ExpectedStateMessageKey)
+		i--
+		dAtA[i] = 0x2a
+	}
 	if m.Content != nil {
 		size, err := m.Content.MarshalToSizedBufferVT(dAtA[:i])
 		if err != nil {
@@ -3116,6 +3150,7 @@ func (m *SendMessageRequest) SizeVT() (n int) {
 		l = m.Content.SizeVT()
 		n += protobuf_go_lite.SizeMessage(1, l)
 	}
+	n += protobuf_go_lite.SizeStringPtr(1, m.ExpectedStateMessageKey)
 	n += len(m.unknownFields)
 	return n
 }
@@ -3434,6 +3469,10 @@ func (x *SendMessageRequest) MarshalProtoText() string {
 	if x.Content != nil {
 		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "content")
 		protobuf_go_lite.TextWriteTextMarshaler(&sb, x.Content)
+	}
+	if x.ExpectedStateMessageKey != nil {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "expected_state_message_key")
+		protobuf_go_lite.TextWriteString(&sb, *x.ExpectedStateMessageKey)
 	}
 	return protobuf_go_lite.TextFinishMessage(&sb)
 }
@@ -4341,6 +4380,16 @@ func (m *SendMessageRequest) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExpectedStateMessageKey", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.ExpectedStateMessageKey = &v
 		default:
 			iNdEx = preIndex
 			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])

--- a/sdk/chat/rpc/rpc.pb.ts
+++ b/sdk/chat/rpc/rpc.pb.ts
@@ -419,6 +419,15 @@ export interface SendMessageRequest {
    * @generated from field: spacewave.chat.ChatMessageContent content = 4;
    */
   content?: ChatMessageContent
+  /**
+   * ExpectedStateMessageKey requires the current state event to have this key.
+   * An empty value requires absent state; omission makes the write unconditional.
+   * Only state changes accept this condition. Accepted transaction retries retain
+   * their original result even when current state has since changed.
+   *
+   * @generated from field: optional string expected_state_message_key = 5;
+   */
+  expectedStateMessageKey?: string
 }
 
 export const SendMessageRequest: MessageType<SendMessageRequest> =
@@ -429,6 +438,13 @@ export const SendMessageRequest: MessageType<SendMessageRequest> =
       { no: 2, name: 'reply_to_key', kind: 'scalar', T: ScalarType.STRING },
       { no: 3, name: 'transaction_id', kind: 'scalar', T: ScalarType.STRING },
       { no: 4, name: 'content', kind: 'message', T: () => ChatMessageContent },
+      {
+        no: 5,
+        name: 'expected_state_message_key',
+        kind: 'scalar',
+        T: ScalarType.STRING,
+        opt: true,
+      },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,
   })

--- a/sdk/chat/rpc/rpc.proto
+++ b/sdk/chat/rpc/rpc.proto
@@ -133,6 +133,11 @@ message SendMessageRequest {
   // Content is the typed message content. When set, it is persisted as given
   // and the legacy text field is rejected if also supplied.
   .spacewave.chat.ChatMessageContent content = 4;
+  // ExpectedStateMessageKey requires the current state event to have this key.
+  // An empty value requires absent state; omission makes the write unconditional.
+  // Only state changes accept this condition. Accepted transaction retries retain
+  // their original result even when current state has since changed.
+  optional string expected_state_message_key = 5;
 }
 
 // SendMessageResponse is the response after sending a message.


### PR DESCRIPTION
State cleanup can race with a newer update. Add an optional expected state event key to SendMessage and check it within the existing World transaction before appending or deduplicating state. A mismatch leaves history and current state unchanged; accepted transaction retries retain their original result.

Validated with the chat package suite, race detection, TypeScript checking, and Go style checks. The World regression covers stale and absent-state conditions, matching cleanup, and accepted retries after newer writes.
