### PR TITLE
feat(chat): allow callers to reuse accepted transactions

### DIFF
--- a/.protoc-manifest.json
+++ b/.protoc-manifest.json
@@ -3440,7 +3440,7 @@
       ]
     },
     "github.com/s4wave/spacewave/sdk/chat/rpc": {
-      "hash": "d168607e532b733e32a73aa05b52af4c73674da3fece54f70fb9c760da634fa6",
+      "hash": "cb39ebd28917ef2e76609fff0ecfe9d3064484a8d15720422bc7117bf69cd668",
       "generatedFiles": [
         "sdk/chat/rpc/rpc.pb.go",
         "sdk/chat/rpc/rpc.pb.ts",

--- a/sdk/chat/chat-resource.go
+++ b/sdk/chat/chat-resource.go
@@ -2,8 +2,6 @@ package spacewave_chat
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"slices"
 	"strconv"
 	"strings"
@@ -374,7 +372,30 @@ func (r *ChatResource) appendMessage(ctx context.Context, wtx world.WorldState, 
 		return nil, errors.New("chat state write condition requires a state change")
 	}
 
-	// Resolve every public relationship inside this transaction and channel.
+	// Resolve the sender-scoped retry before reserving a history position.
+	msgKey := ""
+	if transactionID := req.GetTransactionId(); transactionID != "" {
+		msgKey, err = TransactionMessageKey(r.objectKey, r.localPeerID, transactionID)
+		if err != nil {
+			return nil, err
+		}
+		prior, err := world.LookupObjectBody[*ChatMessage](ctx, wtx, msgKey, NewChatMessageBlock)
+		if err != nil && !errors.Is(err, world.ErrObjectNotFound) {
+			return nil, err
+		}
+		if prior != nil {
+			personPeerID := prior.GetPersonPeerId()
+			if personPeerID == "" {
+				personPeerID = prior.GetSenderPeerId()
+			}
+			if prior.GetSenderPeerId() != r.localPeerID || personPeerID != r.personPeerID || !req.GetReuseAcceptedTransaction() && (!prior.GetContent().EqualVT(content) || prior.GetReplyToKey() != req.GetReplyToKey()) {
+				return nil, errors.New("chat send transaction conflicts with its accepted message")
+			}
+			return &spacewave_chat_rpc.SendMessageResponse{MessageKey: msgKey}, nil
+		}
+	}
+
+	// Resolve relationships only for new writes; accepted retries retain their original targets.
 	relation := content.GetCiphertext().GetRelation()
 	for _, key := range []string{relation.GetTargetKey(), relation.GetReplyToKey(), content.GetAnnotation().GetTargetKey()} {
 		if key == "" {
@@ -386,27 +407,6 @@ func (r *ChatResource) appendMessage(ctx context.Context, wtx world.WorldState, 
 		}
 		if _, err := world.LookupObjectBody[*ChatMessage](ctx, wtx, key, NewChatMessageBlock); err != nil {
 			return nil, errors.Wrap(err, "resolve chat relation target")
-		}
-	}
-
-	// Resolve the sender-scoped retry before reserving a history position.
-	msgKey := ""
-	if transactionID := req.GetTransactionId(); transactionID != "" {
-		digest := sha256.Sum256([]byte(strconv.Itoa(len(r.localPeerID)) + ":" + r.localPeerID + transactionID))
-		msgKey = r.objectKey + "/message/tx-" + hex.EncodeToString(digest[:])
-		prior, err := world.LookupObjectBody[*ChatMessage](ctx, wtx, msgKey, NewChatMessageBlock)
-		if err != nil && !errors.Is(err, world.ErrObjectNotFound) {
-			return nil, err
-		}
-		if prior != nil {
-			personPeerID := prior.GetPersonPeerId()
-			if personPeerID == "" {
-				personPeerID = prior.GetSenderPeerId()
-			}
-			if prior.GetSenderPeerId() != r.localPeerID || personPeerID != r.personPeerID || !prior.GetContent().EqualVT(content) || prior.GetReplyToKey() != req.GetReplyToKey() {
-				return nil, errors.New("chat send transaction conflicts with its accepted message")
-			}
-			return &spacewave_chat_rpc.SendMessageResponse{MessageKey: msgKey}, nil
 		}
 	}
 

--- a/sdk/chat/rpc/rpc.pb.go
+++ b/sdk/chat/rpc/rpc.pb.go
@@ -363,7 +363,7 @@ type SendMessageRequest struct {
 	// ReplyToKey is the optional key of the message to reply to.
 	ReplyToKey string `protobuf:"bytes,2,opt,name=reply_to_key,json=replyToKey,proto3" json:"replyToKey,omitempty"`
 	// TransactionId identifies a retryable send within the authenticated sender
-	// and channel. Reuse with different content is rejected; empty always appends.
+	// and channel. By default, differing content is rejected; empty always appends.
 	TransactionId string `protobuf:"bytes,3,opt,name=transaction_id,json=transactionId,proto3" json:"transactionId,omitempty"`
 	// Content is the typed message content. When set, it is persisted as given
 	// and the legacy text field is rejected if also supplied.
@@ -373,6 +373,10 @@ type SendMessageRequest struct {
 	// Only state changes accept this condition. Accepted transaction retries retain
 	// their original result even when current state has since changed.
 	ExpectedStateMessageKey *string `protobuf:"bytes,5,opt,name=expected_state_message_key,json=expectedStateMessageKey,proto3,oneof" json:"expectedStateMessageKey,omitempty"`
+	// ReuseAcceptedTransaction returns the original message for a valid retry
+	// even when its content or reply differs. The authenticated author must still
+	// match. It has no effect when TransactionId is empty.
+	ReuseAcceptedTransaction bool `protobuf:"varint,6,opt,name=reuse_accepted_transaction,json=reuseAcceptedTransaction,proto3" json:"reuseAcceptedTransaction,omitempty"`
 }
 
 func (x *SendMessageRequest) Reset() {
@@ -414,6 +418,13 @@ func (x *SendMessageRequest) GetExpectedStateMessageKey() string {
 		return *x.ExpectedStateMessageKey
 	}
 	return ""
+}
+
+func (x *SendMessageRequest) GetReuseAcceptedTransaction() bool {
+	if x != nil {
+		return x.ReuseAcceptedTransaction
+	}
+	return false
 }
 
 // SendMessageResponse is the response after sending a message.
@@ -730,6 +741,7 @@ func (m *SendMessageRequest) CloneVT() *SendMessageRequest {
 	r.Text = m.Text
 	r.ReplyToKey = m.ReplyToKey
 	r.TransactionId = m.TransactionId
+	r.ReuseAcceptedTransaction = m.ReuseAcceptedTransaction
 	r.Content = protobuf_go_lite.CloneVTValue(m.Content)
 	r.ExpectedStateMessageKey = protobuf_go_lite.ClonePtr(m.ExpectedStateMessageKey)
 	if len(m.unknownFields) > 0 {
@@ -1099,6 +1111,9 @@ func (this *SendMessageRequest) EqualVT(that *SendMessageRequest) bool {
 		return false
 	}
 	if !protobuf_go_lite.EqualPtr(this.ExpectedStateMessageKey, that.ExpectedStateMessageKey) {
+		return false
+	}
+	if this.ReuseAcceptedTransaction != that.ReuseAcceptedTransaction {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -1885,6 +1900,11 @@ func (x *SendMessageRequest) MarshalProtoJSON(s *json.MarshalState) {
 		s.WriteObjectField("expectedStateMessageKey")
 		s.WriteString(*x.ExpectedStateMessageKey)
 	}
+	if x.ReuseAcceptedTransaction || s.HasField("reuseAcceptedTransaction") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("reuseAcceptedTransaction")
+		s.WriteBool(x.ReuseAcceptedTransaction)
+	}
 	s.WriteObjectEnd()
 }
 
@@ -1926,6 +1946,9 @@ func (x *SendMessageRequest) UnmarshalProtoJSON(s *json.UnmarshalState) {
 			}
 			t := s.ReadString()
 			x.ExpectedStateMessageKey = &t
+		case "reuse_accepted_transaction", "reuseAcceptedTransaction":
+			s.AddField("reuse_accepted_transaction")
+			x.ReuseAcceptedTransaction = s.ReadBool()
 		}
 	})
 }
@@ -2749,6 +2772,11 @@ func (m *SendMessageRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
 	}
+	if m.ReuseAcceptedTransaction {
+		i = protobuf_go_lite.EncodeBool(dAtA, i, m.ReuseAcceptedTransaction)
+		i--
+		dAtA[i] = 0x30
+	}
 	if m.ExpectedStateMessageKey != nil {
 		i = protobuf_go_lite.EncodeString(dAtA, i, *m.ExpectedStateMessageKey)
 		i--
@@ -3151,6 +3179,7 @@ func (m *SendMessageRequest) SizeVT() (n int) {
 		n += protobuf_go_lite.SizeMessage(1, l)
 	}
 	n += protobuf_go_lite.SizeStringPtr(1, m.ExpectedStateMessageKey)
+	n += protobuf_go_lite.SizeBoolNonZero(1, m.ReuseAcceptedTransaction)
 	n += len(m.unknownFields)
 	return n
 }
@@ -3473,6 +3502,10 @@ func (x *SendMessageRequest) MarshalProtoText() string {
 	if x.ExpectedStateMessageKey != nil {
 		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "expected_state_message_key")
 		protobuf_go_lite.TextWriteString(&sb, *x.ExpectedStateMessageKey)
+	}
+	if x.ReuseAcceptedTransaction != false {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "reuse_accepted_transaction")
+		protobuf_go_lite.TextWriteBool(&sb, x.ReuseAcceptedTransaction)
 	}
 	return protobuf_go_lite.TextFinishMessage(&sb)
 }
@@ -4390,6 +4423,16 @@ func (m *SendMessageRequest) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			m.ExpectedStateMessageKey = &v
+		case 6:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ReuseAcceptedTransaction", wireType)
+			}
+			var v bool
+			v, iNdEx, err = protobuf_go_lite.DecodeVarintBool(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.ReuseAcceptedTransaction = bool(v)
 		default:
 			iNdEx = preIndex
 			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])

--- a/sdk/chat/rpc/rpc.pb.ts
+++ b/sdk/chat/rpc/rpc.pb.ts
@@ -407,7 +407,7 @@ export interface SendMessageRequest {
   replyToKey?: string
   /**
    * TransactionId identifies a retryable send within the authenticated sender
-   * and channel. Reuse with different content is rejected; empty always appends.
+   * and channel. By default, differing content is rejected; empty always appends.
    *
    * @generated from field: string transaction_id = 3;
    */
@@ -428,6 +428,14 @@ export interface SendMessageRequest {
    * @generated from field: optional string expected_state_message_key = 5;
    */
   expectedStateMessageKey?: string
+  /**
+   * ReuseAcceptedTransaction returns the original message for a valid retry
+   * even when its content or reply differs. The authenticated author must still
+   * match. It has no effect when TransactionId is empty.
+   *
+   * @generated from field: bool reuse_accepted_transaction = 6;
+   */
+  reuseAcceptedTransaction?: boolean
 }
 
 export const SendMessageRequest: MessageType<SendMessageRequest> =
@@ -444,6 +452,12 @@ export const SendMessageRequest: MessageType<SendMessageRequest> =
         kind: 'scalar',
         T: ScalarType.STRING,
         opt: true,
+      },
+      {
+        no: 6,
+        name: 'reuse_accepted_transaction',
+        kind: 'scalar',
+        T: ScalarType.BOOL,
       },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,

--- a/sdk/chat/rpc/rpc.proto
+++ b/sdk/chat/rpc/rpc.proto
@@ -128,7 +128,7 @@ message SendMessageRequest {
   // ReplyToKey is the optional key of the message to reply to.
   string reply_to_key = 2;
   // TransactionId identifies a retryable send within the authenticated sender
-  // and channel. Reuse with different content is rejected; empty always appends.
+  // and channel. By default, differing content is rejected; empty always appends.
   string transaction_id = 3;
   // Content is the typed message content. When set, it is persisted as given
   // and the legacy text field is rejected if also supplied.
@@ -138,6 +138,10 @@ message SendMessageRequest {
   // Only state changes accept this condition. Accepted transaction retries retain
   // their original result even when current state has since changed.
   optional string expected_state_message_key = 5;
+  // ReuseAcceptedTransaction returns the original message for a valid retry
+  // even when its content or reply differs. The authenticated author must still
+  // match. It has no effect when TransactionId is empty.
+  bool reuse_accepted_transaction = 6;
 }
 
 // SendMessageResponse is the response after sending a message.

--- a/sdk/chat/send-retry_test.go
+++ b/sdk/chat/send-retry_test.go
@@ -23,9 +23,16 @@ func TestChatResourceSendRetryRetainsHistory(t *testing.T) {
 	createChatChannel(t, ctx, ws, GeneralChannelKey, "General")
 	first := NewChatResource(ws, tb.Engine, GeneralChannelKey, "alice")
 	request := &spacewave_chat_rpc.SendMessageRequest{Text: "retained", TransactionId: "device-a/send-1"}
+	messageKey, err := TransactionMessageKey(GeneralChannelKey, "alice", request.GetTransactionId())
+	if err != nil {
+		t.Fatal(err)
+	}
 	accepted, err := first.SendMessage(ctx, request)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if accepted.GetMessageKey() != messageKey {
+		t.Fatal("send changed its precomputed transaction message identity")
 	}
 	seqno, err := ws.GetSeqno(ctx)
 	if err != nil {
@@ -53,6 +60,32 @@ func TestChatResourceSendRetryRetainsHistory(t *testing.T) {
 	conflict.Text = "changed"
 	if _, err := resumed.SendMessage(ctx, conflict); err == nil {
 		t.Fatal("accepted conflicting reuse of send identity")
+	}
+
+	// Opt-in replay ignores changed bodies and relationships without weakening author identity.
+	conflict.ReuseAcceptedTransaction = true
+	conflict.Text = ""
+	conflict.ReplyToKey = GeneralChannelKey + "/message/missing"
+	conflict.Content = &ChatMessageContent{Content: &ChatMessageContent_Annotation{
+		Annotation: &ChatAnnotation{TargetKey: conflict.ReplyToKey, Key: "changed"},
+	}}
+	replayed, err = resumed.SendMessage(ctx, conflict)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replayed.GetMessageKey() != accepted.GetMessageKey() {
+		t.Fatal("opt-in replay changed the accepted message")
+	}
+	after, err = ws.GetSeqno(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after != seqno {
+		t.Fatal("opt-in replay published a World revision")
+	}
+	otherPerson := NewChatResourceForPerson(ws, tb.Engine, GeneralChannelKey, "alice", "another-person")
+	if _, err := otherPerson.SendMessage(ctx, conflict); err == nil {
+		t.Fatal("opt-in replay accepted a different person under the same device identity")
 	}
 
 	// A second authenticated sender has an independent transaction namespace.

--- a/sdk/chat/transaction.go
+++ b/sdk/chat/transaction.go
@@ -1,0 +1,19 @@
+package spacewave_chat
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+// TransactionMessageKey identifies a retryable send within its channel World.
+// It neither creates a message nor grants access. Callers supply the authenticated sender.
+func TransactionMessageKey(channelKey, senderPeerID, transactionID string) (string, error) {
+	if channelKey == "" || senderPeerID == "" || transactionID == "" {
+		return "", errors.New("chat transaction identity requires a channel, sender, and transaction ID")
+	}
+	digest := sha256.Sum256([]byte(strconv.Itoa(len(senderPeerID)) + ":" + senderPeerID + transactionID))
+	return channelKey + "/message/tx-" + hex.EncodeToString(digest[:]), nil
+}


### PR DESCRIPTION
Retrying a send with changed content normally remains a conflict. Callers can now opt into returning the originally accepted message while retaining authenticated author checks and leaving history unchanged.

Export the existing transaction message-key calculation so callers can identify a retry before sending it. Existing stored keys retain their format.

Validation: chat package tests and race tests passed; TypeScript checking, Go style checking, generation, and Go fix passed.
