### PR TITLE
fix(release): include SQL in browser plugin builds

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -157,6 +157,12 @@ jobs:
           set -euo pipefail
           scripts/release/build-browser-plugin.sh spacewave-notes
 
+      - name: Build browser plugin channel manifest (spacewave-sql)
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts/release/build-browser-plugin.sh spacewave-sql
+
       - name: Build browser plugin channel manifest (spacewave-v86)
         shell: bash
         run: |

--- a/scripts/release/build-browser-plugin.sh
+++ b/scripts/release/build-browser-plugin.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 plugin="${1:-}"
 case "${plugin}" in
-  spacewave-core|spacewave-web|spacewave-app|spacewave-notes|spacewave-v86|spacewave-cli-plugin|web)
+  spacewave-core|spacewave-web|spacewave-app|spacewave-notes|spacewave-v86|spacewave-sql|spacewave-cli-plugin|web)
     ;;
   "")
     echo "usage: $0 <browser-plugin-id>" >&2


### PR DESCRIPTION
Include spacewave-sql in browser plugin release builds so the published channel contains the SQL plugin declared by the browser manifest set.

Validation: shell syntax and diff checks pass. The staging Actions build will exercise the producer.
