### PR TITLE
feat(sobject): retain readable history after departure

### DIFF
--- a/.protoc-manifest.json
+++ b/.protoc-manifest.json
@@ -3751,7 +3751,7 @@
       ]
     },
     "github.com/s4wave/spacewave/sdk/sobject": {
-      "hash": "8e2e4a3652034baeff6a4aa089d382a4276fe9bd6469223a7af839c6993d2aff",
+      "hash": "89ce05029efe4eccd29bf41f5d0de7a95681523c36b7ded4ab531e129b4f3f0d",
       "generatedFiles": [
         "sdk/sobject/sobject.pb.go",
         "sdk/sobject/sobject.pb.ts",

--- a/core/provider/local/config-history.go
+++ b/core/provider/local/config-history.go
@@ -103,18 +103,7 @@ func NewSOHostSyncFuncs(store kvtx.Store) *sobject.SOHostSyncFuncs {
 			}
 			defer tx.Discard()
 
-			// The shared traversal checks content hashes, missing history and budgets.
-			return sobject.ReadConfigSuffix(ctx, base, target, func(ctx context.Context, head []byte) (*sobject.SOConfigChange, error) {
-				data, found, err := tx.Get(ctx, SOConfigHistoryEntryKey(id, head))
-				if err != nil || !found {
-					return nil, err
-				}
-				entry := &sobject.SOConfigChange{}
-				if err := entry.UnmarshalVT(data); err != nil {
-					return nil, err
-				}
-				return entry, nil
-			})
+			return readSOConfigHistory(ctx, tx, id, base, target)
 		},
 	}
 }
@@ -140,4 +129,47 @@ func WriteSOConfigCheckpoint(ctx context.Context, tx kvtx.Tx, id string, config 
 		return err
 	}
 	return tx.Set(ctx, key, data)
+}
+
+// readSOConfigHistory traverses immutable entries in the caller's read transaction.
+func readSOConfigHistory(ctx context.Context, tx kvtx.Tx, id string, base, target []byte) ([]*sobject.SOConfigChange, error) {
+	return sobject.ReadConfigSuffix(ctx, base, target, func(ctx context.Context, head []byte) (*sobject.SOConfigChange, error) {
+		data, found, err := tx.Get(ctx, SOConfigHistoryEntryKey(id, head))
+		if err != nil || !found {
+			return nil, err
+		}
+		entry := &sobject.SOConfigChange{}
+		if err := entry.UnmarshalVT(data); err != nil {
+			return nil, err
+		}
+		return entry, nil
+	})
+}
+
+// ReadSharedObjectConfigHistory returns accepted lineage from the local trust checkpoint.
+func (s *SharedObject) ReadSharedObjectConfigHistory(ctx context.Context, target *sobject.SharedObjectConfig) (*sobject.SharedObjectConfig, []*sobject.SOConfigChange, error) {
+	read, err := s.objStore.NewTransaction(ctx, false)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer read.Discard()
+	data, found, err := read.Get(ctx, SOConfigHistoryCheckpointKey(s.GetSharedObjectID()))
+	if err != nil {
+		return nil, nil, err
+	}
+	if !found {
+		return nil, nil, sobject.ErrConfigHistoryUnavailable
+	}
+	base := &sobject.SharedObjectConfig{}
+	if err := base.UnmarshalVT(data); err != nil {
+		return nil, nil, err
+	}
+	changes, err := readSOConfigHistory(ctx, read, s.GetSharedObjectID(), base.GetConfigChainHash(), target.GetConfigChainHash())
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := sobject.VerifyConfigChainSuffix(base, target, changes); err != nil {
+		return nil, nil, err
+	}
+	return base, changes, nil
 }

--- a/core/provider/local/config-history_test.go
+++ b/core/provider/local/config-history_test.go
@@ -72,7 +72,7 @@ func TestSOConfigHistoryRetainsHostChanges(t *testing.T) {
 	// Apply a real host change through the provider transaction and its retry boundary.
 	faults := kvtest.NewFaultStore(backend, kvtest.FaultBeforeCommit)
 	store := &configHistoryFaultStore{backend: backend, writes: faults}
-	watch, lock, syncFuncs := NewObjectStoreSOStateFuncs(ctx, store)
+	watch, lock, syncFuncs := NewObjectStoreSOStateFuncs(ctx, store, "")
 	host := sobject.NewSOHost(ctx, watch, lock, testSharedObjectID, syncFuncs)
 	t.Cleanup(host.ClearContext)
 	entry, err := sobject.BuildSOConfigChange(initial.GetConfig(), initial.GetConfig(), sobject.SOConfigChangeType_SO_CONFIG_CHANGE_TYPE_GENESIS, priv, nil)
@@ -124,7 +124,7 @@ func TestSOConfigHistoryRetainsHostChanges(t *testing.T) {
 	read.Discard()
 
 	// A fresh provider instance must recover exactly the committed host state.
-	watchAgain, lockAgain, syncAgain := NewObjectStoreSOStateFuncs(ctx, backend)
+	watchAgain, lockAgain, syncAgain := NewObjectStoreSOStateFuncs(ctx, backend, "")
 	reopened := sobject.NewSOHost(ctx, watchAgain, lockAgain, testSharedObjectID, syncAgain)
 	t.Cleanup(reopened.ClearContext)
 	got, err := reopened.GetHostState(ctx)

--- a/core/provider/local/invite-join.go
+++ b/core/provider/local/invite-join.go
@@ -21,7 +21,8 @@ const directInviteOwnerWaitTimeout = 5 * time.Second
 // the owner to be reachable on the live transport.
 var ErrDirectInviteOwnerMustBeOnline = errors.New("space owner must be online to accept this invite directly")
 
-// JoinViaInvite executes the full invite join flow:
+// JoinViaInvite executes the full invite join flow.
+//
 // 1. Ensures a session transport is running (starts one if needed)
 // 2. Opens an SRPC stream to the owner and sends AcceptInviteRequest
 // 3. Receives the SOGrant from the owner
@@ -206,6 +207,10 @@ func (a *ProviderAccount) mountInvitedSO(
 
 	if err := localSO.soHost.InstallInviteSnapshot(ctx, result.SharedObjectState); err != nil {
 		return errors.Wrap(err, "install owner shared object state")
+	}
+	// Admission is complete only when body mounts can observe the accepted grant.
+	if err := localSO.lsoHost.waitPublishedConfig(ctx, result.SharedObjectState.GetConfig()); err != nil {
+		return errors.Wrap(err, "publish invited shared object state")
 	}
 
 	// Persist the SO to the account's SO list so it survives restarts

--- a/core/provider/local/leave-sobject_test.go
+++ b/core/provider/local/leave-sobject_test.go
@@ -95,6 +95,13 @@ func TestNativeSpaceLeave(t *testing.T) {
 	if len(after.GetConfig().GetParticipants()) != 1 || after.GetConfig().GetParticipants()[0].GetPeerId() != object.GetPeerID().String() {
 		t.Fatalf("departure did not preserve only the remaining owner: %v", after.GetConfig().GetParticipants())
 	}
+	base, changes, err := object.ReadSharedObjectConfigHistory(ctx, after.GetConfig())
+	if err != nil || len(changes) == 0 {
+		t.Fatalf("owner lost native departure history: %v", err)
+	}
+	if err := sobject.VerifyConfigChainSuffix(base, after.GetConfig(), changes); err != nil {
+		t.Fatalf("owner history does not prove current participation: %v", err)
+	}
 	retired, err := copy.GetSOHostState(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -121,6 +128,16 @@ func TestNativeSpaceLeave(t *testing.T) {
 		return true, nil
 	}, nil); err != nil {
 		t.Fatal(err)
+	}
+	checkpoint, err := copy.GetSharedObjectReadCheckpoint(ctx)
+	if err != nil || checkpoint == nil {
+		t.Fatalf("departed copy lost read checkpoint: %v", err)
+	}
+	if !checkpoint.Config.EqualVT(before.GetConfig()) {
+		t.Fatal("checkpoint audience differs from the readable native snapshot")
+	}
+	if _, err := checkpoint.Snapshot.GetTransformer(ctx); err != nil {
+		t.Fatalf("checkpoint lost its historical decryption grant: %v", err)
 	}
 	if err := reader.LeaveSharedObject(ctx, readerSession.GetPrivKey(), id); err != nil {
 		t.Fatalf("repeated departure failed: %v", err)

--- a/core/provider/local/peer-import_test.go
+++ b/core/provider/local/peer-import_test.go
@@ -73,7 +73,7 @@ func TestPeerImportRetainsAuthority(t *testing.T) {
 	// Reject inaccessible candidates before any durable or watched state changes.
 	faults := kvtest.NewFaultStore(backend, kvtest.FaultBeforeCommit)
 	store := &configHistoryFaultStore{backend: backend, writes: faults}
-	watch, lock, syncFuncs := NewObjectStoreSOStateFuncs(ctx, store)
+	watch, lock, syncFuncs := NewObjectStoreSOStateFuncs(ctx, store, readerID)
 	host := sobject.NewSOHost(ctx, watch, lock, testSharedObjectID, syncFuncs)
 	t.Cleanup(host.ClearContext)
 	change, err := sobject.BuildSOConfigChange(initial.Config, initial.Config, sobject.SOConfigChangeType_SO_CONFIG_CHANGE_TYPE_ADD_INVITE, owner, nil)
@@ -103,7 +103,7 @@ func TestPeerImportRetainsAuthority(t *testing.T) {
 	if faults.Opened() != 2 || faults.DelegatedCommits() != 1 {
 		t.Fatalf("attempts = %d, commits = %d", faults.Opened(), faults.DelegatedCommits())
 	}
-	watchAgain, lockAgain, syncAgain := NewObjectStoreSOStateFuncs(ctx, backend)
+	watchAgain, lockAgain, syncAgain := NewObjectStoreSOStateFuncs(ctx, backend, readerID)
 	reopened := sobject.NewSOHost(ctx, watchAgain, lockAgain, testSharedObjectID, syncAgain)
 	t.Cleanup(reopened.ClearContext)
 	got, err = reopened.GetHostState(ctx)
@@ -142,6 +142,24 @@ func TestPeerImportRetainsAuthority(t *testing.T) {
 		t.Fatalf("revocation did not preserve root and commit authority: %v", err)
 	}
 
+	// A fresh storage read recovers only the last readable configuration and root.
+	archived, err := backend.NewTransaction(ctx, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	archiveData, found, err := archived.Get(ctx, readCheckpointKey(testSharedObjectID))
+	archived.Discard()
+	if err != nil || !found {
+		t.Fatalf("read checkpoint missing after removal: %v", err)
+	}
+	checkpointState := &sobject.SOState{}
+	if err := checkpointState.UnmarshalVT(archiveData); err != nil {
+		t.Fatal(err)
+	}
+	if !checkpointState.Config.EqualVT(candidate.Config) || !checkpointState.Root.EqualVT(candidate.Root) {
+		t.Fatal("read checkpoint did not retain the last readable snapshot")
+	}
+
 	// Explicit invitation authority replaces the upgrade checkpoint with its accepted head.
 	rejoined := got.CloneVT()
 	rejoined.Config = initial.Config.CloneVT()
@@ -161,6 +179,9 @@ func TestPeerImportRetainsAuthority(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(read.Discard)
+	if _, found, err := read.Get(ctx, readCheckpointKey(testSharedObjectID)); err != nil || found {
+		t.Fatalf("readmission retained obsolete read checkpoint: found=%v err=%v", found, err)
+	}
 	checkpointData, found, err := read.Get(ctx, SOConfigHistoryCheckpointKey(testSharedObjectID))
 	if err != nil || !found {
 		t.Fatalf("invitation checkpoint missing: %v", err)

--- a/core/provider/local/read-checkpoint.go
+++ b/core/provider/local/read-checkpoint.go
@@ -1,0 +1,85 @@
+package provider_local
+
+import (
+	"context"
+
+	"github.com/s4wave/spacewave/core/sobject"
+	"github.com/s4wave/spacewave/db/kvtx"
+	"github.com/s4wave/spacewave/net/peer"
+)
+
+// readCheckpointKey addresses private history, outside replicated SOState.
+func readCheckpointKey(sharedObjectID string) []byte {
+	return []byte("so/" + sharedObjectID + "/read-checkpoint")
+}
+
+// writeReadCheckpoint retains the last readable root at the authority commit boundary.
+// Readmission removes the checkpoint because the current World owns history again.
+func writeReadCheckpoint(
+	ctx context.Context,
+	tx kvtx.Tx,
+	sharedObjectID string,
+	localPeer peer.ID,
+	previous, next *sobject.SOState,
+) error {
+	if localPeer == "" {
+		return nil
+	}
+	readable := func(state *sobject.SOState) bool {
+		for _, participant := range state.GetConfig().GetParticipants() {
+			if participant.GetPeerId() == localPeer.String() {
+				return sobject.CanReadState(participant.GetRole())
+			}
+		}
+		return false
+	}
+	wasReadable, isReadable := readable(previous), readable(next)
+	if wasReadable == isReadable {
+		return nil
+	}
+	key := readCheckpointKey(sharedObjectID)
+	if isReadable {
+		return tx.Delete(ctx, key)
+	}
+
+	// Only this participant's grant is needed to decode the retained root.
+	checkpoint := &sobject.SOState{
+		Config: previous.GetConfig(),
+		Root:   previous.GetRoot(),
+	}
+	for _, grant := range previous.GetRootGrants() {
+		if grant.GetPeerId() == localPeer.String() {
+			checkpoint.RootGrants = append(checkpoint.RootGrants, grant)
+		}
+	}
+	data, err := checkpoint.MarshalVT()
+	if err != nil {
+		return err
+	}
+	return tx.Set(ctx, key, data)
+}
+
+// GetSharedObjectReadCheckpoint returns the last readable snapshot retained at departure.
+// A nil snapshot means this provider has no retained history for this participant.
+func (s *SharedObject) GetSharedObjectReadCheckpoint(ctx context.Context) (*sobject.SharedObjectReadCheckpoint, error) {
+	read, err := s.objStore.NewTransaction(ctx, false)
+	if err != nil {
+		return nil, err
+	}
+	defer read.Discard()
+	data, found, err := read.Get(ctx, readCheckpointKey(s.GetSharedObjectID()))
+	if err != nil || !found {
+		return nil, err
+	}
+	state := &sobject.SOState{}
+	if err := state.UnmarshalVT(data); err != nil {
+		return nil, err
+	}
+	if err := state.Validate(s.GetSharedObjectID()); err != nil {
+		return nil, err
+	}
+	return &sobject.SharedObjectReadCheckpoint{
+		Snapshot: sobject.NewSOStateParticipantHandle(s.lsoHost.le, s.lsoHost.sfs, s.GetSharedObjectID(), state, s.localPriv, s.localPid),
+		Config:   state.GetConfig().CloneVT(),
+	}, nil
+}

--- a/core/provider/local/sobject.go
+++ b/core/provider/local/sobject.go
@@ -132,7 +132,7 @@ func (s *SharedObject) QueueOperation(ctx context.Context, op []byte) (string, e
 // Returns the current state nonce (greater than or equal to the nonce when the op was applied).
 // After ClearOperation has been called, this will return success even for failed ops!
 // If the operation was rejected, returns 0, true, error.
-// Any other error returns 0, false, error
+// Any other error returns 0, false, error.
 func (s *SharedObject) WaitOperation(ctx context.Context, localID string) (uint64, bool, error) {
 	return s.lsoHost.WaitOperation(ctx, localID)
 }
@@ -370,7 +370,7 @@ func (t *sobjectTracker) executeSharedObjectTracker(rctx context.Context) (rerr 
 
 	// Construct the shared object state handle.
 	// Since this is the "local" provider we can "lock" the state with an in-memory lock.
-	watchFn, lockFn, syncFuncs := NewObjectStoreSOStateFuncs(ctx, objStore)
+	watchFn, lockFn, syncFuncs := NewObjectStoreSOStateFuncs(ctx, objStore, localPeerID)
 	soHost := sobject.NewSOHost(ctx, watchFn, lockFn, sharedObjectID, syncFuncs)
 
 	// construct the local host logic

--- a/core/provider/local/sohost.go
+++ b/core/provider/local/sohost.go
@@ -44,6 +44,8 @@ type LocalSOHost struct {
 	soHost *sobject.SOHost
 	// stateSnapCtr contains the current state snapshot
 	stateSnapCtr *ccontainer.CContainer[sobject.SharedObjectStateSnapshot]
+	// publishedConfigCtr acknowledges the configuration represented by stateSnapCtr.
+	publishedConfigCtr *ccontainer.CContainer[*sobject.SharedObjectConfig]
 }
 
 // queueOpTxn contains the txn to queue an operation.
@@ -77,16 +79,17 @@ func NewLocalSOHost(
 	}
 
 	return &LocalSOHost{
-		le:             le,
-		privKey:        privKey,
-		peerID:         peerID,
-		pubKey:         pubKey,
-		objStore:       objStore,
-		soHost:         soHost,
-		sharedObjectID: sharedObjectID,
-		sfs:            sfs,
-		queueOpCh:      make(chan *queueOpTxn),
-		stateSnapCtr:   ccontainer.NewCContainer[sobject.SharedObjectStateSnapshot](nil),
+		le:                 le,
+		privKey:            privKey,
+		peerID:             peerID,
+		pubKey:             pubKey,
+		objStore:           objStore,
+		soHost:             soHost,
+		sharedObjectID:     sharedObjectID,
+		sfs:                sfs,
+		queueOpCh:          make(chan *queueOpTxn),
+		stateSnapCtr:       ccontainer.NewCContainer[sobject.SharedObjectStateSnapshot](nil),
+		publishedConfigCtr: ccontainer.NewCContainer[*sobject.SharedObjectConfig](nil),
 	}, nil
 }
 
@@ -137,6 +140,7 @@ func (l *LocalSOHost) Execute(ctx context.Context) error {
 			l.peerID,
 		), localState.CloneVT())
 		l.stateSnapCtr.SetValue(snap)
+		l.publishedConfigCtr.SetValue(soState.GetConfig().CloneVT())
 	}
 
 	processUpdatedSoState := func(updatedSoState *sobject.SOState) error {
@@ -344,6 +348,30 @@ func (l *LocalSOHost) executeQueueOp(
 	return nil
 }
 
+// waitPublishedConfig waits until body readers can observe target or a verified descendant.
+func (l *LocalSOHost) waitPublishedConfig(ctx context.Context, target *sobject.SharedObjectConfig) error {
+	if target == nil || l.publishedConfigCtr == nil {
+		return errors.New("published SharedObject configuration is unavailable")
+	}
+	_, err := l.publishedConfigCtr.WaitValueWithValidator(ctx, func(current *sobject.SharedObjectConfig) (bool, error) {
+		if current == nil || current.GetConfigChainSeqno() < target.GetConfigChainSeqno() {
+			return false, nil
+		}
+		if current.EqualVT(target) {
+			return true, nil
+		}
+		changes, err := l.soHost.ReadConfigHistory(ctx, target.GetConfigChainHash(), current.GetConfigChainHash())
+		if err != nil {
+			return false, err
+		}
+		if err := sobject.VerifyConfigChainSuffix(target, current, changes); err != nil {
+			return false, err
+		}
+		return true, nil
+	}, nil)
+	return err
+}
+
 // AccessSharedObjectState adds a reference to the state and returns the state container.
 func (l *LocalSOHost) AccessSharedObjectState(ctx context.Context, released func()) (ccontainer.Watchable[sobject.SharedObjectStateSnapshot], func(), error) {
 	return l.stateSnapCtr, func() {}, nil
@@ -487,7 +515,7 @@ func (l *LocalSOHost) localOperationInner(
 // Returns the current state nonce (greater than or equal to the nonce when the op was applied).
 // After ClearOperation has been called, this will return success even for failed ops!
 // If the operation was rejected, returns 0, true, error.
-// Any other error returns 0, false, error
+// Any other error returns 0, false, error.
 func (l *LocalSOHost) WaitOperation(ctx context.Context, localID string) (uint64, bool, error) {
 	if seqno, rejected, err, resolved := l.localOpResultOutcome(ctx, localID); err != nil || resolved {
 		if err == nil && resolved && !rejected && l.soHost.CanWatchSOState() {

--- a/core/provider/local/sohost_test.go
+++ b/core/provider/local/sohost_test.go
@@ -242,6 +242,27 @@ func TestWaitOperationWaitsForDurableLocalQueueTransmission(t *testing.T) {
 	}
 }
 
+func TestWaitPublishedConfigFencesBodySnapshot(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	host, _ := newTestLocalSOHost(t)
+	host.publishedConfigCtr = ccontainer.NewCContainer[*sobject.SharedObjectConfig](nil)
+	target := &sobject.SharedObjectConfig{ConfigChainSeqno: 7, ConfigChainHash: []byte("accepted")}
+
+	done := make(chan error, 1)
+	go func() { done <- host.waitPublishedConfig(ctx, target) }()
+	host.publishedConfigCtr.SetValue(&sobject.SharedObjectConfig{ConfigChainSeqno: 6, ConfigChainHash: []byte("stale")})
+	select {
+	case err := <-done:
+		t.Fatalf("wait returned before the body snapshot reached admission: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	host.publishedConfigCtr.SetValue(target.CloneVT())
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestWaitOperationUsesAcceptedLocalResult(t *testing.T) {
 	ctx := context.Background()
 	host, localPeer := newTestLocalSOHost(t)

--- a/core/provider/local/sostate.go
+++ b/core/provider/local/sostate.go
@@ -12,13 +12,15 @@ import (
 	"github.com/s4wave/spacewave/db/object"
 	trace "github.com/s4wave/spacewave/db/traceutil"
 	"github.com/s4wave/spacewave/db/world"
+	"github.com/s4wave/spacewave/net/peer"
 )
 
 // NewObjectStoreSOStateFuncs constructs a SOHostState backed by an object store and in-memory locks.
 //
 // Assumes no other writers will access the object store.
 // rctx is the context to use for looking up states from the object store.
-func NewObjectStoreSOStateFuncs(rctx context.Context, objStore object.ObjectStore) (
+// localPeer binds private read checkpoints to the local participant; empty disables retention.
+func NewObjectStoreSOStateFuncs(rctx context.Context, objStore object.ObjectStore, localPeer peer.ID) (
 	watchFn sobject.SOStateWatchFunc,
 	lockFn sobject.SOStateLockFunc,
 	syncFuncs *sobject.SOHostSyncFuncs,
@@ -148,6 +150,9 @@ func NewObjectStoreSOStateFuncs(rctx context.Context, objStore object.ObjectStor
 							if err := WriteSOConfigHistory(ctx, tx, sharedObjectID, initialState.GetConfig(), state.GetConfig(), changes); err != nil {
 								return err
 							}
+						}
+						if err := writeReadCheckpoint(ctx, tx, sharedObjectID, localPeer, initialState, state); err != nil {
+							return err
 						}
 						return tx.Set(ctx, ent.key, data)
 					},

--- a/core/resource/sobject/read-checkpoint.go
+++ b/core/resource/sobject/read-checkpoint.go
@@ -1,0 +1,53 @@
+package resource_sobject
+
+import (
+	"context"
+
+	resource_server "github.com/s4wave/spacewave/bldr/resource/server"
+	resource_world "github.com/s4wave/spacewave/core/resource/world"
+	"github.com/s4wave/spacewave/core/sobject"
+	sobject_world_engine "github.com/s4wave/spacewave/core/sobject/world/engine"
+	"github.com/s4wave/spacewave/net/peer"
+	s4wave_sobject "github.com/s4wave/spacewave/sdk/sobject"
+	s4wave_world "github.com/s4wave/spacewave/sdk/world"
+)
+
+// OpenReadCheckpoint opens retained World history without live body or write authority.
+func (r *SharedObjectResource) OpenReadCheckpoint(
+	ctx context.Context,
+	_ *s4wave_sobject.OpenReadCheckpointRequest,
+) (*s4wave_sobject.OpenReadCheckpointResponse, error) {
+	accessor, ok := r.sharedObject.(sobject.SharedObjectReadCheckpointAccessor)
+	if !ok {
+		return &s4wave_sobject.OpenReadCheckpointResponse{}, nil
+	}
+	snapshot, err := accessor.GetSharedObjectReadCheckpoint(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if snapshot == nil {
+		return &s4wave_sobject.OpenReadCheckpointResponse{}, nil
+	}
+	resourceCtx, err := resource_server.MustGetResourceClientContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	sessionPeerID := peer.ID("")
+	if r.sessionPeerID != "" {
+		sessionPeerID, err = peer.IDB58Decode(r.sessionPeerID)
+		if err != nil {
+			return nil, err
+		}
+	}
+	engine, release, err := sobject_world_engine.OpenReadCheckpoint(ctx, r.le, r.b, r.sharedObject, snapshot.Snapshot)
+	if err != nil {
+		return nil, err
+	}
+	resource := resource_world.NewEngineResource(r.le, r.b, engine, nil, &s4wave_world.EngineInfo{}, resource_world.WithSessionPeerID(sessionPeerID))
+	id, err := resourceCtx.AddResource(resource.GetMux(), release)
+	if err != nil {
+		release()
+		return nil, err
+	}
+	return &s4wave_sobject.OpenReadCheckpointResponse{ResourceId: id, Config: snapshot.Config}, nil
+}

--- a/core/resource/sobject/sobject-participation.go
+++ b/core/resource/sobject/sobject-participation.go
@@ -1,0 +1,52 @@
+package resource_sobject
+
+import (
+	"github.com/aperturerobotics/util/ccontainer"
+	"github.com/pkg/errors"
+	"github.com/s4wave/spacewave/core/sobject"
+	s4wave_sobject "github.com/s4wave/spacewave/sdk/sobject"
+)
+
+// WatchSharedObjectParticipation observes accepted authority without requiring body decryption.
+func (r *SharedObjectResource) WatchSharedObjectParticipation(
+	_ *s4wave_sobject.WatchSharedObjectParticipationRequest,
+	stream s4wave_sobject.SRPCSharedObjectResourceService_WatchSharedObjectParticipationStream,
+) error {
+	// The mounted SharedObject supplies both the viewer and the retained native state.
+	host, ok := r.sharedObject.(sobject.InviteHost)
+	if !ok {
+		return errors.New("shared object does not expose native participation")
+	}
+	ctx := stream.Context()
+	state, release, err := host.GetSOHost().GetSOStateCtr(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	// Root progress and transport health do not manufacture participation transitions.
+	var previous *sobject.SharedObjectConfig
+	return ccontainer.WatchChanges(ctx, nil, state, func(value *sobject.SOState) error {
+		if value.GetConfig() == nil || value.GetConfig().EqualVT(previous) {
+			return nil
+		}
+		config := value.GetConfig().CloneVT()
+		participation := &s4wave_sobject.SharedObjectParticipation{
+			ViewerPeerId: r.sharedObject.GetPeerID().String(),
+			Config:       config,
+		}
+		if history, ok := r.sharedObject.(sobject.SharedObjectConfigHistoryAccessor); ok {
+			base, changes, err := history.ReadSharedObjectConfigHistory(ctx, config)
+			if err != nil && !errors.Is(err, sobject.ErrConfigHistoryUnavailable) {
+				return err
+			}
+			participation.ConfigHistoryBase = base
+			participation.ConfigHistoryChanges = changes
+		}
+		if err := stream.Send(participation); err != nil {
+			return err
+		}
+		previous = config
+		return nil
+	}, nil)
+}

--- a/core/sobject/config-history-accessor.go
+++ b/core/sobject/config-history-accessor.go
@@ -1,0 +1,10 @@
+package sobject
+
+import "context"
+
+// SharedObjectConfigHistoryAccessor reads the retained native lineage of an accepted head.
+// Missing history cannot be reconstructed from client observations.
+type SharedObjectConfigHistoryAccessor interface {
+	// ReadSharedObjectConfigHistory returns the held checkpoint and verified changes through target.
+	ReadSharedObjectConfigHistory(ctx context.Context, target *SharedObjectConfig) (*SharedObjectConfig, []*SOConfigChange, error)
+}

--- a/core/sobject/dir-mount-sobject-body.go
+++ b/core/sobject/dir-mount-sobject-body.go
@@ -2,7 +2,6 @@ package sobject
 
 import (
 	"context"
-	"time"
 
 	"github.com/aperturerobotics/controllerbus/bus"
 	"github.com/aperturerobotics/controllerbus/directive"
@@ -79,9 +78,6 @@ func (v *mountSharedObjectBodyValue[T]) GetSharedObjectBody() T {
 	return v.body
 }
 
-// _ is a type assertion
-var _ MountSharedObjectBodyValue[any] = (*mountSharedObjectBodyValue[any])(nil)
-
 // ExMountSharedObjectBody executes a directive to mount the body of a shared object.
 //
 // If returnIfIdle is set, returns when the directive becomes idle.
@@ -154,8 +150,7 @@ func NewMountSharedObjectBodyWithSource(ref *SharedObjectRef, bodyType string, s
 	}
 }
 
-// Validate validates the directive.
-// This is a cursory validation to see if the values "look correct."
+// Validate checks whether the directive has a valid SharedObject reference.
 func (d *mountSharedObjectBody) Validate() error {
 	if err := d.ref.Validate(); err != nil {
 		return err
@@ -165,12 +160,10 @@ func (d *mountSharedObjectBody) Validate() error {
 
 // GetValueOptions returns options relating to value handling.
 func (d *mountSharedObjectBody) GetValueOptions() directive.ValueOptions {
-	return directive.ValueOptions{
-		// UnrefDisposeDur is the duration to wait to dispose a directive after all
-		// references have been released.
-		UnrefDisposeDur:            time.Millisecond * 100,
-		UnrefDisposeEmptyImmediate: true,
-	}
+	// A mounted body owns a live World engine. Dispose it with its final
+	// reference so a later admission cannot reuse an engine that is closing
+	// under the previous participation state.
+	return directive.ValueOptions{}
 }
 
 // MountSharedObjectBodyRef returns the shared object id to mount.
@@ -226,5 +219,7 @@ func (d *mountSharedObjectBody) GetDebugVals() directive.DebugValues {
 	}
 }
 
-// _ is a type assertion
-var _ MountSharedObjectBody = (*mountSharedObjectBody)(nil)
+var (
+	_ MountSharedObjectBodyValue[any] = (*mountSharedObjectBodyValue[any])(nil)
+	_ MountSharedObjectBody           = (*mountSharedObjectBody)(nil)
+)

--- a/core/sobject/read-checkpoint.go
+++ b/core/sobject/read-checkpoint.go
@@ -1,0 +1,19 @@
+package sobject
+
+import "context"
+
+// SharedObjectReadCheckpointAccessor exposes history retained before read access ended.
+// The snapshot is immutable and conveys no current membership or write authority.
+type SharedObjectReadCheckpointAccessor interface {
+	// GetSharedObjectReadCheckpoint returns nil when no history was retained.
+	GetSharedObjectReadCheckpoint(ctx context.Context) (*SharedObjectReadCheckpoint, error)
+}
+
+// SharedObjectReadCheckpoint binds a historical World to its historical audience.
+// Config is descriptive history, never current participant authority.
+type SharedObjectReadCheckpoint struct {
+	// Snapshot decodes only the root retained at departure.
+	Snapshot SharedObjectStateSnapshot
+	// Config records the audience at that root.
+	Config *SharedObjectConfig
+}

--- a/core/sobject/world/engine/engine.go
+++ b/core/sobject/world/engine/engine.go
@@ -46,8 +46,6 @@ func StartEngineWithConfig(
 type blkEngine struct {
 	// bengine serves the World rooted at cursor.
 	bengine *world_block.Engine
-	// cursor retains the block store and root for this engine.
-	cursor *bucket_lookup.Cursor
 	// decodedBlocks shares decoded blocks across replay engines.
 	decodedBlocks *block.DecodedBlockCache
 	// ownDecodedBlocks requires Release to close a privately allocated cache.
@@ -58,7 +56,7 @@ type blkEngine struct {
 
 // Release releases the engine resources.
 func (w *blkEngine) Release() {
-	w.cursor.Release()
+	_ = w.bengine.Close()
 	if w.ownDecodedBlocks {
 		w.decodedBlocks.Close()
 	}
@@ -72,6 +70,21 @@ func (c *Controller) buildBlkEngine(
 	so sobject.SharedObject,
 	headRef *bucket.ObjectRef,
 	transformConf *block_transform.Config,
+) (*blkEngine, error) {
+	return buildBlockEngine(ctx, le, c.bus, c.sfs, so, headRef, transformConf, c.buildLookupWorldOp(le), c.conf.GetVerbose())
+}
+
+// buildBlockEngine binds a World root to its SharedObject block store.
+func buildBlockEngine(
+	ctx context.Context,
+	le *logrus.Entry,
+	b bus.Bus,
+	sfs *block_transform.StepFactorySet,
+	so sobject.SharedObject,
+	headRef *bucket.ObjectRef,
+	transformConf *block_transform.Config,
+	lookupWorldOp world.LookupOp,
+	verbose bool,
 ) (*blkEngine, error) {
 	ctx, task := trace.NewTask(ctx, "alpha/so-engine/build-block-engine")
 	defer task.End()
@@ -88,7 +101,7 @@ func (c *Controller) buildBlkEngine(
 		var err error
 		xfrm, err = newWorldTransformer(
 			controller.ConstructOpts{Logger: le},
-			c.sfs,
+			sfs,
 			transformConf,
 		)
 		task.End()
@@ -125,9 +138,9 @@ func (c *Controller) buildBlkEngine(
 		taskCtx, task := trace.NewTask(ctx, "alpha/so-engine/build-block-engine/new-cursor")
 		cursor = bucket_lookup.NewCursor(
 			taskCtx,
-			c.bus,
+			b,
 			le,
-			c.sfs,
+			sfs,
 			blockStore,
 			xfrm,
 			headRef,
@@ -145,9 +158,7 @@ func (c *Controller) buildBlkEngine(
 		task.End()
 	}
 
-	lookupWorldOp := c.buildLookupWorldOp(le)
-
-	// Build the world engine
+	// Transfer cursor ownership to the World engine, including constructor failure.
 	var bengine *world_block.Engine
 	{
 		taskCtx, task := trace.NewTask(ctx, "alpha/so-engine/build-block-engine/new-world-engine")
@@ -158,11 +169,10 @@ func (c *Controller) buildBlkEngine(
 			cursor,
 			lookupWorldOp,
 			nil, // no commit function needed
-			c.conf.GetVerbose(),
+			verbose,
 		)
 		task.End()
 		if err != nil {
-			cursor.Release()
 			return nil, err
 		}
 	}
@@ -170,7 +180,6 @@ func (c *Controller) buildBlkEngine(
 	closeDecodedBlocks = false
 	return &blkEngine{
 		bengine:          bengine,
-		cursor:           cursor,
 		decodedBlocks:    decodedBlocks,
 		ownDecodedBlocks: ownDecodedBlocks,
 		lookupOp:         lookupWorldOp,

--- a/core/sobject/world/engine/lease_test.go
+++ b/core/sobject/world/engine/lease_test.go
@@ -22,11 +22,9 @@ func TestWorldEngineLeaseLifecycle(t *testing.T) {
 	defer tb.Release()
 
 	soA := &leaseTestSharedObject{
-		testSharedObject: testSharedObject{
-			blockStore: newTestBlockStore("provider-block-store-a", tb.Volume),
-		},
-		id:  "object-a",
-		vol: tb.Volume,
+		blockStore: newTestBlockStore("provider-block-store-a", tb.Volume),
+		id:         "object-a",
+		vol:        tb.Volume,
 	}
 	engineA := &Controller{bus: tb.Bus, engineID: "world-x"}
 	leaseA, _, err := engineA.acquireWorldEngineLease(ctx, soA)
@@ -41,11 +39,9 @@ func TestWorldEngineLeaseLifecycle(t *testing.T) {
 	}
 
 	soB := &leaseTestSharedObject{
-		testSharedObject: testSharedObject{
-			blockStore: newTestBlockStore("provider-block-store-b", tb.Volume),
-		},
-		id:  "object-b",
-		vol: tb.Volume,
+		blockStore: newTestBlockStore("provider-block-store-b", tb.Volume),
+		id:         "object-b",
+		vol:        tb.Volume,
 	}
 	leaseB, _, err := engineB.acquireWorldEngineLease(ctx, soB)
 	if err != nil {
@@ -78,11 +74,9 @@ func TestWorldEngineLeaseLossStopsEngineContext(t *testing.T) {
 	lease := newTestWorldEngineLease()
 	vol := &leaseTestVolume{Volume: tb.Volume, lease: lease, detectsLoss: true}
 	so := &leaseTestSharedObject{
-		testSharedObject: testSharedObject{
-			blockStore: newTestBlockStore("provider-block-store-loss", tb.Volume),
-		},
-		id:  "object-loss",
-		vol: vol,
+		blockStore: newTestBlockStore("provider-block-store-loss", tb.Volume),
+		id:         "object-loss",
+		vol:        vol,
 	}
 	c := &Controller{bus: tb.Bus, engineID: "world-loss"}
 	acquired, detectsLoss, err := c.acquireWorldEngineLease(ctx, so)

--- a/core/sobject/world/engine/read-checkpoint.go
+++ b/core/sobject/world/engine/read-checkpoint.go
@@ -1,0 +1,119 @@
+package sobject_world_engine
+
+import (
+	"context"
+
+	"github.com/aperturerobotics/controllerbus/bus"
+	"github.com/s4wave/spacewave/core/sobject"
+	"github.com/s4wave/spacewave/db/block"
+	transform_all "github.com/s4wave/spacewave/db/block/transform/all"
+	"github.com/s4wave/spacewave/db/bucket"
+	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
+	"github.com/s4wave/spacewave/db/tx"
+	"github.com/s4wave/spacewave/db/world"
+	"github.com/sirupsen/logrus"
+)
+
+// OpenReadCheckpoint serves one retained World without starting a live body controller.
+// Release closes the cursor after all readers have released their transactions.
+func OpenReadCheckpoint(
+	ctx context.Context,
+	le *logrus.Entry,
+	b bus.Bus,
+	so sobject.SharedObject,
+	snapshot sobject.SharedObjectStateSnapshot,
+) (world.Engine, func(), error) {
+	head, err := finalizationWorldRoot(ctx, snapshot)
+	if err != nil {
+		return nil, nil, err
+	}
+	engine, err := buildBlockEngine(ctx, le, b, transform_all.BuildFactorySet(), so, head, head.GetTransformConf(), nil, false)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &readCheckpointEngine{Engine: engine.bengine, bus: b, le: le}, engine.Release, nil
+}
+
+// readCheckpointEngine rejects mutations through every exported World surface.
+type readCheckpointEngine struct {
+	world.Engine
+	bus bus.Bus
+	le  *logrus.Entry
+}
+
+// NewTransaction opens a read snapshot; a write request cannot acquire authority.
+func (e *readCheckpointEngine) NewTransaction(ctx context.Context, write bool) (world.Tx, error) {
+	if write {
+		return nil, tx.ErrNotWrite
+	}
+	return e.Engine.NewTransaction(ctx, false)
+}
+
+// Sync has no writes or live head to publish.
+func (e *readCheckpointEngine) Sync(context.Context) (bool, error) {
+	return false, nil
+}
+
+// BuildStorageCursor returns a cursor whose bucket cannot accept raw writes.
+func (e *readCheckpointEngine) BuildStorageCursor(ctx context.Context) (*bucket_lookup.Cursor, error) {
+	cursor, err := e.Engine.BuildStorageCursor(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return e.readOnlyCursor(ctx, cursor, cursor.Release), nil
+}
+
+// AccessWorldState exposes a bounded read-only cursor at the requested root.
+func (e *readCheckpointEngine) AccessWorldState(ctx context.Context, ref *bucket.ObjectRef, cb func(*bucket_lookup.Cursor) error) error {
+	return e.Engine.AccessWorldState(ctx, ref, func(cursor *bucket_lookup.Cursor) error {
+		return cb(e.readOnlyCursor(ctx, cursor, nil))
+	})
+}
+
+func (e *readCheckpointEngine) readOnlyCursor(ctx context.Context, cursor *bucket_lookup.Cursor, release func()) *bucket_lookup.Cursor {
+	opArgs := cursor.GetOpArgs()
+	opArgs.VolumeId = ""
+	read := bucket_lookup.NewCursorWithRelease(
+		ctx,
+		e.bus,
+		e.le,
+		cursor.GetStepFactorySet(),
+		&readOnlyBlockStore{StoreOps: cursor.GetBucket()},
+		cursor.GetTransformer(),
+		cursor.GetRef(),
+		opArgs,
+		cursor.GetTransformConf(),
+		release,
+	)
+	read.SetBucketIDOverride(cursor.GetBucketIDOverride())
+	return read
+}
+
+// readOnlyBlockStore preserves block reads while rejecting every storage mutation.
+type readOnlyBlockStore struct {
+	block.StoreOps
+}
+
+func (s *readOnlyBlockStore) BeginReadOperation(ctx context.Context) (block.StoreOps, func(), error) {
+	store, release, err := s.StoreOps.BeginReadOperation(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &readOnlyBlockStore{StoreOps: store}, release, nil
+}
+
+func (s *readOnlyBlockStore) PutBlock(context.Context, []byte, *block.PutOpts) (*block.BlockRef, bool, error) {
+	return nil, false, tx.ErrNotWrite
+}
+
+func (s *readOnlyBlockStore) PutBlockBatch(context.Context, []*block.PutBatchEntry) error {
+	return tx.ErrNotWrite
+}
+
+func (s *readOnlyBlockStore) RmBlock(context.Context, *block.BlockRef) error {
+	return tx.ErrNotWrite
+}
+
+func (s *readOnlyBlockStore) Sync(context.Context) (bool, error) {
+	return false, tx.ErrNotWrite
+}

--- a/core/sobject/world/engine/read-checkpoint_test.go
+++ b/core/sobject/world/engine/read-checkpoint_test.go
@@ -1,0 +1,58 @@
+package sobject_world_engine
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/s4wave/spacewave/core/sobject"
+	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
+	"github.com/s4wave/spacewave/db/tx"
+	world_block "github.com/s4wave/spacewave/db/world/block"
+)
+
+// TestReadCheckpointFreezesWorld verifies the historical root and rejects write transactions.
+func TestReadCheckpointFreezesWorld(t *testing.T) {
+	ctx := t.Context()
+	c, so, head := newProcessTestWorld(t, ctx)
+	known := applyTransactionTestObject(t, c, so, head, "known-object")
+	snapshot := newTestFinalizationSnapshot(t, &sobject.SORoot{InnerSeqno: 2}, known.GetHeadRef())
+	_ = applyTransactionTestObject(t, c, so, known, "later-object")
+	engine, release, err := OpenReadCheckpoint(ctx, c.le, c.bus, so, snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		release()
+		if _, err := engine.NewTransaction(ctx, false); !errors.Is(err, world_block.ErrEngineClosed) {
+			t.Fatalf("released checkpoint retained its engine: %v", err)
+		}
+	}()
+	read, err := engine.NewTransaction(ctx, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer read.Discard()
+	if found, err := read.HasObject(ctx, "known-object"); err != nil || !found {
+		t.Fatalf("checkpoint lost known object: found=%v err=%v", found, err)
+	}
+	if found, err := read.HasObject(ctx, "later-object"); err != nil || found {
+		t.Fatalf("checkpoint exposed later object: found=%v err=%v", found, err)
+	}
+	if _, err := engine.NewTransaction(ctx, true); !errors.Is(err, tx.ErrNotWrite) {
+		t.Fatalf("checkpoint accepted write transaction: %v", err)
+	}
+	cursor, err := engine.BuildStorageCursor(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cursor.Release()
+	if _, _, err := cursor.PutBlock(ctx, []byte("unreferenced history write"), nil); !errors.Is(err, tx.ErrNotWrite) {
+		t.Fatalf("checkpoint storage cursor accepted a write: %v", err)
+	}
+	if err := engine.AccessWorldState(ctx, nil, func(cursor *bucket_lookup.Cursor) error {
+		_, _, err := cursor.PutBlock(ctx, []byte("root history write"), nil)
+		return err
+	}); !errors.Is(err, tx.ErrNotWrite) {
+		t.Fatalf("checkpoint World cursor accepted a write: %v", err)
+	}
+}

--- a/core/sobject/world/engine/tx_test.go
+++ b/core/sobject/world/engine/tx_test.go
@@ -30,8 +30,8 @@ func TestWatchStateKeepsAcceptedWorldBase(t *testing.T) {
 		pending:                  []*sobject.QueuedSOOperation{{LocalId: "pending", OpData: marshalApplyTxOpForProcessTest(t, op)}},
 	}
 	shared := &transactionSharedObject{
-		testFinalizationSharedObject: testFinalizationSharedObject{testSharedObject: *so},
-		snapshot:                     snapshot,
+		testSharedObject: *so,
+		snapshot:         snapshot,
 	}
 	engine := newSoEngine(c, shared, ws.bengine)
 
@@ -66,8 +66,8 @@ func TestWriteTransactionRefreshesAcceptedBase(t *testing.T) {
 	t.Cleanup(ws.Release)
 	accepted := applyTransactionTestObject(t, c, so, head, "remote-object")
 	shared := &transactionSharedObject{
-		testFinalizationSharedObject: testFinalizationSharedObject{testSharedObject: *so},
-		snapshot:                     newTestFinalizationSnapshot(t, &sobject.SORoot{InnerSeqno: 2}, accepted.GetHeadRef()),
+		testSharedObject: *so,
+		snapshot:         newTestFinalizationSnapshot(t, &sobject.SORoot{InnerSeqno: 2}, accepted.GetHeadRef()),
 	}
 	engine := newSoEngine(c, shared, ws.bengine)
 
@@ -127,8 +127,8 @@ func TestWriteTransactionRetainsSharedObjectBase(t *testing.T) {
 	}
 	t.Cleanup(ws.Release)
 	shared := &transactionSharedObject{
-		testFinalizationSharedObject: testFinalizationSharedObject{testSharedObject: *so},
-		snapshot:                     newTestFinalizationSnapshot(t, &sobject.SORoot{InnerSeqno: 1}, head.GetHeadRef()),
+		testSharedObject: *so,
+		snapshot:         newTestFinalizationSnapshot(t, &sobject.SORoot{InnerSeqno: 1}, head.GetHeadRef()),
 	}
 	engine := newSoEngine(c, shared, ws.bengine)
 	tx, err := engine.NewTransaction(ctx, true)

--- a/sdk/sobject/sobject.pb.go
+++ b/sdk/sobject/sobject.pb.go
@@ -14,6 +14,65 @@ import (
 	sobject "github.com/s4wave/spacewave/core/sobject"
 )
 
+// WatchSharedObjectParticipationRequest selects the already mounted SharedObject.
+type WatchSharedObjectParticipationRequest struct {
+	unknownFields []byte
+}
+
+func (x *WatchSharedObjectParticipationRequest) Reset() {
+	*x = WatchSharedObjectParticipationRequest{}
+}
+
+func (*WatchSharedObjectParticipationRequest) ProtoMessage() {}
+
+// SharedObjectParticipation is the configuration accepted by the native host for its own participant.
+// It grants no content access and does not treat a remote refusal as a configuration change.
+type SharedObjectParticipation struct {
+	unknownFields []byte
+	// ViewerPeerId identifies the native participant bound to this mounted SharedObject.
+	ViewerPeerId string `protobuf:"bytes,1,opt,name=viewer_peer_id,json=viewerPeerId,proto3" json:"viewerPeerId,omitempty"`
+	// Config is the retained native configuration, including an accepted departure.
+	Config *sobject.SharedObjectConfig `protobuf:"bytes,2,opt,name=config,proto3" json:"config,omitempty"`
+	// ConfigHistoryBase is the native trust checkpoint when retained lineage is available.
+	ConfigHistoryBase *sobject.SharedObjectConfig `protobuf:"bytes,3,opt,name=config_history_base,json=configHistoryBase,proto3" json:"configHistoryBase,omitempty"`
+	// ConfigHistoryChanges is the verified oldest-first suffix from the checkpoint through Config.
+	ConfigHistoryChanges []*sobject.SOConfigChange `protobuf:"bytes,4,rep,name=config_history_changes,json=configHistoryChanges,proto3" json:"configHistoryChanges,omitempty"`
+}
+
+func (x *SharedObjectParticipation) Reset() {
+	*x = SharedObjectParticipation{}
+}
+
+func (*SharedObjectParticipation) ProtoMessage() {}
+
+func (x *SharedObjectParticipation) GetViewerPeerId() string {
+	if x != nil {
+		return x.ViewerPeerId
+	}
+	return ""
+}
+
+func (x *SharedObjectParticipation) GetConfig() *sobject.SharedObjectConfig {
+	if x != nil {
+		return x.Config
+	}
+	return nil
+}
+
+func (x *SharedObjectParticipation) GetConfigHistoryBase() *sobject.SharedObjectConfig {
+	if x != nil {
+		return x.ConfigHistoryBase
+	}
+	return nil
+}
+
+func (x *SharedObjectParticipation) GetConfigHistoryChanges() []*sobject.SOConfigChange {
+	if x != nil {
+		return x.ConfigHistoryChanges
+	}
+	return nil
+}
+
 // WatchSharedObjectHealthRequest is the request type for WatchSharedObjectHealth.
 type WatchSharedObjectHealthRequest struct {
 	unknownFields []byte
@@ -112,6 +171,80 @@ func (*MountSharedObjectBodyResponse_ResourceId) isMountSharedObjectBodyResponse
 
 func (*MountSharedObjectBodyResponse_Health) isMountSharedObjectBodyResponse_Result() {}
 
+// OpenReadCheckpointRequest selects the native participant's retained history.
+type OpenReadCheckpointRequest struct {
+	unknownFields []byte
+}
+
+func (x *OpenReadCheckpointRequest) Reset() {
+	*x = OpenReadCheckpointRequest{}
+}
+
+func (*OpenReadCheckpointRequest) ProtoMessage() {}
+
+// OpenReadCheckpointResponse returns a read-only World engine when history exists.
+type OpenReadCheckpointResponse struct {
+	unknownFields []byte
+	// ResourceId is zero when no checkpoint was retained.
+	ResourceId uint32 `protobuf:"varint,1,opt,name=resource_id,json=resourceId,proto3" json:"resourceId,omitempty"`
+	// Config is the historical audience at the retained root, not current authority.
+	Config *sobject.SharedObjectConfig `protobuf:"bytes,2,opt,name=config,proto3" json:"config,omitempty"`
+}
+
+func (x *OpenReadCheckpointResponse) Reset() {
+	*x = OpenReadCheckpointResponse{}
+}
+
+func (*OpenReadCheckpointResponse) ProtoMessage() {}
+
+func (x *OpenReadCheckpointResponse) GetResourceId() uint32 {
+	if x != nil {
+		return x.ResourceId
+	}
+	return 0
+}
+
+func (x *OpenReadCheckpointResponse) GetConfig() *sobject.SharedObjectConfig {
+	if x != nil {
+		return x.Config
+	}
+	return nil
+}
+
+func (m *WatchSharedObjectParticipationRequest) CloneVT() *WatchSharedObjectParticipationRequest {
+	if m == nil {
+		return (*WatchSharedObjectParticipationRequest)(nil)
+	}
+	r := new(WatchSharedObjectParticipationRequest)
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = slices.Clone(m.unknownFields)
+	}
+	return r
+}
+
+func (m *WatchSharedObjectParticipationRequest) CloneMessageVT() protobuf_go_lite.CloneMessage {
+	return m.CloneVT()
+}
+
+func (m *SharedObjectParticipation) CloneVT() *SharedObjectParticipation {
+	if m == nil {
+		return (*SharedObjectParticipation)(nil)
+	}
+	r := new(SharedObjectParticipation)
+	r.ViewerPeerId = m.ViewerPeerId
+	r.Config = protobuf_go_lite.CloneVTValue(m.Config)
+	r.ConfigHistoryBase = protobuf_go_lite.CloneVTValue(m.ConfigHistoryBase)
+	r.ConfigHistoryChanges = protobuf_go_lite.CloneVTSlice(m.ConfigHistoryChanges)
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = slices.Clone(m.unknownFields)
+	}
+	return r
+}
+
+func (m *SharedObjectParticipation) CloneMessageVT() protobuf_go_lite.CloneMessage {
+	return m.CloneVT()
+}
+
 func (m *WatchSharedObjectHealthRequest) CloneVT() *WatchSharedObjectHealthRequest {
 	if m == nil {
 		return (*WatchSharedObjectHealthRequest)(nil)
@@ -202,6 +335,84 @@ func (m *MountSharedObjectBodyResponse_Health) CloneVT() *MountSharedObjectBodyR
 
 func (m *MountSharedObjectBodyResponse_Health) CloneOneofVT() isMountSharedObjectBodyResponse_Result {
 	return m.CloneVT()
+}
+
+func (m *OpenReadCheckpointRequest) CloneVT() *OpenReadCheckpointRequest {
+	if m == nil {
+		return (*OpenReadCheckpointRequest)(nil)
+	}
+	r := new(OpenReadCheckpointRequest)
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = slices.Clone(m.unknownFields)
+	}
+	return r
+}
+
+func (m *OpenReadCheckpointRequest) CloneMessageVT() protobuf_go_lite.CloneMessage {
+	return m.CloneVT()
+}
+
+func (m *OpenReadCheckpointResponse) CloneVT() *OpenReadCheckpointResponse {
+	if m == nil {
+		return (*OpenReadCheckpointResponse)(nil)
+	}
+	r := new(OpenReadCheckpointResponse)
+	r.ResourceId = m.ResourceId
+	r.Config = protobuf_go_lite.CloneVTValue(m.Config)
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = slices.Clone(m.unknownFields)
+	}
+	return r
+}
+
+func (m *OpenReadCheckpointResponse) CloneMessageVT() protobuf_go_lite.CloneMessage {
+	return m.CloneVT()
+}
+
+func (this *WatchSharedObjectParticipationRequest) EqualVT(that *WatchSharedObjectParticipationRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *WatchSharedObjectParticipationRequest) EqualMessageVT(thatMsg any) bool {
+	that, ok := thatMsg.(*WatchSharedObjectParticipationRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+
+func (this *SharedObjectParticipation) EqualVT(that *SharedObjectParticipation) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.ViewerPeerId != that.ViewerPeerId {
+		return false
+	}
+	if !protobuf_go_lite.IsEqualVT(this.Config, that.Config) {
+		return false
+	}
+	if !protobuf_go_lite.IsEqualVT(this.ConfigHistoryBase, that.ConfigHistoryBase) {
+		return false
+	}
+	if !protobuf_go_lite.EqualVTSliceImplicit(this.ConfigHistoryChanges, that.ConfigHistoryChanges, func() *sobject.SOConfigChange { return &sobject.SOConfigChange{} }) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *SharedObjectParticipation) EqualMessageVT(thatMsg any) bool {
+	that, ok := thatMsg.(*SharedObjectParticipation)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
 }
 
 func (this *WatchSharedObjectHealthRequest) EqualVT(that *WatchSharedObjectHealthRequest) bool {
@@ -319,6 +530,171 @@ func (this *MountSharedObjectBodyResponse_Health) EqualVT(thatIface isMountShare
 		return false
 	}
 	return true
+}
+
+func (this *OpenReadCheckpointRequest) EqualVT(that *OpenReadCheckpointRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *OpenReadCheckpointRequest) EqualMessageVT(thatMsg any) bool {
+	that, ok := thatMsg.(*OpenReadCheckpointRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+
+func (this *OpenReadCheckpointResponse) EqualVT(that *OpenReadCheckpointResponse) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.ResourceId != that.ResourceId {
+		return false
+	}
+	if !protobuf_go_lite.IsEqualVT(this.Config, that.Config) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *OpenReadCheckpointResponse) EqualMessageVT(thatMsg any) bool {
+	that, ok := thatMsg.(*OpenReadCheckpointResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+
+// MarshalProtoJSON marshals the WatchSharedObjectParticipationRequest message to JSON.
+func (x *WatchSharedObjectParticipationRequest) MarshalProtoJSON(s *json.MarshalState) {
+	if x == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteObjectStart()
+	s.WriteObjectEnd()
+}
+
+// MarshalJSON marshals the WatchSharedObjectParticipationRequest to JSON.
+func (x *WatchSharedObjectParticipationRequest) MarshalJSON() ([]byte, error) {
+	return json.DefaultMarshalerConfig.Marshal(x)
+}
+
+// UnmarshalProtoJSON unmarshals the WatchSharedObjectParticipationRequest message from JSON.
+func (x *WatchSharedObjectParticipationRequest) UnmarshalProtoJSON(s *json.UnmarshalState) {
+	if s.ReadNil() {
+		return
+	}
+	s.ReadObject(func(key string) {
+		// no fields
+	})
+}
+
+// UnmarshalJSON unmarshals the WatchSharedObjectParticipationRequest from JSON.
+func (x *WatchSharedObjectParticipationRequest) UnmarshalJSON(b []byte) error {
+	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
+}
+
+// MarshalProtoJSON marshals the SharedObjectParticipation message to JSON.
+func (x *SharedObjectParticipation) MarshalProtoJSON(s *json.MarshalState) {
+	if x == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteObjectStart()
+	var wroteField bool
+	if x.ViewerPeerId != "" || s.HasField("viewerPeerId") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("viewerPeerId")
+		s.WriteString(x.ViewerPeerId)
+	}
+	if x.Config != nil || s.HasField("config") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("config")
+		x.Config.MarshalProtoJSON(s.WithField("config"))
+	}
+	if x.ConfigHistoryBase != nil || s.HasField("configHistoryBase") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("configHistoryBase")
+		x.ConfigHistoryBase.MarshalProtoJSON(s.WithField("configHistoryBase"))
+	}
+	if len(x.ConfigHistoryChanges) > 0 || s.HasField("configHistoryChanges") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("configHistoryChanges")
+		s.WriteArrayStart()
+		var wroteElement bool
+		for _, element := range x.ConfigHistoryChanges {
+			s.WriteMoreIf(&wroteElement)
+			element.MarshalProtoJSON(s.WithField("configHistoryChanges"))
+		}
+		s.WriteArrayEnd()
+	}
+	s.WriteObjectEnd()
+}
+
+// MarshalJSON marshals the SharedObjectParticipation to JSON.
+func (x *SharedObjectParticipation) MarshalJSON() ([]byte, error) {
+	return json.DefaultMarshalerConfig.Marshal(x)
+}
+
+// UnmarshalProtoJSON unmarshals the SharedObjectParticipation message from JSON.
+func (x *SharedObjectParticipation) UnmarshalProtoJSON(s *json.UnmarshalState) {
+	if s.ReadNil() {
+		return
+	}
+	s.ReadObject(func(key string) {
+		switch key {
+		default:
+			s.Skip() // ignore unknown field
+		case "viewer_peer_id", "viewerPeerId":
+			s.AddField("viewer_peer_id")
+			x.ViewerPeerId = s.ReadString()
+		case "config":
+			if s.ReadNil() {
+				x.Config = nil
+				return
+			}
+			x.Config = &sobject.SharedObjectConfig{}
+			x.Config.UnmarshalProtoJSON(s.WithField("config", true))
+		case "config_history_base", "configHistoryBase":
+			if s.ReadNil() {
+				x.ConfigHistoryBase = nil
+				return
+			}
+			x.ConfigHistoryBase = &sobject.SharedObjectConfig{}
+			x.ConfigHistoryBase.UnmarshalProtoJSON(s.WithField("config_history_base", true))
+		case "config_history_changes", "configHistoryChanges":
+			s.AddField("config_history_changes")
+			if s.ReadNil() {
+				x.ConfigHistoryChanges = nil
+				return
+			}
+			s.ReadArray(func() {
+				if s.ReadNil() {
+					x.ConfigHistoryChanges = append(x.ConfigHistoryChanges, nil)
+					return
+				}
+				v := &sobject.SOConfigChange{}
+				v.UnmarshalProtoJSON(s.WithField("config_history_changes", false))
+				if s.Err() != nil {
+					return
+				}
+				x.ConfigHistoryChanges = append(x.ConfigHistoryChanges, v)
+			})
+		}
+	})
+}
+
+// UnmarshalJSON unmarshals the SharedObjectParticipation from JSON.
+func (x *SharedObjectParticipation) UnmarshalJSON(b []byte) error {
+	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
 }
 
 // MarshalProtoJSON marshals the WatchSharedObjectHealthRequest message to JSON.
@@ -485,6 +861,191 @@ func (x *MountSharedObjectBodyResponse) UnmarshalProtoJSON(s *json.UnmarshalStat
 // UnmarshalJSON unmarshals the MountSharedObjectBodyResponse from JSON.
 func (x *MountSharedObjectBodyResponse) UnmarshalJSON(b []byte) error {
 	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
+}
+
+// MarshalProtoJSON marshals the OpenReadCheckpointRequest message to JSON.
+func (x *OpenReadCheckpointRequest) MarshalProtoJSON(s *json.MarshalState) {
+	if x == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteObjectStart()
+	s.WriteObjectEnd()
+}
+
+// MarshalJSON marshals the OpenReadCheckpointRequest to JSON.
+func (x *OpenReadCheckpointRequest) MarshalJSON() ([]byte, error) {
+	return json.DefaultMarshalerConfig.Marshal(x)
+}
+
+// UnmarshalProtoJSON unmarshals the OpenReadCheckpointRequest message from JSON.
+func (x *OpenReadCheckpointRequest) UnmarshalProtoJSON(s *json.UnmarshalState) {
+	if s.ReadNil() {
+		return
+	}
+	s.ReadObject(func(key string) {
+		// no fields
+	})
+}
+
+// UnmarshalJSON unmarshals the OpenReadCheckpointRequest from JSON.
+func (x *OpenReadCheckpointRequest) UnmarshalJSON(b []byte) error {
+	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
+}
+
+// MarshalProtoJSON marshals the OpenReadCheckpointResponse message to JSON.
+func (x *OpenReadCheckpointResponse) MarshalProtoJSON(s *json.MarshalState) {
+	if x == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteObjectStart()
+	var wroteField bool
+	if x.ResourceId != 0 || s.HasField("resourceId") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("resourceId")
+		s.WriteUint32(x.ResourceId)
+	}
+	if x.Config != nil || s.HasField("config") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("config")
+		x.Config.MarshalProtoJSON(s.WithField("config"))
+	}
+	s.WriteObjectEnd()
+}
+
+// MarshalJSON marshals the OpenReadCheckpointResponse to JSON.
+func (x *OpenReadCheckpointResponse) MarshalJSON() ([]byte, error) {
+	return json.DefaultMarshalerConfig.Marshal(x)
+}
+
+// UnmarshalProtoJSON unmarshals the OpenReadCheckpointResponse message from JSON.
+func (x *OpenReadCheckpointResponse) UnmarshalProtoJSON(s *json.UnmarshalState) {
+	if s.ReadNil() {
+		return
+	}
+	s.ReadObject(func(key string) {
+		switch key {
+		default:
+			s.Skip() // ignore unknown field
+		case "resource_id", "resourceId":
+			s.AddField("resource_id")
+			x.ResourceId = s.ReadUint32()
+		case "config":
+			if s.ReadNil() {
+				x.Config = nil
+				return
+			}
+			x.Config = &sobject.SharedObjectConfig{}
+			x.Config.UnmarshalProtoJSON(s.WithField("config", true))
+		}
+	})
+}
+
+// UnmarshalJSON unmarshals the OpenReadCheckpointResponse from JSON.
+func (x *OpenReadCheckpointResponse) UnmarshalJSON(b []byte) error {
+	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
+}
+
+func (m *WatchSharedObjectParticipationRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *WatchSharedObjectParticipationRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *WatchSharedObjectParticipationRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *SharedObjectParticipation) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SharedObjectParticipation) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *SharedObjectParticipation) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	if len(m.ConfigHistoryChanges) > 0 {
+		for iNdEx := len(m.ConfigHistoryChanges) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.ConfigHistoryChanges[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x22
+		}
+	}
+	if m.ConfigHistoryBase != nil {
+		size, err := m.ConfigHistoryBase.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if m.Config != nil {
+		size, err := m.Config.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.ViewerPeerId) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.ViewerPeerId)
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *WatchSharedObjectHealthRequest) MarshalVT() (dAtA []byte, err error) {
@@ -671,6 +1232,118 @@ func (m *MountSharedObjectBodyResponse_Health) MarshalToSizedBufferVT(dAtA []byt
 	return len(dAtA) - i, nil
 }
 
+func (m *OpenReadCheckpointRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *OpenReadCheckpointRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *OpenReadCheckpointRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *OpenReadCheckpointResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *OpenReadCheckpointResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *OpenReadCheckpointResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	if m.Config != nil {
+		size, err := m.Config.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.ResourceId != 0 {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(m.ResourceId))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *WatchSharedObjectParticipationRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *SharedObjectParticipation) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.ViewerPeerId)
+	if m.Config != nil {
+		l = m.Config.SizeVT()
+		n += protobuf_go_lite.SizeMessage(1, l)
+	}
+	if m.ConfigHistoryBase != nil {
+		l = m.ConfigHistoryBase.SizeVT()
+		n += protobuf_go_lite.SizeMessage(1, l)
+	}
+	for _, e := range m.ConfigHistoryChanges {
+		l = e.SizeVT()
+		n += protobuf_go_lite.SizeMessage(1, l)
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *WatchSharedObjectHealthRequest) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -743,6 +1416,75 @@ func (m *MountSharedObjectBodyResponse_Health) SizeVT() (n int) {
 	return n
 }
 
+func (m *OpenReadCheckpointRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *OpenReadCheckpointResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	n += protobuf_go_lite.SizeVarintNonZero(1, m.ResourceId)
+	if m.Config != nil {
+		l = m.Config.SizeVT()
+		n += protobuf_go_lite.SizeMessage(1, l)
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (x *WatchSharedObjectParticipationRequest) MarshalProtoText() string {
+	var sb protobuf_go_lite.TextBuilder
+	protobuf_go_lite.TextStartMessage(&sb, "WatchSharedObjectParticipationRequest")
+	return protobuf_go_lite.TextFinishMessage(&sb)
+}
+
+func (x *WatchSharedObjectParticipationRequest) String() string {
+	return x.MarshalProtoText()
+}
+
+func (x *SharedObjectParticipation) MarshalProtoText() string {
+	var sb protobuf_go_lite.TextBuilder
+	initialLen := protobuf_go_lite.TextStartMessage(&sb, "SharedObjectParticipation")
+	if x.ViewerPeerId != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "viewer_peer_id")
+		protobuf_go_lite.TextWriteString(&sb, x.ViewerPeerId)
+	}
+	if x.Config != nil {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "config")
+		protobuf_go_lite.TextWriteTextMarshaler(&sb, x.Config)
+	}
+	if x.ConfigHistoryBase != nil {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "config_history_base")
+		protobuf_go_lite.TextWriteTextMarshaler(&sb, x.ConfigHistoryBase)
+	}
+	if len(x.ConfigHistoryChanges) > 0 {
+		protobuf_go_lite.TextWriteListStart(&sb, initialLen, "config_history_changes")
+		for i, v := range x.ConfigHistoryChanges {
+			protobuf_go_lite.TextWriteListSeparator(&sb, i)
+			if v == nil {
+				protobuf_go_lite.TextWriteTextMarshaler(&sb, &sobject.SOConfigChange{})
+			} else {
+				protobuf_go_lite.TextWriteTextMarshaler(&sb, v)
+			}
+		}
+		protobuf_go_lite.TextWriteListEnd(&sb)
+	}
+	return protobuf_go_lite.TextFinishMessage(&sb)
+}
+
+func (x *SharedObjectParticipation) String() string {
+	return x.MarshalProtoText()
+}
+
 func (x *WatchSharedObjectHealthRequest) MarshalProtoText() string {
 	var sb protobuf_go_lite.TextBuilder
 	protobuf_go_lite.TextStartMessage(&sb, "WatchSharedObjectHealthRequest")
@@ -797,6 +1539,173 @@ func (x *MountSharedObjectBodyResponse) MarshalProtoText() string {
 
 func (x *MountSharedObjectBodyResponse) String() string {
 	return x.MarshalProtoText()
+}
+
+func (x *OpenReadCheckpointRequest) MarshalProtoText() string {
+	var sb protobuf_go_lite.TextBuilder
+	protobuf_go_lite.TextStartMessage(&sb, "OpenReadCheckpointRequest")
+	return protobuf_go_lite.TextFinishMessage(&sb)
+}
+
+func (x *OpenReadCheckpointRequest) String() string {
+	return x.MarshalProtoText()
+}
+
+func (x *OpenReadCheckpointResponse) MarshalProtoText() string {
+	var sb protobuf_go_lite.TextBuilder
+	initialLen := protobuf_go_lite.TextStartMessage(&sb, "OpenReadCheckpointResponse")
+	if x.ResourceId != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "resource_id")
+		protobuf_go_lite.TextWriteUint(&sb, x.ResourceId)
+	}
+	if x.Config != nil {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "config")
+		protobuf_go_lite.TextWriteTextMarshaler(&sb, x.Config)
+	}
+	return protobuf_go_lite.TextFinishMessage(&sb)
+}
+
+func (x *OpenReadCheckpointResponse) String() string {
+	return x.MarshalProtoText()
+}
+
+func (m *WatchSharedObjectParticipationRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	var err error
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		wire, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+		if err != nil {
+			return err
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: WatchSharedObjectParticipationRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: WatchSharedObjectParticipationRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protobuf_go_lite.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+
+func (m *SharedObjectParticipation) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	var err error
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		wire, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+		if err != nil {
+			return err
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SharedObjectParticipation: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SharedObjectParticipation: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ViewerPeerId", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.ViewerPeerId = v
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Config", wireType)
+			}
+			msgStart, postIndex, err := protobuf_go_lite.DecodeLengthDelimited(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			if m.Config == nil {
+				m.Config = &sobject.SharedObjectConfig{}
+			}
+			if err := m.Config.UnmarshalVT(dAtA[msgStart:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ConfigHistoryBase", wireType)
+			}
+			msgStart, postIndex, err := protobuf_go_lite.DecodeLengthDelimited(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			if m.ConfigHistoryBase == nil {
+				m.ConfigHistoryBase = &sobject.SharedObjectConfig{}
+			}
+			if err := m.ConfigHistoryBase.UnmarshalVT(dAtA[msgStart:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ConfigHistoryChanges", wireType)
+			}
+			msgStart, postIndex, err := protobuf_go_lite.DecodeLengthDelimited(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.ConfigHistoryChanges = append(m.ConfigHistoryChanges, &sobject.SOConfigChange{})
+			if err := m.ConfigHistoryChanges[len(m.ConfigHistoryChanges)-1].UnmarshalVT(dAtA[msgStart:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protobuf_go_lite.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
 }
 
 func (m *WatchSharedObjectHealthRequest) UnmarshalVT(dAtA []byte) error {
@@ -991,6 +1900,116 @@ func (m *MountSharedObjectBodyResponse) UnmarshalVT(dAtA []byte) error {
 					return err
 				}
 				m.Result = &MountSharedObjectBodyResponse_Health{Health: v}
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protobuf_go_lite.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+
+func (m *OpenReadCheckpointRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	var err error
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		wire, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+		if err != nil {
+			return err
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: OpenReadCheckpointRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: OpenReadCheckpointRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protobuf_go_lite.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+
+func (m *OpenReadCheckpointResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	var err error
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		wire, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+		if err != nil {
+			return err
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: OpenReadCheckpointResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: OpenReadCheckpointResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ResourceId", wireType)
+			}
+			m.ResourceId = 0
+			m.ResourceId, iNdEx, err = protobuf_go_lite.DecodeVarintUint32(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Config", wireType)
+			}
+			msgStart, postIndex, err := protobuf_go_lite.DecodeLengthDelimited(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			if m.Config == nil {
+				m.Config = &sobject.SharedObjectConfig{}
+			}
+			if err := m.Config.UnmarshalVT(dAtA[msgStart:postIndex]); err != nil {
+				return err
 			}
 			iNdEx = postIndex
 		default:

--- a/sdk/sobject/sobject.pb.ts
+++ b/sdk/sobject/sobject.pb.ts
@@ -7,11 +7,84 @@ import {
   createEmptyMessageType,
   createMessageType,
 } from '@aptre/protobuf-es-lite/message'
-import { SharedObjectHealth } from '../../core/sobject/sobject.pb.js'
-import type { PartialFieldInfo } from '@aptre/protobuf-es-lite/field'
+import {
+  SharedObjectConfig,
+  SharedObjectHealth,
+  SOConfigChange,
+} from '../../core/sobject/sobject.pb.js'
 import { ScalarType } from '@aptre/protobuf-es-lite/scalar'
+import type { PartialFieldInfo } from '@aptre/protobuf-es-lite/field'
 
 export const protobufPackage = 's4wave.sobject'
+
+/**
+ * WatchSharedObjectParticipationRequest selects the already mounted SharedObject.
+ *
+ * @generated from message s4wave.sobject.WatchSharedObjectParticipationRequest
+ */
+export interface WatchSharedObjectParticipationRequest {}
+
+export const WatchSharedObjectParticipationRequest: MessageType<WatchSharedObjectParticipationRequest> =
+  /* @__PURE__ */ createEmptyMessageType<WatchSharedObjectParticipationRequest>(
+    's4wave.sobject.WatchSharedObjectParticipationRequest',
+    true,
+  )
+
+/**
+ * SharedObjectParticipation is the configuration accepted by the native host for its own participant.
+ * It grants no content access and does not treat a remote refusal as a configuration change.
+ *
+ * @generated from message s4wave.sobject.SharedObjectParticipation
+ */
+export interface SharedObjectParticipation {
+  /**
+   * ViewerPeerId identifies the native participant bound to this mounted SharedObject.
+   *
+   * @generated from field: string viewer_peer_id = 1;
+   */
+  viewerPeerId?: string
+  /**
+   * Config is the retained native configuration, including an accepted departure.
+   *
+   * @generated from field: sobject.SharedObjectConfig config = 2;
+   */
+  config?: SharedObjectConfig
+  /**
+   * ConfigHistoryBase is the native trust checkpoint when retained lineage is available.
+   *
+   * @generated from field: sobject.SharedObjectConfig config_history_base = 3;
+   */
+  configHistoryBase?: SharedObjectConfig
+  /**
+   * ConfigHistoryChanges is the verified oldest-first suffix from the checkpoint through Config.
+   *
+   * @generated from field: repeated sobject.SOConfigChange config_history_changes = 4;
+   */
+  configHistoryChanges?: SOConfigChange[]
+}
+
+export const SharedObjectParticipation: MessageType<SharedObjectParticipation> =
+  /* @__PURE__ */ createMessageType({
+    typeName: 's4wave.sobject.SharedObjectParticipation',
+    fields: [
+      { no: 1, name: 'viewer_peer_id', kind: 'scalar', T: ScalarType.STRING },
+      { no: 2, name: 'config', kind: 'message', T: () => SharedObjectConfig },
+      {
+        no: 3,
+        name: 'config_history_base',
+        kind: 'message',
+        T: () => SharedObjectConfig,
+      },
+      {
+        no: 4,
+        name: 'config_history_changes',
+        kind: 'message',
+        T: () => SOConfigChange,
+        repeated: true,
+      },
+    ] satisfies readonly PartialFieldInfo[],
+    packedByDefault: true,
+  })
 
 /**
  * WatchSharedObjectHealthRequest is the request type for WatchSharedObjectHealth.
@@ -116,6 +189,49 @@ export const MountSharedObjectBodyResponse: MessageType<MountSharedObjectBodyRes
         T: () => SharedObjectHealth,
         oneof: 'result',
       },
+    ] satisfies readonly PartialFieldInfo[],
+    packedByDefault: true,
+  })
+
+/**
+ * OpenReadCheckpointRequest selects the native participant's retained history.
+ *
+ * @generated from message s4wave.sobject.OpenReadCheckpointRequest
+ */
+export interface OpenReadCheckpointRequest {}
+
+export const OpenReadCheckpointRequest: MessageType<OpenReadCheckpointRequest> =
+  /* @__PURE__ */ createEmptyMessageType<OpenReadCheckpointRequest>(
+    's4wave.sobject.OpenReadCheckpointRequest',
+    true,
+  )
+
+/**
+ * OpenReadCheckpointResponse returns a read-only World engine when history exists.
+ *
+ * @generated from message s4wave.sobject.OpenReadCheckpointResponse
+ */
+export interface OpenReadCheckpointResponse {
+  /**
+   * ResourceId is zero when no checkpoint was retained.
+   *
+   * @generated from field: uint32 resource_id = 1;
+   */
+  resourceId?: number
+  /**
+   * Config is the historical audience at the retained root, not current authority.
+   *
+   * @generated from field: sobject.SharedObjectConfig config = 2;
+   */
+  config?: SharedObjectConfig
+}
+
+export const OpenReadCheckpointResponse: MessageType<OpenReadCheckpointResponse> =
+  /* @__PURE__ */ createMessageType({
+    typeName: 's4wave.sobject.OpenReadCheckpointResponse',
+    fields: [
+      { no: 1, name: 'resource_id', kind: 'scalar', T: ScalarType.UINT32 },
+      { no: 2, name: 'config', kind: 'message', T: () => SharedObjectConfig },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,
   })

--- a/sdk/sobject/sobject.proto
+++ b/sdk/sobject/sobject.proto
@@ -3,10 +3,33 @@ package s4wave.sobject;
 
 import "github.com/s4wave/spacewave/core/sobject/sobject.proto";
 
+// SharedObjectResourceService exposes retained native state independently of readable body access.
 service SharedObjectResourceService {
   rpc WatchSharedObjectHealth(WatchSharedObjectHealthRequest) returns (stream WatchSharedObjectHealthResponse);
+  // WatchSharedObjectParticipation observes held native authority without mounting content.
+  rpc WatchSharedObjectParticipation(WatchSharedObjectParticipationRequest) returns (stream SharedObjectParticipation);
+
+  // OpenReadCheckpoint opens immutable World history retained before departure.
+  rpc OpenReadCheckpoint(OpenReadCheckpointRequest) returns (OpenReadCheckpointResponse);
 
   rpc MountSharedObjectBody(MountSharedObjectBodyRequest) returns (MountSharedObjectBodyResponse);
+}
+
+// WatchSharedObjectParticipationRequest selects the already mounted SharedObject.
+message WatchSharedObjectParticipationRequest {
+}
+
+// SharedObjectParticipation is the configuration accepted by the native host for its own participant.
+// It grants no content access and does not treat a remote refusal as a configuration change.
+message SharedObjectParticipation {
+  // ViewerPeerId identifies the native participant bound to this mounted SharedObject.
+  string viewer_peer_id = 1;
+  // Config is the retained native configuration, including an accepted departure.
+  .sobject.SharedObjectConfig config = 2;
+  // ConfigHistoryBase is the native trust checkpoint when retained lineage is available.
+  .sobject.SharedObjectConfig config_history_base = 3;
+  // ConfigHistoryChanges is the verified oldest-first suffix from the checkpoint through Config.
+  repeated .sobject.SOConfigChange config_history_changes = 4;
 }
 
 // WatchSharedObjectHealthRequest is the request type for WatchSharedObjectHealth.
@@ -30,4 +53,15 @@ message MountSharedObjectBodyResponse {
     // Health is returned when body construction failed with typed SharedObject health.
     .sobject.SharedObjectHealth health = 2;
   }
+}
+
+// OpenReadCheckpointRequest selects the native participant's retained history.
+message OpenReadCheckpointRequest {}
+
+// OpenReadCheckpointResponse returns a read-only World engine when history exists.
+message OpenReadCheckpointResponse {
+  // ResourceId is zero when no checkpoint was retained.
+  uint32 resource_id = 1;
+  // Config is the historical audience at the retained root, not current authority.
+  .sobject.SharedObjectConfig config = 2;
 }

--- a/sdk/sobject/sobject_srpc.pb.go
+++ b/sdk/sobject/sobject_srpc.pb.go
@@ -15,6 +15,10 @@ type SRPCSharedObjectResourceServiceClient interface {
 	SRPCClient() srpc.Client
 
 	WatchSharedObjectHealth(ctx context.Context, in *WatchSharedObjectHealthRequest) (SRPCSharedObjectResourceService_WatchSharedObjectHealthClient, error)
+	// WatchSharedObjectParticipation observes held native authority without mounting content.
+	WatchSharedObjectParticipation(ctx context.Context, in *WatchSharedObjectParticipationRequest) (SRPCSharedObjectResourceService_WatchSharedObjectParticipationClient, error)
+	// OpenReadCheckpoint opens immutable World history retained before departure.
+	OpenReadCheckpoint(ctx context.Context, in *OpenReadCheckpointRequest) (*OpenReadCheckpointResponse, error)
 
 	MountSharedObjectBody(ctx context.Context, in *MountSharedObjectBodyRequest) (*MountSharedObjectBodyResponse, error)
 }
@@ -71,6 +75,49 @@ func (x *srpcSharedObjectResourceService_WatchSharedObjectHealthClient) RecvTo(m
 	return x.MsgRecv(m)
 }
 
+func (c *srpcSharedObjectResourceServiceClient) WatchSharedObjectParticipation(ctx context.Context, in *WatchSharedObjectParticipationRequest) (SRPCSharedObjectResourceService_WatchSharedObjectParticipationClient, error) {
+	stream, err := c.cc.NewStream(ctx, c.serviceID, "WatchSharedObjectParticipation", in)
+	if err != nil {
+		return nil, err
+	}
+	strm := &srpcSharedObjectResourceService_WatchSharedObjectParticipationClient{stream}
+	if err := strm.CloseSend(); err != nil {
+		return nil, err
+	}
+	return strm, nil
+}
+
+type SRPCSharedObjectResourceService_WatchSharedObjectParticipationClient interface {
+	srpc.Stream
+	Recv() (*SharedObjectParticipation, error)
+	RecvTo(*SharedObjectParticipation) error
+}
+
+type srpcSharedObjectResourceService_WatchSharedObjectParticipationClient struct {
+	srpc.Stream
+}
+
+func (x *srpcSharedObjectResourceService_WatchSharedObjectParticipationClient) Recv() (*SharedObjectParticipation, error) {
+	m := new(SharedObjectParticipation)
+	if err := x.MsgRecv(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func (x *srpcSharedObjectResourceService_WatchSharedObjectParticipationClient) RecvTo(m *SharedObjectParticipation) error {
+	return x.MsgRecv(m)
+}
+
+func (c *srpcSharedObjectResourceServiceClient) OpenReadCheckpoint(ctx context.Context, in *OpenReadCheckpointRequest) (*OpenReadCheckpointResponse, error) {
+	out := new(OpenReadCheckpointResponse)
+	err := c.cc.ExecCall(ctx, c.serviceID, "OpenReadCheckpoint", in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *srpcSharedObjectResourceServiceClient) MountSharedObjectBody(ctx context.Context, in *MountSharedObjectBodyRequest) (*MountSharedObjectBodyResponse, error) {
 	out := new(MountSharedObjectBodyResponse)
 	err := c.cc.ExecCall(ctx, c.serviceID, "MountSharedObjectBody", in, out)
@@ -82,6 +129,10 @@ func (c *srpcSharedObjectResourceServiceClient) MountSharedObjectBody(ctx contex
 
 type SRPCSharedObjectResourceServiceServer interface {
 	WatchSharedObjectHealth(*WatchSharedObjectHealthRequest, SRPCSharedObjectResourceService_WatchSharedObjectHealthStream) error
+	// WatchSharedObjectParticipation observes held native authority without mounting content.
+	WatchSharedObjectParticipation(*WatchSharedObjectParticipationRequest, SRPCSharedObjectResourceService_WatchSharedObjectParticipationStream) error
+	// OpenReadCheckpoint opens immutable World history retained before departure.
+	OpenReadCheckpoint(context.Context, *OpenReadCheckpointRequest) (*OpenReadCheckpointResponse, error)
 
 	MountSharedObjectBody(context.Context, *MountSharedObjectBodyRequest) (*MountSharedObjectBodyResponse, error)
 }
@@ -113,6 +164,8 @@ func (d *SRPCSharedObjectResourceServiceHandler) GetServiceID() string { return 
 func (SRPCSharedObjectResourceServiceHandler) GetMethodIDs() []string {
 	return []string{
 		"WatchSharedObjectHealth",
+		"WatchSharedObjectParticipation",
+		"OpenReadCheckpoint",
 		"MountSharedObjectBody",
 	}
 }
@@ -128,6 +181,10 @@ func (d *SRPCSharedObjectResourceServiceHandler) InvokeMethod(
 	switch methodID {
 	case "WatchSharedObjectHealth":
 		return true, d.InvokeMethod_WatchSharedObjectHealth(d.impl, strm)
+	case "WatchSharedObjectParticipation":
+		return true, d.InvokeMethod_WatchSharedObjectParticipation(d.impl, strm)
+	case "OpenReadCheckpoint":
+		return true, d.InvokeMethod_OpenReadCheckpoint(d.impl, strm)
 	case "MountSharedObjectBody":
 		return true, d.InvokeMethod_MountSharedObjectBody(d.impl, strm)
 	default:
@@ -142,6 +199,27 @@ func (SRPCSharedObjectResourceServiceHandler) InvokeMethod_WatchSharedObjectHeal
 	}
 	serverStrm := &srpcSharedObjectResourceService_WatchSharedObjectHealthStream{strm}
 	return impl.WatchSharedObjectHealth(req, serverStrm)
+}
+
+func (SRPCSharedObjectResourceServiceHandler) InvokeMethod_WatchSharedObjectParticipation(impl SRPCSharedObjectResourceServiceServer, strm srpc.Stream) error {
+	req := new(WatchSharedObjectParticipationRequest)
+	if err := strm.MsgRecv(req); err != nil {
+		return err
+	}
+	serverStrm := &srpcSharedObjectResourceService_WatchSharedObjectParticipationStream{strm}
+	return impl.WatchSharedObjectParticipation(req, serverStrm)
+}
+
+func (SRPCSharedObjectResourceServiceHandler) InvokeMethod_OpenReadCheckpoint(impl SRPCSharedObjectResourceServiceServer, strm srpc.Stream) error {
+	req := new(OpenReadCheckpointRequest)
+	if err := strm.MsgRecv(req); err != nil {
+		return err
+	}
+	out, err := impl.OpenReadCheckpoint(strm.Context(), req)
+	if err != nil {
+		return err
+	}
+	return strm.MsgSend(out)
 }
 
 func (SRPCSharedObjectResourceServiceHandler) InvokeMethod_MountSharedObjectBody(impl SRPCSharedObjectResourceServiceServer, strm srpc.Stream) error {
@@ -177,6 +255,37 @@ func (x *srpcSharedObjectResourceService_WatchSharedObjectHealthStream) SendAndC
 		}
 	}
 	return x.CloseSend()
+}
+
+type SRPCSharedObjectResourceService_WatchSharedObjectParticipationStream interface {
+	srpc.Stream
+	Send(*SharedObjectParticipation) error
+	SendAndClose(*SharedObjectParticipation) error
+}
+
+type srpcSharedObjectResourceService_WatchSharedObjectParticipationStream struct {
+	srpc.Stream
+}
+
+func (x *srpcSharedObjectResourceService_WatchSharedObjectParticipationStream) Send(m *SharedObjectParticipation) error {
+	return x.MsgSend(m)
+}
+
+func (x *srpcSharedObjectResourceService_WatchSharedObjectParticipationStream) SendAndClose(m *SharedObjectParticipation) error {
+	if m != nil {
+		if err := x.MsgSend(m); err != nil {
+			return err
+		}
+	}
+	return x.CloseSend()
+}
+
+type SRPCSharedObjectResourceService_OpenReadCheckpointStream interface {
+	srpc.Stream
+}
+
+type srpcSharedObjectResourceService_OpenReadCheckpointStream struct {
+	srpc.Stream
 }
 
 type SRPCSharedObjectResourceService_MountSharedObjectBodyStream interface {

--- a/sdk/sobject/sobject_srpc.pb.ts
+++ b/sdk/sobject/sobject_srpc.pb.ts
@@ -5,8 +5,12 @@
 import {
   MountSharedObjectBodyRequest,
   MountSharedObjectBodyResponse,
+  OpenReadCheckpointRequest,
+  OpenReadCheckpointResponse,
+  SharedObjectParticipation,
   WatchSharedObjectHealthRequest,
   WatchSharedObjectHealthResponse,
+  WatchSharedObjectParticipationRequest,
 } from './sobject.pb.js'
 import { MethodKind } from '@aptre/protobuf-es-lite'
 import {
@@ -17,6 +21,8 @@ import {
 } from 'starpc'
 
 /**
+ * SharedObjectResourceService exposes retained native state independently of readable body access.
+ *
  * @generated from service s4wave.sobject.SharedObjectResourceService
  */
 export const SharedObjectResourceServiceDefinition = {
@@ -32,6 +38,28 @@ export const SharedObjectResourceServiceDefinition = {
       kind: MethodKind.ServerStreaming,
     },
     /**
+     * WatchSharedObjectParticipation observes held native authority without mounting content.
+     *
+     * @generated from rpc s4wave.sobject.SharedObjectResourceService.WatchSharedObjectParticipation
+     */
+    WatchSharedObjectParticipation: {
+      name: 'WatchSharedObjectParticipation',
+      I: WatchSharedObjectParticipationRequest,
+      O: SharedObjectParticipation,
+      kind: MethodKind.ServerStreaming,
+    },
+    /**
+     * OpenReadCheckpoint opens immutable World history retained before departure.
+     *
+     * @generated from rpc s4wave.sobject.SharedObjectResourceService.OpenReadCheckpoint
+     */
+    OpenReadCheckpoint: {
+      name: 'OpenReadCheckpoint',
+      I: OpenReadCheckpointRequest,
+      O: OpenReadCheckpointResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
      * @generated from rpc s4wave.sobject.SharedObjectResourceService.MountSharedObjectBody
      */
     MountSharedObjectBody: {
@@ -44,6 +72,8 @@ export const SharedObjectResourceServiceDefinition = {
 } as const
 
 /**
+ * SharedObjectResourceService exposes retained native state independently of readable body access.
+ *
  * @generated from service s4wave.sobject.SharedObjectResourceService
  */
 export interface SharedObjectResourceService {
@@ -56,6 +86,26 @@ export interface SharedObjectResourceService {
   ): MessageStream<WatchSharedObjectHealthResponse>
 
   /**
+   * WatchSharedObjectParticipation observes held native authority without mounting content.
+   *
+   * @generated from rpc s4wave.sobject.SharedObjectResourceService.WatchSharedObjectParticipation
+   */
+  WatchSharedObjectParticipation(
+    request: WatchSharedObjectParticipationRequest,
+    abortSignal?: AbortSignal,
+  ): MessageStream<SharedObjectParticipation>
+
+  /**
+   * OpenReadCheckpoint opens immutable World history retained before departure.
+   *
+   * @generated from rpc s4wave.sobject.SharedObjectResourceService.OpenReadCheckpoint
+   */
+  OpenReadCheckpoint(
+    request: OpenReadCheckpointRequest,
+    abortSignal?: AbortSignal,
+  ): Promise<OpenReadCheckpointResponse>
+
+  /**
    * @generated from rpc s4wave.sobject.SharedObjectResourceService.MountSharedObjectBody
    */
   MountSharedObjectBody(
@@ -65,6 +115,8 @@ export interface SharedObjectResourceService {
 }
 
 /**
+ * SharedObjectResourceService exposes retained native state independently of readable body access.
+ *
  * @generated from service s4wave.sobject.SharedObjectResourceService
  */
 export interface SharedObjectResourceServiceHandler {
@@ -76,6 +128,28 @@ export interface SharedObjectResourceServiceHandler {
     abortSignal: AbortSignal,
     context: ServerContext,
   ): MessageStream<WatchSharedObjectHealthResponse>
+
+  /**
+   * WatchSharedObjectParticipation observes held native authority without mounting content.
+   *
+   * @generated from rpc s4wave.sobject.SharedObjectResourceService.WatchSharedObjectParticipation
+   */
+  WatchSharedObjectParticipation(
+    request: WatchSharedObjectParticipationRequest,
+    abortSignal: AbortSignal,
+    context: ServerContext,
+  ): MessageStream<SharedObjectParticipation>
+
+  /**
+   * OpenReadCheckpoint opens immutable World history retained before departure.
+   *
+   * @generated from rpc s4wave.sobject.SharedObjectResourceService.OpenReadCheckpoint
+   */
+  OpenReadCheckpoint(
+    request: OpenReadCheckpointRequest,
+    abortSignal: AbortSignal,
+    context: ServerContext,
+  ): Promise<OpenReadCheckpointResponse>
 
   /**
    * @generated from rpc s4wave.sobject.SharedObjectResourceService.MountSharedObjectBody
@@ -97,6 +171,9 @@ export class SharedObjectResourceServiceClient implements SharedObjectResourceSe
     this.service = opts?.service || SharedObjectResourceServiceServiceName
     this.rpc = rpc
     this.WatchSharedObjectHealth = this.WatchSharedObjectHealth.bind(this)
+    this.WatchSharedObjectParticipation =
+      this.WatchSharedObjectParticipation.bind(this)
+    this.OpenReadCheckpoint = this.OpenReadCheckpoint.bind(this)
     this.MountSharedObjectBody = this.MountSharedObjectBody.bind(this)
   }
   /**
@@ -115,6 +192,45 @@ export class SharedObjectResourceServiceClient implements SharedObjectResourceSe
       abortSignal || undefined,
     )
     return buildDecodeMessageTransform(WatchSharedObjectHealthResponse)(result)
+  }
+
+  /**
+   * WatchSharedObjectParticipation observes held native authority without mounting content.
+   *
+   * @generated from rpc s4wave.sobject.SharedObjectResourceService.WatchSharedObjectParticipation
+   */
+  WatchSharedObjectParticipation(
+    request: WatchSharedObjectParticipationRequest,
+    abortSignal?: AbortSignal,
+  ): MessageStream<SharedObjectParticipation> {
+    const requestMsg = WatchSharedObjectParticipationRequest.create(request)
+    const result = this.rpc.serverStreamingRequest(
+      this.service,
+      SharedObjectResourceServiceDefinition.methods
+        .WatchSharedObjectParticipation.name,
+      WatchSharedObjectParticipationRequest.toBinary(requestMsg),
+      abortSignal || undefined,
+    )
+    return buildDecodeMessageTransform(SharedObjectParticipation)(result)
+  }
+
+  /**
+   * OpenReadCheckpoint opens immutable World history retained before departure.
+   *
+   * @generated from rpc s4wave.sobject.SharedObjectResourceService.OpenReadCheckpoint
+   */
+  async OpenReadCheckpoint(
+    request: OpenReadCheckpointRequest,
+    abortSignal?: AbortSignal,
+  ): Promise<OpenReadCheckpointResponse> {
+    const requestMsg = OpenReadCheckpointRequest.create(request)
+    const result = await this.rpc.request(
+      this.service,
+      SharedObjectResourceServiceDefinition.methods.OpenReadCheckpoint.name,
+      OpenReadCheckpointRequest.toBinary(requestMsg),
+      abortSignal || undefined,
+    )
+    return OpenReadCheckpointResponse.fromBinary(result)
   }
 
   /**


### PR DESCRIPTION
A local participant that leaves a SharedObject now retains its last readable World root and its own decoding grant in the same transaction that commits the access change. The SharedObject Resource exposes accepted configuration lineage and a read-only historical engine, while readmission removes the checkpoint. Existing objects without a retained checkpoint report history as unavailable.

Mounted bodies now close with their final reference, preventing a later admission from reusing a World engine that is already closing under the previous participation state. The historical engine rejects write transactions and raw storage mutations.

Validation:
- `go test -race ./core/provider/local ./core/resource/sobject ./core/sobject ./core/sobject/world/engine`
- `bun run gen`
- `go test ./core/provider/local ./core/resource/sobject ./core/sobject ./core/sobject/world/engine`
- `GOOS=linux GOARCH=amd64 go build ./cmd/spacewave`
