### PR TITLE
fix(ci): synchronize solicitation offers and E2E readiness

### DIFF
--- a/core/e2e/e2e_test.go
+++ b/core/e2e/e2e_test.go
@@ -18,7 +18,6 @@ import (
 	plugin_host_wazero_quickjs "github.com/s4wave/spacewave/bldr/plugin/host/wazero-quickjs"
 	bldr_project "github.com/s4wave/spacewave/bldr/project"
 	bldr_project_controller "github.com/s4wave/spacewave/bldr/project/controller"
-	"github.com/s4wave/spacewave/bldr/testbed"
 	bldr_web_bundler_vite_compiler "github.com/s4wave/spacewave/bldr/web/bundler/vite/compiler"
 	s4wave_core_e2e "github.com/s4wave/spacewave/core/e2e"
 	resource_testbed "github.com/s4wave/spacewave/core/resource/testbed"
@@ -30,6 +29,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// TestSpacewaveCoreE2E runs the TypeScript fixture against native core services.
 // TIER: pr
 func TestSpacewaveCoreE2E(t *testing.T) {
 	if os.Getenv("RUN_CORE_E2E") == "" {
@@ -71,7 +71,7 @@ func TestSpacewaveCoreE2E(t *testing.T) {
 	}
 
 	// build the bldr testbed
-	tb, err := testbed.BuildTestbed(ctx, le)
+	tb, err := s4wave_core_e2e.NewNativeTestbed(ctx, le)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -129,8 +129,8 @@ func TestSpacewaveCoreE2E(t *testing.T) {
 	}
 	defer relObjectTypeCtrl()
 
-	// load the go plugin host
-	processHost, _, processRef, err := loader.WaitExecControllerRunningTyped[*plugin_host_process.Controller](
+	// Load the native Go plugin host.
+	_, _, processRef, err := loader.WaitExecControllerRunningTyped[*plugin_host_process.Controller](
 		ctx,
 		tb.GetBus(),
 		resolver.NewLoadControllerWithConfig(plugin_host_process.NewConfig(pluginStateDir, pluginDistDir)),
@@ -140,10 +140,9 @@ func TestSpacewaveCoreE2E(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 	defer processRef.Release()
-	_ = processHost
 
-	// load the js plugin host
-	quickjsHost, _, quickjsHostRef, err := loader.WaitExecControllerRunningTyped[*plugin_host_wazero_quickjs.Controller](
+	// Load QuickJS for the TypeScript fixture and frontend plugins.
+	_, _, quickjsHostRef, err := loader.WaitExecControllerRunningTyped[*plugin_host_wazero_quickjs.Controller](
 		ctx,
 		tb.GetBus(),
 		resolver.NewLoadControllerWithConfig(plugin_host_wazero_quickjs.NewConfig()),
@@ -153,7 +152,6 @@ func TestSpacewaveCoreE2E(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 	defer quickjsHostRef.Release()
-	_ = quickjsHost
 
 	// load the merged project config
 	projectConfig, err := s4wave_core_e2e.LoadProjectConfig(repoRoot)
@@ -180,7 +178,7 @@ func TestSpacewaveCoreE2E(t *testing.T) {
 	projCtrlConf.FetchManifestRemote = "devtool"
 
 	// run the project controller, which also compiles and starts the plugins
-	projCtrl, _, projCtrlRef, err := loader.WaitExecControllerRunningTyped[*bldr_project_controller.Controller](
+	_, _, projCtrlRef, err := loader.WaitExecControllerRunningTyped[*bldr_project_controller.Controller](
 		ctx,
 		tb.GetBus(),
 		resolver.NewLoadControllerWithConfig(projCtrlConf),
@@ -190,12 +188,15 @@ func TestSpacewaveCoreE2E(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 	defer projCtrlRef.Release()
-	_ = projCtrl
 
+	// Observe both plugin startup and the fixture's terminal result.
 	type testResult struct {
-		success  bool
+		// success reports the fixture's completed acceptance result.
+		success bool
+		// errorMsg contains a failed assertion reported by the fixture.
 		errorMsg string
-		err      error
+		// err contains a transport or lifecycle failure while awaiting the result.
+		err error
 	}
 	waitCtx, waitCancel := context.WithCancel(ctx)
 	defer waitCancel()

--- a/core/e2e/native-testbed.go
+++ b/core/e2e/native-testbed.go
@@ -1,0 +1,25 @@
+//go:build !js
+
+package s4wave_core_e2e
+
+import (
+	"context"
+
+	plugin_host_default "github.com/s4wave/spacewave/bldr/plugin/host/default"
+	plugin_host_scheduler "github.com/s4wave/spacewave/bldr/plugin/host/scheduler"
+	"github.com/s4wave/spacewave/bldr/testbed"
+	"github.com/sirupsen/logrus"
+)
+
+// NewNativeTestbed builds the native E2E host with QuickJS reserved for the
+// TypeScript fixture and frontend plugins. Go plugins run as native processes.
+func NewNativeTestbed(ctx context.Context, le *logrus.Entry) (*testbed.Testbed, error) {
+	return testbed.BuildTestbedWithSchedulerConfig(ctx, le, func(
+		engineID, objectKey, volumeID, peerID string,
+	) *plugin_host_scheduler.Config {
+		return plugin_host_default.NewNativeDesktopSchedulerConfig(
+			"", engineID, objectKey, volumeID, peerID, true, false, false,
+			[]string{"spacewave-e2e", "spacewave-web", "spacewave-app"},
+		)
+	})
+}

--- a/core/trace/service/discovery_test.go
+++ b/core/trace/service/discovery_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/aperturerobotics/controllerbus/controller/loader"
@@ -21,7 +22,6 @@ import (
 	plugin_host_wazero_quickjs "github.com/s4wave/spacewave/bldr/plugin/host/wazero-quickjs"
 	bldr_project "github.com/s4wave/spacewave/bldr/project"
 	bldr_project_controller "github.com/s4wave/spacewave/bldr/project/controller"
-	"github.com/s4wave/spacewave/bldr/testbed"
 	bldr_web_bundler_vite_compiler "github.com/s4wave/spacewave/bldr/web/bundler/vite/compiler"
 	s4wave_core_e2e "github.com/s4wave/spacewave/core/e2e"
 	space_world_objecttypes "github.com/s4wave/spacewave/core/space/world/objecttypes"
@@ -34,10 +34,13 @@ import (
 )
 
 const (
-	corePluginID  = "spacewave-core"
+	// corePluginID identifies the native application service plugin.
+	corePluginID = "spacewave-core"
+	// debugPluginID identifies the native debugging service plugin.
 	debugPluginID = "spacewave-debug"
 )
 
+// setupPluginClients builds isolated native plugins and resolves their RPC clients.
 func setupPluginClients(
 	ctx context.Context,
 	t *testing.T,
@@ -46,10 +49,12 @@ func setupPluginClients(
 ) map[string]srpc.Client {
 	t.Helper()
 
+	// Retain compiler and subprocess diagnostics for startup failures.
 	log := logrus.New()
-	log.SetLevel(logrus.InfoLevel)
+	log.SetLevel(logrus.DebugLevel)
 	le := logrus.NewEntry(log)
 
+	// Materialize sources and plugin state in an isolated test directory.
 	wd, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
@@ -70,7 +75,8 @@ func setupPluginClients(
 		t.Fatal(err)
 	}
 
-	tb, err := testbed.BuildTestbed(ctx, le)
+	// Compose native execution with the project's manifest builders.
+	tb, err := s4wave_core_e2e.NewNativeTestbed(ctx, le)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,6 +94,7 @@ func setupPluginClients(
 	sr.AddFactory(volume_rpc_server.NewFactory(b))
 	sr.AddFactory(world_block_engine.NewFactory(b))
 
+	// Mount the test volume identity and application object types.
 	volPeer, err := tb.GetVolume().GetPeer(ctx, true)
 	if err != nil {
 		t.Fatal(err)
@@ -106,6 +113,7 @@ func setupPluginClients(
 	}
 	t.Cleanup(relObjectTypeCtrl)
 
+	// Start both hosts; scheduler policy selects each plugin's permitted runtime.
 	_, _, processRef, err := loader.WaitExecControllerRunningTyped[*plugin_host_process.Controller](
 		ctx,
 		b,
@@ -128,6 +136,7 @@ func setupPluginClients(
 	}
 	t.Cleanup(quickjsRef.Release)
 
+	// Enable trace services in the project's native plugin configurations.
 	projectConfig, err := s4wave_core_e2e.LoadProjectConfig(repoRoot)
 	if err == nil {
 		err = InjectTraceConfig(projectConfig)
@@ -138,7 +147,7 @@ func setupPluginClients(
 	if err != nil {
 		t.Fatal(err)
 	}
-	projectConfig.Start.Plugins = append([]string(nil), startPlugins...)
+	projectConfig.Start.Plugins = slices.Clone(startPlugins)
 	projectConfig.Remotes = map[string]*bldr_project.RemoteConfig{
 		"devtool": {
 			EngineId:       tb.GetWorldEngineID(),
@@ -148,6 +157,7 @@ func setupPluginClients(
 		},
 	}
 
+	// Compile and launch the requested startup plugins.
 	projCtrlConf := bldr_project_controller.NewConfig(repoRoot, workDir, projectConfig, false, true)
 	projCtrlConf.FetchManifestRemote = "devtool"
 	_, _, projCtrlRef, err := loader.WaitExecControllerRunningTyped[*bldr_project_controller.Controller](
@@ -161,6 +171,7 @@ func setupPluginClients(
 	}
 	t.Cleanup(projCtrlRef.Release)
 
+	// Retain each client reference for the test's lifetime.
 	clients := make(map[string]srpc.Client, len(pluginIDs))
 	for _, pluginID := range pluginIDs {
 		pluginClient, pluginRef, err := bldr_plugin.ExPluginLoadWaitClient(ctx, b, pluginID, nil)
@@ -174,11 +185,13 @@ func setupPluginClients(
 	return clients
 }
 
+// TestTraceServiceDiscovery discovers and streams a trace from the core plugin.
 func TestTraceServiceDiscovery(t *testing.T) {
 	if os.Getenv("RUN_TRACE_E2E") == "" {
 		t.Skip("set RUN_TRACE_E2E=1 to run trace service discovery E2E tests")
 	}
 
+	// Start a recording through the plugin's discovered trace service.
 	ctx := context.Background()
 	clients := setupPluginClients(ctx, t, []string{corePluginID}, []string{corePluginID})
 	pluginClient := clients[corePluginID]
@@ -189,6 +202,7 @@ func TestTraceServiceDiscovery(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Stop the recording and require at least one streamed trace chunk.
 	stopStrm, err := traceClient.StopTrace(ctx, &s4wave_trace.StopTraceRequest{})
 	if err != nil {
 		t.Fatal(err)
@@ -214,11 +228,13 @@ func TestTraceServiceDiscovery(t *testing.T) {
 	}
 }
 
+// TestTraceServiceAllPlugins records traces from core and debug with frontend plugins loaded.
 func TestTraceServiceAllPlugins(t *testing.T) {
 	if os.Getenv("RUN_TRACE_E2E") == "" {
 		t.Skip("set RUN_TRACE_E2E=1 to run trace service discovery E2E tests")
 	}
 
+	// Load frontend plugins alongside both native trace providers.
 	ctx := context.Background()
 	clients := setupPluginClients(
 		ctx,
@@ -227,6 +243,7 @@ func TestTraceServiceAllPlugins(t *testing.T) {
 		[]string{corePluginID, debugPluginID},
 	)
 
+	// Verify that each provider independently returns a complete trace stream.
 	for _, pluginID := range []string{corePluginID, debugPluginID} {
 		t.Run(pluginID, func(t *testing.T) {
 			traceClient := s4wave_trace.NewSRPCTraceServiceClient(clients[pluginID])

--- a/e2e/runtime/devwasm/devwasm.go
+++ b/e2e/runtime/devwasm/devwasm.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// defaultWait bounds browser actions outside event-specific readiness waits.
 const defaultWait = 120 * time.Second
 
 // Options configures the dev WASM runtime adapter.
@@ -23,14 +24,19 @@ type Options struct{}
 
 // Adapter drives scenarios through the existing browser WASM harness.
 type Adapter struct {
-	h                 *wasm.Harness
-	ctx               playwright.BrowserContext
-	page              playwright.Page
+	// h owns the application server and browser process.
+	h *wasm.Harness
+	// ctx retains origin storage across pages in one scenario session.
+	ctx playwright.BrowserContext
+	// page is the active document receiving scenario actions.
+	page playwright.Page
+	// resetDriveOnReady returns a newly opened Drive to its root folder.
 	resetDriveOnReady bool
 }
 
 // New boots the browser WASM harness and opens the first scenario page.
 func New(ctx context.Context, _ Options) (*Adapter, error) {
+	// Select the requested browser compiler before booting the harness.
 	compiler, err := wasm.ResolveE2EWasmCompiler()
 	if err != nil {
 		return nil, errors.Wrap(err, "resolve devwasm compiler")
@@ -48,6 +54,8 @@ func New(ctx context.Context, _ Options) (*Adapter, error) {
 	case wasm.E2EWasmCompilerGoScript:
 		bootOptions = append(bootOptions, wasm.WithGoScriptBrowserStartup())
 	}
+
+	// Start the application and browser, releasing both on partial startup.
 	h, err := wasm.Boot(ctx, logrus.NewEntry(logrus.New()), bootOptions...)
 	if err != nil {
 		return nil, errors.Wrap(err, "boot devwasm harness")
@@ -56,6 +64,8 @@ func New(ctx context.Context, _ Options) (*Adapter, error) {
 		h.Release()
 		return nil, errors.Wrap(err, "launch devwasm browser")
 	}
+
+	// Create the initial scenario session.
 	a := &Adapter{h: h}
 	if err := a.newPage(); err != nil {
 		a.Close()
@@ -79,7 +89,9 @@ func (a *Adapter) Close() {
 	}
 }
 
+// newPage opens a document in the current storage context, creating it if absent.
 func (a *Adapter) newPage() error {
+	// Retain storage when replacing a document in the same session.
 	var err error
 	if a.ctx == nil {
 		a.ctx, err = a.h.Browser().NewContext(playwright.BrowserNewContextOptions{AcceptDownloads: new(true)})
@@ -87,6 +99,8 @@ func (a *Adapter) newPage() error {
 			return errors.Wrap(err, "create browser context")
 		}
 	}
+
+	// Open the active scenario document.
 	a.page, err = a.ctx.NewPage()
 	if err != nil {
 		return errors.Wrap(err, "create browser page")
@@ -122,6 +136,7 @@ func (a *Adapter) ResetSession(requirement runtime.SessionRequirement) error {
 
 // OpenRoute opens route through a document load or committed client-side hash.
 func (a *Adapter) OpenRoute(route string) error {
+	// Load the application only when the current document is blank.
 	if !strings.HasPrefix(route, "/") {
 		route = "/" + route
 	}
@@ -134,6 +149,8 @@ func (a *Adapter) OpenRoute(route string) error {
 		}
 		return a.WaitForEvent(runtime.EventAppReady)
 	}
+
+	// Route within a live document so its workers and connections survive.
 	targetHash := warmRouteHash(route)
 	a.resetDriveOnReady = route == "/quickstart/drive" && pageHash(a.page.URL()) != targetHash
 	if err := a.openRouteClientSide(targetHash); err != nil {
@@ -142,6 +159,7 @@ func (a *Adapter) OpenRoute(route string) error {
 	return a.WaitForEvent(runtime.EventAppReady)
 }
 
+// openRouteClientSide waits for the shell to commit a hash route in place.
 func (a *Adapter) openRouteClientSide(targetHash string) error {
 	_, err := a.page.WaitForFunction(`({ targetHash }) => {
 		const eventName = 's4wave:shell-tab-path-committed'
@@ -173,7 +191,9 @@ func (a *Adapter) openRouteClientSide(targetHash string) error {
 	return err
 }
 
+// waitForNextTabPathCommit observes the shell commit produced by run.
 func (a *Adapter) waitForNextTabPathCommit(action string, run func() error) error {
+	// Arm the browser listener before dispatching the action.
 	const key = "__s4waveE2ENextTabPathCommit"
 	if _, err := a.page.Evaluate(`({ key }) => {
 		const eventName = 's4wave:shell-tab-path-committed'
@@ -194,13 +214,18 @@ func (a *Adapter) waitForNextTabPathCommit(action string, run func() error) erro
 	}`, map[string]any{"key": key}); err != nil {
 		return errors.Wrapf(err, "arm tab path commit wait before %s", action)
 	}
+
+	// Remove the listener if the action fails before committing a route.
 	if err := run(); err != nil {
+		// Navigation failure may already have destroyed this document.
 		_, _ = a.page.Evaluate(`({ key }) => {
 			window[key]?.cleanup?.()
 			delete window[key]
 		}`, map[string]any{"key": key})
 		return err
 	}
+
+	// Await the recorded commit and release its document marker.
 	_, err := a.page.WaitForFunction(`({ key }) => window[key]?.promise`, map[string]any{"key": key}, playwright.PageWaitForFunctionOptions{Timeout: durationMS(defaultWait)})
 	_, _ = a.page.Evaluate(`({ key }) => delete window[key]`, map[string]any{"key": key})
 	if err != nil {
@@ -209,10 +234,12 @@ func (a *Adapter) waitForNextTabPathCommit(action string, run func() error) erro
 	return nil
 }
 
+// needsDocumentLoad distinguishes an uninitialized page from a live app route.
 func needsDocumentLoad(pageURL string) bool {
 	return pageURL == "" || pageURL == "about:blank"
 }
 
+// pageHash returns the route fragment without its query parameters.
 func pageHash(pageURL string) string {
 	hashIndex := strings.IndexByte(pageURL, '#')
 	if hashIndex < 0 {
@@ -231,12 +258,14 @@ func warmRouteHash(route string) string {
 	return "#" + route
 }
 
+// driveBrowser selects the last visible Drive pane in the active document.
 func (a *Adapter) driveBrowser() playwright.Locator {
 	return a.page.Locator("[data-testid='unixfs-browser']:visible").Last()
 }
 
 // ClickControl activates a named Drive control or Playwright selector.
 func (a *Adapter) ClickControl(control string) error {
+	// Folder creation uses the inline editor rather than a page-level control.
 	if control == "confirm" {
 		return a.driveBrowser().Locator("input[placeholder='Folder name']:visible").First().Press("Enter")
 	}
@@ -244,11 +273,8 @@ func (a *Adapter) ClickControl(control string) error {
 		browser := a.driveBrowser()
 		input := browser.Locator("input[placeholder='Folder name']:visible").First()
 		buttons := browser.Locator("button[title='New folder']:not([disabled]):visible")
-		// Count is a snapshot. Right after navigating into a folder the browser
-		// that driveBrowser resolves is the newly mounted one, whose toolbar has
-		// not rendered its actions yet, so the snapshot can be zero. That left
-		// the loop below with nothing to click and spent the whole wait on an
-		// input no click had opened. Wait for a clickable button first.
+
+		// A newly mounted folder can render its toolbar after the browser pane.
 		if err := buttons.First().WaitFor(playwright.LocatorWaitForOptions{
 			Timeout: durationMS(defaultWait),
 		}); err != nil {
@@ -272,6 +298,8 @@ func (a *Adapter) ClickControl(control string) error {
 		}
 		return input.WaitFor(playwright.LocatorWaitForOptions{Timeout: durationMS(defaultWait)})
 	}
+
+	// Map scenario control names to the current interface.
 	selectors := map[string]string{
 		"drive":        "text=Create a Drive",
 		"up":           "button[title='Up']:not([disabled]):visible",
@@ -352,6 +380,7 @@ func (a *Adapter) ExpectAbsent(content string) error {
 	return a.waitForText(content, false)
 }
 
+// waitForText observes DOM changes until the requested visibility holds.
 func (a *Adapter) waitForText(content string, wantVisible bool) error {
 	_, err := a.page.WaitForFunction(`({ content, wantVisible }) => {
 		const isVisible = (element) => {
@@ -384,6 +413,7 @@ func (a *Adapter) waitForText(content string, wantVisible bool) error {
 // DeleteSpace deletes the current Space and waits for the dialog to close and
 // the Space name to leave the observed UI state.
 func (a *Adapter) DeleteSpace() error {
+	// Open the current object's menu, retaining diagnostics on failure.
 	menu := a.page.Locator("[role='button'][aria-label='Open shared object menu']:visible").Last()
 	if err := menu.Click(); err != nil {
 		snapshot, snapshotErr := a.page.Evaluate(`() => ({
@@ -402,6 +432,8 @@ func (a *Adapter) DeleteSpace() error {
 		}
 		return errors.Wrap(err, "open shared object menu")
 	}
+
+	// Reach the deletion dialog through the object's danger zone.
 	danger := a.page.Locator("button").Filter(playwright.LocatorFilterOptions{HasText: "Danger Zone"}).Last()
 	if err := danger.Click(); err != nil {
 		return errors.Wrap(err, "open danger zone")
@@ -410,6 +442,8 @@ func (a *Adapter) DeleteSpace() error {
 	if err := trigger.Click(); err != nil {
 		return errors.Wrap(err, "open delete space dialog")
 	}
+
+	// Confirm the displayed Space name and wait for its removal.
 	input := a.page.Locator("[role='dialog'] input:visible").First()
 	spaceName, err := input.GetAttribute("placeholder")
 	if err != nil {
@@ -427,6 +461,7 @@ func (a *Adapter) DeleteSpace() error {
 	return a.waitForSpaceDeleted(spaceName)
 }
 
+// waitForSpaceDeleted observes both dialog dismissal and removal from the UI.
 func (a *Adapter) waitForSpaceDeleted(spaceName string) error {
 	_, err := a.page.WaitForFunction(`({ spaceName }) => {
 		const isVisible = (element) => {
@@ -465,6 +500,12 @@ func (a *Adapter) ExpectRoute(route string) error {
 
 // WaitForEvent waits for a named app readiness transition.
 func (a *Adapter) WaitForEvent(event runtime.Event) error {
+	// Reuse the harness's deferred-boot and Resource SDK readiness contract.
+	if event == runtime.EventAppReady {
+		return wasm.WaitForAppReady(a.page)
+	}
+
+	// Complete first-use navigation before checking the Drive pane.
 	if event == runtime.EventDriveReady {
 		var introErr error
 		for range 3 {
@@ -532,8 +573,9 @@ func (a *Adapter) WaitForEvent(event runtime.Event) error {
 			a.resetDriveOnReady = false
 		}
 	}
+
+	// Other events expose their state through visible or hidden DOM elements.
 	selector := map[runtime.Event]string{
-		runtime.EventAppReady:           "body",
 		runtime.EventDriveReady:         "[data-testid='unixfs-browser']:visible",
 		runtime.EventDriveSettled:       "[data-testid='unixfs-loading-diagnostics']",
 		runtime.EventContentReady:       "pre",
@@ -549,9 +591,10 @@ func (a *Adapter) WaitForEvent(event runtime.Event) error {
 	return a.page.Locator(selector).First().WaitFor(options)
 }
 
+// eventTimeout gives initialization longer than content convergence.
 func eventTimeout(event runtime.Event) time.Duration {
 	switch event {
-	case runtime.EventAppReady, runtime.EventDriveReady:
+	case runtime.EventDriveReady:
 		return 2 * time.Minute
 	case runtime.EventDriveSettled, runtime.EventContentReady, runtime.EventSpaceListConverged:
 		return 30 * time.Second
@@ -562,10 +605,13 @@ func eventTimeout(event runtime.Event) time.Duration {
 
 // OpenSecondTab opens route in a new page inside the current browser context.
 func (a *Adapter) OpenSecondTab(route string) (runtime.Tab, error) {
+	// Open the additional document in the same origin storage context.
 	page, err := a.ctx.NewPage()
 	if err != nil {
 		return nil, err
 	}
+
+	// Route through the adapter while preserving its original active page.
 	old := a.page
 	a.page = page
 	if err := a.OpenRoute(route); err != nil {
@@ -582,6 +628,7 @@ func (a *Adapter) BackgroundTab(tab runtime.Tab) error {
 	return runtime.Unsupported("background-tab", "devwasm cannot control operating-system tab focus")
 }
 
+// isTransientNavigationError recognizes evaluation invalidated by navigation.
 func isTransientNavigationError(message string) bool {
 	message = strings.ToLower(message)
 	return strings.Contains(message, "execution context was destroyed") ||
@@ -599,13 +646,20 @@ func (a *Adapter) RestartWorkerHost() error {
 	return runtime.Unsupported("restart-worker-host", "devwasm does not expose worker-host lifecycle control")
 }
 
-type tab struct{ page playwright.Page }
+// tab identifies an additional browser document in the scenario session.
+type tab struct {
+	// page is the document opened by OpenSecondTab.
+	page playwright.Page
+}
 
+// ID returns the document's current URL.
 func (t *tab) ID() string { return t.page.URL() }
 
+// durationMS converts a Go duration to a Playwright timeout.
 func durationMS(d time.Duration) *float64 {
 	ms := float64(d.Milliseconds())
 	return &ms
 }
 
+// _ is a type assertion
 var _ runtime.Runtime = (*Adapter)(nil)

--- a/e2e/wasm/drive-account-delete-opfs-subtree-goscript_test.go
+++ b/e2e/wasm/drive-account-delete-opfs-subtree-goscript_test.go
@@ -14,7 +14,7 @@ import (
 // (db/volume/js/opfs/runtime.go). Its presence fingerprints a live OPFS volume
 // subtree, so listing markers from the page is a path-agnostic way to assert a
 // volume subtree exists and, after account deletion, is gone.
-const opfsFormatMarkerName = ".spacewave-opfs-format.json"
+const opfsFormatMarkerName = ".spacewave-opfs-format"
 
 // TestGoScriptDriveAccountDeleteRemovesOpfsSubtree proves that deleting an
 // account removes its OPFS volume subtree. Under E2E_WASM_WORKER_MODE=shared the
@@ -26,6 +26,7 @@ const opfsFormatMarkerName = ".spacewave-opfs-format.json"
 // SharedWorker scope throws SecurityError), and OPFS is origin-global, so the
 // page observes exactly what the bridge wrote and removed.
 func TestGoScriptDriveAccountDeleteRemovesOpfsSubtree(t *testing.T) {
+	// This case exercises the GoScript OPFS bridge.
 	compiler, err := ResolveE2EWasmCompiler()
 	if err != nil {
 		t.Fatalf("resolve wasm compiler: %v", err)
@@ -34,6 +35,7 @@ func TestGoScriptDriveAccountDeleteRemovesOpfsSubtree(t *testing.T) {
 		t.Skipf("requires %s", E2EWasmCompilerGoScript)
 	}
 
+	// Create one account and record its OPFS subtree before deletion.
 	sess := harness(t).NewCleanSession(t)
 	scenario := CreateDriveScenario(t, harness(t), sess)
 	page := scenario.GetSession().Page()
@@ -45,6 +47,7 @@ func TestGoScriptDriveAccountDeleteRemovesOpfsSubtree(t *testing.T) {
 		t.Fatalf("expected an OPFS volume format marker after drive ready, found none")
 	}
 
+	// Delete through the account API that owns its volume lifetime.
 	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
 	defer cancel()
 
@@ -86,6 +89,7 @@ func TestGoScriptDriveAccountDeleteRemovesOpfsSubtree(t *testing.T) {
 func listOpfsFormatMarkers(t testing.TB, page playwright.Page) []string {
 	t.Helper()
 
+	// Inspect the origin's storage directly, independently of worker routing.
 	result, err := page.Evaluate(`async (markerName) => {
 		const out = []
 		const walk = async (dir, prefix) => {
@@ -106,6 +110,7 @@ func listOpfsFormatMarkers(t testing.TB, page playwright.Page) []string {
 		t.Fatalf("list OPFS format markers: %v", err)
 	}
 
+	// Decode the browser's marker paths without assuming a volume ID layout.
 	entries, ok := result.([]any)
 	if !ok {
 		t.Fatalf("OPFS marker list: unexpected result type %T", result)

--- a/e2e/wasm/navigation.go
+++ b/e2e/wasm/navigation.go
@@ -15,27 +15,45 @@ import (
 // DriveReadyResult is the browser-observed evidence that the Drive quickstart
 // reached content-ready, beyond merely rendering the file browser frame.
 type DriveReadyResult struct {
-	Body                      string
-	Hash                      string
-	ContentReadyMs            int
-	QuickstartState           string
+	// Body contains the visible Drive text at content readiness.
+	Body string
+	// Hash is the browser route at content readiness.
+	Hash string
+	// ContentReadyMs is the browser timestamp when starter content appeared.
+	ContentReadyMs int
+	// QuickstartState is the last published quickstart phase.
+	QuickstartState string
+	// QuickstartProgressReadyMs is when the progress view became ready.
 	QuickstartProgressReadyMs *int
-	QuickstartContentReadyMs  *int
-	QuickstartFinishedMs      *int
-	QuickstartError           string
-	QuickstartTiming          map[string]any
+	// QuickstartContentReadyMs is when the quickstart published content readiness.
+	QuickstartContentReadyMs *int
+	// QuickstartFinishedMs is when the quickstart completed its work.
+	QuickstartFinishedMs *int
+	// QuickstartError contains the quickstart's terminal failure, if any.
+	QuickstartError string
+	// QuickstartTiming retains the complete browser timing record.
+	QuickstartTiming map[string]any
 }
 
 // WaitForApp waits for the real app runtime, not the prerendered shell, to be
 // connected to the Resource SDK.
 func WaitForApp(t testing.TB, page playwright.Page) {
 	t.Helper()
+	if err := WaitForAppReady(page); err != nil {
+		t.Fatal(err)
+	}
+}
 
+// WaitForAppReady boots the app when deferred and waits for its Resource SDK
+// connection, returning diagnostics when startup fails.
+func WaitForAppReady(page playwright.Page) error {
+	// Budget cold compiler startup separately from ordinary navigation.
 	deadlineMS := 120000
 	if E2EWasmSlowCompilerEnabled() {
 		deadlineMS = 240000
 	}
 
+	// Re-enter evaluation when startup replaces the document's JS context.
 	deadline := time.Now().Add(time.Duration(deadlineMS) * time.Millisecond)
 	var lastErr error
 	for time.Now().Before(deadline) {
@@ -81,20 +99,21 @@ func WaitForApp(t testing.TB, page playwright.Page) {
 		return null
 	}`, map[string]any{"deadlineMS": evalWindowMS})
 		if err == nil {
-			return
+			return nil
 		}
 		lastErr = err
 		if !isTransientAppWaitError(err) {
 			break
 		}
-		time.Sleep(250 * time.Millisecond)
+		<-time.After(250 * time.Millisecond)
 	}
 
+	// Include the current page state when the runtime never becomes available.
 	body, bodyErr := page.Locator("body").TextContent()
 	if bodyErr != nil {
 		body = "failed to read body text: " + bodyErr.Error()
 	}
-	t.Fatalf(
+	return errors.Errorf(
 		"app not ready: %v\nurl: %s\nbody: %s",
 		lastErr,
 		page.URL(),
@@ -102,6 +121,7 @@ func WaitForApp(t testing.TB, page playwright.Page) {
 	)
 }
 
+// isTransientAppWaitError recognizes document replacement and incomplete boot.
 func isTransientAppWaitError(err error) bool {
 	if err == nil {
 		return false
@@ -114,6 +134,7 @@ func isTransientAppWaitError(err error) bool {
 		strings.Contains(msg, "debug context did not initialize before deadline")
 }
 
+// AssertBrowserStartupDone verifies that the connected runtime revealed its frame.
 func AssertBrowserStartupDone(t testing.TB, h *Harness, page playwright.Page) map[string]any {
 	t.Helper()
 
@@ -138,6 +159,7 @@ func AssertBrowserStartupDone(t testing.TB, h *Harness, page playwright.Page) ma
 	return proof
 }
 
+// AssertRootImportMap requires the shared React and protobuf runtime specifiers.
 func AssertRootImportMap(t testing.TB, h *Harness, page playwright.Page) {
 	t.Helper()
 
@@ -157,6 +179,7 @@ func AssertRootImportMap(t testing.TB, h *Harness, page playwright.Page) {
 	}
 }
 
+// readRuntimeStartupProof reads the browser's published startup state.
 func readRuntimeStartupProof(t testing.TB, h *Harness, page playwright.Page) map[string]any {
 	t.Helper()
 
@@ -183,6 +206,7 @@ func NavigateHash(t testing.TB, h *Harness, page playwright.Page, hash string) {
 	}
 }
 
+// visibleDriveBrowser selects the first visible Drive pane.
 func visibleDriveBrowser(page playwright.Page) playwright.Locator {
 	return page.Locator("[data-testid='unixfs-browser']:visible").First()
 }
@@ -191,6 +215,7 @@ func visibleDriveBrowser(page playwright.Page) playwright.Locator {
 func WaitForDriveShell(t testing.TB, page playwright.Page) {
 	t.Helper()
 
+	// Complete onboarding before waiting for the raw file browser.
 	CompleteDriveIntroWizardIfPresent(t, page)
 	err := visibleDriveBrowser(page).WaitFor(
 		playwright.LocatorWaitForOptions{Timeout: playwright.Float(120000)},
@@ -338,6 +363,7 @@ func WaitForEmptySpaceReady(t testing.TB, page playwright.Page) {
 		}
 	}
 
+	// Require the quickstart to have reached the new Space's route without error.
 	raw, err := page.Evaluate(`() => {
 		const timing = globalThis.__s4waveQuickstartTiming ?? globalThis.__s4wave_debug?.quickstartTiming ?? null
 		return {
@@ -365,6 +391,7 @@ func WaitForEmptySpaceReady(t testing.TB, page playwright.Page) {
 	}
 }
 
+// completeDriveIntroWizardScript advances the first-use wizard to the file browser.
 const completeDriveIntroWizardScript = `async () => {
 	const deadline = Date.now() + 120000
 	const actionLabels = ['Next', 'Got it, start exploring', 'Open files']
@@ -513,6 +540,7 @@ func WaitForDriveReady(t testing.TB, h *Harness, page playwright.Page) DriveRead
 
 	WaitForDriveShell(t, page)
 
+	// Wait for starter content, then retain the quickstart's timing evidence.
 	raw, err := page.Evaluate(h.Script("wait-for-drive.ts"), map[string]any{
 		"deadlineMs": 120000,
 	})
@@ -526,6 +554,7 @@ func WaitForDriveReady(t testing.TB, h *Harness, page playwright.Page) DriveRead
 	return result
 }
 
+// parseDriveReadyResult decodes the browser's Drive readiness and timing record.
 func parseDriveReadyResult(t testing.TB, raw any) DriveReadyResult {
 	t.Helper()
 
@@ -549,16 +578,19 @@ func parseDriveReadyResult(t testing.TB, raw any) DriveReadyResult {
 	return result
 }
 
+// stringField reads an optional string from a browser record.
 func stringField(m map[string]any, key string) string {
 	v, _ := m[key].(string)
 	return v
 }
 
+// boolField reads an optional boolean from a browser record.
 func boolField(m map[string]any, key string) bool {
 	v, _ := m[key].(bool)
 	return v
 }
 
+// intField converts an optional browser number to an integer.
 func intField(m map[string]any, key string) int {
 	switch v := m[key].(type) {
 	case float64:
@@ -570,6 +602,7 @@ func intField(m map[string]any, key string) int {
 	}
 }
 
+// mapField requires a nested browser record.
 func mapField(t testing.TB, m map[string]any, key string) map[string]any {
 	t.Helper()
 
@@ -580,6 +613,7 @@ func mapField(t testing.TB, m map[string]any, key string) map[string]any {
 	return v
 }
 
+// optionalIntField distinguishes a missing browser number from zero.
 func optionalIntField(m map[string]any, key string) *int {
 	switch v := m[key].(type) {
 	case float64:
@@ -592,6 +626,7 @@ func optionalIntField(m map[string]any, key string) *int {
 	}
 }
 
+// AssertQuickstartContentAfterProgress checks the quickstart's recorded phase order.
 func AssertQuickstartContentAfterProgress(t testing.TB, result DriveReadyResult) {
 	t.Helper()
 
@@ -633,6 +668,7 @@ func AssertQuickstartContentAfterProgress(t testing.TB, result DriveReadyResult)
 	}
 }
 
+// formatOptionalMs formats a present timing value or its missing marker.
 func formatOptionalMs(v *int) string {
 	if v == nil {
 		return "<missing>"
@@ -640,6 +676,7 @@ func formatOptionalMs(v *int) string {
 	return strconv.Itoa(*v) + "ms"
 }
 
+// trimPageText bounds diagnostic output after collapsing whitespace.
 func trimPageText(s string) string {
 	s = strings.Join(strings.Fields(s), " ")
 	if len(s) <= 800 {
@@ -648,8 +685,7 @@ func trimPageText(s string) string {
 	return s[:800] + "..."
 }
 
-// parseQuickstartRoute extracts sessionIndex and spaceID from a URL like:
-// http://host/#/u/{sessionIndex}/so/{spaceID}/...
+// parseQuickstartRoute extracts the Session index and Space ID from a hash route.
 func parseQuickstartRoute(rawURL string) (uint32, string, error) {
 	hashIdx := strings.Index(rawURL, "#")
 	if hashIdx == -1 || hashIdx == len(rawURL)-1 {

--- a/net/link/solicit/controller/control-upgrade_test.go
+++ b/net/link/solicit/controller/control-upgrade_test.go
@@ -1,0 +1,79 @@
+package link_solicit_controller
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"testing"
+
+	link_solicit "github.com/s4wave/spacewave/net/link/solicit"
+	"github.com/s4wave/spacewave/net/peer"
+	"github.com/s4wave/spacewave/net/protocol"
+	stream_packet "github.com/s4wave/spacewave/net/stream/packet"
+)
+
+// TestControlStreamUpgradeRequiresOfferAcknowledgement keeps a hash-only probe
+// acknowledgement from opening a stream before the peer has its incarnation.
+func TestControlStreamUpgradeRequiresOfferAcknowledgement(t *testing.T) {
+	// Start one control loop with a local offer and a manually driven peer.
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	c := newTestSolicitController(t)
+	ls := newTestLinkState(peer.ID("a"), peer.ID("b"))
+	ss := &solicitState{
+		dir:         link_solicit.NewSolicitProtocol(protocol.ID("test/upgrade"), nil, "", 0),
+		incarnation: bytes.Repeat([]byte{1}, solicitationIncarnationSize),
+		handler:     newTestResolverHandler(),
+	}
+	c.links[ls.ml.GetLinkUUID()] = ls
+	c.solicitations[ss] = struct{}{}
+	localConn, remoteConn := net.Pipe()
+	defer localConn.Close()
+	defer remoteConn.Close()
+	maxMessageSize := maxExchangeMessageSize(c.maxHashes)
+	localSess := stream_packet.NewSession(localConn, maxMessageSize)
+	remoteSess := stream_packet.NewSession(remoteConn, maxMessageSize)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.runControlStream(ctx, ls, localSess)
+	}()
+	defer func() {
+		cancel()
+		<-done
+	}()
+
+	// Acknowledge only the probe, while advertising the peer's full offer.
+	probe := recvSolicitationExchange(t, remoteSess)
+	if len(probe.GetProtocolHashes()) != 1 || len(probe.GetOffers()) != 0 {
+		t.Fatal("initial capability probe must carry only the legacy hash set")
+	}
+	remote := &link_solicit.SolicitationExchange{
+		SupportsOfferIncarnations: true,
+		Generation:                1,
+		AcknowledgedGeneration:    probe.GetGeneration(),
+		Offers: []*link_solicit.SolicitationOffer{{
+			ProtocolHash: probe.GetProtocolHashes()[0],
+			Incarnation:  bytes.Repeat([]byte{2}, solicitationIncarnationSize),
+		}},
+	}
+	if err := remoteSess.SendMsg(remote); err != nil {
+		t.Fatal(err)
+	}
+
+	// The first complete offer must require a distinct acknowledgement.
+	offer := recvSolicitationExchange(t, remoteSess)
+	if offer.GetGeneration() != probe.GetGeneration()+1 {
+		t.Fatalf("offer generation = %d, want %d", offer.GetGeneration(), probe.GetGeneration()+1)
+	}
+	if len(offer.GetOffers()) != 1 || offer.GetAcknowledgedGeneration() != remote.GetGeneration() {
+		t.Fatal("upgraded exchange must carry the local offer and acknowledge the peer")
+	}
+	if matches := findSolicitationMatches(c.decodeExchange(offer), c.decodeExchange(remote)); len(matches) != 0 {
+		t.Fatal("probe acknowledgement matched an unacknowledged incarnation")
+	}
+	remote.AcknowledgedGeneration = offer.GetGeneration()
+	if matches := findSolicitationMatches(c.decodeExchange(offer), c.decodeExchange(remote)); len(matches) != 1 {
+		t.Fatal("complete offer acknowledgement did not match the protocol")
+	}
+}

--- a/net/link/solicit/controller/controller.go
+++ b/net/link/solicit/controller/controller.go
@@ -53,19 +53,17 @@ type Controller struct {
 	// maxHashes is the maximum number of solicit hashes sent per control stream.
 	maxHashes uint32
 
+	// bcast guards solicitation registration, link state, and pending opens.
 	bcast broadcast.Broadcast
 	// linkRoutines manages per-link control stream goroutines.
 	linkRoutines *keyed.Keyed[uint64, struct{}]
 	// openRoutines manages solicited stream openings outside control loops.
 	openRoutines *keyed.Keyed[solicitationOpenKey, struct{}]
-	// solicitations tracks active SolicitProtocol directives.
-	// guarded by bcast
+	// solicitations tracks active SolicitProtocol directives, guarded by bcast.
 	solicitations map[*solicitState]struct{}
-	// links tracks active link states.
-	// guarded by bcast
-	links map[uint64]*linkState // key: link UUID
-	// opens owns pending solicited stream openings.
-	// guarded by bcast
+	// links indexes active link states by UUID, guarded by bcast.
+	links map[uint64]*linkState
+	// opens owns pending solicited stream openings, guarded by bcast.
 	opens map[solicitationOpenKey]solicitationOpen
 }
 
@@ -77,8 +75,8 @@ type solicitState struct {
 	handler directive.ResolverHandler
 	// incarnation distinguishes this lifetime from equivalent successors.
 	incarnation []byte
-	// disposed prevents publication after directive disposal.
-	disposed bool // guarded by Controller.bcast
+	// disposed prevents publication after disposal, guarded by Controller.bcast.
+	disposed bool
 }
 
 // linkState tracks per-link solicitation state.
@@ -91,13 +89,14 @@ type linkState struct {
 	sessionID []byte
 	// localIsLower records whether our peer ID sorts below the remote's.
 	localIsLower bool
-	// refCount counts active users of this link state.
+	// refCount counts active users of this state, guarded by Controller.bcast.
 	refCount int
 
-	// guarded by Controller.bcast
 	// remoteExchange is the peer's most recently advertised offer generation.
+	// It is guarded by Controller.bcast.
 	remoteExchange *solicitationExchange
 	// matched suppresses duplicate streams for each bilateral incarnation pair.
+	// It is guarded by Controller.bcast.
 	matched map[string]struct{}
 }
 
@@ -165,6 +164,7 @@ type solicitationOpen struct {
 
 // NewController constructs a new solicitation controller.
 func NewController(le *logrus.Entry, conf *Config) (*Controller, error) {
+	// Allocate the shared state before constructing its keyed routines.
 	c := &Controller{
 		le:            le,
 		maxHashes:     conf.GetMaxHashesOrDefault(),
@@ -172,6 +172,8 @@ func NewController(le *logrus.Entry, conf *Config) (*Controller, error) {
 		links:         make(map[uint64]*linkState),
 		opens:         make(map[solicitationOpenKey]solicitationOpen),
 	}
+
+	// Keep control streams and one-shot opens under their keyed lifetimes.
 	c.linkRoutines = keyed.NewKeyed(c.buildLinkRoutine,
 		keyed.WithExitLogger[uint64, struct{}](le),
 	)
@@ -223,6 +225,7 @@ func (c *Controller) buildLinkRoutine(uuid uint64) (keyed.Routine, struct{}) {
 
 // buildOpenRoutine constructs a one-shot solicited stream opening routine.
 func (c *Controller) buildOpenRoutine(key solicitationOpenKey) (keyed.Routine, struct{}) {
+	// Snapshot the registered opening while its metadata remains available.
 	var open solicitationOpen
 	c.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
 		open = c.opens[key]
@@ -230,6 +233,8 @@ func (c *Controller) buildOpenRoutine(key solicitationOpenKey) (keyed.Routine, s
 	if open.ls == nil {
 		return nil, struct{}{}
 	}
+
+	// Run one opening; the keyed exit callback retires its metadata.
 	return func(ctx context.Context) error {
 		c.openSolicitedStream(ctx, open.ls, open.match)
 		return nil
@@ -267,6 +272,7 @@ func (c *Controller) handleSolicitProtocol(
 	di directive.Instance,
 	d link_solicit.SolicitProtocol,
 ) ([]directive.Resolver, error) {
+	// Bind equivalent protocol demand to this directive's lifetime.
 	incarnation := make([]byte, solicitationIncarnationSize)
 	if _, err := rand.Read(incarnation); err != nil {
 		return nil, errors.Wrap(err, "generate solicitation incarnation")
@@ -277,6 +283,7 @@ func (c *Controller) handleSolicitProtocol(
 		c.removeSolicitation(ss)
 	})
 
+	// Publish the offer only while its resolver can receive streams.
 	return directive.Resolvers(directive.NewFuncResolver(func(
 		rctx context.Context,
 		rh directive.ResolverHandler,
@@ -439,6 +446,7 @@ func (c *Controller) removeLink(uuid uint64) {
 
 // retireLinkOpens removes pending metadata and cancels every open for a link.
 func (c *Controller) retireLinkOpens(uuid uint64) {
+	// Retire pending metadata under the same lock as link removal.
 	keys := make(map[solicitationOpenKey]struct{})
 	c.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
 		for key := range c.opens {
@@ -449,6 +457,8 @@ func (c *Controller) retireLinkOpens(uuid uint64) {
 			keys[key] = struct{}{}
 		}
 	})
+
+	// Include openings registered concurrently with metadata retirement.
 	for _, key := range c.openRoutines.GetKeys() {
 		if key.linkUUID == uuid {
 			keys[key] = struct{}{}
@@ -660,6 +670,7 @@ func (c *Controller) computeExchange(
 	ls *linkState,
 	offers []solicitationOffer,
 ) *solicitationExchange {
+	// Derive and order the bounded discovery set for this physical link.
 	for i := range offers {
 		offers[i].hash = link_solicit.ComputeProtocolHash(
 			ls.sessionID,
@@ -672,6 +683,7 @@ func (c *Controller) computeExchange(
 		offers = offers[:c.maxHashes]
 	}
 
+	// Retain stable hashes for the initial legacy-compatible capability probe.
 	hashes := make([][]byte, len(offers))
 	for i := range offers {
 		hashes[i] = slices.Clone(offers[i].hash)
@@ -690,6 +702,7 @@ func (c *Controller) resolveMatch(
 	match solicitationMatch,
 	ms link.MountedStream,
 ) bool {
+	// Select only live local offers matching the peer's current incarnation.
 	var matches []*solicitState
 	c.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
 		if !c.controlStreamLinkActiveLocked(ls) ||
@@ -719,6 +732,7 @@ func (c *Controller) resolveMatch(
 		}
 	})
 
+	// Publish outside the lock because directive callbacks may re-enter us.
 	var emitted bool
 	for _, ss := range matches {
 		sms := link_solicit.NewSolicitMountedStream(ms)
@@ -756,6 +770,7 @@ func (c *Controller) openSolicitedStream(
 	ls *linkState,
 	match solicitationMatch,
 ) {
+	// Open a protocol bound to the exact bilateral offer pair.
 	pid := protocol.ID(SolicitStreamPrefix + encodeSolicitationMatch(ls, match))
 
 	ms, err := ls.ml.OpenMountedStream(ctx, pid, stream.OpenOpts{})
@@ -765,6 +780,7 @@ func (c *Controller) openSolicitedStream(
 		return
 	}
 
+	// A retired offer cannot retain a newly opened stream.
 	if !c.resolveMatch(ls, match, ms) {
 		ms.GetStream().Close()
 	}
@@ -785,6 +801,7 @@ func encodeSolicitationMatch(ls *linkState, match solicitationMatch) string {
 
 // decodeSolicitationMatch parses a stream protocol suffix for the receiving side.
 func decodeSolicitationMatch(ls *linkState, encoded string) (solicitationMatch, error) {
+	// Decode the stable protocol hash shared with legacy peers.
 	parts := strings.Split(encoded, ":")
 	if len(parts) != 1 && len(parts) != 3 {
 		return solicitationMatch{}, errors.New("invalid solicitation match field count")
@@ -797,6 +814,8 @@ func decodeSolicitationMatch(ls *linkState, encoded string) (solicitationMatch, 
 	if len(parts) == 1 {
 		return match, nil
 	}
+
+	// Restore local and remote incarnations from canonical peer order.
 	lower, err := hex.DecodeString(parts[1])
 	if err != nil || len(lower) != solicitationIncarnationSize {
 		return solicitationMatch{}, errors.New("invalid lower solicitation incarnation")
@@ -818,6 +837,7 @@ func (c *Controller) handleIncomingSolicitedStream(
 	encodedMatch string,
 	ms link.MountedStream,
 ) {
+	// Locate the tracked physical link before interpreting the stream match.
 	lnk := ms.GetLink()
 	uuid := lnk.GetLinkUUID()
 
@@ -832,6 +852,7 @@ func (c *Controller) handleIncomingSolicitedStream(
 		return
 	}
 
+	// Reject malformed or retired offer pairs before publishing the stream.
 	match, err := decodeSolicitationMatch(ls, encodedMatch)
 	if err != nil {
 		c.le.WithError(err).Warn("invalid solicited stream match")
@@ -853,6 +874,7 @@ func (c *Controller) runControlStream(
 	ls *linkState,
 	sess *stream_packet.Session,
 ) {
+	// Keep both watchers and packet reads within the control stream lifetime.
 	le := ls.le.WithField("phase", "control-stream")
 	le.Debug("control stream started")
 	defer sess.Close()
@@ -878,6 +900,7 @@ func (c *Controller) runControlStream(
 		}
 	}()
 
+	// Observe local offer changes without blocking their registration callbacks.
 	localCh := make(chan struct{}, 1)
 	localErrCh := make(chan error, 1)
 	go func() {
@@ -899,6 +922,7 @@ func (c *Controller) runControlStream(
 		}
 	}()
 
+	// Keep generation accounting in the single exchange loop.
 	var localExchange *solicitationExchange
 	var peerSupportsOfferIncarnations bool
 	sendLocalExchange := func(exchange *solicitationExchange) bool {
@@ -911,6 +935,7 @@ func (c *Controller) runControlStream(
 		return true
 	}
 	handleLocalWake := func() bool {
+		// Snapshot the current local and remote offers.
 		snap := c.currentControlStreamLocalSnapshot(ls)
 		if snap.linkRemoved {
 			return false
@@ -919,6 +944,8 @@ func (c *Controller) runControlStream(
 		if linkRemoved {
 			return false
 		}
+
+		// Advance the local generation only when its offer set changes.
 		newExchange := c.computeExchange(ls, snap.offers)
 		newExchange.generation = 1
 		if localExchange != nil {
@@ -928,6 +955,8 @@ func (c *Controller) runControlStream(
 				newExchange.generation++
 			}
 		}
+
+		// Withdraw retired opens before publishing and matching the new set.
 		c.pruneRetiredMatches(ls, newExchange, remoteExchange)
 		if !solicitationExchangesEqual(localExchange, newExchange) {
 			if !sendLocalExchange(newExchange) {
@@ -940,6 +969,7 @@ func (c *Controller) runControlStream(
 		return true
 	}
 
+	// Send the capability probe before processing the peer's exchanges.
 	select {
 	case <-ctx.Done():
 		return
@@ -954,6 +984,7 @@ func (c *Controller) runControlStream(
 		}
 	}
 
+	// Serialize offer publication, peer acknowledgements, and match admission.
 	for {
 		select {
 		case <-ctx.Done():
@@ -978,11 +1009,18 @@ func (c *Controller) runControlStream(
 				return
 			}
 			c.pruneRetiredMatches(ls, localExchange, remoteExchange)
+			// The capability probe carried hashes without incarnations. Publish
+			// the complete offers as a new generation so its acknowledgement
+			// proves the peer can accept the stream's incarnation pair.
+			upgraded := !peerSupportsOfferIncarnations && remoteExchange.supportsOfferIncarnations
 			peerSupportsOfferIncarnations = remoteExchange.supportsOfferIncarnations
 			if remoteExchange.supportsOfferIncarnations &&
 				localExchange.supportsOfferIncarnations &&
-				localExchange.acknowledgedGeneration != remoteExchange.generation {
+				(upgraded || localExchange.acknowledgedGeneration != remoteExchange.generation) {
 				acknowledged := cloneSolicitationExchange(localExchange)
+				if upgraded {
+					acknowledged.generation++
+				}
 				acknowledged.acknowledgedGeneration = remoteExchange.generation
 				if !sendLocalExchange(acknowledged) {
 					return
@@ -1000,6 +1038,7 @@ func (c *Controller) pruneRetiredMatches(
 	ls *linkState,
 	local, remote *solicitationExchange,
 ) {
+	// Compute the bilateral set that still permits incarnation-bound openings.
 	active := make(map[string]struct{})
 	if local != nil && remote != nil &&
 		local.supportsOfferIncarnations && remote.supportsOfferIncarnations {
@@ -1008,6 +1047,7 @@ func (c *Controller) pruneRetiredMatches(
 		}
 	}
 
+	// Retire suppression and pending opens for pairs outside that set.
 	var retired []solicitationOpenKey
 	c.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
 		for matchKey := range ls.matched {
@@ -1028,6 +1068,8 @@ func (c *Controller) pruneRetiredMatches(
 			}
 		}
 	})
+
+	// Cancel keyed work outside the state lock.
 	for _, key := range retired {
 		c.openRoutines.RemoveKey(key)
 	}
@@ -1039,6 +1081,7 @@ func (c *Controller) evaluateMatches(
 	ls *linkState,
 	local, remote *solicitationExchange,
 ) {
+	// Only mutually acknowledged offer generations may admit streams.
 	if local == nil || remote == nil {
 		return
 	}
@@ -1047,6 +1090,8 @@ func (c *Controller) evaluateMatches(
 		WithField("remote-count", len(remote.hashes)).
 		WithField("match-count", len(matches)).
 		Debug("evaluated matches")
+
+	// Register each pair once and open it from the lower peer.
 	for _, match := range matches {
 		matchKey := encodeSolicitationMatch(ls, match)
 		var exists, linkActive bool
@@ -1084,8 +1129,10 @@ func (c *Controller) evaluateMatches(
 // startOpenRoutine registers an opening and removes the keyed entry if its
 // metadata or link was retired before registration completed.
 func (c *Controller) startOpenRoutine(key solicitationOpenKey) {
+	// Register the keyed routine before checking for concurrent retirement.
 	c.openRoutines.SetKey(key, true)
 
+	// Remove work whose metadata or physical link no longer exists.
 	var retained bool
 	c.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
 		open, exists := c.opens[key]
@@ -1102,12 +1149,15 @@ func (c *Controller) sendExchange(
 	exchange *solicitationExchange,
 	sendOffers bool,
 ) error {
+	// Probe using legacy hashes until the peer advertises incarnation support.
 	msg := &link_solicit.SolicitationExchange{
 		ProtocolHashes:            exchange.hashes,
 		SupportsOfferIncarnations: true,
 		Generation:                exchange.generation,
 		AcknowledgedGeneration:    exchange.acknowledgedGeneration,
 	}
+
+	// Send complete offers within the negotiated packet bound after upgrade.
 	if sendOffers {
 		msg.ProtocolHashes = nil
 		msg.Offers = make([]*link_solicit.SolicitationOffer, len(exchange.offers))
@@ -1125,12 +1175,14 @@ func (c *Controller) sendExchange(
 func (c *Controller) decodeExchange(
 	msg *link_solicit.SolicitationExchange,
 ) *solicitationExchange {
+	// Normalize and bound the legacy hash set.
 	hashes := cloneHashes(msg.GetProtocolHashes())
 	if len(hashes) > int(c.maxHashes) {
 		hashes = hashes[:c.maxHashes]
 	}
 	link_solicit.SortHashes(hashes)
 
+	// Validate incarnation pairs before deriving their stable discovery hashes.
 	offers := make([]solicitationOffer, 0, len(msg.GetOffers()))
 	for _, wireOffer := range msg.GetOffers() {
 		if len(wireOffer.GetProtocolHash()) != link_solicit.HashSize ||
@@ -1184,6 +1236,7 @@ func solicitationOfferSetsEqual(a, b *solicitationExchange) bool {
 func findSolicitationMatches(
 	local, remote *solicitationExchange,
 ) []solicitationMatch {
+	// Legacy peers suppress matches by stable hash for the physical link lifetime.
 	if !local.supportsOfferIncarnations || !remote.supportsOfferIncarnations {
 		hashes := link_solicit.FindMatchingHashes(local.hashes, remote.hashes)
 		matches := make([]solicitationMatch, len(hashes))
@@ -1192,6 +1245,8 @@ func findSolicitationMatches(
 		}
 		return matches
 	}
+
+	// Both sides must have observed the other's complete offer generation.
 	if local.acknowledgedGeneration != remote.generation ||
 		remote.acknowledgedGeneration != local.generation {
 		return nil


### PR DESCRIPTION
Fix the failures in run 34304312474: require acknowledgement of complete solicitation offers after capability negotiation, wait for the connected app runtime in Drive scenarios, and use the current OPFS marker name. Native core and trace fixtures now use the desktop scheduler policy so Go plugins cannot accidentally start in QuickJS.

Validation: the new deterministic handshake regression fails on the original source; 200 retained-link restarts and the controller race suite pass. All eight Drive scenarios, multi-tab failover with reload persistence, native core E2E, and both trace-service tests pass locally. The complete GoScript command is being rechecked with the dependency and embedded-literal fixes already on master.
