### PR TITLE
feat(chat): retain protocol event relationships

### DIFF
--- a/.protoc-manifest.json
+++ b/.protoc-manifest.json
@@ -3430,7 +3430,7 @@
       ]
     },
     "github.com/s4wave/spacewave/sdk/chat/content": {
-      "hash": "95494bae906a1955bdf1ce5a20c548fd0da3f3d36716ee046125627f985c2859",
+      "hash": "18e54aa1b67c59ff13892e9c734282d8ea4aa66f22421749a70f9b53d2cd7ff7",
       "generatedFiles": [
         "sdk/chat/content/content.pb.go",
         "sdk/chat/content/content.pb.ts"

--- a/sdk/chat/chat-content.go
+++ b/sdk/chat/chat-content.go
@@ -14,7 +14,7 @@ type ChatMessageContent_Ciphertext = spacewave_chat_content.ChatMessageContent_C
 // ChatCiphertext is the shared encrypted envelope used by storage and RPC.
 type ChatCiphertext = spacewave_chat_content.ChatCiphertext
 
-// ChatRelation is the shared message relationship used by encrypted transports.
+// ChatRelation is shared relationship metadata stored beside supported message bodies.
 type ChatRelation = spacewave_chat_content.ChatRelation
 
 // ChatAnnotation is an attributed public reaction to a channel message.

--- a/sdk/chat/chat-event_test.go
+++ b/sdk/chat/chat-event_test.go
@@ -50,6 +50,27 @@ func TestProtocolEventHistory(t *testing.T) {
 		t.Fatalf("timeline event replaced channel state: %v %v", state, err)
 	}
 
+	// Extension events retain native relationships and reject unavailable targets.
+	related := request.CloneVT()
+	related.TransactionId = "related-event"
+	related.Content.GetEvent().Type = "m.room.related"
+	related.Content.GetEvent().ContentJson = `{"body":"related"}`
+	related.Content.GetEvent().Relation = &ChatRelation{Type: "m.thread", TargetKey: sent.GetMessageKey()}
+	relationResult, err := channel.SendMessage(ctx, related)
+	if err != nil {
+		t.Fatal(err)
+	}
+	relationRead, err := reader.GetMessage(ctx, &chat_rpc.GetMessageRequest{MessageKey: relationResult.GetMessageKey()})
+	if err != nil || !relationRead.GetMessage().GetContent().EqualVT(related.GetContent()) {
+		t.Fatalf("stored event relationship changed: %v %v", relationRead, err)
+	}
+	invalidRelation := related.CloneVT()
+	invalidRelation.TransactionId = "invalid-relation"
+	invalidRelation.Content.GetEvent().Relation.TargetKey = key + "/message/missing"
+	if _, err := channel.SendMessage(ctx, invalidRelation); err == nil {
+		t.Fatal("accepted an unavailable event relationship")
+	}
+
 	// Conflicting retries and malformed bodies leave history unchanged.
 	conflict := request.CloneVT()
 	conflict.Content.GetEvent().ContentJson = `{}`
@@ -65,7 +86,7 @@ func TestProtocolEventHistory(t *testing.T) {
 		}
 	}
 	info, err := reader.GetChannelInfo(ctx, &chat_rpc.GetChannelInfoRequest{})
-	if err != nil || info.GetMessageCount() != 1 {
+	if err != nil || info.GetMessageCount() != 2 {
 		t.Fatalf("rejected sends advanced history: %v %v", info, err)
 	}
 

--- a/sdk/chat/chat-resource.go
+++ b/sdk/chat/chat-resource.go
@@ -397,7 +397,8 @@ func (r *ChatResource) appendMessage(ctx context.Context, wtx world.WorldState, 
 
 	// Resolve relationships only for new writes; accepted retries retain their original targets.
 	relation := content.GetCiphertext().GetRelation()
-	for _, key := range []string{relation.GetTargetKey(), relation.GetReplyToKey(), content.GetAnnotation().GetTargetKey()} {
+	eventRelation := content.GetEvent().GetRelation()
+	for _, key := range []string{relation.GetTargetKey(), relation.GetReplyToKey(), eventRelation.GetTargetKey(), eventRelation.GetReplyToKey(), content.GetAnnotation().GetTargetKey()} {
 		if key == "" {
 			continue
 		}
@@ -803,10 +804,8 @@ func normalizeSendMessageContent(req *spacewave_chat_rpc.SendMessageRequest) (*C
 		if value == nil || value.Ciphertext.GetAlgorithm() == "" || value.Ciphertext.GetCiphertext() == "" || value.Ciphertext.GetSenderKey() == "" || value.Ciphertext.GetSessionId() == "" {
 			return nil, errors.New("chat encrypted content is incomplete")
 		}
-		if relation := value.Ciphertext.GetRelation(); relation != nil {
-			if len(relation.GetType()) > 255 || len(relation.GetKey()) > 4096 || len(relation.GetTargetKey()) > 4096 || len(relation.GetReplyToKey()) > 4096 || (relation.GetType() == "") != (relation.GetTargetKey() == "") || relation.GetTargetKey() == "" && relation.GetReplyToKey() == "" {
-				return nil, errors.New("chat relationship is incomplete or exceeds its bounds")
-			}
+		if err := value.Ciphertext.GetRelation().Validate(); err != nil {
+			return nil, err
 		}
 	case *ChatMessageContent_Annotation:
 		if value == nil || value.Annotation.GetTargetKey() == "" || len(value.Annotation.GetTargetKey()) > 4096 || value.Annotation.GetKey() == "" || len(value.Annotation.GetKey()) > 4096 {

--- a/sdk/chat/content/content.pb.go
+++ b/sdk/chat/content/content.pb.go
@@ -210,6 +210,8 @@ type ChatEvent struct {
 	// ContentJson is a complete JSON object, bounded to 64 KiB.
 	// The producing protocol validates its schema and canonicalizes its encoding.
 	ContentJson string `protobuf:"bytes,2,opt,name=content_json,json=contentJson,proto3" json:"contentJson,omitempty"`
+	// Relation is protocol-neutral routing metadata expressed in native message keys.
+	Relation *ChatRelation `protobuf:"bytes,3,opt,name=relation,proto3" json:"relation,omitempty"`
 }
 
 func (x *ChatEvent) Reset() {
@@ -230,6 +232,13 @@ func (x *ChatEvent) GetContentJson() string {
 		return x.ContentJson
 	}
 	return ""
+}
+
+func (x *ChatEvent) GetRelation() *ChatRelation {
+	if x != nil {
+		return x.Relation
+	}
+	return nil
 }
 
 // ChatMessageContent contains the message body.
@@ -414,6 +423,7 @@ func (m *ChatEvent) CloneVT() *ChatEvent {
 	r := new(ChatEvent)
 	r.Type = m.Type
 	r.ContentJson = m.ContentJson
+	r.Relation = protobuf_go_lite.CloneVTValue(m.Relation)
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = slices.Clone(m.unknownFields)
 	}
@@ -635,6 +645,9 @@ func (this *ChatEvent) EqualVT(that *ChatEvent) bool {
 		return false
 	}
 	if this.ContentJson != that.ContentJson {
+		return false
+	}
+	if !protobuf_go_lite.IsEqualVT(this.Relation, that.Relation) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -1048,6 +1061,11 @@ func (x *ChatEvent) MarshalProtoJSON(s *json.MarshalState) {
 		s.WriteObjectField("contentJson")
 		s.WriteString(x.ContentJson)
 	}
+	if x.Relation != nil || s.HasField("relation") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("relation")
+		x.Relation.MarshalProtoJSON(s.WithField("relation"))
+	}
 	s.WriteObjectEnd()
 }
 
@@ -1071,6 +1089,13 @@ func (x *ChatEvent) UnmarshalProtoJSON(s *json.UnmarshalState) {
 		case "content_json", "contentJson":
 			s.AddField("content_json")
 			x.ContentJson = s.ReadString()
+		case "relation":
+			if s.ReadNil() {
+				x.Relation = nil
+				return
+			}
+			x.Relation = &ChatRelation{}
+			x.Relation.UnmarshalProtoJSON(s.WithField("relation", true))
 		}
 	})
 }
@@ -1421,6 +1446,16 @@ func (m *ChatEvent) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
 	}
+	if m.Relation != nil {
+		size, err := m.Relation.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
+	}
 	if len(m.ContentJson) > 0 {
 		i = protobuf_go_lite.EncodeString(dAtA, i, m.ContentJson)
 		i--
@@ -1651,6 +1686,10 @@ func (m *ChatEvent) SizeVT() (n int) {
 	_ = l
 	n += protobuf_go_lite.SizeStringNonEmpty(1, m.Type)
 	n += protobuf_go_lite.SizeStringNonEmpty(1, m.ContentJson)
+	if m.Relation != nil {
+		l = m.Relation.SizeVT()
+		n += protobuf_go_lite.SizeMessage(1, l)
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -1852,6 +1891,10 @@ func (x *ChatEvent) MarshalProtoText() string {
 	if x.ContentJson != "" {
 		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "content_json")
 		protobuf_go_lite.TextWriteString(&sb, x.ContentJson)
+	}
+	if x.Relation != nil {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "relation")
+		protobuf_go_lite.TextWriteTextMarshaler(&sb, x.Relation)
 	}
 	return protobuf_go_lite.TextFinishMessage(&sb)
 }
@@ -2280,6 +2323,21 @@ func (m *ChatEvent) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			m.ContentJson = v
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Relation", wireType)
+			}
+			msgStart, postIndex, err := protobuf_go_lite.DecodeLengthDelimited(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			if m.Relation == nil {
+				m.Relation = &ChatRelation{}
+			}
+			if err := m.Relation.UnmarshalVT(dAtA[msgStart:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])

--- a/sdk/chat/content/content.pb.ts
+++ b/sdk/chat/content/content.pb.ts
@@ -205,6 +205,12 @@ export interface ChatEvent {
    * @generated from field: string content_json = 2;
    */
   contentJson?: string
+  /**
+   * Relation is protocol-neutral routing metadata expressed in native message keys.
+   *
+   * @generated from field: spacewave.chat.ChatRelation relation = 3;
+   */
+  relation?: ChatRelation
 }
 
 export const ChatEvent: MessageType<ChatEvent> =
@@ -213,6 +219,7 @@ export const ChatEvent: MessageType<ChatEvent> =
     fields: [
       { no: 1, name: 'type', kind: 'scalar', T: ScalarType.STRING },
       { no: 2, name: 'content_json', kind: 'scalar', T: ScalarType.STRING },
+      { no: 3, name: 'relation', kind: 'message', T: () => ChatRelation },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,
   })

--- a/sdk/chat/content/content.proto
+++ b/sdk/chat/content/content.proto
@@ -59,6 +59,8 @@ message ChatEvent {
   // ContentJson is a complete JSON object, bounded to 64 KiB.
   // The producing protocol validates its schema and canonicalizes its encoding.
   string content_json = 2;
+  // Relation is protocol-neutral routing metadata expressed in native message keys.
+  ChatRelation relation = 3;
 }
 
 // ChatMessageContent contains the message body.

--- a/sdk/chat/content/event.go
+++ b/sdk/chat/content/event.go
@@ -24,5 +24,19 @@ func (e *ChatEvent) Validate() error {
 	if value.Type() != fastjson.TypeObject {
 		return errors.New("chat event content must be a JSON object")
 	}
+	return e.GetRelation().Validate()
+}
+
+// Validate checks one optional relationship expressed in native message keys.
+func (r *ChatRelation) Validate() error {
+	if r == nil {
+		return nil
+	}
+	if len(r.GetType()) > 255 || len(r.GetKey()) > 4096 || len(r.GetTargetKey()) > 4096 || len(r.GetReplyToKey()) > 4096 {
+		return errors.New("chat relationship is incomplete or exceeds its bounds")
+	}
+	if (r.GetType() == "") != (r.GetTargetKey() == "") || r.GetTargetKey() == "" && r.GetReplyToKey() == "" {
+		return errors.New("chat relationship is incomplete or exceeds its bounds")
+	}
 	return nil
 }


### PR DESCRIPTION
Matrix extension events now retain native relationship targets beside their bounded JSON bodies, so thread replies, replacements, and other related events survive shared channel storage. The chat owner validates the same relation contract used by encrypted messages and resolves every target inside the channel transaction.

Validation:
- `bun run gen` (stable second run)
- `go test -count=1 ./sdk/chat`
- `go test -race -count=1 ./sdk/chat`
- `go vet ./sdk/chat`
- `bun run typecheck`
- Linux arm64 Spacewave build and upstream Matrix Complement relation/media integration
