### PR TITLE
perf(bucket): batch object copy writes

### DIFF
--- a/db/bucket/lookup/object-copy.go
+++ b/db/bucket/lookup/object-copy.go
@@ -136,6 +136,7 @@ func copyObjectToBucket(
 		return destinationRef, ObjectCopyStats{}, nil
 	}
 
+	// Resolve the destination's storage and encoding for the complete copy.
 	writeCursor, err := destCursor.FollowRef(ctx, destinationRef)
 	if err != nil {
 		if err == context.Canceled {
@@ -145,12 +146,21 @@ func copyObjectToBucket(
 	}
 	defer writeCursor.Release()
 
+	// Read encoded source blocks and decode only for child traversal.
 	readBkt := srcCursor.GetBucket()
 	readXfrm := srcCursor.GetTransformer()
 	if readXfrm == nil {
 		readXfrm = block_transform.NewTransformerWithSteps(nil)
 	}
 	writeBkt := writeCursor.GetBucket()
+
+	// Bound pending payloads while amortizing destination ownership updates.
+	const maxPendingBytes = 4 << 20
+	writes := block.NewBufferedStoreWithSettings(ctx, writeBkt, &block.BufferedStoreSettings{
+		MaxPendingEntries: 128,
+		MaxPendingBytes:   maxPendingBytes,
+		DrainBatchEntries: 128,
+	})
 
 	// seenMtx guards the set of block references claimed by copy workers.
 	var seenMtx sync.Mutex
@@ -192,10 +202,9 @@ func copyObjectToBucket(
 		ctx,
 		NewWalkObjectBlocksWithRef(srcRef.GetRootRef(), rootCtor),
 		func(ent *WalkObjectBlocksEntry) (bool, error) {
+			// Let the caller recover a read error before deciding traversal.
 			var cntu bool
 			var err error
-
-			// The callback may recover a read error.
 			if cb != nil {
 				cntu, err = cb(ent)
 			} else {
@@ -225,17 +234,18 @@ func copyObjectToBucket(
 				return false, nil
 			}
 
+			// Preserve existence accounting and subtree skipping, but submit even
+			// existing blocks so the destination establishes its own GC ownership.
 			seenBlockCount.Add(1)
 			logicalSourceBytes.Add(int64(len(ent.Data)))
-			// Most implementations check existence inside PutBlock.
-			var writeRef *block.BlockRef
-			var writeExisted bool
-			writeRef, writeExisted, err = writeBkt.PutBlock(ctx, ent.Data, &block.PutOpts{
-				HashType:      ent.Ref.GetHash().GetHashType(),
-				ForceBlockRef: ent.Ref,
-			})
-			if err == nil && !writeRef.EqualsRef(ent.Ref) {
-				err = errors.Errorf("wrote to different ref %s", writeRef.MarshalString())
+			writeExisted, err := writeBkt.GetBlockExists(ctx, ent.Ref)
+			if err == nil {
+				// A single large block must not wait for capacity it can never fit.
+				var target block.StoreOps = writes
+				if len(ent.Data) > maxPendingBytes {
+					target = writeBkt
+				}
+				err = target.PutBlockBatch(ctx, []*block.PutBatchEntry{{Ref: ent.Ref, Data: ent.Data}})
 			}
 			if err != nil && err != context.Canceled {
 				err = errors.Wrapf(err, "write ref %s", ent.Ref.MarshalString())
@@ -249,6 +259,7 @@ func copyObjectToBucket(
 				}
 			}
 
+			// Honor the caller's existing-subtree completeness guarantee.
 			if skipSubtreeExists && writeExisted && err == nil {
 				skippedSubtrees.Add(1)
 				if err := reportProgress(); err != nil {
@@ -257,6 +268,7 @@ func copyObjectToBucket(
 				return false, nil
 			}
 
+			// Report accepted work before traversing the remaining children.
 			if progressErr := reportProgress(); progressErr != nil {
 				return false, progressErr
 			}
@@ -266,6 +278,14 @@ func copyObjectToBucket(
 		maxConcurrency,
 		false,
 	)
+
+	// The returned root becomes usable only after all payloads and ownership
+	// updates have reached the destination's durability fence.
+	if err == nil {
+		_, err = writes.Sync(ctx)
+	}
+
+	// Preserve logical accounting even when the copy fails to complete.
 	stats := snapshot()
 	trace.Logf(ctx, "copy-block-seen-count", "%d", stats.BlocksSeen)
 	trace.Logf(ctx, "copy-block-copied-count", "%d", stats.BlocksCopied)

--- a/db/bucket/lookup/object-copy_test.go
+++ b/db/bucket/lookup/object-copy_test.go
@@ -1,14 +1,83 @@
 package bucket_lookup
 
 import (
+	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 
 	"github.com/s4wave/spacewave/db/block"
+	"github.com/s4wave/spacewave/db/block/byteslice"
 	block_mock "github.com/s4wave/spacewave/db/block/mock"
 	"github.com/s4wave/spacewave/db/bucket"
 	bucket_mock "github.com/s4wave/spacewave/db/bucket/mock"
 )
+
+// copyDestination observes the copy's storage boundary and injects failures.
+type copyDestination struct {
+	// StoreOps supplies real in-memory block storage.
+	block.StoreOps
+	// batchSizes records the submitted ownership batches.
+	batchSizes []int
+	// syncs counts completed-copy durability requests.
+	syncs int
+	// batchErr rejects a destination write batch when set.
+	batchErr error
+	// syncErr rejects the final durability fence when set.
+	syncErr error
+}
+
+// TestCopyObjectLargerThanBuffer preserves valid single-block copies that exceed
+// the batching budget, rather than waiting forever for impossible capacity.
+func TestCopyObjectLargerThanBuffer(t *testing.T) {
+	// Store an encoded block larger than the copy's pending-byte budget.
+	ctx := t.Context()
+	source := block_mock.NewMockStore(0)
+	destination := block_mock.NewMockStore(0)
+	data := make([]byte, 5<<20)
+	root, _, err := source.PutBlock(ctx, data, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Copy between distinct buckets using the raw block constructor.
+	src := NewCursor(ctx, nil, nil, nil, source, nil,
+		&bucket.ObjectRef{BucketId: "source", RootRef: root},
+		&bucket.BucketOpArgs{BucketId: "source"}, nil)
+	defer src.Release()
+	dest := NewCursor(ctx, nil, nil, nil, destination, nil,
+		&bucket.ObjectRef{BucketId: "destination"},
+		&bucket.BucketOpArgs{BucketId: "destination"}, nil)
+	defer dest.Release()
+	ref, err := CopyObjectToBucket(ctx, dest, src, byteslice.NewByteSliceBlock, 1, false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A completed root must resolve to the entire original payload.
+	stored, found, err := destination.GetBlock(ctx, ref.GetRootRef())
+	if err != nil || !found || len(stored) != len(data) {
+		t.Fatalf("large copy: bytes=%d found=%t err=%v", len(stored), found, err)
+	}
+}
+
+// PutBlockBatch records each batch before passing it to storage.
+func (d *copyDestination) PutBlockBatch(ctx context.Context, entries []*block.PutBatchEntry) error {
+	d.batchSizes = append(d.batchSizes, len(entries))
+	if d.batchErr != nil {
+		return d.batchErr
+	}
+	return d.StoreOps.PutBlockBatch(ctx, entries)
+}
+
+// Sync can fail the final fence independently of successful block writes.
+func (d *copyDestination) Sync(ctx context.Context) (bool, error) {
+	d.syncs++
+	if d.syncErr != nil {
+		return false, d.syncErr
+	}
+	return d.StoreOps.Sync(ctx)
+}
 
 // sharedCopyBlock references the same child twice to form a shared subtree.
 type sharedCopyBlock struct {
@@ -28,10 +97,11 @@ func (b *sharedCopyBlock) GetBlockRefCtor(uint32) block.Ctor {
 
 // TestCopyObjectPrunesSharedSubtrees checks bounded traversal and complete storage.
 func TestCopyObjectPrunesSharedSubtrees(t *testing.T) {
+	// Build a graph with two references to each successive child.
 	const depth = 8
 	ctx := t.Context()
 	source := block_mock.NewMockStore(0)
-	destination := block_mock.NewMockStore(0)
+	destination := &copyDestination{StoreOps: block_mock.NewMockStore(0)}
 	refs := make([]*block.BlockRef, 0, depth+1)
 	var root *block.BlockRef
 	for range depth + 1 {
@@ -49,6 +119,7 @@ func TestCopyObjectPrunesSharedSubtrees(t *testing.T) {
 		refs = append(refs, root)
 	}
 
+	// Give the copy distinct source and destination bucket identities.
 	src := NewCursor(ctx, nil, nil, nil, source, nil,
 		&bucket.ObjectRef{BucketId: "source", RootRef: root},
 		&bucket.BucketOpArgs{BucketId: "source"}, nil)
@@ -58,6 +129,7 @@ func TestCopyObjectPrunesSharedSubtrees(t *testing.T) {
 		&bucket.BucketOpArgs{BucketId: "destination"}, nil)
 	defer dest.Release()
 
+	// Count logical visits while concurrent workers prune shared descendants.
 	var visits atomic.Int64
 	ref, stats, err := CopyObjectToBucketWithStats(ctx, dest, src,
 		func() block.Block { return &sharedCopyBlock{} }, 2, false,
@@ -70,6 +142,8 @@ func TestCopyObjectPrunesSharedSubtrees(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// Verify every distinct block reached a single fenced destination batch.
 	if got, want := visits.Load(), int64(2*depth+1); got != want {
 		t.Fatalf("visited %d blocks, want %d: shared descendants were revisited", got, want)
 	}
@@ -84,5 +158,27 @@ func TestCopyObjectPrunesSharedSubtrees(t *testing.T) {
 		if err != nil || !found {
 			t.Fatalf("copied block %v: found=%v, err=%v", ref, found, err)
 		}
+	}
+	if len(destination.batchSizes) != 1 || destination.batchSizes[0] != depth+1 || destination.syncs != 1 {
+		t.Fatalf("copy did not batch and fence its writes: batches=%v syncs=%d", destination.batchSizes, destination.syncs)
+	}
+
+	// Existing payloads still need the destination's ownership write. A failed
+	// final batch or durability fence must never return a completed root.
+	for _, failure := range []string{"batch", "sync"} {
+		t.Run(failure, func(t *testing.T) {
+			injected := errors.New("destination " + failure + " failed")
+			destination.batchErr, destination.syncErr = nil, nil
+			if failure == "batch" {
+				destination.batchErr = injected
+			} else {
+				destination.syncErr = injected
+			}
+			ref, stats, err := CopyObjectToBucketWithStats(ctx, dest, src,
+				func() block.Block { return &sharedCopyBlock{} }, 2, false, nil)
+			if !errors.Is(err, injected) || ref != nil || stats.BlocksExisting != depth+1 {
+				t.Fatalf("copy accepted failed destination: ref=%v stats=%+v err=%v", ref, stats, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Background manifest copies wrote blocks individually, causing an OPFS ownership publication for each block while users reopened saved objects. Batch copy writes through the existing buffered store, retain destination ownership for existing payloads, and complete the destination durability fence before returning a root. Single blocks larger than the buffer budget write directly.

Validation passed:

- Focused copy, transform, materializer RPC, cancellation, and race tests, including batch/fence failures and an oversized block.
- Chromium and WebKit saved-Canvas reopen tests.
- Full browser restart offline, persisted Drive reads, and first-use Git repository creation offline.

In the local fixture, the fourth reopen fell from 3.00 to 1.91 seconds in Chromium and 4.80 to 3.42 seconds in WebKit. First samples varied and were slower in the candidate runs. Traced OPFS publications fell from 1,267 to 441; the traces cover different elapsed durations and are not a CPU-time comparison.
