### PR TITLE
feat(chat): index active threads

### DIFF
--- a/.protoc-manifest.json
+++ b/.protoc-manifest.json
@@ -3420,7 +3420,7 @@
       ]
     },
     "github.com/s4wave/spacewave/sdk/chat": {
-      "hash": "4f1c9ee24d3124082b107b050bf4fa83fc42915a6144876ecf3b381e9dc88b11",
+      "hash": "d43123ca344da5a968fefffb12a7c214ad74a165e3d4b99dabb3bea89540bc24",
       "generatedFiles": [
         "sdk/chat/chat.pb.go",
         "sdk/chat/chat.pb.ts"
@@ -3440,7 +3440,7 @@
       ]
     },
     "github.com/s4wave/spacewave/sdk/chat/rpc": {
-      "hash": "cb39ebd28917ef2e76609fff0ecfe9d3064484a8d15720422bc7117bf69cd668",
+      "hash": "8074b6a90f4770b186881bf6b14a681b1d87c6b3892915f65f45b7ff8ab24950",
       "generatedFiles": [
         "sdk/chat/rpc/rpc.pb.go",
         "sdk/chat/rpc/rpc.pb.ts",

--- a/sdk/chat/chat-resource.go
+++ b/sdk/chat/chat-resource.go
@@ -318,6 +318,12 @@ func (r *ChatResource) SendMessage(
 	ctx context.Context,
 	req *spacewave_chat_rpc.SendMessageRequest,
 ) (*spacewave_chat_rpc.SendMessageResponse, error) {
+	// Advance legacy indexing in bounded work before entering the append transaction.
+	if r.engine != nil && r.localPeerID != "" && r.personPeerID != "" {
+		if err := r.ensureThreadIndex(ctx); err != nil {
+			return nil, err
+		}
+	}
 	response, err := r.commitMessage(ctx, req)
 	if err != nil {
 		return nil, err
@@ -457,6 +463,12 @@ func (r *ChatResource) appendMessage(ctx context.Context, wtx world.WorldState, 
 		}
 	}
 
+	// Every new append advances an already initialized history prefix atomically.
+	if channel.ThreadIndexedMessageCount == nil ||
+		channel.GetThreadIndexedMessageCount() != channel.GetMessageCount() {
+		return nil, ErrChatThreadIndexBuilding
+	}
+
 	// Append the accepted message and its page entry in one World transaction.
 	index, msgKey, err := r.appendChannelMessageKey(ctx, wtx, msgKey, state)
 	if err != nil {
@@ -512,6 +524,9 @@ func (r *ChatResource) appendMessage(ctx context.Context, wtx world.WorldState, 
 		if err := wtx.SetGraphQuad(ctx, NewChatStateQuad(r.objectKey, msgKey, state.GetType(), state.GetStateKey())); err != nil {
 			return nil, err
 		}
+	}
+	if err := r.indexAppendedMessage(ctx, wtx, msgKey, msg); err != nil {
+		return nil, err
 	}
 	return &spacewave_chat_rpc.SendMessageResponse{MessageKey: msgKey}, nil
 }

--- a/sdk/chat/chat-thread.go
+++ b/sdk/chat/chat-thread.go
@@ -1,0 +1,418 @@
+package spacewave_chat
+
+import (
+	"context"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/s4wave/spacewave/db/block"
+	"github.com/s4wave/spacewave/db/world"
+	spacewave_chat_rpc "github.com/s4wave/spacewave/sdk/chat/rpc"
+)
+
+const (
+	// maxThreadMigrationMessages bounds legacy backfill work per request.
+	maxThreadMigrationMessages = 250
+	// maxThreadScanLimit bounds filtering work independently of channel size.
+	maxThreadScanLimit = 250
+)
+
+// ErrChatThreadIndexBuilding asks a caller to retry after bounded legacy backfill.
+var ErrChatThreadIndexBuilding = errors.New("chat thread index is still building")
+
+// ListThreads returns native thread summaries in descending activity order.
+func (r *ChatResource) ListThreads(
+	ctx context.Context,
+	req *spacewave_chat_rpc.ListThreadsRequest,
+) (*spacewave_chat_rpc.ListThreadsResponse, error) {
+	if err := r.ensureThreadIndex(ctx); err != nil {
+		return nil, err
+	}
+	channel, err := r.readChannel(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	limit := req.GetLimit()
+	if limit == 0 || limit > maxMessageListLimit {
+		limit = defaultMessageListLimit
+	}
+	threadKey := channel.GetThreadHeadKey()
+	if req != nil && req.BeforeIndex != nil {
+		beforeIndex := req.GetBeforeIndex()
+		if beforeIndex >= channel.GetMessageCount() {
+			return nil, errors.New("thread cursor exceeds channel history")
+		}
+		messageKey, err := r.readMessageKeyAt(ctx, r.ws, beforeIndex)
+		if err != nil {
+			return nil, err
+		}
+		message, err := world.LookupObjectBody[*ChatMessage](ctx, r.ws, messageKey, NewChatMessageBlock)
+		if err != nil {
+			return nil, err
+		}
+		relation := chatMessageRelation(message)
+		if relation.GetType() != "m.thread" || relation.GetTargetKey() == "" {
+			return nil, errors.New("thread cursor does not identify a thread reply")
+		}
+		cursorKey, err := r.chatThreadKey(relation.GetTargetKey())
+		if err != nil {
+			return nil, err
+		}
+		cursor, err := r.readThread(ctx, r.ws, cursorKey)
+		if err != nil {
+			return nil, err
+		}
+		threadKey = cursor.GetOlderThreadKey()
+	}
+
+	response := &spacewave_chat_rpc.ListThreadsResponse{}
+	var lastScanned *ChatThread
+	for scanned := 0; threadKey != "" && scanned < maxThreadScanLimit && len(response.Threads) < int(limit); scanned++ {
+		thread, err := r.readThread(ctx, r.ws, threadKey)
+		if err != nil {
+			return nil, err
+		}
+		lastScanned = thread
+		threadKey = thread.GetOlderThreadKey()
+
+		participated, err := r.threadParticipated(ctx, thread)
+		if err != nil {
+			return nil, err
+		}
+		if req.GetParticipatedOnly() && !participated {
+			continue
+		}
+		root, err := r.readMessage(ctx, thread.GetRootMessageKey())
+		if err != nil {
+			return nil, err
+		}
+		latest, err := r.readMessage(ctx, thread.GetLatestMessageKey())
+		if err != nil {
+			return nil, err
+		}
+		if root == nil || latest == nil {
+			return nil, errors.New("thread index references a missing message")
+		}
+		response.Threads = append(response.Threads, &spacewave_chat_rpc.ChatThreadInfo{
+			Root:                    root,
+			LatestReply:             latest,
+			ReplyCount:              thread.GetReplyCount(),
+			CurrentUserParticipated: participated,
+		})
+	}
+	if threadKey != "" && lastScanned != nil {
+		next := lastScanned.GetLatestMessageIndex()
+		response.NextBeforeIndex = &next
+	}
+	return response, nil
+}
+
+// ensureThreadIndex migrates a legacy channel once before serving indexed reads.
+func (r *ChatResource) ensureThreadIndex(ctx context.Context) error {
+	channel, err := r.readChannel(ctx)
+	if err != nil {
+		return err
+	}
+	if channel.ThreadIndexedMessageCount != nil &&
+		channel.GetThreadIndexedMessageCount() == channel.GetMessageCount() {
+		return nil
+	}
+	if r.engine == nil {
+		return errors.New("legacy chat thread index requires a writable resource")
+	}
+
+	tx, err := r.engine.NewTransaction(ctx, true)
+	if err != nil {
+		return err
+	}
+	defer tx.Discard()
+	channel, err = world.LookupObjectBody[*ChatChannel](ctx, tx, r.objectKey, NewChatChannelBlock)
+	if err != nil {
+		return err
+	}
+	changed, complete, err := r.updateThreadIndex(ctx, tx, channel, maxThreadMigrationMessages)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		return nil
+	}
+	if err := r.writeChannel(ctx, tx, channel); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+	if _, err := r.engine.Sync(ctx); err != nil {
+		return err
+	}
+	if !complete {
+		return ErrChatThreadIndexBuilding
+	}
+	return nil
+}
+
+// updateThreadIndex extends or initializes the index through current history.
+func (r *ChatResource) updateThreadIndex(
+	ctx context.Context,
+	ws world.WorldState,
+	channel *ChatChannel,
+	messageLimit uint64,
+) (bool, bool, error) {
+	if messageLimit == 0 {
+		return false, false, errors.New("chat thread migration limit must be positive")
+	}
+	initialized := channel.ThreadIndexedMessageCount != nil
+	if !initialized {
+		if channel.GetThreadHeadKey() != "" {
+			return false, false, errors.New("legacy chat thread index contains current-format state")
+		}
+		channel.ThreadIndexedMessageCount = new(uint64)
+	}
+	if channel.GetThreadIndexedMessageCount() > channel.GetMessageCount() {
+		return false, false, errors.New("chat thread index exceeds channel history")
+	}
+
+	changed := !initialized
+	startIndex := channel.GetThreadIndexedMessageCount()
+	endIndex := startIndex + min(messageLimit, channel.GetMessageCount()-startIndex)
+	for index := startIndex; index < endIndex; index++ {
+		messageKey, err := r.readMessageKeyAt(ctx, ws, index)
+		if err != nil {
+			return false, false, err
+		}
+		message, err := world.LookupObjectBody[*ChatMessage](ctx, ws, messageKey, NewChatMessageBlock)
+		if err != nil {
+			return false, false, err
+		}
+		if err := r.indexThreadReply(ctx, ws, channel, messageKey, message); err != nil {
+			return false, false, err
+		}
+		indexedMessageCount := index + 1
+		channel.ThreadIndexedMessageCount = &indexedMessageCount
+		changed = true
+	}
+	return changed, channel.GetThreadIndexedMessageCount() == channel.GetMessageCount(), nil
+}
+
+// indexAppendedMessage advances the current index with one newly retained message.
+func (r *ChatResource) indexAppendedMessage(ctx context.Context, ws world.WorldState, messageKey string, message *ChatMessage) error {
+	channel, err := world.LookupObjectBody[*ChatChannel](ctx, ws, r.objectKey, NewChatChannelBlock)
+	if err != nil {
+		return err
+	}
+	if channel.ThreadIndexedMessageCount == nil ||
+		channel.GetThreadIndexedMessageCount() != message.GetIndex() ||
+		channel.GetMessageCount() != message.GetIndex()+1 {
+		return errors.New("chat thread index does not match appended history")
+	}
+	if err := r.indexThreadReply(ctx, ws, channel, messageKey, message); err != nil {
+		return err
+	}
+	indexedMessageCount := channel.GetMessageCount()
+	channel.ThreadIndexedMessageCount = &indexedMessageCount
+	return r.writeChannel(ctx, ws, channel)
+}
+
+// indexThreadReply updates the activity list and participation set for one reply.
+func (r *ChatResource) indexThreadReply(
+	ctx context.Context,
+	ws world.WorldState,
+	channel *ChatChannel,
+	messageKey string,
+	message *ChatMessage,
+) error {
+	relation := chatMessageRelation(message)
+	if relation.GetType() != "m.thread" || relation.GetTargetKey() == "" {
+		return nil
+	}
+	threadKey, err := r.chatThreadKey(relation.GetTargetKey())
+	if err != nil {
+		return err
+	}
+	thread, err := r.readThread(ctx, ws, threadKey)
+	if err != nil && !errors.Is(err, world.ErrObjectNotFound) {
+		return err
+	}
+	if thread == nil {
+		thread = &ChatThread{
+			RootMessageKey:     relation.GetTargetKey(),
+			LatestMessageKey:   messageKey,
+			LatestMessageIndex: message.GetIndex(),
+			ReplyCount:         1,
+			OlderThreadKey:     channel.GetThreadHeadKey(),
+		}
+		if headKey := channel.GetThreadHeadKey(); headKey != "" {
+			head, err := r.readThread(ctx, ws, headKey)
+			if err != nil {
+				return err
+			}
+			if head.GetNewerThreadKey() != "" {
+				return errors.New("chat thread head has a newer link")
+			}
+			head.NewerThreadKey = threadKey
+			if err := r.writeThread(ctx, ws, headKey, head); err != nil {
+				return err
+			}
+		}
+		channel.ThreadHeadKey = threadKey
+	} else {
+		if thread.GetRootMessageKey() != relation.GetTargetKey() || thread.GetLatestMessageIndex() >= message.GetIndex() {
+			return errors.New("chat thread index order is inconsistent")
+		}
+		thread.LatestMessageKey = messageKey
+		thread.LatestMessageIndex = message.GetIndex()
+		thread.ReplyCount++
+		if channel.GetThreadHeadKey() != threadKey {
+			newerKey := thread.GetNewerThreadKey()
+			if newerKey == "" {
+				return errors.New("non-head chat thread has no newer link")
+			}
+			newer, err := r.readThread(ctx, ws, newerKey)
+			if err != nil {
+				return err
+			}
+			if newer.GetOlderThreadKey() != threadKey {
+				return errors.New("chat thread newer link is inconsistent")
+			}
+			newer.OlderThreadKey = thread.GetOlderThreadKey()
+			if err := r.writeThread(ctx, ws, newerKey, newer); err != nil {
+				return err
+			}
+			if olderKey := thread.GetOlderThreadKey(); olderKey != "" {
+				older, err := r.readThread(ctx, ws, olderKey)
+				if err != nil {
+					return err
+				}
+				if older.GetNewerThreadKey() != threadKey {
+					return errors.New("chat thread older link is inconsistent")
+				}
+				older.NewerThreadKey = thread.GetNewerThreadKey()
+				if err := r.writeThread(ctx, ws, olderKey, older); err != nil {
+					return err
+				}
+			}
+			headKey := channel.GetThreadHeadKey()
+			head, err := r.readThread(ctx, ws, headKey)
+			if err != nil {
+				return err
+			}
+			if head.GetNewerThreadKey() != "" {
+				return errors.New("chat thread head has a newer link")
+			}
+			head.NewerThreadKey = threadKey
+			if err := r.writeThread(ctx, ws, headKey, head); err != nil {
+				return err
+			}
+			thread.NewerThreadKey = ""
+			thread.OlderThreadKey = headKey
+			channel.ThreadHeadKey = threadKey
+		}
+	}
+	if err := r.writeThread(ctx, ws, threadKey, thread); err != nil {
+		return err
+	}
+
+	personPeerID := message.GetPersonPeerId()
+	if personPeerID == "" {
+		personPeerID = message.GetSenderPeerId()
+	}
+	if personPeerID == "" {
+		return errors.New("thread reply has no attributed person")
+	}
+	return ws.SetGraphQuad(ctx, NewChatThreadParticipantQuad(threadKey, personPeerID))
+}
+
+// threadParticipated checks the authenticated person without enumerating participants.
+func (r *ChatResource) threadParticipated(ctx context.Context, thread *ChatThread) (bool, error) {
+	if r.personPeerID == "" {
+		return false, nil
+	}
+	threadKey, err := r.chatThreadKey(thread.GetRootMessageKey())
+	if err != nil {
+		return false, err
+	}
+	quads, err := r.ws.LookupGraphQuads(
+		ctx,
+		NewChatThreadParticipantQuad(threadKey, r.personPeerID),
+		1,
+	)
+	return len(quads) != 0, err
+}
+
+// chatThreadKey derives a bounded channel-owned key from a validated root key.
+func (r *ChatResource) chatThreadKey(rootMessageKey string) (string, error) {
+	suffix, found := strings.CutPrefix(rootMessageKey, r.objectKey+"/message/")
+	if !found || suffix == "" || strings.ContainsAny(suffix, "/\x00") {
+		return "", errors.New("thread root belongs to another channel")
+	}
+	return r.objectKey + "/thread/" + suffix, nil
+}
+
+// chatMessageRelation returns public relationship metadata from supported bodies.
+func chatMessageRelation(message *ChatMessage) *ChatRelation {
+	content := message.GetContent()
+	if content.GetEvent() != nil {
+		return content.GetEvent().GetRelation()
+	}
+	if content.GetCiphertext() != nil {
+		return content.GetCiphertext().GetRelation()
+	}
+	return nil
+}
+
+// readMessageKeyAt resolves one stable history position through its bounded page.
+func (r *ChatResource) readMessageKeyAt(ctx context.Context, ws world.WorldState, index uint64) (string, error) {
+	page, err := world.LookupObjectBody[*ChatMessagePage](ctx, ws, r.messagePageKey(index/chatMessagePageSize), NewChatMessagePageBlock)
+	if err != nil {
+		return "", err
+	}
+	offset := index % chatMessagePageSize
+	if offset >= uint64(len(page.GetMessageKeys())) || page.GetMessageKeys()[offset] == "" {
+		return "", errors.New("chat history page is missing an indexed message")
+	}
+	return page.GetMessageKeys()[offset], nil
+}
+
+// readThread loads one bounded thread summary.
+func (r *ChatResource) readThread(ctx context.Context, ws world.WorldState, key string) (*ChatThread, error) {
+	return world.LookupObjectBody[*ChatThread](ctx, ws, key, NewChatThreadBlock)
+}
+
+// writeThread creates or replaces one thread summary inside the caller's transaction.
+func (r *ChatResource) writeThread(ctx context.Context, ws world.WorldState, key string, thread *ChatThread) error {
+	object, found, err := ws.GetObject(ctx, key)
+	if err != nil {
+		return err
+	}
+	if !found {
+		object, err = ws.CreateObject(ctx, key, nil)
+		if err != nil {
+			return err
+		}
+	}
+	defer world.ReleaseObjectState(object)
+	_, _, err = world.AccessObjectState(ctx, object, true, func(cursor *block.Cursor) error {
+		cursor.SetBlock(thread, true)
+		return nil
+	})
+	return err
+}
+
+// writeChannel replaces channel metadata inside the caller's transaction.
+func (r *ChatResource) writeChannel(ctx context.Context, ws world.WorldState, channel *ChatChannel) error {
+	object, found, err := ws.GetObject(ctx, r.objectKey)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return world.ErrObjectNotFound
+	}
+	defer world.ReleaseObjectState(object)
+	_, _, err = world.AccessObjectState(ctx, object, true, func(cursor *block.Cursor) error {
+		cursor.SetBlock(channel, true)
+		return nil
+	})
+	return err
+}

--- a/sdk/chat/chat-thread_test.go
+++ b/sdk/chat/chat-thread_test.go
@@ -1,0 +1,218 @@
+package spacewave_chat
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
+	"github.com/s4wave/spacewave/db/block"
+	"github.com/s4wave/spacewave/db/world"
+	db_world_testbed "github.com/s4wave/spacewave/db/world/testbed"
+	world_types "github.com/s4wave/spacewave/db/world/types"
+	chat_rpc "github.com/s4wave/spacewave/sdk/chat/rpc"
+)
+
+// TestChatResourceListThreadsRetainsOrderCountsAndReplyParticipation exercises the native index contract.
+func TestChatResourceListThreadsRetainsOrderCountsAndReplyParticipation(t *testing.T) {
+	ctx := t.Context()
+	tb, err := db_world_testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(tb.Release)
+	ws := world.NewEngineWorldState(tb.Engine, true)
+	const channelKey = "chat/channel/thread-index"
+	if _, _, err := ws.ApplyWorldOp(ctx, &CreateChatChannelOp{
+		ObjectKey: channelKey,
+		Name:      "Threads",
+		Timestamp: timestamppb.Now(),
+	}, tb.Volume.GetPeerID()); err != nil {
+		t.Fatal(err)
+	}
+	alice := NewChatResourceForPerson(ws, tb.Engine, channelKey, "alice-device", "alice")
+	bob := NewChatResourceForPerson(ws, tb.Engine, channelKey, "bob-device", "bob")
+	t.Cleanup(alice.Close)
+	t.Cleanup(bob.Close)
+
+	rootA := sendThreadTestEvent(t, ctx, alice, "root-a", nil)
+	replyA := sendThreadTestEvent(t, ctx, bob, "reply-a", &ChatRelation{Type: "m.thread", TargetKey: rootA})
+	rootB := sendThreadTestEvent(t, ctx, bob, "root-b", nil)
+	replyB := sendThreadTestEvent(t, ctx, alice, "reply-b", &ChatRelation{Type: "m.thread", TargetKey: rootB})
+
+	page, err := alice.ListThreads(ctx, &chat_rpc.ListThreadsRequest{Limit: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.GetThreads()) != 1 || page.GetThreads()[0].GetRoot().GetObjectKey() != rootB ||
+		page.GetThreads()[0].GetLatestReply().GetObjectKey() != replyB ||
+		page.GetThreads()[0].GetReplyCount() != 1 || !page.GetThreads()[0].GetCurrentUserParticipated() ||
+		page.NextBeforeIndex == nil {
+		t.Fatalf("first thread page = %v", page)
+	}
+	second, err := alice.ListThreads(ctx, &chat_rpc.ListThreadsRequest{
+		BeforeIndex: page.NextBeforeIndex,
+		Limit:       1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(second.GetThreads()) != 1 || second.GetThreads()[0].GetRoot().GetObjectKey() != rootA ||
+		second.GetThreads()[0].GetLatestReply().GetObjectKey() != replyA ||
+		second.GetThreads()[0].GetCurrentUserParticipated() || second.NextBeforeIndex != nil {
+		t.Fatalf("second thread page = %v", second)
+	}
+	participated, err := alice.ListThreads(ctx, &chat_rpc.ListThreadsRequest{ParticipatedOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(participated.GetThreads()) != 1 || participated.GetThreads()[0].GetRoot().GetObjectKey() != rootB {
+		t.Fatalf("participated threads = %v", participated)
+	}
+
+	latestA := sendThreadTestEvent(t, ctx, alice, "reply-a-latest", &ChatRelation{Type: "m.thread", TargetKey: rootA})
+	if retry := sendThreadTestEvent(t, ctx, alice, "reply-a-latest", &ChatRelation{Type: "m.thread", TargetKey: rootA}); retry != latestA {
+		t.Fatalf("retry key = %q, want %q", retry, latestA)
+	}
+	updated, err := alice.ListThreads(ctx, &chat_rpc.ListThreadsRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(updated.GetThreads()) != 2 || updated.GetThreads()[0].GetRoot().GetObjectKey() != rootA ||
+		updated.GetThreads()[0].GetLatestReply().GetObjectKey() != latestA ||
+		updated.GetThreads()[0].GetReplyCount() != 2 || !updated.GetThreads()[0].GetCurrentUserParticipated() {
+		t.Fatalf("updated threads = %v", updated)
+	}
+}
+
+// TestChatResourceListThreadsMigratesLegacyHistoryOnce proves compatibility without repeated scans.
+func TestChatResourceListThreadsMigratesLegacyHistoryOnce(t *testing.T) {
+	ctx := t.Context()
+	tb, err := db_world_testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(tb.Release)
+	ws := world.NewEngineWorldState(tb.Engine, true)
+	const channelKey = "chat/channel/legacy-threads"
+	createChatChannel(t, ctx, ws, channelKey, "Legacy")
+	rootKey := channelKey + "/message/0"
+	createChatMessage(t, ctx, ws, channelKey, rootKey, "root", "alice-device")
+	replyKey := channelKey + "/message/1"
+	createLegacyThreadReply(t, ctx, ws, channelKey, replyKey, rootKey)
+
+	resource := NewChatResourceForPerson(ws, tb.Engine, channelKey, "bob-device", "bob")
+	t.Cleanup(resource.Close)
+	tx, err := tb.Engine.NewTransaction(ctx, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Discard()
+	legacyChannel, err := world.LookupObjectBody[*ChatChannel](ctx, tx, channelKey, NewChatChannelBlock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changed, complete, err := resource.updateThreadIndex(ctx, tx, legacyChannel, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed || complete || legacyChannel.GetThreadIndexedMessageCount() != 1 {
+		t.Fatalf("bounded migration = changed %t, complete %t, channel %v", changed, complete, legacyChannel)
+	}
+	if err := resource.writeChannel(ctx, tx, legacyChannel); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tb.Engine.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+	page, err := resource.ListThreads(ctx, &chat_rpc.ListThreadsRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.GetThreads()) != 1 || page.GetThreads()[0].GetRoot().GetObjectKey() != rootKey ||
+		page.GetThreads()[0].GetLatestReply().GetObjectKey() != replyKey ||
+		!page.GetThreads()[0].GetCurrentUserParticipated() {
+		t.Fatalf("migrated threads = %v", page)
+	}
+	channel, err := resource.readChannel(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if channel.ThreadIndexedMessageCount == nil || channel.GetThreadIndexedMessageCount() != channel.GetMessageCount() ||
+		channel.GetThreadHeadKey() == "" {
+		t.Fatalf("migrated channel index = %v", channel)
+	}
+	before, err := ws.GetSeqno(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resource.ListThreads(ctx, &chat_rpc.ListThreadsRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	after, err := ws.GetSeqno(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after != before {
+		t.Fatalf("current index read changed world seqno from %d to %d", before, after)
+	}
+}
+
+func sendThreadTestEvent(
+	t *testing.T,
+	ctx context.Context,
+	resource *ChatResource,
+	transactionID string,
+	relation *ChatRelation,
+) string {
+	t.Helper()
+	response, err := resource.SendMessage(ctx, &chat_rpc.SendMessageRequest{
+		TransactionId: transactionID,
+		Content: &ChatMessageContent{Content: &ChatMessageContent_Event{Event: &ChatEvent{
+			Type:        "m.room.message",
+			ContentJson: `{"body":"test","msgtype":"m.text"}`,
+			Relation:    relation,
+		}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return response.GetMessageKey()
+}
+
+func createLegacyThreadReply(
+	t *testing.T,
+	ctx context.Context,
+	ws world.WorldState,
+	channelKey string,
+	messageKey string,
+	rootKey string,
+) {
+	t.Helper()
+	_, _, err := world.CreateWorldObject(ctx, ws, messageKey, func(cursor *block.Cursor) error {
+		cursor.SetBlock(&ChatMessage{
+			SenderPeerId: "bob-device",
+			PersonPeerId: "bob",
+			Content: &ChatMessageContent{Content: &ChatMessageContent_Event{Event: &ChatEvent{
+				Type:        "m.room.message",
+				ContentJson: `{"body":"legacy","msgtype":"m.text"}`,
+				Relation:    &ChatRelation{Type: "m.thread", TargetKey: rootKey},
+			}}},
+			CreatedAt: timestamppb.Now(),
+			Index:     1,
+		}, true)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := world_types.SetObjectType(ctx, ws, messageKey, ChatMessageTypeID); err != nil {
+		t.Fatal(err)
+	}
+	appendChatMessageKey(t, ctx, ws, channelKey, messageKey)
+	if err := ws.SetGraphQuad(ctx, world.NewGraphQuadWithKeys(channelKey, PredChannelMessage.String(), messageKey, "")); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/sdk/chat/chat.go
+++ b/sdk/chat/chat.go
@@ -21,10 +21,23 @@ var PredMessageSender = quad.IRI("spacewave-chat/message-sender")
 // PredChannelState links a channel to the latest event for each state identity.
 var PredChannelState = quad.IRI("spacewave-chat/channel-state")
 
+// PredThreadParticipant marks a thread summary with an attributed person label.
+var PredThreadParticipant = quad.IRI("spacewave-chat/thread-participant")
+
 // NewChatStateQuad links a channel state identity to its retained message.
 // Empty messageKey selects the current event for this identity in a graph query.
 func NewChatStateQuad(channelKey, messageKey, stateType, stateKey string) world.GraphQuad {
 	return world.NewGraphQuadWithKeys(channelKey, PredChannelState.String(), messageKey, quad.String(stateType+"\x00"+stateKey).String())
+}
+
+// NewChatThreadParticipantQuad records a verified person who authored a canonical thread reply.
+func NewChatThreadParticipantQuad(threadKey, personPeerID string) world.GraphQuad {
+	return world.NewGraphQuadWithKeys(
+		threadKey,
+		PredThreadParticipant.String(),
+		threadKey,
+		quad.String(personPeerID).String(),
+	)
 }
 
 // NewChatChannelBlock constructs a new ChatChannel block.
@@ -40,6 +53,11 @@ func NewChatMessageBlock() block.Block {
 // NewChatMessagePageBlock constructs a new ChatMessagePage block.
 func NewChatMessagePageBlock() block.Block {
 	return &ChatMessagePage{}
+}
+
+// NewChatThreadBlock constructs a new ChatThread block.
+func NewChatThreadBlock() block.Block {
+	return &ChatThread{}
 }
 
 // MarshalBlock marshals the ChatChannel to bytes.
@@ -87,8 +105,25 @@ func (m *ChatMessagePage) Validate() error {
 	return nil
 }
 
+// MarshalBlock marshals the ChatThread to bytes.
+func (t *ChatThread) MarshalBlock() ([]byte, error) {
+	return t.MarshalVT()
+}
+
+// UnmarshalBlock unmarshals the ChatThread from bytes.
+func (t *ChatThread) UnmarshalBlock(data []byte) error {
+	return t.UnmarshalVT(data)
+}
+
+// Validate performs cursory checks on the ChatThread.
+func (t *ChatThread) Validate() error {
+	return nil
+}
+
 var _ block.Block = (*ChatChannel)(nil)
 
 var _ block.Block = (*ChatMessage)(nil)
 
 var _ block.Block = (*ChatMessagePage)(nil)
+
+var _ block.Block = (*ChatThread)(nil)

--- a/sdk/chat/chat.pb.go
+++ b/sdk/chat/chat.pb.go
@@ -36,6 +36,11 @@ type ChatChannel struct {
 	// EncryptionAlgorithm is the channel encryption policy. Empty allows plaintext;
 	// once enabled it cannot change. Annotations and state changes remain public.
 	EncryptionAlgorithm string `protobuf:"bytes,7,opt,name=encryption_algorithm,json=encryptionAlgorithm,proto3" json:"encryptionAlgorithm,omitempty"`
+	// ThreadHeadKey starts the activity-ordered thread-summary list.
+	ThreadHeadKey string `protobuf:"bytes,8,opt,name=thread_head_key,json=threadHeadKey,proto3" json:"threadHeadKey,omitempty"`
+	// ThreadIndexedMessageCount is the history prefix represented by the thread index.
+	// Presence distinguishes an initialized empty index from legacy channel state.
+	ThreadIndexedMessageCount *uint64 `protobuf:"varint,9,opt,name=thread_indexed_message_count,json=threadIndexedMessageCount,proto3,oneof" json:"threadIndexedMessageCount,omitempty"`
 }
 
 func (x *ChatChannel) Reset() {
@@ -91,6 +96,20 @@ func (x *ChatChannel) GetEncryptionAlgorithm() string {
 		return x.EncryptionAlgorithm
 	}
 	return ""
+}
+
+func (x *ChatChannel) GetThreadHeadKey() string {
+	if x != nil {
+		return x.ThreadHeadKey
+	}
+	return ""
+}
+
+func (x *ChatChannel) GetThreadIndexedMessageCount() uint64 {
+	if x != nil && x.ThreadIndexedMessageCount != nil {
+		return *x.ThreadIndexedMessageCount
+	}
+	return 0
 }
 
 // ChatMessage is a chat message world object linked to a channel.
@@ -177,6 +196,71 @@ func (x *ChatMessagePage) GetMessageKeys() []string {
 		return x.MessageKeys
 	}
 	return nil
+}
+
+// ChatThread stores one bounded summary in the channel's activity-ordered thread index.
+type ChatThread struct {
+	unknownFields []byte
+	// RootMessageKey is the immutable root identity summarized by this snapshot.
+	RootMessageKey string `protobuf:"bytes,1,opt,name=root_message_key,json=rootMessageKey,proto3" json:"rootMessageKey,omitempty"`
+	// LatestMessageKey is the newest canonical reply captured by this snapshot.
+	LatestMessageKey string `protobuf:"bytes,2,opt,name=latest_message_key,json=latestMessageKey,proto3" json:"latestMessageKey,omitempty"`
+	// LatestMessageIndex orders threads by their newest canonical reply.
+	LatestMessageIndex uint64 `protobuf:"varint,3,opt,name=latest_message_index,json=latestMessageIndex,proto3" json:"latestMessageIndex,omitempty"`
+	// ReplyCount is the number of canonical thread replies.
+	ReplyCount uint64 `protobuf:"varint,4,opt,name=reply_count,json=replyCount,proto3" json:"replyCount,omitempty"`
+	// NewerThreadKey establishes the preceding entry in activity order.
+	NewerThreadKey string `protobuf:"bytes,5,opt,name=newer_thread_key,json=newerThreadKey,proto3" json:"newerThreadKey,omitempty"`
+	// OlderThreadKey establishes the following entry in activity order.
+	OlderThreadKey string `protobuf:"bytes,6,opt,name=older_thread_key,json=olderThreadKey,proto3" json:"olderThreadKey,omitempty"`
+}
+
+func (x *ChatThread) Reset() {
+	*x = ChatThread{}
+}
+
+func (*ChatThread) ProtoMessage() {}
+
+func (x *ChatThread) GetRootMessageKey() string {
+	if x != nil {
+		return x.RootMessageKey
+	}
+	return ""
+}
+
+func (x *ChatThread) GetLatestMessageKey() string {
+	if x != nil {
+		return x.LatestMessageKey
+	}
+	return ""
+}
+
+func (x *ChatThread) GetLatestMessageIndex() uint64 {
+	if x != nil {
+		return x.LatestMessageIndex
+	}
+	return 0
+}
+
+func (x *ChatThread) GetReplyCount() uint64 {
+	if x != nil {
+		return x.ReplyCount
+	}
+	return 0
+}
+
+func (x *ChatThread) GetNewerThreadKey() string {
+	if x != nil {
+		return x.NewerThreadKey
+	}
+	return ""
+}
+
+func (x *ChatThread) GetOlderThreadKey() string {
+	if x != nil {
+		return x.OlderThreadKey
+	}
+	return ""
 }
 
 // InitChatDemoOp creates a "General" channel on space quickstart.
@@ -310,8 +394,10 @@ func (m *ChatChannel) CloneVT() *ChatChannel {
 	r.MessageCount = m.MessageCount
 	r.CreatorPeerId = m.CreatorPeerId
 	r.EncryptionAlgorithm = m.EncryptionAlgorithm
+	r.ThreadHeadKey = m.ThreadHeadKey
 	r.CreatedAt = protobuf_go_lite.CloneVTValue(m.CreatedAt)
 	r.ReadPositions = protobuf_go_lite.CloneVTMap(m.ReadPositions)
+	r.ThreadIndexedMessageCount = protobuf_go_lite.ClonePtr(m.ThreadIndexedMessageCount)
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = slices.Clone(m.unknownFields)
 	}
@@ -356,6 +442,27 @@ func (m *ChatMessagePage) CloneVT() *ChatMessagePage {
 }
 
 func (m *ChatMessagePage) CloneMessageVT() protobuf_go_lite.CloneMessage {
+	return m.CloneVT()
+}
+
+func (m *ChatThread) CloneVT() *ChatThread {
+	if m == nil {
+		return (*ChatThread)(nil)
+	}
+	r := new(ChatThread)
+	r.RootMessageKey = m.RootMessageKey
+	r.LatestMessageKey = m.LatestMessageKey
+	r.LatestMessageIndex = m.LatestMessageIndex
+	r.ReplyCount = m.ReplyCount
+	r.NewerThreadKey = m.NewerThreadKey
+	r.OlderThreadKey = m.OlderThreadKey
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = slices.Clone(m.unknownFields)
+	}
+	return r
+}
+
+func (m *ChatThread) CloneMessageVT() protobuf_go_lite.CloneMessage {
 	return m.CloneVT()
 }
 
@@ -424,6 +531,12 @@ func (this *ChatChannel) EqualVT(that *ChatChannel) bool {
 	if this.EncryptionAlgorithm != that.EncryptionAlgorithm {
 		return false
 	}
+	if this.ThreadHeadKey != that.ThreadHeadKey {
+		return false
+	}
+	if !protobuf_go_lite.EqualPtr(this.ThreadIndexedMessageCount, that.ThreadIndexedMessageCount) {
+		return false
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
@@ -484,6 +597,41 @@ func (this *ChatMessagePage) EqualVT(that *ChatMessagePage) bool {
 
 func (this *ChatMessagePage) EqualMessageVT(thatMsg any) bool {
 	that, ok := thatMsg.(*ChatMessagePage)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+
+func (this *ChatThread) EqualVT(that *ChatThread) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.RootMessageKey != that.RootMessageKey {
+		return false
+	}
+	if this.LatestMessageKey != that.LatestMessageKey {
+		return false
+	}
+	if this.LatestMessageIndex != that.LatestMessageIndex {
+		return false
+	}
+	if this.ReplyCount != that.ReplyCount {
+		return false
+	}
+	if this.NewerThreadKey != that.NewerThreadKey {
+		return false
+	}
+	if this.OlderThreadKey != that.OlderThreadKey {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *ChatThread) EqualMessageVT(thatMsg any) bool {
+	that, ok := thatMsg.(*ChatThread)
 	if !ok {
 		return false
 	}
@@ -652,6 +800,16 @@ func (x *ChatChannel) MarshalProtoJSON(s *json.MarshalState) {
 		s.WriteObjectField("encryptionAlgorithm")
 		s.WriteString(x.EncryptionAlgorithm)
 	}
+	if x.ThreadHeadKey != "" || s.HasField("threadHeadKey") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("threadHeadKey")
+		s.WriteString(x.ThreadHeadKey)
+	}
+	if x.ThreadIndexedMessageCount != nil {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("threadIndexedMessageCount")
+		s.WriteUint64(*x.ThreadIndexedMessageCount)
+	}
 	s.WriteObjectEnd()
 }
 
@@ -703,6 +861,17 @@ func (x *ChatChannel) UnmarshalProtoJSON(s *json.UnmarshalState) {
 		case "encryption_algorithm", "encryptionAlgorithm":
 			s.AddField("encryption_algorithm")
 			x.EncryptionAlgorithm = s.ReadString()
+		case "thread_head_key", "threadHeadKey":
+			s.AddField("thread_head_key")
+			x.ThreadHeadKey = s.ReadString()
+		case "thread_indexed_message_count", "threadIndexedMessageCount":
+			s.AddField("thread_indexed_message_count")
+			if s.ReadNil() {
+				x.ThreadIndexedMessageCount = nil
+				return
+			}
+			t := s.ReadUint64()
+			x.ThreadIndexedMessageCount = &t
 		}
 	})
 }
@@ -845,6 +1014,88 @@ func (x *ChatMessagePage) UnmarshalProtoJSON(s *json.UnmarshalState) {
 
 // UnmarshalJSON unmarshals the ChatMessagePage from JSON.
 func (x *ChatMessagePage) UnmarshalJSON(b []byte) error {
+	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
+}
+
+// MarshalProtoJSON marshals the ChatThread message to JSON.
+func (x *ChatThread) MarshalProtoJSON(s *json.MarshalState) {
+	if x == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteObjectStart()
+	var wroteField bool
+	if x.RootMessageKey != "" || s.HasField("rootMessageKey") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("rootMessageKey")
+		s.WriteString(x.RootMessageKey)
+	}
+	if x.LatestMessageKey != "" || s.HasField("latestMessageKey") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("latestMessageKey")
+		s.WriteString(x.LatestMessageKey)
+	}
+	if x.LatestMessageIndex != 0 || s.HasField("latestMessageIndex") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("latestMessageIndex")
+		s.WriteUint64(x.LatestMessageIndex)
+	}
+	if x.ReplyCount != 0 || s.HasField("replyCount") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("replyCount")
+		s.WriteUint64(x.ReplyCount)
+	}
+	if x.NewerThreadKey != "" || s.HasField("newerThreadKey") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("newerThreadKey")
+		s.WriteString(x.NewerThreadKey)
+	}
+	if x.OlderThreadKey != "" || s.HasField("olderThreadKey") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("olderThreadKey")
+		s.WriteString(x.OlderThreadKey)
+	}
+	s.WriteObjectEnd()
+}
+
+// MarshalJSON marshals the ChatThread to JSON.
+func (x *ChatThread) MarshalJSON() ([]byte, error) {
+	return json.DefaultMarshalerConfig.Marshal(x)
+}
+
+// UnmarshalProtoJSON unmarshals the ChatThread message from JSON.
+func (x *ChatThread) UnmarshalProtoJSON(s *json.UnmarshalState) {
+	if s.ReadNil() {
+		return
+	}
+	s.ReadObject(func(key string) {
+		switch key {
+		default:
+			s.Skip() // ignore unknown field
+		case "root_message_key", "rootMessageKey":
+			s.AddField("root_message_key")
+			x.RootMessageKey = s.ReadString()
+		case "latest_message_key", "latestMessageKey":
+			s.AddField("latest_message_key")
+			x.LatestMessageKey = s.ReadString()
+		case "latest_message_index", "latestMessageIndex":
+			s.AddField("latest_message_index")
+			x.LatestMessageIndex = s.ReadUint64()
+		case "reply_count", "replyCount":
+			s.AddField("reply_count")
+			x.ReplyCount = s.ReadUint64()
+		case "newer_thread_key", "newerThreadKey":
+			s.AddField("newer_thread_key")
+			x.NewerThreadKey = s.ReadString()
+		case "older_thread_key", "olderThreadKey":
+			s.AddField("older_thread_key")
+			x.OlderThreadKey = s.ReadString()
+		}
+	})
+}
+
+// UnmarshalJSON unmarshals the ChatThread from JSON.
+func (x *ChatThread) UnmarshalJSON(b []byte) error {
 	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
 }
 
@@ -1038,6 +1289,16 @@ func (m *ChatChannel) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
 	}
+	if m.ThreadIndexedMessageCount != nil {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(*m.ThreadIndexedMessageCount))
+		i--
+		dAtA[i] = 0x48
+	}
+	if len(m.ThreadHeadKey) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.ThreadHeadKey)
+		i--
+		dAtA[i] = 0x42
+	}
 	if len(m.EncryptionAlgorithm) > 0 {
 		i = protobuf_go_lite.EncodeString(dAtA, i, m.EncryptionAlgorithm)
 		i--
@@ -1207,6 +1468,68 @@ func (m *ChatMessagePage) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *ChatThread) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ChatThread) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *ChatThread) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	if len(m.OlderThreadKey) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.OlderThreadKey)
+		i--
+		dAtA[i] = 0x32
+	}
+	if len(m.NewerThreadKey) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.NewerThreadKey)
+		i--
+		dAtA[i] = 0x2a
+	}
+	if m.ReplyCount != 0 {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(m.ReplyCount))
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.LatestMessageIndex != 0 {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(m.LatestMessageIndex))
+		i--
+		dAtA[i] = 0x18
+	}
+	if len(m.LatestMessageKey) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.LatestMessageKey)
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.RootMessageKey) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.RootMessageKey)
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *InitChatDemoOp) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -1353,6 +1676,8 @@ func (m *ChatChannel) SizeVT() (n int) {
 	}
 	n += protobuf_go_lite.SizeStringNonEmpty(1, m.CreatorPeerId)
 	n += protobuf_go_lite.SizeStringNonEmpty(1, m.EncryptionAlgorithm)
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.ThreadHeadKey)
+	n += protobuf_go_lite.SizeVarintPtr(1, m.ThreadIndexedMessageCount)
 	n += len(m.unknownFields)
 	return n
 }
@@ -1386,6 +1711,22 @@ func (m *ChatMessagePage) SizeVT() (n int) {
 	var l int
 	_ = l
 	n += protobuf_go_lite.SizeStringSlice(1, m.MessageKeys)
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *ChatThread) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.RootMessageKey)
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.LatestMessageKey)
+	n += protobuf_go_lite.SizeVarintNonZero(1, m.LatestMessageIndex)
+	n += protobuf_go_lite.SizeVarintNonZero(1, m.ReplyCount)
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.NewerThreadKey)
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.OlderThreadKey)
 	n += len(m.unknownFields)
 	return n
 }
@@ -1487,6 +1828,14 @@ func (x *ChatChannel) MarshalProtoText() string {
 		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "encryption_algorithm")
 		protobuf_go_lite.TextWriteString(&sb, x.EncryptionAlgorithm)
 	}
+	if x.ThreadHeadKey != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "thread_head_key")
+		protobuf_go_lite.TextWriteString(&sb, x.ThreadHeadKey)
+	}
+	if x.ThreadIndexedMessageCount != nil {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "thread_indexed_message_count")
+		protobuf_go_lite.TextWriteUint(&sb, *x.ThreadIndexedMessageCount)
+	}
 	return protobuf_go_lite.TextFinishMessage(&sb)
 }
 
@@ -1543,6 +1892,40 @@ func (x *ChatMessagePage) MarshalProtoText() string {
 }
 
 func (x *ChatMessagePage) String() string {
+	return x.MarshalProtoText()
+}
+
+func (x *ChatThread) MarshalProtoText() string {
+	var sb protobuf_go_lite.TextBuilder
+	initialLen := protobuf_go_lite.TextStartMessage(&sb, "ChatThread")
+	if x.RootMessageKey != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "root_message_key")
+		protobuf_go_lite.TextWriteString(&sb, x.RootMessageKey)
+	}
+	if x.LatestMessageKey != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "latest_message_key")
+		protobuf_go_lite.TextWriteString(&sb, x.LatestMessageKey)
+	}
+	if x.LatestMessageIndex != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "latest_message_index")
+		protobuf_go_lite.TextWriteUint(&sb, x.LatestMessageIndex)
+	}
+	if x.ReplyCount != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "reply_count")
+		protobuf_go_lite.TextWriteUint(&sb, x.ReplyCount)
+	}
+	if x.NewerThreadKey != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "newer_thread_key")
+		protobuf_go_lite.TextWriteString(&sb, x.NewerThreadKey)
+	}
+	if x.OlderThreadKey != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "older_thread_key")
+		protobuf_go_lite.TextWriteString(&sb, x.OlderThreadKey)
+	}
+	return protobuf_go_lite.TextFinishMessage(&sb)
+}
+
+func (x *ChatThread) String() string {
 	return x.MarshalProtoText()
 }
 
@@ -1737,6 +2120,26 @@ func (m *ChatChannel) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			m.EncryptionAlgorithm = v
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ThreadHeadKey", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.ThreadHeadKey = v
+		case 9:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ThreadIndexedMessageCount", wireType)
+			}
+			var v uint64
+			v, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.ThreadIndexedMessageCount = &v
 		default:
 			iNdEx = preIndex
 			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
@@ -1902,6 +2305,107 @@ func (m *ChatMessagePage) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			m.MessageKeys = append(m.MessageKeys, v)
+		default:
+			iNdEx = preIndex
+			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protobuf_go_lite.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+
+func (m *ChatThread) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	var err error
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		wire, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+		if err != nil {
+			return err
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ChatThread: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ChatThread: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RootMessageKey", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.RootMessageKey = v
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LatestMessageKey", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.LatestMessageKey = v
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LatestMessageIndex", wireType)
+			}
+			m.LatestMessageIndex = 0
+			m.LatestMessageIndex, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ReplyCount", wireType)
+			}
+			m.ReplyCount = 0
+			m.ReplyCount, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NewerThreadKey", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.NewerThreadKey = v
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field OlderThreadKey", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.OlderThreadKey = v
 		default:
 			iNdEx = preIndex
 			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])

--- a/sdk/chat/chat.pb.ts
+++ b/sdk/chat/chat.pb.ts
@@ -63,6 +63,19 @@ export interface ChatChannel {
    * @generated from field: string encryption_algorithm = 7;
    */
   encryptionAlgorithm?: string
+  /**
+   * ThreadHeadKey starts the activity-ordered thread-summary list.
+   *
+   * @generated from field: string thread_head_key = 8;
+   */
+  threadHeadKey?: string
+  /**
+   * ThreadIndexedMessageCount is the history prefix represented by the thread index.
+   * Presence distinguishes an initialized empty index from legacy channel state.
+   *
+   * @generated from field: optional uint64 thread_indexed_message_count = 9;
+   */
+  threadIndexedMessageCount?: bigint
 }
 
 export const ChatChannel: MessageType<ChatChannel> =
@@ -86,6 +99,14 @@ export const ChatChannel: MessageType<ChatChannel> =
         name: 'encryption_algorithm',
         kind: 'scalar',
         T: ScalarType.STRING,
+      },
+      { no: 8, name: 'thread_head_key', kind: 'scalar', T: ScalarType.STRING },
+      {
+        no: 9,
+        name: 'thread_indexed_message_count',
+        kind: 'scalar',
+        T: ScalarType.UINT64,
+        opt: true,
       },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,
@@ -175,6 +196,74 @@ export const ChatMessagePage: MessageType<ChatMessagePage> =
         T: ScalarType.STRING,
         repeated: true,
       },
+    ] satisfies readonly PartialFieldInfo[],
+    packedByDefault: true,
+  })
+
+/**
+ * ChatThread stores one bounded summary in the channel's activity-ordered thread index.
+ *
+ * @generated from message spacewave.chat.ChatThread
+ */
+export interface ChatThread {
+  /**
+   * RootMessageKey is the immutable root identity summarized by this snapshot.
+   *
+   * @generated from field: string root_message_key = 1;
+   */
+  rootMessageKey?: string
+  /**
+   * LatestMessageKey is the newest canonical reply captured by this snapshot.
+   *
+   * @generated from field: string latest_message_key = 2;
+   */
+  latestMessageKey?: string
+  /**
+   * LatestMessageIndex orders threads by their newest canonical reply.
+   *
+   * @generated from field: uint64 latest_message_index = 3;
+   */
+  latestMessageIndex?: bigint
+  /**
+   * ReplyCount is the number of canonical thread replies.
+   *
+   * @generated from field: uint64 reply_count = 4;
+   */
+  replyCount?: bigint
+  /**
+   * NewerThreadKey establishes the preceding entry in activity order.
+   *
+   * @generated from field: string newer_thread_key = 5;
+   */
+  newerThreadKey?: string
+  /**
+   * OlderThreadKey establishes the following entry in activity order.
+   *
+   * @generated from field: string older_thread_key = 6;
+   */
+  olderThreadKey?: string
+}
+
+export const ChatThread: MessageType<ChatThread> =
+  /* @__PURE__ */ createMessageType({
+    typeName: 'spacewave.chat.ChatThread',
+    fields: [
+      { no: 1, name: 'root_message_key', kind: 'scalar', T: ScalarType.STRING },
+      {
+        no: 2,
+        name: 'latest_message_key',
+        kind: 'scalar',
+        T: ScalarType.STRING,
+      },
+      {
+        no: 3,
+        name: 'latest_message_index',
+        kind: 'scalar',
+        T: ScalarType.UINT64,
+      },
+      { no: 4, name: 'reply_count', kind: 'scalar', T: ScalarType.UINT64 },
+      { no: 5, name: 'newer_thread_key', kind: 'scalar', T: ScalarType.STRING },
+      { no: 6, name: 'older_thread_key', kind: 'scalar', T: ScalarType.STRING },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,
   })

--- a/sdk/chat/chat.proto
+++ b/sdk/chat/chat.proto
@@ -26,6 +26,11 @@ message ChatChannel {
   // EncryptionAlgorithm is the channel encryption policy. Empty allows plaintext;
   // once enabled it cannot change. Annotations and state changes remain public.
   string encryption_algorithm = 7;
+  // ThreadHeadKey starts the activity-ordered thread-summary list.
+  string thread_head_key = 8;
+  // ThreadIndexedMessageCount is the history prefix represented by the thread index.
+  // Presence distinguishes an initialized empty index from legacy channel state.
+  optional uint64 thread_indexed_message_count = 9;
 }
 
 // ChatMessage is a chat message world object linked to a channel.
@@ -49,6 +54,22 @@ message ChatMessage {
 message ChatMessagePage {
   // MessageKeys are page-local message object keys in creation order.
   repeated string message_keys = 1;
+}
+
+// ChatThread stores one bounded summary in the channel's activity-ordered thread index.
+message ChatThread {
+  // RootMessageKey is the immutable root identity summarized by this snapshot.
+  string root_message_key = 1;
+  // LatestMessageKey is the newest canonical reply captured by this snapshot.
+  string latest_message_key = 2;
+  // LatestMessageIndex orders threads by their newest canonical reply.
+  uint64 latest_message_index = 3;
+  // ReplyCount is the number of canonical thread replies.
+  uint64 reply_count = 4;
+  // NewerThreadKey establishes the preceding entry in activity order.
+  string newer_thread_key = 5;
+  // OlderThreadKey establishes the following entry in activity order.
+  string older_thread_key = 6;
 }
 
 // InitChatDemoOp creates a "General" channel on space quickstart.

--- a/sdk/chat/create-channel.go
+++ b/sdk/chat/create-channel.go
@@ -63,11 +63,12 @@ func (o *CreateChatChannelOp) ApplyWorldOp(
 
 	objKey := o.GetObjectKey()
 	channel := &ChatChannel{
-		Name:                o.GetName(),
-		Topic:               o.GetTopic(),
-		CreatedAt:           o.GetTimestamp(),
-		CreatorPeerId:       sender.String(),
-		EncryptionAlgorithm: o.GetEncryptionAlgorithm(),
+		Name:                      o.GetName(),
+		Topic:                     o.GetTopic(),
+		CreatedAt:                 o.GetTimestamp(),
+		CreatorPeerId:             sender.String(),
+		EncryptionAlgorithm:       o.GetEncryptionAlgorithm(),
+		ThreadIndexedMessageCount: new(uint64),
 	}
 
 	if _, _, err := world.CreateWorldObject(ctx, ws, objKey, func(bcs *block.Cursor) error {

--- a/sdk/chat/init-chat-demo.go
+++ b/sdk/chat/init-chat-demo.go
@@ -54,8 +54,9 @@ func (o *InitChatDemoOp) ApplyWorldOp(
 	}
 
 	channel := &ChatChannel{
-		Name:      "General",
-		CreatedAt: o.GetTimestamp(),
+		Name:                      "General",
+		CreatedAt:                 o.GetTimestamp(),
+		ThreadIndexedMessageCount: new(uint64),
 	}
 	if _, _, err := world.CreateWorldObject(ctx, ws, objKey, func(bcs *block.Cursor) error {
 		bcs.SetBlock(channel, true)

--- a/sdk/chat/rpc/rpc.pb.go
+++ b/sdk/chat/rpc/rpc.pb.go
@@ -324,6 +324,120 @@ func (x *ListMessagesResponse) GetHasMore() bool {
 	return false
 }
 
+// ListThreadsRequest selects an activity-ordered thread page.
+type ListThreadsRequest struct {
+	unknownFields []byte
+	// BeforeIndex resumes after the thread whose latest reply has this history index.
+	BeforeIndex *uint64 `protobuf:"varint,1,opt,name=before_index,json=beforeIndex,proto3,oneof" json:"beforeIndex,omitempty"`
+	// Limit is the maximum number of matching threads to return.
+	Limit uint32 `protobuf:"varint,2,opt,name=limit,proto3" json:"limit,omitempty"`
+	// ParticipatedOnly selects threads with a reply by the authenticated person.
+	ParticipatedOnly bool `protobuf:"varint,3,opt,name=participated_only,json=participatedOnly,proto3" json:"participatedOnly,omitempty"`
+}
+
+func (x *ListThreadsRequest) Reset() {
+	*x = ListThreadsRequest{}
+}
+
+func (*ListThreadsRequest) ProtoMessage() {}
+
+func (x *ListThreadsRequest) GetBeforeIndex() uint64 {
+	if x != nil && x.BeforeIndex != nil {
+		return *x.BeforeIndex
+	}
+	return 0
+}
+
+func (x *ListThreadsRequest) GetLimit() uint32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+func (x *ListThreadsRequest) GetParticipatedOnly() bool {
+	if x != nil {
+		return x.ParticipatedOnly
+	}
+	return false
+}
+
+// ChatThreadInfo projects one native thread summary.
+type ChatThreadInfo struct {
+	unknownFields []byte
+	// Root is the retained thread-root message.
+	Root *ChatMessageInfo `protobuf:"bytes,1,opt,name=root,proto3" json:"root,omitempty"`
+	// LatestReply is the newest canonical thread reply.
+	LatestReply *ChatMessageInfo `protobuf:"bytes,2,opt,name=latest_reply,json=latestReply,proto3" json:"latestReply,omitempty"`
+	// ReplyCount is the number of canonical thread replies.
+	ReplyCount uint64 `protobuf:"varint,3,opt,name=reply_count,json=replyCount,proto3" json:"replyCount,omitempty"`
+	// CurrentUserParticipated reports whether the authenticated person wrote a reply.
+	CurrentUserParticipated bool `protobuf:"varint,4,opt,name=current_user_participated,json=currentUserParticipated,proto3" json:"currentUserParticipated,omitempty"`
+}
+
+func (x *ChatThreadInfo) Reset() {
+	*x = ChatThreadInfo{}
+}
+
+func (*ChatThreadInfo) ProtoMessage() {}
+
+func (x *ChatThreadInfo) GetRoot() *ChatMessageInfo {
+	if x != nil {
+		return x.Root
+	}
+	return nil
+}
+
+func (x *ChatThreadInfo) GetLatestReply() *ChatMessageInfo {
+	if x != nil {
+		return x.LatestReply
+	}
+	return nil
+}
+
+func (x *ChatThreadInfo) GetReplyCount() uint64 {
+	if x != nil {
+		return x.ReplyCount
+	}
+	return 0
+}
+
+func (x *ChatThreadInfo) GetCurrentUserParticipated() bool {
+	if x != nil {
+		return x.CurrentUserParticipated
+	}
+	return false
+}
+
+// ListThreadsResponse contains one bounded thread page.
+type ListThreadsResponse struct {
+	unknownFields []byte
+	// Threads is ordered from most to least recent activity.
+	Threads []*ChatThreadInfo `protobuf:"bytes,1,rep,name=threads,proto3" json:"threads,omitempty"`
+	// NextBeforeIndex resumes after the last summary examined by this page.
+	NextBeforeIndex *uint64 `protobuf:"varint,2,opt,name=next_before_index,json=nextBeforeIndex,proto3,oneof" json:"nextBeforeIndex,omitempty"`
+}
+
+func (x *ListThreadsResponse) Reset() {
+	*x = ListThreadsResponse{}
+}
+
+func (*ListThreadsResponse) ProtoMessage() {}
+
+func (x *ListThreadsResponse) GetThreads() []*ChatThreadInfo {
+	if x != nil {
+		return x.Threads
+	}
+	return nil
+}
+
+func (x *ListThreadsResponse) GetNextBeforeIndex() uint64 {
+	if x != nil && x.NextBeforeIndex != nil {
+		return *x.NextBeforeIndex
+	}
+	return 0
+}
+
 // WatchMessagesRequest is a request to stream messages.
 type WatchMessagesRequest struct {
 	unknownFields []byte
@@ -702,6 +816,60 @@ func (m *ListMessagesResponse) CloneMessageVT() protobuf_go_lite.CloneMessage {
 	return m.CloneVT()
 }
 
+func (m *ListThreadsRequest) CloneVT() *ListThreadsRequest {
+	if m == nil {
+		return (*ListThreadsRequest)(nil)
+	}
+	r := new(ListThreadsRequest)
+	r.Limit = m.Limit
+	r.ParticipatedOnly = m.ParticipatedOnly
+	r.BeforeIndex = protobuf_go_lite.ClonePtr(m.BeforeIndex)
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = slices.Clone(m.unknownFields)
+	}
+	return r
+}
+
+func (m *ListThreadsRequest) CloneMessageVT() protobuf_go_lite.CloneMessage {
+	return m.CloneVT()
+}
+
+func (m *ChatThreadInfo) CloneVT() *ChatThreadInfo {
+	if m == nil {
+		return (*ChatThreadInfo)(nil)
+	}
+	r := new(ChatThreadInfo)
+	r.ReplyCount = m.ReplyCount
+	r.CurrentUserParticipated = m.CurrentUserParticipated
+	r.Root = protobuf_go_lite.CloneVTValue(m.Root)
+	r.LatestReply = protobuf_go_lite.CloneVTValue(m.LatestReply)
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = slices.Clone(m.unknownFields)
+	}
+	return r
+}
+
+func (m *ChatThreadInfo) CloneMessageVT() protobuf_go_lite.CloneMessage {
+	return m.CloneVT()
+}
+
+func (m *ListThreadsResponse) CloneVT() *ListThreadsResponse {
+	if m == nil {
+		return (*ListThreadsResponse)(nil)
+	}
+	r := new(ListThreadsResponse)
+	r.Threads = protobuf_go_lite.CloneVTSlice(m.Threads)
+	r.NextBeforeIndex = protobuf_go_lite.ClonePtr(m.NextBeforeIndex)
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = slices.Clone(m.unknownFields)
+	}
+	return r
+}
+
+func (m *ListThreadsResponse) CloneMessageVT() protobuf_go_lite.CloneMessage {
+	return m.CloneVT()
+}
+
 func (m *WatchMessagesRequest) CloneVT() *WatchMessagesRequest {
 	if m == nil {
 		return (*WatchMessagesRequest)(nil)
@@ -1049,6 +1217,84 @@ func (this *ListMessagesResponse) EqualVT(that *ListMessagesResponse) bool {
 
 func (this *ListMessagesResponse) EqualMessageVT(thatMsg any) bool {
 	that, ok := thatMsg.(*ListMessagesResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+
+func (this *ListThreadsRequest) EqualVT(that *ListThreadsRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !protobuf_go_lite.EqualPtr(this.BeforeIndex, that.BeforeIndex) {
+		return false
+	}
+	if this.Limit != that.Limit {
+		return false
+	}
+	if this.ParticipatedOnly != that.ParticipatedOnly {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *ListThreadsRequest) EqualMessageVT(thatMsg any) bool {
+	that, ok := thatMsg.(*ListThreadsRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+
+func (this *ChatThreadInfo) EqualVT(that *ChatThreadInfo) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !protobuf_go_lite.IsEqualVT(this.Root, that.Root) {
+		return false
+	}
+	if !protobuf_go_lite.IsEqualVT(this.LatestReply, that.LatestReply) {
+		return false
+	}
+	if this.ReplyCount != that.ReplyCount {
+		return false
+	}
+	if this.CurrentUserParticipated != that.CurrentUserParticipated {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *ChatThreadInfo) EqualMessageVT(thatMsg any) bool {
+	that, ok := thatMsg.(*ChatThreadInfo)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+
+func (this *ListThreadsResponse) EqualVT(that *ListThreadsResponse) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !protobuf_go_lite.EqualVTSliceImplicit(this.Threads, that.Threads, func() *ChatThreadInfo { return &ChatThreadInfo{} }) {
+		return false
+	}
+	if !protobuf_go_lite.EqualPtr(this.NextBeforeIndex, that.NextBeforeIndex) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *ListThreadsResponse) EqualMessageVT(thatMsg any) bool {
+	that, ok := thatMsg.(*ListThreadsResponse)
 	if !ok {
 		return false
 	}
@@ -1771,6 +2017,219 @@ func (x *ListMessagesResponse) UnmarshalProtoJSON(s *json.UnmarshalState) {
 
 // UnmarshalJSON unmarshals the ListMessagesResponse from JSON.
 func (x *ListMessagesResponse) UnmarshalJSON(b []byte) error {
+	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
+}
+
+// MarshalProtoJSON marshals the ListThreadsRequest message to JSON.
+func (x *ListThreadsRequest) MarshalProtoJSON(s *json.MarshalState) {
+	if x == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteObjectStart()
+	var wroteField bool
+	if x.BeforeIndex != nil {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("beforeIndex")
+		s.WriteUint64(*x.BeforeIndex)
+	}
+	if x.Limit != 0 || s.HasField("limit") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("limit")
+		s.WriteUint32(x.Limit)
+	}
+	if x.ParticipatedOnly || s.HasField("participatedOnly") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("participatedOnly")
+		s.WriteBool(x.ParticipatedOnly)
+	}
+	s.WriteObjectEnd()
+}
+
+// MarshalJSON marshals the ListThreadsRequest to JSON.
+func (x *ListThreadsRequest) MarshalJSON() ([]byte, error) {
+	return json.DefaultMarshalerConfig.Marshal(x)
+}
+
+// UnmarshalProtoJSON unmarshals the ListThreadsRequest message from JSON.
+func (x *ListThreadsRequest) UnmarshalProtoJSON(s *json.UnmarshalState) {
+	if s.ReadNil() {
+		return
+	}
+	s.ReadObject(func(key string) {
+		switch key {
+		default:
+			s.Skip() // ignore unknown field
+		case "before_index", "beforeIndex":
+			s.AddField("before_index")
+			if s.ReadNil() {
+				x.BeforeIndex = nil
+				return
+			}
+			t := s.ReadUint64()
+			x.BeforeIndex = &t
+		case "limit":
+			s.AddField("limit")
+			x.Limit = s.ReadUint32()
+		case "participated_only", "participatedOnly":
+			s.AddField("participated_only")
+			x.ParticipatedOnly = s.ReadBool()
+		}
+	})
+}
+
+// UnmarshalJSON unmarshals the ListThreadsRequest from JSON.
+func (x *ListThreadsRequest) UnmarshalJSON(b []byte) error {
+	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
+}
+
+// MarshalProtoJSON marshals the ChatThreadInfo message to JSON.
+func (x *ChatThreadInfo) MarshalProtoJSON(s *json.MarshalState) {
+	if x == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteObjectStart()
+	var wroteField bool
+	if x.Root != nil || s.HasField("root") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("root")
+		x.Root.MarshalProtoJSON(s.WithField("root"))
+	}
+	if x.LatestReply != nil || s.HasField("latestReply") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("latestReply")
+		x.LatestReply.MarshalProtoJSON(s.WithField("latestReply"))
+	}
+	if x.ReplyCount != 0 || s.HasField("replyCount") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("replyCount")
+		s.WriteUint64(x.ReplyCount)
+	}
+	if x.CurrentUserParticipated || s.HasField("currentUserParticipated") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("currentUserParticipated")
+		s.WriteBool(x.CurrentUserParticipated)
+	}
+	s.WriteObjectEnd()
+}
+
+// MarshalJSON marshals the ChatThreadInfo to JSON.
+func (x *ChatThreadInfo) MarshalJSON() ([]byte, error) {
+	return json.DefaultMarshalerConfig.Marshal(x)
+}
+
+// UnmarshalProtoJSON unmarshals the ChatThreadInfo message from JSON.
+func (x *ChatThreadInfo) UnmarshalProtoJSON(s *json.UnmarshalState) {
+	if s.ReadNil() {
+		return
+	}
+	s.ReadObject(func(key string) {
+		switch key {
+		default:
+			s.Skip() // ignore unknown field
+		case "root":
+			if s.ReadNil() {
+				x.Root = nil
+				return
+			}
+			x.Root = &ChatMessageInfo{}
+			x.Root.UnmarshalProtoJSON(s.WithField("root", true))
+		case "latest_reply", "latestReply":
+			if s.ReadNil() {
+				x.LatestReply = nil
+				return
+			}
+			x.LatestReply = &ChatMessageInfo{}
+			x.LatestReply.UnmarshalProtoJSON(s.WithField("latest_reply", true))
+		case "reply_count", "replyCount":
+			s.AddField("reply_count")
+			x.ReplyCount = s.ReadUint64()
+		case "current_user_participated", "currentUserParticipated":
+			s.AddField("current_user_participated")
+			x.CurrentUserParticipated = s.ReadBool()
+		}
+	})
+}
+
+// UnmarshalJSON unmarshals the ChatThreadInfo from JSON.
+func (x *ChatThreadInfo) UnmarshalJSON(b []byte) error {
+	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
+}
+
+// MarshalProtoJSON marshals the ListThreadsResponse message to JSON.
+func (x *ListThreadsResponse) MarshalProtoJSON(s *json.MarshalState) {
+	if x == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteObjectStart()
+	var wroteField bool
+	if len(x.Threads) > 0 || s.HasField("threads") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("threads")
+		s.WriteArrayStart()
+		var wroteElement bool
+		for _, element := range x.Threads {
+			s.WriteMoreIf(&wroteElement)
+			element.MarshalProtoJSON(s.WithField("threads"))
+		}
+		s.WriteArrayEnd()
+	}
+	if x.NextBeforeIndex != nil {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("nextBeforeIndex")
+		s.WriteUint64(*x.NextBeforeIndex)
+	}
+	s.WriteObjectEnd()
+}
+
+// MarshalJSON marshals the ListThreadsResponse to JSON.
+func (x *ListThreadsResponse) MarshalJSON() ([]byte, error) {
+	return json.DefaultMarshalerConfig.Marshal(x)
+}
+
+// UnmarshalProtoJSON unmarshals the ListThreadsResponse message from JSON.
+func (x *ListThreadsResponse) UnmarshalProtoJSON(s *json.UnmarshalState) {
+	if s.ReadNil() {
+		return
+	}
+	s.ReadObject(func(key string) {
+		switch key {
+		default:
+			s.Skip() // ignore unknown field
+		case "threads":
+			s.AddField("threads")
+			if s.ReadNil() {
+				x.Threads = nil
+				return
+			}
+			s.ReadArray(func() {
+				if s.ReadNil() {
+					x.Threads = append(x.Threads, nil)
+					return
+				}
+				v := &ChatThreadInfo{}
+				v.UnmarshalProtoJSON(s.WithField("threads", false))
+				if s.Err() != nil {
+					return
+				}
+				x.Threads = append(x.Threads, v)
+			})
+		case "next_before_index", "nextBeforeIndex":
+			s.AddField("next_before_index")
+			if s.ReadNil() {
+				x.NextBeforeIndex = nil
+				return
+			}
+			t := s.ReadUint64()
+			x.NextBeforeIndex = &t
+		}
+	})
+}
+
+// UnmarshalJSON unmarshals the ListThreadsResponse from JSON.
+func (x *ListThreadsResponse) UnmarshalJSON(b []byte) error {
 	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
 }
 
@@ -2667,6 +3126,164 @@ func (m *ListMessagesResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) 
 	return len(dAtA) - i, nil
 }
 
+func (m *ListThreadsRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ListThreadsRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *ListThreadsRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	if m.ParticipatedOnly {
+		i = protobuf_go_lite.EncodeBool(dAtA, i, m.ParticipatedOnly)
+		i--
+		dAtA[i] = 0x18
+	}
+	if m.Limit != 0 {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(m.Limit))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.BeforeIndex != nil {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(*m.BeforeIndex))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ChatThreadInfo) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ChatThreadInfo) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *ChatThreadInfo) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	if m.CurrentUserParticipated {
+		i = protobuf_go_lite.EncodeBool(dAtA, i, m.CurrentUserParticipated)
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.ReplyCount != 0 {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(m.ReplyCount))
+		i--
+		dAtA[i] = 0x18
+	}
+	if m.LatestReply != nil {
+		size, err := m.LatestReply.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.Root != nil {
+		size, err := m.Root.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ListThreadsResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ListThreadsResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *ListThreadsResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	if m.NextBeforeIndex != nil {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(*m.NextBeforeIndex))
+		i--
+		dAtA[i] = 0x10
+	}
+	if len(m.Threads) > 0 {
+		for iNdEx := len(m.Threads) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.Threads[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *WatchMessagesRequest) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -3141,6 +3758,54 @@ func (m *ListMessagesResponse) SizeVT() (n int) {
 	return n
 }
 
+func (m *ListThreadsRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	n += protobuf_go_lite.SizeVarintPtr(1, m.BeforeIndex)
+	n += protobuf_go_lite.SizeVarintNonZero(1, m.Limit)
+	n += protobuf_go_lite.SizeBoolNonZero(1, m.ParticipatedOnly)
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *ChatThreadInfo) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Root != nil {
+		l = m.Root.SizeVT()
+		n += protobuf_go_lite.SizeMessage(1, l)
+	}
+	if m.LatestReply != nil {
+		l = m.LatestReply.SizeVT()
+		n += protobuf_go_lite.SizeMessage(1, l)
+	}
+	n += protobuf_go_lite.SizeVarintNonZero(1, m.ReplyCount)
+	n += protobuf_go_lite.SizeBoolNonZero(1, m.CurrentUserParticipated)
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *ListThreadsResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	for _, e := range m.Threads {
+		l = e.SizeVT()
+		n += protobuf_go_lite.SizeMessage(1, l)
+	}
+	n += protobuf_go_lite.SizeVarintPtr(1, m.NextBeforeIndex)
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *WatchMessagesRequest) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -3445,6 +4110,80 @@ func (x *ListMessagesResponse) MarshalProtoText() string {
 }
 
 func (x *ListMessagesResponse) String() string {
+	return x.MarshalProtoText()
+}
+
+func (x *ListThreadsRequest) MarshalProtoText() string {
+	var sb protobuf_go_lite.TextBuilder
+	initialLen := protobuf_go_lite.TextStartMessage(&sb, "ListThreadsRequest")
+	if x.BeforeIndex != nil {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "before_index")
+		protobuf_go_lite.TextWriteUint(&sb, *x.BeforeIndex)
+	}
+	if x.Limit != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "limit")
+		protobuf_go_lite.TextWriteUint(&sb, x.Limit)
+	}
+	if x.ParticipatedOnly != false {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "participated_only")
+		protobuf_go_lite.TextWriteBool(&sb, x.ParticipatedOnly)
+	}
+	return protobuf_go_lite.TextFinishMessage(&sb)
+}
+
+func (x *ListThreadsRequest) String() string {
+	return x.MarshalProtoText()
+}
+
+func (x *ChatThreadInfo) MarshalProtoText() string {
+	var sb protobuf_go_lite.TextBuilder
+	initialLen := protobuf_go_lite.TextStartMessage(&sb, "ChatThreadInfo")
+	if x.Root != nil {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "root")
+		protobuf_go_lite.TextWriteTextMarshaler(&sb, x.Root)
+	}
+	if x.LatestReply != nil {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "latest_reply")
+		protobuf_go_lite.TextWriteTextMarshaler(&sb, x.LatestReply)
+	}
+	if x.ReplyCount != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "reply_count")
+		protobuf_go_lite.TextWriteUint(&sb, x.ReplyCount)
+	}
+	if x.CurrentUserParticipated != false {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "current_user_participated")
+		protobuf_go_lite.TextWriteBool(&sb, x.CurrentUserParticipated)
+	}
+	return protobuf_go_lite.TextFinishMessage(&sb)
+}
+
+func (x *ChatThreadInfo) String() string {
+	return x.MarshalProtoText()
+}
+
+func (x *ListThreadsResponse) MarshalProtoText() string {
+	var sb protobuf_go_lite.TextBuilder
+	initialLen := protobuf_go_lite.TextStartMessage(&sb, "ListThreadsResponse")
+	if len(x.Threads) > 0 {
+		protobuf_go_lite.TextWriteListStart(&sb, initialLen, "threads")
+		for i, v := range x.Threads {
+			protobuf_go_lite.TextWriteListSeparator(&sb, i)
+			if v == nil {
+				protobuf_go_lite.TextWriteTextMarshaler(&sb, &ChatThreadInfo{})
+			} else {
+				protobuf_go_lite.TextWriteTextMarshaler(&sb, v)
+			}
+		}
+		protobuf_go_lite.TextWriteListEnd(&sb)
+	}
+	if x.NextBeforeIndex != nil {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "next_before_index")
+		protobuf_go_lite.TextWriteUint(&sb, *x.NextBeforeIndex)
+	}
+	return protobuf_go_lite.TextFinishMessage(&sb)
+}
+
+func (x *ListThreadsResponse) String() string {
 	return x.MarshalProtoText()
 }
 
@@ -4226,6 +4965,236 @@ func (m *ListMessagesResponse) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			m.HasMore = bool(v)
+		default:
+			iNdEx = preIndex
+			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protobuf_go_lite.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+
+func (m *ListThreadsRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	var err error
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		wire, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+		if err != nil {
+			return err
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ListThreadsRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ListThreadsRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BeforeIndex", wireType)
+			}
+			var v uint64
+			v, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.BeforeIndex = &v
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Limit", wireType)
+			}
+			m.Limit = 0
+			m.Limit, iNdEx, err = protobuf_go_lite.DecodeVarintUint32(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ParticipatedOnly", wireType)
+			}
+			var v bool
+			v, iNdEx, err = protobuf_go_lite.DecodeVarintBool(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.ParticipatedOnly = bool(v)
+		default:
+			iNdEx = preIndex
+			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protobuf_go_lite.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+
+func (m *ChatThreadInfo) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	var err error
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		wire, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+		if err != nil {
+			return err
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ChatThreadInfo: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ChatThreadInfo: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Root", wireType)
+			}
+			msgStart, postIndex, err := protobuf_go_lite.DecodeLengthDelimited(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			if m.Root == nil {
+				m.Root = &ChatMessageInfo{}
+			}
+			if err := m.Root.UnmarshalVT(dAtA[msgStart:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LatestReply", wireType)
+			}
+			msgStart, postIndex, err := protobuf_go_lite.DecodeLengthDelimited(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			if m.LatestReply == nil {
+				m.LatestReply = &ChatMessageInfo{}
+			}
+			if err := m.LatestReply.UnmarshalVT(dAtA[msgStart:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ReplyCount", wireType)
+			}
+			m.ReplyCount = 0
+			m.ReplyCount, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CurrentUserParticipated", wireType)
+			}
+			var v bool
+			v, iNdEx, err = protobuf_go_lite.DecodeVarintBool(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.CurrentUserParticipated = bool(v)
+		default:
+			iNdEx = preIndex
+			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protobuf_go_lite.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+
+func (m *ListThreadsResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	var err error
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		wire, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+		if err != nil {
+			return err
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ListThreadsResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ListThreadsResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Threads", wireType)
+			}
+			msgStart, postIndex, err := protobuf_go_lite.DecodeLengthDelimited(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.Threads = append(m.Threads, &ChatThreadInfo{})
+			if err := m.Threads[len(m.Threads)-1].UnmarshalVT(dAtA[msgStart:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NextBeforeIndex", wireType)
+			}
+			var v uint64
+			v, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.NextBeforeIndex = &v
 		default:
 			iNdEx = preIndex
 			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])

--- a/sdk/chat/rpc/rpc.pb.ts
+++ b/sdk/chat/rpc/rpc.pb.ts
@@ -346,6 +346,145 @@ export const ListMessagesResponse: MessageType<ListMessagesResponse> =
   })
 
 /**
+ * ListThreadsRequest selects an activity-ordered thread page.
+ *
+ * @generated from message spacewave.chat.rpc.ListThreadsRequest
+ */
+export interface ListThreadsRequest {
+  /**
+   * BeforeIndex resumes after the thread whose latest reply has this history index.
+   *
+   * @generated from field: optional uint64 before_index = 1;
+   */
+  beforeIndex?: bigint
+  /**
+   * Limit is the maximum number of matching threads to return.
+   *
+   * @generated from field: uint32 limit = 2;
+   */
+  limit?: number
+  /**
+   * ParticipatedOnly selects threads with a reply by the authenticated person.
+   *
+   * @generated from field: bool participated_only = 3;
+   */
+  participatedOnly?: boolean
+}
+
+export const ListThreadsRequest: MessageType<ListThreadsRequest> =
+  /* @__PURE__ */ createMessageType({
+    typeName: 'spacewave.chat.rpc.ListThreadsRequest',
+    fields: [
+      {
+        no: 1,
+        name: 'before_index',
+        kind: 'scalar',
+        T: ScalarType.UINT64,
+        opt: true,
+      },
+      { no: 2, name: 'limit', kind: 'scalar', T: ScalarType.UINT32 },
+      { no: 3, name: 'participated_only', kind: 'scalar', T: ScalarType.BOOL },
+    ] satisfies readonly PartialFieldInfo[],
+    packedByDefault: true,
+  })
+
+/**
+ * ChatThreadInfo projects one native thread summary.
+ *
+ * @generated from message spacewave.chat.rpc.ChatThreadInfo
+ */
+export interface ChatThreadInfo {
+  /**
+   * Root is the retained thread-root message.
+   *
+   * @generated from field: spacewave.chat.rpc.ChatMessageInfo root = 1;
+   */
+  root?: ChatMessageInfo
+  /**
+   * LatestReply is the newest canonical thread reply.
+   *
+   * @generated from field: spacewave.chat.rpc.ChatMessageInfo latest_reply = 2;
+   */
+  latestReply?: ChatMessageInfo
+  /**
+   * ReplyCount is the number of canonical thread replies.
+   *
+   * @generated from field: uint64 reply_count = 3;
+   */
+  replyCount?: bigint
+  /**
+   * CurrentUserParticipated reports whether the authenticated person wrote a reply.
+   *
+   * @generated from field: bool current_user_participated = 4;
+   */
+  currentUserParticipated?: boolean
+}
+
+export const ChatThreadInfo: MessageType<ChatThreadInfo> =
+  /* @__PURE__ */ createMessageType({
+    typeName: 'spacewave.chat.rpc.ChatThreadInfo',
+    fields: [
+      { no: 1, name: 'root', kind: 'message', T: () => ChatMessageInfo },
+      {
+        no: 2,
+        name: 'latest_reply',
+        kind: 'message',
+        T: () => ChatMessageInfo,
+      },
+      { no: 3, name: 'reply_count', kind: 'scalar', T: ScalarType.UINT64 },
+      {
+        no: 4,
+        name: 'current_user_participated',
+        kind: 'scalar',
+        T: ScalarType.BOOL,
+      },
+    ] satisfies readonly PartialFieldInfo[],
+    packedByDefault: true,
+  })
+
+/**
+ * ListThreadsResponse contains one bounded thread page.
+ *
+ * @generated from message spacewave.chat.rpc.ListThreadsResponse
+ */
+export interface ListThreadsResponse {
+  /**
+   * Threads is ordered from most to least recent activity.
+   *
+   * @generated from field: repeated spacewave.chat.rpc.ChatThreadInfo threads = 1;
+   */
+  threads?: ChatThreadInfo[]
+  /**
+   * NextBeforeIndex resumes after the last summary examined by this page.
+   *
+   * @generated from field: optional uint64 next_before_index = 2;
+   */
+  nextBeforeIndex?: bigint
+}
+
+export const ListThreadsResponse: MessageType<ListThreadsResponse> =
+  /* @__PURE__ */ createMessageType({
+    typeName: 'spacewave.chat.rpc.ListThreadsResponse',
+    fields: [
+      {
+        no: 1,
+        name: 'threads',
+        kind: 'message',
+        T: () => ChatThreadInfo,
+        repeated: true,
+      },
+      {
+        no: 2,
+        name: 'next_before_index',
+        kind: 'scalar',
+        T: ScalarType.UINT64,
+        opt: true,
+      },
+    ] satisfies readonly PartialFieldInfo[],
+    packedByDefault: true,
+  })
+
+/**
  * WatchMessagesRequest is a request to stream messages.
  *
  * @generated from message spacewave.chat.rpc.WatchMessagesRequest

--- a/sdk/chat/rpc/rpc.proto
+++ b/sdk/chat/rpc/rpc.proto
@@ -17,6 +17,8 @@ service ChatResourceService {
   rpc GetMessage(GetMessageRequest) returns (GetMessageResponse);
   // ListMessages returns a bounded page of channel history.
   rpc ListMessages(ListMessagesRequest) returns (ListMessagesResponse);
+  // ListThreads returns activity-ordered native thread summaries.
+  rpc ListThreads(ListThreadsRequest) returns (ListThreadsResponse);
   // WatchMessages streams channel messages after each shared-state change.
   rpc WatchMessages(WatchMessagesRequest) returns (stream WatchMessagesResponse);
   // SendMessage appends one message or resolves an identical retry.
@@ -109,6 +111,36 @@ message ListMessagesResponse {
   repeated ChatMessageInfo messages = 1;
   // HasMore indicates more messages exist in the selected pagination direction.
   bool has_more = 2;
+}
+
+// ListThreadsRequest selects an activity-ordered thread page.
+message ListThreadsRequest {
+  // BeforeIndex resumes after the thread whose latest reply has this history index.
+  optional uint64 before_index = 1;
+  // Limit is the maximum number of matching threads to return.
+  uint32 limit = 2;
+  // ParticipatedOnly selects threads with a reply by the authenticated person.
+  bool participated_only = 3;
+}
+
+// ChatThreadInfo projects one native thread summary.
+message ChatThreadInfo {
+  // Root is the retained thread-root message.
+  ChatMessageInfo root = 1;
+  // LatestReply is the newest canonical thread reply.
+  ChatMessageInfo latest_reply = 2;
+  // ReplyCount is the number of canonical thread replies.
+  uint64 reply_count = 3;
+  // CurrentUserParticipated reports whether the authenticated person wrote a reply.
+  bool current_user_participated = 4;
+}
+
+// ListThreadsResponse contains one bounded thread page.
+message ListThreadsResponse {
+  // Threads is ordered from most to least recent activity.
+  repeated ChatThreadInfo threads = 1;
+  // NextBeforeIndex resumes after the last summary examined by this page.
+  optional uint64 next_before_index = 2;
 }
 
 // WatchMessagesRequest is a request to stream messages.

--- a/sdk/chat/rpc/rpc_srpc.pb.go
+++ b/sdk/chat/rpc/rpc_srpc.pb.go
@@ -22,6 +22,8 @@ type SRPCChatResourceServiceClient interface {
 	GetMessage(ctx context.Context, in *GetMessageRequest) (*GetMessageResponse, error)
 	// ListMessages returns a bounded page of channel history.
 	ListMessages(ctx context.Context, in *ListMessagesRequest) (*ListMessagesResponse, error)
+	// ListThreads returns activity-ordered native thread summaries.
+	ListThreads(ctx context.Context, in *ListThreadsRequest) (*ListThreadsResponse, error)
 	// WatchMessages streams channel messages after each shared-state change.
 	WatchMessages(ctx context.Context, in *WatchMessagesRequest) (SRPCChatResourceService_WatchMessagesClient, error)
 	// SendMessage appends one message or resolves an identical retry.
@@ -80,6 +82,15 @@ func (c *srpcChatResourceServiceClient) GetMessage(ctx context.Context, in *GetM
 func (c *srpcChatResourceServiceClient) ListMessages(ctx context.Context, in *ListMessagesRequest) (*ListMessagesResponse, error) {
 	out := new(ListMessagesResponse)
 	err := c.cc.ExecCall(ctx, c.serviceID, "ListMessages", in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *srpcChatResourceServiceClient) ListThreads(ctx context.Context, in *ListThreadsRequest) (*ListThreadsResponse, error) {
+	out := new(ListThreadsResponse)
+	err := c.cc.ExecCall(ctx, c.serviceID, "ListThreads", in, out)
 	if err != nil {
 		return nil, err
 	}
@@ -156,6 +167,8 @@ type SRPCChatResourceServiceServer interface {
 	GetMessage(context.Context, *GetMessageRequest) (*GetMessageResponse, error)
 	// ListMessages returns a bounded page of channel history.
 	ListMessages(context.Context, *ListMessagesRequest) (*ListMessagesResponse, error)
+	// ListThreads returns activity-ordered native thread summaries.
+	ListThreads(context.Context, *ListThreadsRequest) (*ListThreadsResponse, error)
 	// WatchMessages streams channel messages after each shared-state change.
 	WatchMessages(*WatchMessagesRequest, SRPCChatResourceService_WatchMessagesStream) error
 	// SendMessage appends one message or resolves an identical retry.
@@ -196,6 +209,7 @@ func (SRPCChatResourceServiceHandler) GetMethodIDs() []string {
 		"GetState",
 		"GetMessage",
 		"ListMessages",
+		"ListThreads",
 		"WatchMessages",
 		"SendMessage",
 		"GetReadPositions",
@@ -220,6 +234,8 @@ func (d *SRPCChatResourceServiceHandler) InvokeMethod(
 		return true, d.InvokeMethod_GetMessage(d.impl, strm)
 	case "ListMessages":
 		return true, d.InvokeMethod_ListMessages(d.impl, strm)
+	case "ListThreads":
+		return true, d.InvokeMethod_ListThreads(d.impl, strm)
 	case "WatchMessages":
 		return true, d.InvokeMethod_WatchMessages(d.impl, strm)
 	case "SendMessage":
@@ -275,6 +291,18 @@ func (SRPCChatResourceServiceHandler) InvokeMethod_ListMessages(impl SRPCChatRes
 		return err
 	}
 	out, err := impl.ListMessages(strm.Context(), req)
+	if err != nil {
+		return err
+	}
+	return strm.MsgSend(out)
+}
+
+func (SRPCChatResourceServiceHandler) InvokeMethod_ListThreads(impl SRPCChatResourceServiceServer, strm srpc.Stream) error {
+	req := new(ListThreadsRequest)
+	if err := strm.MsgRecv(req); err != nil {
+		return err
+	}
+	out, err := impl.ListThreads(strm.Context(), req)
 	if err != nil {
 		return err
 	}
@@ -355,6 +383,14 @@ type SRPCChatResourceService_ListMessagesStream interface {
 }
 
 type srpcChatResourceService_ListMessagesStream struct {
+	srpc.Stream
+}
+
+type SRPCChatResourceService_ListThreadsStream interface {
+	srpc.Stream
+}
+
+type srpcChatResourceService_ListThreadsStream struct {
 	srpc.Stream
 }
 

--- a/sdk/chat/rpc/rpc_srpc.pb.ts
+++ b/sdk/chat/rpc/rpc_srpc.pb.ts
@@ -13,6 +13,8 @@ import {
   GetStateResponse,
   ListMessagesRequest,
   ListMessagesResponse,
+  ListThreadsRequest,
+  ListThreadsResponse,
   SendMessageRequest,
   SendMessageResponse,
   UpdateReadPositionRequest,
@@ -78,6 +80,17 @@ export const ChatResourceServiceDefinition = {
       name: 'ListMessages',
       I: ListMessagesRequest,
       O: ListMessagesResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * ListThreads returns activity-ordered native thread summaries.
+     *
+     * @generated from rpc spacewave.chat.rpc.ChatResourceService.ListThreads
+     */
+    ListThreads: {
+      name: 'ListThreads',
+      I: ListThreadsRequest,
+      O: ListThreadsResponse,
       kind: MethodKind.Unary,
     },
     /**
@@ -174,6 +187,16 @@ export interface ChatResourceService {
   ): Promise<ListMessagesResponse>
 
   /**
+   * ListThreads returns activity-ordered native thread summaries.
+   *
+   * @generated from rpc spacewave.chat.rpc.ChatResourceService.ListThreads
+   */
+  ListThreads(
+    request: ListThreadsRequest,
+    abortSignal?: AbortSignal,
+  ): Promise<ListThreadsResponse>
+
+  /**
    * WatchMessages streams channel messages after each shared-state change.
    *
    * @generated from rpc spacewave.chat.rpc.ChatResourceService.WatchMessages
@@ -265,6 +288,17 @@ export interface ChatResourceServiceHandler {
   ): Promise<ListMessagesResponse>
 
   /**
+   * ListThreads returns activity-ordered native thread summaries.
+   *
+   * @generated from rpc spacewave.chat.rpc.ChatResourceService.ListThreads
+   */
+  ListThreads(
+    request: ListThreadsRequest,
+    abortSignal: AbortSignal,
+    context: ServerContext,
+  ): Promise<ListThreadsResponse>
+
+  /**
    * WatchMessages streams channel messages after each shared-state change.
    *
    * @generated from rpc spacewave.chat.rpc.ChatResourceService.WatchMessages
@@ -322,6 +356,7 @@ export class ChatResourceServiceClient implements ChatResourceService {
     this.GetState = this.GetState.bind(this)
     this.GetMessage = this.GetMessage.bind(this)
     this.ListMessages = this.ListMessages.bind(this)
+    this.ListThreads = this.ListThreads.bind(this)
     this.WatchMessages = this.WatchMessages.bind(this)
     this.SendMessage = this.SendMessage.bind(this)
     this.GetReadPositions = this.GetReadPositions.bind(this)
@@ -401,6 +436,25 @@ export class ChatResourceServiceClient implements ChatResourceService {
       abortSignal || undefined,
     )
     return ListMessagesResponse.fromBinary(result)
+  }
+
+  /**
+   * ListThreads returns activity-ordered native thread summaries.
+   *
+   * @generated from rpc spacewave.chat.rpc.ChatResourceService.ListThreads
+   */
+  async ListThreads(
+    request: ListThreadsRequest,
+    abortSignal?: AbortSignal,
+  ): Promise<ListThreadsResponse> {
+    const requestMsg = ListThreadsRequest.create(request)
+    const result = await this.rpc.request(
+      this.service,
+      ChatResourceServiceDefinition.methods.ListThreads.name,
+      ListThreadsRequest.toBinary(requestMsg),
+      abortSignal || undefined,
+    )
+    return ListThreadsResponse.fromBinary(result)
   }
 
   /**


### PR DESCRIPTION
Matrix thread pagination was rebuilding every summary by scanning the channel's complete retained history. Chat now owns an activity-ordered thread index and exposes bounded `ListThreads` pages with reply counts and authenticated-person participation.

The index advances atomically with message append. Existing channels backfill at most 250 messages per retry and block new appends until the stored prefix is current, so compatibility work cannot turn one request into a history-sized operation.

Validation:
- `go test ./sdk/chat/... ./core/resource/space`
- `go test -race ./sdk/chat`
- `bun run typecheck`
- `aptre lint ./sdk/chat/...`
- generated sources regenerated with `bun run gen`
