### PR TITLE
feat(web): accept explicit ResourceClient in runtime providers

### DIFF
--- a/web/sdk/app/SpacewaveRuntimeProviders.test.tsx
+++ b/web/sdk/app/SpacewaveRuntimeProviders.test.tsx
@@ -5,6 +5,8 @@ const mocks = vi.hoisted(() => {
   const state: {
     bldrContext: unknown
     rootResource: unknown
+    lastRootClient: unknown
+    lastResourcesClient: unknown
   } = {
     bldrContext: null,
     rootResource: {
@@ -13,8 +15,11 @@ const mocks = vi.hoisted(() => {
       error: null,
       retry: vi.fn(),
     },
+    lastRootClient: 'never-set',
+    lastResourcesClient: 'never-set',
   }
   const resourceClientInstances: unknown[] = []
+  const rootAtoms: unknown[] = []
   return {
     getBldrContext: () => state.bldrContext,
     setBldrContext: (value: unknown) => {
@@ -24,6 +29,15 @@ const mocks = vi.hoisted(() => {
     setRootResource: (value: unknown) => {
       state.rootResource = value
     },
+    getLastRootClient: () => state.lastRootClient,
+    setLastRootClient: (value: unknown) => {
+      state.lastRootClient = value
+    },
+    getLastResourcesClient: () => state.lastResourcesClient,
+    setLastResourcesClient: (value: unknown) => {
+      state.lastResourcesClient = value
+    },
+    rootAtoms,
     resourceClientDispose: vi.fn(),
     resourceClientInstances,
   }
@@ -34,9 +48,16 @@ vi.mock('@aptre/bldr-react', () => ({
 }))
 
 vi.mock('@aptre/bldr-sdk/hooks/ResourcesContext.js', () => ({
-  ResourcesProvider: ({ children }: { children: React.ReactNode }) => (
-    <>{children}</>
-  ),
+  ResourcesProvider: ({
+    client,
+    children,
+  }: {
+    client: unknown
+    children: React.ReactNode
+  }) => {
+    mocks.setLastResourcesClient(client)
+    return <>{children}</>
+  },
 }))
 
 vi.mock('@aptre/bldr-sdk/resource/index.js', () => ({
@@ -60,7 +81,10 @@ vi.mock('starpc', () => ({
 }))
 
 vi.mock('@s4wave/web/hooks/useRootResource.js', () => ({
-  useRootResourceWithClient: () => mocks.getRootResource(),
+  useRootResourceWithClient: (client: unknown) => {
+    mocks.setLastRootClient(client)
+    return mocks.getRootResource()
+  },
 }))
 
 vi.mock('@s4wave/web/hooks/useViewerRegistry.js', () => ({
@@ -99,9 +123,18 @@ vi.mock('@s4wave/web/contexts/contexts.js', () => ({
 }))
 
 vi.mock('@s4wave/web/state/index.js', () => ({
-  StateNamespaceProvider: ({ children }: { children: React.ReactNode }) => (
-    <>{children}</>
-  ),
+  // Fresh object per call mirrors the real atom() factory identity behavior.
+  atom: () => ({}),
+  StateNamespaceProvider: ({
+    rootAtom,
+    children,
+  }: {
+    rootAtom?: unknown
+    children: React.ReactNode
+  }) => {
+    mocks.rootAtoms.push(rootAtom)
+    return <>{children}</>
+  },
 }))
 
 vi.mock('@s4wave/web/command/index.js', () => ({
@@ -119,7 +152,15 @@ vi.mock('@s4wave/web/ui/ErrorState.js', () => ({
   ),
 }))
 
+import type { Client as ResourceClient } from '@aptre/bldr-sdk/resource/index.js'
+import type { StateType } from '@s4wave/web/state/index.js'
+
 import { SpacewaveRuntimeProviders } from './SpacewaveRuntimeProviders.js'
+
+// Real atom factory from the unmocked state module for rootAtom instances.
+const realState = await vi.importActual<
+  typeof import('@s4wave/web/state/index.js')
+>('@s4wave/web/state/index.js')
 
 describe('SpacewaveRuntimeProviders', () => {
   beforeEach(() => {
@@ -130,6 +171,9 @@ describe('SpacewaveRuntimeProviders', () => {
       error: null,
       retry: vi.fn(),
     })
+    mocks.setLastRootClient('never-set')
+    mocks.setLastResourcesClient('never-set')
+    mocks.rootAtoms.length = 0
     mocks.resourceClientDispose.mockClear()
     mocks.resourceClientInstances.length = 0
   })
@@ -186,7 +230,7 @@ describe('SpacewaveRuntimeProviders', () => {
       },
     })
 
-    render(
+    const { unmount } = render(
       <SpacewaveRuntimeProviders staticViewers={[]} staticConfigTypes={[]}>
         {({ rootResource, resourceClient }) => (
           <div>
@@ -197,5 +241,260 @@ describe('SpacewaveRuntimeProviders', () => {
     )
 
     expect(await screen.findByText('ready')).toBeDefined()
+
+    // Default mode owns the client it created: unmount disposes it.
+    unmount()
+    expect(mocks.resourceClientDispose).toHaveBeenCalled()
+  })
+
+  it('renders with a supplied client and no Bldr context', () => {
+    mocks.setRootResource({
+      value: {},
+      loading: false,
+      error: null,
+      retry: vi.fn(),
+    })
+    const fakeClient = { dispose: vi.fn() } as unknown as ResourceClient
+
+    render(
+      <SpacewaveRuntimeProviders
+        staticViewers={[]}
+        staticConfigTypes={[]}
+        resourceClient={fakeClient}
+      >
+        <div>ready</div>
+      </SpacewaveRuntimeProviders>,
+    )
+
+    expect(screen.getByText('ready')).toBeDefined()
+    expect(mocks.getLastRootClient()).toBe(fakeClient)
+    expect(mocks.getLastResourcesClient()).toBe(fakeClient)
+    // The supplied client is passed through, never constructed here.
+    expect(mocks.resourceClientInstances).toHaveLength(0)
+  })
+
+  it('does not fall back to the Bldr transport when the supplied client is null', () => {
+    mocks.setBldrContext({
+      webView: {
+        getUuid: () => 'web-view-1',
+      },
+      webDocument: {
+        buildWebViewHostOpenStream: () => ({}),
+      },
+    })
+
+    render(
+      <SpacewaveRuntimeProviders
+        staticViewers={[]}
+        staticConfigTypes={[]}
+        resourceClient={null}
+      >
+        <div>ready</div>
+      </SpacewaveRuntimeProviders>,
+    )
+
+    expect(
+      screen.getByRole('heading', { name: 'Starting Spacewave' }),
+    ).toBeDefined()
+    expect(screen.queryByText('ready')).toBeNull()
+    expect(mocks.getLastRootClient()).toBeNull()
+    expect(mocks.getLastResourcesClient()).toBeNull()
+    expect(mocks.resourceClientInstances).toHaveLength(0)
+    cleanup()
+
+    // A present-but-undefined prop is explicit pending too, not omitted:
+    // presence dispatch, not nullness, selects the connection mode.
+    const { unmount: unmountPending } = render(
+      <SpacewaveRuntimeProviders
+        staticViewers={[]}
+        staticConfigTypes={[]}
+        resourceClient={undefined}
+      >
+        <div>ready</div>
+      </SpacewaveRuntimeProviders>,
+    )
+
+    expect(
+      screen.getByRole('heading', { name: 'Starting Spacewave' }),
+    ).toBeDefined()
+    expect(mocks.getLastRootClient()).toBeNull()
+    expect(mocks.resourceClientInstances).toHaveLength(0)
+    unmountPending()
+  })
+
+  it('propagates a replaced client to the root resource and providers', () => {
+    mocks.setRootResource({
+      value: {},
+      loading: false,
+      error: null,
+      retry: vi.fn(),
+    })
+    const clientA = { dispose: vi.fn() } as unknown as ResourceClient
+    const clientB = { dispose: vi.fn() } as unknown as ResourceClient
+
+    const { rerender } = render(
+      <SpacewaveRuntimeProviders
+        staticViewers={[]}
+        staticConfigTypes={[]}
+        resourceClient={clientA}
+      >
+        <div>ready</div>
+      </SpacewaveRuntimeProviders>,
+    )
+    expect(mocks.getLastRootClient()).toBe(clientA)
+    expect(mocks.getLastResourcesClient()).toBe(clientA)
+
+    rerender(
+      <SpacewaveRuntimeProviders
+        staticViewers={[]}
+        staticConfigTypes={[]}
+        resourceClient={clientB}
+      >
+        <div>ready</div>
+      </SpacewaveRuntimeProviders>,
+    )
+    expect(mocks.getLastRootClient()).toBe(clientB)
+    expect(mocks.getLastResourcesClient()).toBe(clientB)
+    // Caller-owned clients are never disposed by the providers.
+    expect(clientA.dispose).not.toHaveBeenCalled()
+    expect(clientB.dispose).not.toHaveBeenCalled()
+  })
+
+  it('does not dispose a caller-owned client on unmount', () => {
+    mocks.setRootResource({
+      value: {},
+      loading: false,
+      error: null,
+      retry: vi.fn(),
+    })
+    const fakeClient = { dispose: vi.fn() } as unknown as ResourceClient
+
+    const { unmount } = render(
+      <SpacewaveRuntimeProviders
+        staticViewers={[]}
+        staticConfigTypes={[]}
+        resourceClient={fakeClient}
+      >
+        <div>ready</div>
+      </SpacewaveRuntimeProviders>,
+    )
+
+    unmount()
+    expect(fakeClient.dispose).not.toHaveBeenCalled()
+    expect(mocks.resourceClientDispose).not.toHaveBeenCalled()
+  })
+
+  it('scopes the root atom per explicit provider instance', () => {
+    mocks.setRootResource({
+      value: {},
+      loading: false,
+      error: null,
+      retry: vi.fn(),
+    })
+
+    const clientA = { dispose: vi.fn() } as unknown as ResourceClient
+    const clientB = { dispose: vi.fn() } as unknown as ResourceClient
+
+    render(
+      <>
+        <SpacewaveRuntimeProviders
+          staticViewers={[]}
+          staticConfigTypes={[]}
+          resourceClient={clientA}
+        >
+          <div>a</div>
+        </SpacewaveRuntimeProviders>
+        <SpacewaveRuntimeProviders
+          staticViewers={[]}
+          staticConfigTypes={[]}
+          resourceClient={clientB}
+        >
+          <div>b</div>
+        </SpacewaveRuntimeProviders>
+      </>,
+    )
+
+    const unique = [...new Set(mocks.rootAtoms)]
+    expect(unique.length).toBe(2)
+    expect(unique.every((atom) => atom != null)).toBe(true)
+  })
+
+  it('honors a caller-supplied root atom in explicit mode', () => {
+    mocks.setRootResource({
+      value: {},
+      loading: false,
+      error: null,
+      retry: vi.fn(),
+    })
+    const supplied = realState.atom<StateType>({})
+
+    render(
+      <SpacewaveRuntimeProviders
+        staticViewers={[]}
+        staticConfigTypes={[]}
+        resourceClient={{ dispose: vi.fn() } as unknown as ResourceClient}
+        rootAtom={supplied}
+      >
+        <div>ready</div>
+      </SpacewaveRuntimeProviders>,
+    )
+
+    expect(mocks.rootAtoms).toContain(supplied)
+  })
+
+  it('keeps the default mode root atom undefined', () => {
+    mocks.setRootResource({
+      value: {},
+      loading: false,
+      error: null,
+      retry: vi.fn(),
+    })
+    mocks.setBldrContext({
+      webView: {
+        getUuid: () => 'web-view-1',
+      },
+      webDocument: {
+        buildWebViewHostOpenStream: () => ({}),
+      },
+    })
+
+    render(
+      <SpacewaveRuntimeProviders staticViewers={[]} staticConfigTypes={[]}>
+        <div>ready</div>
+      </SpacewaveRuntimeProviders>,
+    )
+
+    expect(mocks.rootAtoms.length).toBeGreaterThan(0)
+    expect(mocks.rootAtoms.every((atom) => atom === undefined)).toBe(true)
+  })
+
+  it('honors a caller-supplied root atom in default mode', () => {
+    mocks.setRootResource({
+      value: {},
+      loading: false,
+      error: null,
+      retry: vi.fn(),
+    })
+    mocks.setBldrContext({
+      webView: {
+        getUuid: () => 'web-view-1',
+      },
+      webDocument: {
+        buildWebViewHostOpenStream: () => ({}),
+      },
+    })
+    const supplied = realState.atom<StateType>({})
+
+    render(
+      <SpacewaveRuntimeProviders
+        staticViewers={[]}
+        staticConfigTypes={[]}
+        rootAtom={supplied}
+      >
+        <div>ready</div>
+      </SpacewaveRuntimeProviders>,
+    )
+
+    expect(mocks.rootAtoms).toContain(supplied)
   })
 })

--- a/web/sdk/app/SpacewaveRuntimeProviders.tsx
+++ b/web/sdk/app/SpacewaveRuntimeProviders.tsx
@@ -23,8 +23,11 @@ import { useRootResourceWithClient } from '@s4wave/web/hooks/useRootResource.js'
 import { ViewerRegistryProvider } from '@s4wave/web/hooks/useViewerRegistry.js'
 import type { ObjectViewerComponent } from '@s4wave/web/object/object.js'
 import {
+  atom,
   StateNamespaceProvider,
+  type Atom,
   type StateAtomAccessor,
+  type StateType,
 } from '@s4wave/web/state/index.js'
 import { ErrorState } from '@s4wave/web/ui/ErrorState.js'
 import { LoadingScreen } from '@s4wave/web/ui/loading/LoadingScreen.js'
@@ -40,18 +43,101 @@ export interface SpacewaveRuntimeContext {
 export interface SpacewaveRuntimeProvidersProps {
   staticViewers: ObjectViewerComponent[]
   staticConfigTypes: StaticConfigTypeRegistration[]
+  /**
+   * ResourceClient for an explicit runtime connection. Present (including
+   * null while pending) bypasses the Bldr WebView transport entirely; the
+   * caller owns the client lifetime. Omitted keeps the default Bldr context
+   * transport.
+   */
+  resourceClient?: ResourceClient | null
+  /**
+   * rootAtom scopes legacy local UI state. Explicit connections default to
+   * a fresh atom so nested state never reaches the outer app's global atom;
+   * the default connection omits it and inherits from the outer tree.
+   */
+  rootAtom?: Atom<StateType>
+  /** resourceService is the service name for the default Bldr transport. */
   resourceService?: string
   children: ReactNode | ((ctx: SpacewaveRuntimeContext) => ReactNode)
 }
 
-export function SpacewaveRuntimeProviders({
+export function SpacewaveRuntimeProviders(
+  props: SpacewaveRuntimeProvidersProps,
+) {
+  // Presence of resourceClient selects the explicit runtime connection; see
+  // SpacewaveRuntimeProvidersProps.resourceClient.
+  if ('resourceClient' in props) {
+    return <ExplicitSpacewaveRuntime {...props} />
+  }
+  return <BldrSpacewaveRuntime {...props} />
+}
+
+/**
+ * ExplicitSpacewaveRuntime renders the provider tree for a caller-owned
+ * ResourceClient, defaulting the root UI atom to a fresh in-memory atom.
+ */
+function ExplicitSpacewaveRuntime({
+  staticViewers,
+  staticConfigTypes,
+  resourceClient,
+  rootAtom,
+  children,
+}: SpacewaveRuntimeProvidersProps) {
+  const scopedRootAtom = useMemo(
+    () => rootAtom ?? atom<StateType>({}),
+    [rootAtom],
+  )
+  return (
+    <RuntimeProviderTree
+      resourceClient={resourceClient ?? null}
+      staticViewers={staticViewers}
+      staticConfigTypes={staticConfigTypes}
+      rootAtom={scopedRootAtom}
+      children={children}
+    />
+  )
+}
+
+/**
+ * BldrSpacewaveRuntime renders the provider tree over the Bldr WebView
+ * transport, creating and disposing the ResourceClient itself.
+ */
+function BldrSpacewaveRuntime({
   staticViewers,
   staticConfigTypes,
   resourceService = defaultResourceService,
+  rootAtom,
   children,
 }: SpacewaveRuntimeProvidersProps) {
   const resourceClient = useSpacewaveResourceClient(resourceService)
+  return (
+    <RuntimeProviderTree
+      resourceClient={resourceClient}
+      staticViewers={staticViewers}
+      staticConfigTypes={staticConfigTypes}
+      rootAtom={rootAtom}
+      children={children}
+    />
+  )
+}
 
+/**
+ * RuntimeProviderTree is the shared provider composition for both runtime
+ * connection modes.
+ */
+function RuntimeProviderTree({
+  resourceClient,
+  staticViewers,
+  staticConfigTypes,
+  rootAtom,
+  children,
+}: {
+  resourceClient: ResourceClient | null
+  staticViewers: ObjectViewerComponent[]
+  staticConfigTypes: StaticConfigTypeRegistration[]
+  rootAtom?: Atom<StateType>
+  children: ReactNode | ((ctx: SpacewaveRuntimeContext) => ReactNode)
+}) {
   return (
     <ViewerRegistryProvider staticViewers={staticViewers}>
       <ConfigTypeRegistryProvider staticConfigTypes={staticConfigTypes}>
@@ -61,6 +147,7 @@ export function SpacewaveRuntimeProviders({
               <ResourcesProvider client={resourceClient}>
                 <SpacewaveRuntimeRoot
                   resourceClient={resourceClient}
+                  rootAtom={rootAtom}
                   children={children}
                 />
               </ResourcesProvider>
@@ -107,9 +194,11 @@ function useSpacewaveResourceClient(
 
 function SpacewaveRuntimeRoot({
   resourceClient,
+  rootAtom,
   children,
 }: {
   resourceClient: ResourceClient | null
+  rootAtom?: Atom<StateType>
   children: ReactNode | ((ctx: SpacewaveRuntimeContext) => ReactNode)
 }) {
   const rootResource = useRootResourceWithClient(resourceClient)
@@ -162,7 +251,10 @@ function SpacewaveRuntimeRoot({
 
   return (
     <RootContext.Provider resource={rootResource}>
-      <StateNamespaceProvider stateAtomAccessor={rootStateAccessor}>
+      <StateNamespaceProvider
+        rootAtom={rootAtom}
+        stateAtomAccessor={rootStateAccessor}
+      >
         <CommandProvider rootResource={rootResource}>
           {renderedChildren}
         </CommandProvider>


### PR DESCRIPTION
Implements the explicit runtime connection seam for nested Spacewave apps.

- SpacewaveRuntimeProvidersProps gains optional resourceClient: presence (including null and undefined while pending) selects an explicit runtime connection that bypasses the Bldr WebView transport entirely; the caller owns the client and the providers never dispose it. Omission keeps the default Bldr context transport with existing create-and-dispose behavior.
- Hooks stay unconditional via a component split: the explicit path never calls useBldrContext or constructs a transport; both paths share one RuntimeProviderTree so the provider composition cannot drift.
- Optional rootAtom prop honored in both modes: explicit connections default to a fresh in-memory atom so nested state never reaches the outer app global atom; default mode omits it and inherits exactly as before.

Checks: focused Vitest 11/11 (web/sdk/app/SpacewaveRuntimeProviders.test.tsx), bun run typecheck (tsgo, whole repo) clean, oxlint web/sdk/app clean. Implementation report: plans/20260909-spacewave-nested-app.d/frontend-connection-implementation.md.