### PR TITLE
feat(bldr): route plugin storage through a selected host provider

### DIFF
--- a/.protoc-manifest.json
+++ b/.protoc-manifest.json
@@ -215,7 +215,7 @@
       ]
     },
     "github.com/s4wave/spacewave/bldr/plugin": {
-      "hash": "4362a4911ef32c3554def4cdc1790f2f7ee9667bd0091513597fecf2ee23cff3",
+      "hash": "1cbad8de55a9a5bb22ecd5933496e61312eaca835db44b96877d97b28c898046",
       "generatedFiles": [
         "bldr/plugin/plugin.pb.go",
         "bldr/plugin/plugin.pb.ts",
@@ -317,7 +317,7 @@
       ]
     },
     "github.com/s4wave/spacewave/bldr/plugin/host/scheduler": {
-      "hash": "f2b83794cf91c762ad7e4e5e3ad9ed3242037cd863d4932952e36faf106ca1de",
+      "hash": "6c226910d7f3e3667893865829fefbb974742d0836e98aeddd911facfcf2f2cc",
       "generatedFiles": [
         "bldr/plugin/host/scheduler/config.pb.go",
         "bldr/plugin/host/scheduler/config.pb.ts"

--- a/bldr/plugin/entrypoint/common.go
+++ b/bldr/plugin/entrypoint/common.go
@@ -264,7 +264,7 @@ func ExecutePluginEntrypoint(
 	// Start the plugin storage controller and use the default storage id.
 	// On js/wasm this resolves to direct OPFS access, and on native it
 	// proxies through the plugin host via RPC.
-	storages := buildPluginStorages(b, sr)
+	storages := buildPluginStorages(b, sr, pluginInfo.GetHostStorageId())
 	hostStorageCtrl := storage_controller.BuildStorageController(
 		bldr_plugin.HostStorageID,
 		storages,

--- a/bldr/plugin/entrypoint/plugin-storage-browser.go
+++ b/bldr/plugin/entrypoint/plugin-storage-browser.go
@@ -5,13 +5,28 @@ package plugin_entrypoint
 import (
 	"github.com/aperturerobotics/controllerbus/bus"
 	"github.com/aperturerobotics/controllerbus/controller/resolver/static"
+	plugin_host_storage "github.com/s4wave/spacewave/bldr/plugin/host/storage"
 	"github.com/s4wave/spacewave/bldr/storage"
 	browser_storage "github.com/s4wave/spacewave/bldr/storage/browser"
 )
 
 // buildPluginStorages builds the storage backends for the plugin.
-// On js builds, uses direct OPFS access instead of proxying through the host.
-func buildPluginStorages(b bus.Bus, sr *static.Resolver) []storage.Storage {
+//
+// When the host selected a Storage ID for this plugin instance, every volume
+// request proxies through the plugin host to that Storage, matching the native
+// path. Otherwise js builds use direct OPFS access instead of proxying through
+// the host.
+func buildPluginStorages(
+	b bus.Bus,
+	sr *static.Resolver,
+	hostStorageID string,
+) []storage.Storage {
+	if hostStorageID != "" {
+		hostStorage := plugin_host_storage.NewPluginHostStorage(hostStorageID)
+		hostStorage.AddFactories(b, sr)
+		return []storage.Storage{hostStorage}
+	}
+
 	storages := browser_storage.BuildStorage(b, "")
 	for _, st := range storages {
 		st.AddFactories(b, sr)

--- a/bldr/plugin/entrypoint/plugin-storage-cloudflare.go
+++ b/bldr/plugin/entrypoint/plugin-storage-cloudflare.go
@@ -9,4 +9,4 @@ import (
 )
 
 // buildPluginStorages exposes no ambient browser or host storage in a facet.
-func buildPluginStorages(bus.Bus, *static.Resolver) []storage.Storage { return nil }
+func buildPluginStorages(bus.Bus, *static.Resolver, string) []storage.Storage { return nil }

--- a/bldr/plugin/entrypoint/plugin-storage-native.go
+++ b/bldr/plugin/entrypoint/plugin-storage-native.go
@@ -11,8 +11,12 @@ import (
 
 // buildPluginStorages builds the storage backends for the plugin.
 // On native builds, uses the plugin host storage (RPC proxy) for cross-process access.
-func buildPluginStorages(b bus.Bus, sr *static.Resolver) []storage.Storage {
-	hostStorage := plugin_host_storage.NewPluginHostStorage()
+func buildPluginStorages(
+	b bus.Bus,
+	sr *static.Resolver,
+	hostStorageID string,
+) []storage.Storage {
+	hostStorage := plugin_host_storage.NewPluginHostStorage(hostStorageID)
 	hostStorage.AddFactories(b, sr)
 	return []storage.Storage{hostStorage}
 }

--- a/bldr/plugin/host/configset/controller_test.go
+++ b/bldr/plugin/host/configset/controller_test.go
@@ -91,7 +91,7 @@ func TestControllerReturnsConfigSetMemberError(t *testing.T) {
 
 	serverExited := make(chan error, 1)
 	server := &observingPluginHostServer{
-		SRPCPluginHostServer: bldr_plugin_host.NewPluginHostServer(ctx, hostBus, le, "spacewave-launcher", "", nil, nil),
+		SRPCPluginHostServer: bldr_plugin_host.NewPluginHostServer(ctx, hostBus, le, "spacewave-launcher", "", nil, nil, ""),
 		exited:               serverExited,
 	}
 	mux := srpc.NewMux()
@@ -157,7 +157,7 @@ func TestPluginHostExecControllerReportsMemberError(t *testing.T) {
 	mux := srpc.NewMux()
 	if err := bldr_plugin.SRPCRegisterPluginHost(
 		mux,
-		bldr_plugin_host.NewPluginHostServer(ctx, hostBus, le, "spacewave-launcher", "", nil, nil),
+		bldr_plugin_host.NewPluginHostServer(ctx, hostBus, le, "spacewave-launcher", "", nil, nil, ""),
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/bldr/plugin/host/plugin-host-server.go
+++ b/bldr/plugin/host/plugin-host-server.go
@@ -30,6 +30,10 @@ type PluginHostServer struct {
 	manifestSnapshot *bldr_manifest.ManifestSnapshot
 	// hostVolumeInfo is the host volume information
 	hostVolumeInfo *volume.VolumeInfo
+	// hostStorageID is the Storage ID on the host bus that this plugin
+	// instance allocates named volumes through. Empty selects the host
+	// default storage.
+	hostStorageID string
 	// pluginFsTracker tracks loaded plugin FSCursor servers
 	// TODO: we need a KeyedRefCountValue type which resolves a value with the same logic as refcount/refcount.go
 	// TODO: that would be a lot simpler and more robust here
@@ -45,6 +49,7 @@ func NewPluginHostServer(
 	instanceKey string,
 	manifest *bldr_manifest.ManifestSnapshot,
 	hostVolumeInfo *volume.VolumeInfo,
+	hostStorageID string,
 ) *PluginHostServer {
 	s := &PluginHostServer{
 		b:                b,
@@ -53,6 +58,7 @@ func NewPluginHostServer(
 		instanceKey:      instanceKey,
 		manifestSnapshot: manifest,
 		hostVolumeInfo:   hostVolumeInfo,
+		hostStorageID:    hostStorageID,
 	}
 	s.pluginFsTracker = keyed.NewKeyedRefCountWithLogger(
 		s.newPluginHostServerFsTracker,
@@ -75,6 +81,7 @@ func (s *PluginHostServer) GetPluginInfo(
 			s.manifestSnapshot.GetManifestRef().Clone(),
 		),
 		HostVolumeInfo: s.hostVolumeInfo,
+		HostStorageId:  s.hostStorageID,
 	}, nil
 }
 

--- a/bldr/plugin/host/scheduler/config.pb.go
+++ b/bldr/plugin/host/scheduler/config.pb.go
@@ -79,6 +79,11 @@ type Config struct {
 	// UpdateGuardPluginIds require a successful UpdateGuard.Prepare call on the
 	// running generation before a different executable replaces it.
 	UpdateGuardPluginIds []string `protobuf:"bytes,17,rep,name=update_guard_plugin_ids,json=updateGuardPluginIds,proto3" json:"updateGuardPluginIds,omitempty"`
+	// HostStorageId selects the Storage ID on the plugin host bus that plugin
+	// instance volumes allocate through. Empty keeps the host default storage.
+	// Top-level plugins leave this unset; instance-scoped runtimes set it to
+	// route the instance's volumes through host-owned storage.
+	HostStorageId string `protobuf:"bytes,18,opt,name=host_storage_id,json=hostStorageId,proto3" json:"hostStorageId,omitempty"`
 }
 
 func (x *Config) Reset() {
@@ -206,6 +211,13 @@ func (x *Config) GetUpdateGuardPluginIds() []string {
 	return nil
 }
 
+func (x *Config) GetHostStorageId() string {
+	if x != nil {
+		return x.HostStorageId
+	}
+	return ""
+}
+
 // PlatformSelectionPolicy restricts a plugin host platform to a plugin ID list.
 type PlatformSelectionPolicy struct {
 	unknownFields []byte
@@ -253,6 +265,7 @@ func (m *Config) CloneVT() *Config {
 	r.InstanceKey = m.InstanceKey
 	r.StartupWaitBudgetDur = m.StartupWaitBudgetDur
 	r.MaterializerPluginId = m.MaterializerPluginId
+	r.HostStorageId = m.HostStorageId
 	r.FetchBackoff = protobuf_go_lite.CloneVTValue(m.FetchBackoff)
 	r.ExecBackoff = protobuf_go_lite.CloneVTValue(m.ExecBackoff)
 	r.PlatformSelectionPolicies = protobuf_go_lite.CloneVTSlice(m.PlatformSelectionPolicies)
@@ -340,6 +353,9 @@ func (this *Config) EqualVT(that *Config) bool {
 		return false
 	}
 	if !protobuf_go_lite.EqualSlice(this.UpdateGuardPluginIds, that.UpdateGuardPluginIds) {
+		return false
+	}
+	if this.HostStorageId != that.HostStorageId {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -475,6 +491,11 @@ func (x *Config) MarshalProtoJSON(s *json.MarshalState) {
 		s.WriteObjectField("updateGuardPluginIds")
 		s.WriteStringArray(x.UpdateGuardPluginIds)
 	}
+	if x.HostStorageId != "" || s.HasField("hostStorageId") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("hostStorageId")
+		s.WriteString(x.HostStorageId)
+	}
 	s.WriteObjectEnd()
 }
 
@@ -574,6 +595,9 @@ func (x *Config) UnmarshalProtoJSON(s *json.UnmarshalState) {
 				return
 			}
 			x.UpdateGuardPluginIds = s.ReadStringArray()
+		case "host_storage_id", "hostStorageId":
+			s.AddField("host_storage_id")
+			x.HostStorageId = s.ReadString()
 		}
 	})
 }
@@ -665,6 +689,13 @@ func (m *Config) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	_ = l
 	if m.unknownFields != nil {
 		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	if len(m.HostStorageId) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.HostStorageId)
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x92
 	}
 	if len(m.UpdateGuardPluginIds) > 0 {
 		for iNdEx := len(m.UpdateGuardPluginIds) - 1; iNdEx >= 0; iNdEx-- {
@@ -855,6 +886,7 @@ func (m *Config) SizeVT() (n int) {
 	n += protobuf_go_lite.SizeStringNonEmpty(1, m.StartupWaitBudgetDur)
 	n += protobuf_go_lite.SizeStringNonEmpty(2, m.MaterializerPluginId)
 	n += protobuf_go_lite.SizeStringSlice(2, m.UpdateGuardPluginIds)
+	n += protobuf_go_lite.SizeStringNonEmpty(2, m.HostStorageId)
 	n += len(m.unknownFields)
 	return n
 }
@@ -957,6 +989,10 @@ func (x *Config) MarshalProtoText() string {
 			protobuf_go_lite.TextWriteString(&sb, v)
 		}
 		protobuf_go_lite.TextWriteListEnd(&sb)
+	}
+	if x.HostStorageId != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "host_storage_id")
+		protobuf_go_lite.TextWriteString(&sb, x.HostStorageId)
 	}
 	return protobuf_go_lite.TextFinishMessage(&sb)
 }
@@ -1189,6 +1225,16 @@ func (m *Config) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			m.UpdateGuardPluginIds = append(m.UpdateGuardPluginIds, v)
+		case 18:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field HostStorageId", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.HostStorageId = v
 		default:
 			iNdEx = preIndex
 			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])

--- a/bldr/plugin/host/scheduler/config.pb.ts
+++ b/bldr/plugin/host/scheduler/config.pb.ts
@@ -2,13 +2,13 @@
 // @generated from file github.com/s4wave/spacewave/bldr/plugin/host/scheduler/config.proto (package plugin.host.scheduler, syntax proto3)
 /* eslint-disable */
 
-import type { MessageType } from '@aptre/protobuf-es-lite/message'
-import { createMessageType } from '@aptre/protobuf-es-lite/message'
-import { ScalarType } from '@aptre/protobuf-es-lite/scalar'
-import type { PartialFieldInfo } from '@aptre/protobuf-es-lite/field'
-import { Backoff } from '@go/github.com/aperturerobotics/util/backoff/backoff.pb.js'
+import type { MessageType } from "@aptre/protobuf-es-lite/message";
+import { createMessageType } from "@aptre/protobuf-es-lite/message";
+import { ScalarType } from "@aptre/protobuf-es-lite/scalar";
+import type { PartialFieldInfo } from "@aptre/protobuf-es-lite/field";
+import { Backoff } from "@go/github.com/aperturerobotics/util/backoff/backoff.pb.js";
 
-export const protobufPackage = 'plugin.host.scheduler'
+export const protobufPackage = "plugin.host.scheduler";
 
 /**
  * PlatformSelectionPolicy restricts a plugin host platform to a plugin ID list.
@@ -22,30 +22,24 @@ export interface PlatformSelectionPolicy {
    *
    * @generated from field: string platform_id = 1;
    */
-  platformId?: string
+  platformId?: string;
   /**
    * AllowedPluginIds are the plugin IDs that may select PlatformId.
    *
    * @generated from field: repeated string allowed_plugin_ids = 2;
    */
-  allowedPluginIds?: string[]
-}
+  allowedPluginIds?: string[];
 
-export const PlatformSelectionPolicy: MessageType<PlatformSelectionPolicy> =
-  /* @__PURE__ */ createMessageType({
-    typeName: 'plugin.host.scheduler.PlatformSelectionPolicy',
+};
+
+export const PlatformSelectionPolicy: MessageType<PlatformSelectionPolicy> = /* @__PURE__ */ createMessageType({
+    typeName: "plugin.host.scheduler.PlatformSelectionPolicy",
     fields: [
-      { no: 1, name: 'platform_id', kind: 'scalar', T: ScalarType.STRING },
-      {
-        no: 2,
-        name: 'allowed_plugin_ids',
-        kind: 'scalar',
-        T: ScalarType.STRING,
-        repeated: true,
-      },
+        { no: 1, name: "platform_id", kind: "scalar", T: ScalarType.STRING },
+        { no: 2, name: "allowed_plugin_ids", kind: "scalar", T: ScalarType.STRING, repeated: true },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,
-  })
+});
 
 /**
  * Config is the plugin host scheduler controller configuration.
@@ -62,7 +56,7 @@ export interface Config {
    *
    * @generated from field: string engine_id = 1;
    */
-  engineId?: string
+  engineId?: string;
   /**
    * ObjectKey is the root object to attach to.
    * If not exists, waits for it to exist.
@@ -71,33 +65,33 @@ export interface Config {
    *
    * @generated from field: string object_key = 2;
    */
-  objectKey?: string
+  objectKey?: string;
   /**
    * PeerId is the peer ID to use for world transactions.
    *
    * @generated from field: string peer_id = 3;
    */
-  peerId?: string
+  peerId?: string;
   /**
    * VolumeId is the identifier of the volume on the plugin host bus.
    * This volume is available for the plugin to use via the volume proxy.
    *
    * @generated from field: string volume_id = 4;
    */
-  volumeId?: string
+  volumeId?: string;
   /**
    * WatchFetchManifest will watch the FetchManifest directive while a plugin is running.
    *
    * @generated from field: bool watch_fetch_manifest = 5;
    */
-  watchFetchManifest?: boolean
+  watchFetchManifest?: boolean;
   /**
    * DisableStoreManifest disables storing manifests fetched with FetchManifest.
    * This is used if we are watching the same world as the FetchManifest resolver.
    *
    * @generated from field: bool disable_store_manifest = 6;
    */
-  disableStoreManifest?: boolean
+  disableStoreManifest?: boolean;
   /**
    * FetchConcurrency limits the number of blocks fetched concurrently per-manifest.
    * If zero, uses a finite default of 2, shared by the serialized active
@@ -109,21 +103,21 @@ export interface Config {
    *
    * @generated from field: uint32 fetch_concurrency = 7;
    */
-  fetchConcurrency?: number
+  fetchConcurrency?: number;
   /**
    * FetchBackoff is the backoff config for fetching plugin manifests.
    * If unset, defaults to reasonable defaults.
    *
    * @generated from field: backoff.Backoff fetch_backoff = 8;
    */
-  fetchBackoff?: Backoff
+  fetchBackoff?: Backoff;
   /**
    * ExecBackoff is the backoff config for executing plugin manifests.
    * If unset, defaults to reasonable defaults.
    *
    * @generated from field: backoff.Backoff exec_backoff = 9;
    */
-  execBackoff?: Backoff
+  execBackoff?: Backoff;
   /**
    * DisableCopyManifest disables copying manifests to the plugin host world bucket.
    * This is used if the manifest bucket is always accessible and locally cached.
@@ -131,13 +125,13 @@ export interface Config {
    *
    * @generated from field: bool disable_copy_manifest = 10;
    */
-  disableCopyManifest?: boolean
+  disableCopyManifest?: boolean;
   /**
    * Verbose enables verbose logging for world ops (slower).
    *
    * @generated from field: bool verbose = 11;
    */
-  verbose?: boolean
+  verbose?: boolean;
   /**
    * PlatformSelectionPolicies restrict selected platform IDs to selected
    * plugin IDs. If empty, every discovered plugin host platform is selectable
@@ -145,21 +139,21 @@ export interface Config {
    *
    * @generated from field: repeated plugin.host.scheduler.PlatformSelectionPolicy platform_selection_policies = 12;
    */
-  platformSelectionPolicies?: PlatformSelectionPolicy[]
+  platformSelectionPolicies?: PlatformSelectionPolicy[];
   /**
    * NoCopyBucketIds lists source buckets that remain authoritative without a
    * full-DAG copy.
    *
    * @generated from field: repeated string no_copy_bucket_ids = 13;
    */
-  noCopyBucketIds?: string[]
+  noCopyBucketIds?: string[];
   /**
    * InstanceKey identifies the isolated plugin instance set resolved by this scheduler.
    * Empty retains the unscoped Dist behavior.
    *
    * @generated from field: string instance_key = 14;
    */
-  instanceKey?: string
+  instanceKey?: string;
   /**
    * StartupWaitBudgetDur is the maximum wall-clock duration a plugin instance
    * may take to complete initial capability registration before its startup
@@ -168,81 +162,54 @@ export interface Config {
    *
    * @generated from field: string startup_wait_budget_dur = 15;
    */
-  startupWaitBudgetDur?: string
+  startupWaitBudgetDur?: string;
   /**
    * MaterializerPluginId is the plugin ID to route manifest materialization
    * through. If empty, the scheduler materializes manifests directly.
    *
    * @generated from field: string materializer_plugin_id = 16;
    */
-  materializerPluginId?: string
+  materializerPluginId?: string;
   /**
    * UpdateGuardPluginIds require a successful UpdateGuard.Prepare call on the
    * running generation before a different executable replaces it.
    *
    * @generated from field: repeated string update_guard_plugin_ids = 17;
    */
-  updateGuardPluginIds?: string[]
-}
+  updateGuardPluginIds?: string[];
+  /**
+   * HostStorageId selects the Storage ID on the plugin host bus that plugin
+   * instance volumes allocate through. Empty keeps the host default storage.
+   * Top-level plugins leave this unset; instance-scoped runtimes set it to
+   * route the instance's volumes through host-owned storage.
+   *
+   * @generated from field: string host_storage_id = 18;
+   */
+  hostStorageId?: string;
+
+};
 
 export const Config: MessageType<Config> = /* @__PURE__ */ createMessageType({
-  typeName: 'plugin.host.scheduler.Config',
-  fields: [
-    { no: 1, name: 'engine_id', kind: 'scalar', T: ScalarType.STRING },
-    { no: 2, name: 'object_key', kind: 'scalar', T: ScalarType.STRING },
-    { no: 3, name: 'peer_id', kind: 'scalar', T: ScalarType.STRING },
-    { no: 4, name: 'volume_id', kind: 'scalar', T: ScalarType.STRING },
-    { no: 5, name: 'watch_fetch_manifest', kind: 'scalar', T: ScalarType.BOOL },
-    {
-      no: 6,
-      name: 'disable_store_manifest',
-      kind: 'scalar',
-      T: ScalarType.BOOL,
-    },
-    { no: 7, name: 'fetch_concurrency', kind: 'scalar', T: ScalarType.UINT32 },
-    { no: 8, name: 'fetch_backoff', kind: 'message', T: () => Backoff },
-    { no: 9, name: 'exec_backoff', kind: 'message', T: () => Backoff },
-    {
-      no: 10,
-      name: 'disable_copy_manifest',
-      kind: 'scalar',
-      T: ScalarType.BOOL,
-    },
-    { no: 11, name: 'verbose', kind: 'scalar', T: ScalarType.BOOL },
-    {
-      no: 12,
-      name: 'platform_selection_policies',
-      kind: 'message',
-      T: () => PlatformSelectionPolicy,
-      repeated: true,
-    },
-    {
-      no: 13,
-      name: 'no_copy_bucket_ids',
-      kind: 'scalar',
-      T: ScalarType.STRING,
-      repeated: true,
-    },
-    { no: 14, name: 'instance_key', kind: 'scalar', T: ScalarType.STRING },
-    {
-      no: 15,
-      name: 'startup_wait_budget_dur',
-      kind: 'scalar',
-      T: ScalarType.STRING,
-    },
-    {
-      no: 16,
-      name: 'materializer_plugin_id',
-      kind: 'scalar',
-      T: ScalarType.STRING,
-    },
-    {
-      no: 17,
-      name: 'update_guard_plugin_ids',
-      kind: 'scalar',
-      T: ScalarType.STRING,
-      repeated: true,
-    },
-  ] satisfies readonly PartialFieldInfo[],
-  packedByDefault: true,
-})
+    typeName: "plugin.host.scheduler.Config",
+    fields: [
+        { no: 1, name: "engine_id", kind: "scalar", T: ScalarType.STRING },
+        { no: 2, name: "object_key", kind: "scalar", T: ScalarType.STRING },
+        { no: 3, name: "peer_id", kind: "scalar", T: ScalarType.STRING },
+        { no: 4, name: "volume_id", kind: "scalar", T: ScalarType.STRING },
+        { no: 5, name: "watch_fetch_manifest", kind: "scalar", T: ScalarType.BOOL },
+        { no: 6, name: "disable_store_manifest", kind: "scalar", T: ScalarType.BOOL },
+        { no: 7, name: "fetch_concurrency", kind: "scalar", T: ScalarType.UINT32 },
+        { no: 8, name: "fetch_backoff", kind: "message", T: () => Backoff },
+        { no: 9, name: "exec_backoff", kind: "message", T: () => Backoff },
+        { no: 10, name: "disable_copy_manifest", kind: "scalar", T: ScalarType.BOOL },
+        { no: 11, name: "verbose", kind: "scalar", T: ScalarType.BOOL },
+        { no: 12, name: "platform_selection_policies", kind: "message", T: () => PlatformSelectionPolicy, repeated: true },
+        { no: 13, name: "no_copy_bucket_ids", kind: "scalar", T: ScalarType.STRING, repeated: true },
+        { no: 14, name: "instance_key", kind: "scalar", T: ScalarType.STRING },
+        { no: 15, name: "startup_wait_budget_dur", kind: "scalar", T: ScalarType.STRING },
+        { no: 16, name: "materializer_plugin_id", kind: "scalar", T: ScalarType.STRING },
+        { no: 17, name: "update_guard_plugin_ids", kind: "scalar", T: ScalarType.STRING, repeated: true },
+        { no: 18, name: "host_storage_id", kind: "scalar", T: ScalarType.STRING },
+    ] satisfies readonly PartialFieldInfo[],
+    packedByDefault: true,
+});

--- a/bldr/plugin/host/scheduler/config.proto
+++ b/bldr/plugin/host/scheduler/config.proto
@@ -67,6 +67,11 @@ message Config {
   // UpdateGuardPluginIds require a successful UpdateGuard.Prepare call on the
   // running generation before a different executable replaces it.
   repeated string update_guard_plugin_ids = 17;
+  // HostStorageId selects the Storage ID on the plugin host bus that plugin
+  // instance volumes allocate through. Empty keeps the host default storage.
+  // Top-level plugins leave this unset; instance-scoped runtimes set it to
+  // route the instance's volumes through host-owned storage.
+  string host_storage_id = 18;
 }
 
 // PlatformSelectionPolicy restricts a plugin host platform to a plugin ID list.

--- a/bldr/plugin/host/scheduler/controller.go
+++ b/bldr/plugin/host/scheduler/controller.go
@@ -479,6 +479,7 @@ func (c *Controller) buildPluginMux(
 		c.conf.GetInstanceKey(),
 		manifest,
 		proxyHostVolInfo,
+		c.conf.GetHostStorageId(),
 	))
 
 	// register plugin dist fs service

--- a/bldr/plugin/host/scheduler/fetch-world-manifest_test.go
+++ b/bldr/plugin/host/scheduler/fetch-world-manifest_test.go
@@ -2257,7 +2257,7 @@ func TestExecPluginReadsExternalManifestViaLookupBlockFromNetwork(t *testing.T) 
 	}
 
 	host := &releaseCDNRuntimePluginHost{
-		testPluginHost: testPluginHost{id: "desktop/darwin/arm64"},
+		id: "desktop/darwin/arm64",
 	}
 	hostCtrl := plugin_host_controller.NewController(
 		le,

--- a/bldr/plugin/host/storage/storage.go
+++ b/bldr/plugin/host/storage/storage.go
@@ -11,11 +11,14 @@ import (
 )
 
 // PluginHostStorage provides storage via the plugin host.
-type PluginHostStorage struct{}
+type PluginHostStorage struct {
+	// storageID selects the host provider; empty selects its default.
+	storageID string
+}
 
 // NewPluginHostStorage constructs the storage.
-func NewPluginHostStorage() *PluginHostStorage {
-	return &PluginHostStorage{}
+func NewPluginHostStorage(storageID string) *PluginHostStorage {
+	return &PluginHostStorage{storageID: storageID}
 }
 
 // GetStorageInfo returns StorageInfo.
@@ -33,7 +36,11 @@ func (s *PluginHostStorage) AddFactories(b bus.Bus, sr *static.Resolver) {
 // Returns nil if the storage cannot produce Volume.
 // baseVolCtrlConf can be nil
 func (s *PluginHostStorage) BuildVolumeConfig(id string, baseVolCtrlConf *volume_controller.Config) (config.Config, error) {
-	return &plugin_host_storage_volume.Config{StorageVolumeId: id, VolumeConfig: baseVolCtrlConf}, nil
+	return &plugin_host_storage_volume.Config{
+		StorageId:       s.storageID,
+		StorageVolumeId: id,
+		VolumeConfig:    baseVolCtrlConf,
+	}, nil
 }
 
 // DeleteVolume is not supported for plugin host storage.

--- a/bldr/plugin/host/storage/storage_test.go
+++ b/bldr/plugin/host/storage/storage_test.go
@@ -1,0 +1,137 @@
+package plugin_host_storage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aperturerobotics/controllerbus/controller"
+	configset_controller "github.com/aperturerobotics/controllerbus/controller/configset/controller"
+	"github.com/aperturerobotics/starpc/srpc"
+	"github.com/s4wave/spacewave/bldr/core"
+	bldr_plugin "github.com/s4wave/spacewave/bldr/plugin"
+	plugin_host "github.com/s4wave/spacewave/bldr/plugin/host"
+	plugin_host_configset "github.com/s4wave/spacewave/bldr/plugin/host/configset"
+	"github.com/s4wave/spacewave/bldr/storage"
+	storage_controller "github.com/s4wave/spacewave/bldr/storage/controller"
+	storage_inmem "github.com/s4wave/spacewave/bldr/storage/inmem"
+	storage_volume "github.com/s4wave/spacewave/bldr/storage/volume"
+	"github.com/s4wave/spacewave/db/block"
+	"github.com/s4wave/spacewave/db/volume"
+	volume_controller "github.com/s4wave/spacewave/db/volume/controller"
+	volume_rpc_server "github.com/s4wave/spacewave/db/volume/rpc/server"
+	bifrost_rpc "github.com/s4wave/spacewave/net/rpc"
+	"github.com/sirupsen/logrus"
+)
+
+// TestSelectedHostStorage isolates identical volume names over the real plugin
+// configset and Volume RPC path, including an unresolved provider selection.
+func TestSelectedHostStorage(t *testing.T) {
+	// Build the host with two distinct providers and a default provider.
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+	le := logrus.NewEntry(logrus.New())
+	hostBus, hostResolver, err := core.NewCoreBus(ctx, le)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hostResolver.AddFactory(volume_rpc_server.NewFactory(hostBus))
+	configSet, err := configset_controller.NewController(le, hostBus)
+	if err != nil {
+		t.Fatal(err)
+	}
+	release, err := hostBus.AddController(ctx, configSet, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(release)
+	for _, id := range []string{"default", "left/app", "right/app"} {
+		release, err := hostBus.AddController(ctx, storage_inmem.NewController(id), nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(release)
+	}
+
+	// Give each plugin its own bus and the ordinary host RPC transport.
+	mount := func(storageID string) (volume.Controller, error) {
+		t.Helper()
+		pluginBus, pluginResolver, err := core.NewCoreBus(ctx, le)
+		if err != nil {
+			return nil, err
+		}
+		pluginResolver.AddFactory(plugin_host_configset.NewFactory(pluginBus))
+		selected := NewPluginHostStorage(storageID)
+		selected.AddFactories(pluginBus, pluginResolver)
+		info := controller.NewInfo("test/plugin-storage", controller.MustParseVersion("0.0.1"), "")
+		storageCtrl := storage_controller.BuildStorageController("default", []storage.Storage{selected}, info)
+		release, err := pluginBus.AddController(ctx, storageCtrl, nil)
+		if err != nil {
+			return nil, err
+		}
+		t.Cleanup(release)
+		mux := srpc.NewMux(bifrost_rpc.NewInvoker(hostBus, "", true))
+		server := plugin_host.NewPluginHostServer(ctx, hostBus, le, "test-plugin", storageID, nil, nil, storageID)
+		if err := bldr_plugin.SRPCRegisterPluginHost(mux, server); err != nil {
+			return nil, err
+		}
+		client := srpc.NewClient(srpc.NewServerPipe(srpc.NewServer(mux)))
+		rpcCtrl := bifrost_rpc.NewClientController(le, pluginBus, info, client, []string{bldr_plugin.HostServiceIDPrefix})
+		release, err = pluginBus.AddController(ctx, rpcCtrl, nil)
+		if err != nil {
+			return nil, err
+		}
+		t.Cleanup(release)
+		vol, ref, err := storage_volume.ExecVolumeController(ctx, pluginBus, &storage_volume.Config{
+			StorageId:       "default",
+			StorageVolumeId: "same/account",
+			VolumeConfig:    &volume_controller.Config{GcIntervalDur: "0"},
+		})
+		if err != nil {
+			return nil, err
+		}
+		t.Cleanup(ref.Release)
+		return vol, nil
+	}
+
+	// Equal names in different selected providers have separate identities and data.
+	volumes := make([]volume.Volume, 0, 3)
+	for _, id := range []string{"", "left/app", "right/app"} {
+		ctrl, err := mount(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		vol, err := ctrl.GetVolume(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		volumes = append(volumes, vol)
+	}
+	ref, _, err := volumes[1].PutBlock(ctx, []byte("left-only"), &block.PutOpts{Sync: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, vol := range volumes {
+		found, err := vol.GetBlockExists(ctx, ref)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if found != (i == 1) {
+			t.Fatalf("provider %d block visibility = %v", i, found)
+		}
+		if i != 1 && vol.GetPeerID() == volumes[1].GetPeerID() {
+			t.Fatalf("provider %d shares the selected provider identity", i)
+		}
+	}
+
+	// An unknown explicit provider stays pending and observes cancellation.
+	missing, err := mount("missing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitCtx, stop := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer stop()
+	if vol, err := missing.GetVolume(waitCtx); err == nil || vol != nil {
+		t.Fatalf("missing provider returned volume %v, error %v", vol, err)
+	}
+}

--- a/bldr/plugin/host/storage/volume/controller.go
+++ b/bldr/plugin/host/storage/volume/controller.go
@@ -2,6 +2,7 @@ package bldr_plugin_host_storage_volume
 
 import (
 	"context"
+	"encoding/base64"
 
 	"github.com/aperturerobotics/controllerbus/bus"
 	"github.com/aperturerobotics/controllerbus/controller"
@@ -65,7 +66,13 @@ func NewFactory(b bus.Bus) controller.Factory {
 func (c *Controller) Execute(ctx context.Context) error {
 	// Start the storage volume on the plugin host.
 	storageVolumeID := c.GetConfig().GetStorageVolumeId()
-	hostVolumeID := "sv-" + storageVolumeID
+	hostStorageID := c.GetConfig().GetStorageId()
+	if hostStorageID == "" {
+		hostStorageID = "default"
+	}
+	hostName := base64.RawURLEncoding.EncodeToString([]byte(hostStorageID)) + "/" +
+		base64.RawURLEncoding.EncodeToString([]byte(storageVolumeID))
+	hostVolumeID := "sv-" + hostName
 
 	hostVolumeConf := c.GetConfig().GetVolumeConfig().CloneVT()
 	if hostVolumeConf == nil {
@@ -77,12 +84,6 @@ func (c *Controller) Execute(ctx context.Context) error {
 	hostVolumeConf.DisablePeer = true
 	hostVolumeConf.DisableEventBlockRm = true
 
-	// Host storage ID defaults
-	hostStorageID := c.GetConfig().GetStorageId()
-	if hostStorageID == "" {
-		hostStorageID = "default"
-	}
-
 	// Start via the plugin host.
 	hostStorageVolumeConf := &storage_volume.Config{
 		StorageId:       hostStorageID,
@@ -93,7 +94,7 @@ func (c *Controller) Execute(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	hostStorageVolumeServiceID := storageVolumeID + "/" + volume_rpc.SRPCAccessVolumesServiceID
+	hostStorageVolumeServiceID := hostName + "/" + volume_rpc.SRPCAccessVolumesServiceID
 	hostStorageVolumeRpcServerConf := &volume_rpc_server.Config{
 		ServiceId:        hostStorageVolumeServiceID,
 		VolumeIdList:     []string{hostVolumeID},

--- a/bldr/plugin/plugin.pb.go
+++ b/bldr/plugin/plugin.pb.go
@@ -169,6 +169,10 @@ type GetPluginInfoResponse struct {
 	HostVolumeInfo *volume.VolumeInfo `protobuf:"bytes,3,opt,name=host_volume_info,json=hostVolumeInfo,proto3" json:"hostVolumeInfo,omitempty"`
 	// Standalone reports that no PluginHost Resource graph is available.
 	Standalone bool `protobuf:"varint,4,opt,name=standalone,proto3" json:"standalone,omitempty"`
+	// HostStorageId is the Storage ID on the plugin host bus that this plugin
+	// instance allocates named volumes through. Empty selects the host default
+	// storage.
+	HostStorageId string `protobuf:"bytes,5,opt,name=host_storage_id,json=hostStorageId,proto3" json:"hostStorageId,omitempty"`
 }
 
 func (x *GetPluginInfoResponse) Reset() {
@@ -203,6 +207,13 @@ func (x *GetPluginInfoResponse) GetStandalone() bool {
 		return x.Standalone
 	}
 	return false
+}
+
+func (x *GetPluginInfoResponse) GetHostStorageId() string {
+	if x != nil {
+		return x.HostStorageId
+	}
+	return ""
 }
 
 // LoadPluginRequest is a request to load a plugin while the RPC is active.
@@ -441,6 +452,7 @@ func (m *GetPluginInfoResponse) CloneVT() *GetPluginInfoResponse {
 	r := new(GetPluginInfoResponse)
 	r.PluginId = m.PluginId
 	r.Standalone = m.Standalone
+	r.HostStorageId = m.HostStorageId
 	r.ManifestRef = protobuf_go_lite.CloneVTValue(m.ManifestRef)
 	r.HostVolumeInfo = protobuf_go_lite.CloneVTValue(m.HostVolumeInfo)
 	if len(m.unknownFields) > 0 {
@@ -641,6 +653,9 @@ func (this *GetPluginInfoResponse) EqualVT(that *GetPluginInfoResponse) bool {
 		return false
 	}
 	if this.Standalone != that.Standalone {
+		return false
+	}
+	if this.HostStorageId != that.HostStorageId {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -1016,6 +1031,11 @@ func (x *GetPluginInfoResponse) MarshalProtoJSON(s *json.MarshalState) {
 		s.WriteObjectField("standalone")
 		s.WriteBool(x.Standalone)
 	}
+	if x.HostStorageId != "" || s.HasField("hostStorageId") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("hostStorageId")
+		s.WriteString(x.HostStorageId)
+	}
 	s.WriteObjectEnd()
 }
 
@@ -1053,6 +1073,9 @@ func (x *GetPluginInfoResponse) UnmarshalProtoJSON(s *json.UnmarshalState) {
 		case "standalone":
 			s.AddField("standalone")
 			x.Standalone = s.ReadBool()
+		case "host_storage_id", "hostStorageId":
+			s.AddField("host_storage_id")
+			x.HostStorageId = s.ReadString()
 		}
 	})
 }
@@ -1520,6 +1543,11 @@ func (m *GetPluginInfoResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error)
 	if m.unknownFields != nil {
 		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
 	}
+	if len(m.HostStorageId) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.HostStorageId)
+		i--
+		dAtA[i] = 0x2a
+	}
 	if m.Standalone {
 		i = protobuf_go_lite.EncodeBool(dAtA, i, m.Standalone)
 		i--
@@ -1843,6 +1871,7 @@ func (m *GetPluginInfoResponse) SizeVT() (n int) {
 		n += protobuf_go_lite.SizeMessage(1, l)
 	}
 	n += protobuf_go_lite.SizeBoolNonZero(1, m.Standalone)
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.HostStorageId)
 	n += len(m.unknownFields)
 	return n
 }
@@ -2000,6 +2029,10 @@ func (x *GetPluginInfoResponse) MarshalProtoText() string {
 	if x.Standalone != false {
 		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "standalone")
 		protobuf_go_lite.TextWriteBool(&sb, x.Standalone)
+	}
+	if x.HostStorageId != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "host_storage_id")
+		protobuf_go_lite.TextWriteString(&sb, x.HostStorageId)
 	}
 	return protobuf_go_lite.TextFinishMessage(&sb)
 }
@@ -2410,6 +2443,16 @@ func (m *GetPluginInfoResponse) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			m.Standalone = bool(v)
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field HostStorageId", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.HostStorageId = v
 		default:
 			iNdEx = preIndex
 			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])

--- a/bldr/plugin/plugin.pb.ts
+++ b/bldr/plugin/plugin.pb.ts
@@ -2,19 +2,16 @@
 // @generated from file github.com/s4wave/spacewave/bldr/plugin/plugin.proto (package bldr.plugin, syntax proto3)
 /* eslint-disable */
 
-import { createEnumType } from '@aptre/protobuf-es-lite/enum'
-import type { MessageType } from '@aptre/protobuf-es-lite/message'
-import {
-  createEmptyMessageType,
-  createMessageType,
-} from '@aptre/protobuf-es-lite/message'
-import { ScalarType } from '@aptre/protobuf-es-lite/scalar'
-import { Timestamp } from '@aptre/protobuf-es-lite/google/protobuf/timestamp'
-import type { PartialFieldInfo } from '@aptre/protobuf-es-lite/field'
-import { ManifestRef } from '../manifest/manifest.pb.js'
-import { VolumeInfo } from '@go/github.com/s4wave/spacewave/db/volume/volume.pb.js'
+import { createEnumType } from "@aptre/protobuf-es-lite/enum";
+import type { MessageType } from "@aptre/protobuf-es-lite/message";
+import { createEmptyMessageType, createMessageType } from "@aptre/protobuf-es-lite/message";
+import { ScalarType } from "@aptre/protobuf-es-lite/scalar";
+import { Timestamp } from "@aptre/protobuf-es-lite/google/protobuf/timestamp";
+import type { PartialFieldInfo } from "@aptre/protobuf-es-lite/field";
+import { ManifestRef } from "../manifest/manifest.pb.js";
+import { VolumeInfo } from "@go/github.com/s4wave/spacewave/db/volume/volume.pb.js";
 
-export const protobufPackage = 'bldr.plugin'
+export const protobufPackage = "bldr.plugin";
 
 /**
  * PluginState is the scheduler state for a plugin instance.
@@ -44,14 +41,11 @@ export enum PluginState {
   PluginState_RUNNING = 2,
 }
 
-export const PluginState_Enum = /* @__PURE__ */ createEnumType(
-  'bldr.plugin.PluginState',
-  [
-    [0, 'PluginState_UNKNOWN'],
-    [1, 'PluginState_REQUESTED'],
-    [2, 'PluginState_RUNNING'],
-  ],
-)
+export const PluginState_Enum = /* @__PURE__ */ createEnumType("bldr.plugin.PluginState", [
+  [0, "PluginState_UNKNOWN"],
+  [1, "PluginState_REQUESTED"],
+  [2, "PluginState_RUNNING"],
+]);
 
 /**
  * PluginStatus holds basic status for a plugin.
@@ -64,96 +58,85 @@ export interface PluginStatus {
    *
    * @generated from field: string plugin_id = 1;
    */
-  pluginId?: string
+  pluginId?: string;
   /**
    * Running indicates the plugin is running.
    *
    * @generated from field: bool running = 2;
    */
-  running?: boolean
+  running?: boolean;
   /**
    * InstanceKey is the optional instance key for instanced plugins.
    *
    * @generated from field: string instance_key = 3;
    */
-  instanceKey?: string
+  instanceKey?: string;
   /**
    * State is the scheduler state for this plugin instance.
    *
    * @generated from field: bldr.plugin.PluginState state = 4;
    */
-  state?: PluginState
+  state?: PluginState;
   /**
    * LastErrorMessage is the most recent plugin execution error summary.
    *
    * @generated from field: string last_error_message = 5;
    */
-  lastErrorMessage?: string
+  lastErrorMessage?: string;
   /**
    * LastErrorAt is when LastErrorMessage was recorded.
    *
    * @generated from field: google.protobuf.Timestamp last_error_at = 6;
    */
-  lastErrorAt?: Date
-}
+  lastErrorAt?: Date;
 
-export const PluginStatus: MessageType<PluginStatus> =
-  /* @__PURE__ */ createMessageType({
-    typeName: 'bldr.plugin.PluginStatus',
+};
+
+export const PluginStatus: MessageType<PluginStatus> = /* @__PURE__ */ createMessageType({
+    typeName: "bldr.plugin.PluginStatus",
     fields: [
-      { no: 1, name: 'plugin_id', kind: 'scalar', T: ScalarType.STRING },
-      { no: 2, name: 'running', kind: 'scalar', T: ScalarType.BOOL },
-      { no: 3, name: 'instance_key', kind: 'scalar', T: ScalarType.STRING },
-      { no: 4, name: 'state', kind: 'enum', T: PluginState_Enum },
-      {
-        no: 5,
-        name: 'last_error_message',
-        kind: 'scalar',
-        T: ScalarType.STRING,
-      },
-      { no: 6, name: 'last_error_at', kind: 'message', T: () => Timestamp },
+        { no: 1, name: "plugin_id", kind: "scalar", T: ScalarType.STRING },
+        { no: 2, name: "running", kind: "scalar", T: ScalarType.BOOL },
+        { no: 3, name: "instance_key", kind: "scalar", T: ScalarType.STRING },
+        { no: 4, name: "state", kind: "enum", T: PluginState_Enum },
+        { no: 5, name: "last_error_message", kind: "scalar", T: ScalarType.STRING },
+        { no: 6, name: "last_error_at", kind: "message", T: () => Timestamp },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,
-  })
+});
 
 /**
  * PrepareUpdateRequest asks the current generation to relinquish its work.
  *
  * @generated from message bldr.plugin.PrepareUpdateRequest
  */
-export interface PrepareUpdateRequest {}
+export interface PrepareUpdateRequest {
 
-export const PrepareUpdateRequest: MessageType<PrepareUpdateRequest> =
-  /* @__PURE__ */ createEmptyMessageType<PrepareUpdateRequest>(
-    'bldr.plugin.PrepareUpdateRequest',
-    true,
-  )
+};
+
+export const PrepareUpdateRequest: MessageType<PrepareUpdateRequest> = /* @__PURE__ */ createEmptyMessageType<PrepareUpdateRequest>("bldr.plugin.PrepareUpdateRequest", true);
 
 /**
  * PrepareUpdateResponse confirms the generation is ready for replacement.
  *
  * @generated from message bldr.plugin.PrepareUpdateResponse
  */
-export interface PrepareUpdateResponse {}
+export interface PrepareUpdateResponse {
 
-export const PrepareUpdateResponse: MessageType<PrepareUpdateResponse> =
-  /* @__PURE__ */ createEmptyMessageType<PrepareUpdateResponse>(
-    'bldr.plugin.PrepareUpdateResponse',
-    true,
-  )
+};
+
+export const PrepareUpdateResponse: MessageType<PrepareUpdateResponse> = /* @__PURE__ */ createEmptyMessageType<PrepareUpdateResponse>("bldr.plugin.PrepareUpdateResponse", true);
 
 /**
  * GetPluginInfoRequest is a request to return the information for the current plugin.
  *
  * @generated from message bldr.plugin.GetPluginInfoRequest
  */
-export interface GetPluginInfoRequest {}
+export interface GetPluginInfoRequest {
 
-export const GetPluginInfoRequest: MessageType<GetPluginInfoRequest> =
-  /* @__PURE__ */ createEmptyMessageType<GetPluginInfoRequest>(
-    'bldr.plugin.GetPluginInfoRequest',
-    true,
-  )
+};
+
+export const GetPluginInfoRequest: MessageType<GetPluginInfoRequest> = /* @__PURE__ */ createEmptyMessageType<GetPluginInfoRequest>("bldr.plugin.GetPluginInfoRequest", true);
 
 /**
  * GetPluginInfoResponse is the response to the GetPluginInfo request.
@@ -166,39 +149,48 @@ export interface GetPluginInfoResponse {
    *
    * @generated from field: string plugin_id = 1;
    */
-  pluginId?: string
+  pluginId?: string;
   /**
    * ManifestRef is the reference to the Manifest object.
    *
    * @generated from field: bldr.manifest.ManifestRef manifest_ref = 2;
    */
-  manifestRef?: ManifestRef
+  manifestRef?: ManifestRef;
   /**
    * HostVolumeInfo is the optional information for the host Volume.
    * The volume is exposed with a ProxyVolume when present.
    *
    * @generated from field: volume.VolumeInfo host_volume_info = 3;
    */
-  hostVolumeInfo?: VolumeInfo
+  hostVolumeInfo?: VolumeInfo;
   /**
    * Standalone reports that no PluginHost Resource graph is available.
    *
    * @generated from field: bool standalone = 4;
    */
-  standalone?: boolean
-}
+  standalone?: boolean;
+  /**
+   * HostStorageId is the Storage ID on the plugin host bus that this plugin
+   * instance allocates named volumes through. Empty selects the host default
+   * storage.
+   *
+   * @generated from field: string host_storage_id = 5;
+   */
+  hostStorageId?: string;
 
-export const GetPluginInfoResponse: MessageType<GetPluginInfoResponse> =
-  /* @__PURE__ */ createMessageType({
-    typeName: 'bldr.plugin.GetPluginInfoResponse',
+};
+
+export const GetPluginInfoResponse: MessageType<GetPluginInfoResponse> = /* @__PURE__ */ createMessageType({
+    typeName: "bldr.plugin.GetPluginInfoResponse",
     fields: [
-      { no: 1, name: 'plugin_id', kind: 'scalar', T: ScalarType.STRING },
-      { no: 2, name: 'manifest_ref', kind: 'message', T: () => ManifestRef },
-      { no: 3, name: 'host_volume_info', kind: 'message', T: () => VolumeInfo },
-      { no: 4, name: 'standalone', kind: 'scalar', T: ScalarType.BOOL },
+        { no: 1, name: "plugin_id", kind: "scalar", T: ScalarType.STRING },
+        { no: 2, name: "manifest_ref", kind: "message", T: () => ManifestRef },
+        { no: 3, name: "host_volume_info", kind: "message", T: () => VolumeInfo },
+        { no: 4, name: "standalone", kind: "scalar", T: ScalarType.BOOL },
+        { no: 5, name: "host_storage_id", kind: "scalar", T: ScalarType.STRING },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,
-  })
+});
 
 /**
  * LoadPluginRequest is a request to load a plugin while the RPC is active.
@@ -211,7 +203,7 @@ export interface LoadPluginRequest {
    *
    * @generated from field: string plugin_id = 1;
    */
-  pluginId?: string
+  pluginId?: string;
   /**
    * InstanceKey is an optional key for instanced plugins.
    * When non-empty, the plugin host uses (plugin_id, instance_key) as the
@@ -221,18 +213,18 @@ export interface LoadPluginRequest {
    *
    * @generated from field: string instance_key = 2;
    */
-  instanceKey?: string
-}
+  instanceKey?: string;
 
-export const LoadPluginRequest: MessageType<LoadPluginRequest> =
-  /* @__PURE__ */ createMessageType({
-    typeName: 'bldr.plugin.LoadPluginRequest',
+};
+
+export const LoadPluginRequest: MessageType<LoadPluginRequest> = /* @__PURE__ */ createMessageType({
+    typeName: "bldr.plugin.LoadPluginRequest",
     fields: [
-      { no: 1, name: 'plugin_id', kind: 'scalar', T: ScalarType.STRING },
-      { no: 2, name: 'instance_key', kind: 'scalar', T: ScalarType.STRING },
+        { no: 1, name: "plugin_id", kind: "scalar", T: ScalarType.STRING },
+        { no: 2, name: "instance_key", kind: "scalar", T: ScalarType.STRING },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,
-  })
+});
 
 /**
  * LoadPluginResponse is a status response to a LoadPlugin request.
@@ -245,17 +237,17 @@ export interface LoadPluginResponse {
    *
    * @generated from field: bldr.plugin.PluginStatus plugin_status = 1;
    */
-  pluginStatus?: PluginStatus
-}
+  pluginStatus?: PluginStatus;
 
-export const LoadPluginResponse: MessageType<LoadPluginResponse> =
-  /* @__PURE__ */ createMessageType({
-    typeName: 'bldr.plugin.LoadPluginResponse',
+};
+
+export const LoadPluginResponse: MessageType<LoadPluginResponse> = /* @__PURE__ */ createMessageType({
+    typeName: "bldr.plugin.LoadPluginResponse",
     fields: [
-      { no: 1, name: 'plugin_status', kind: 'message', T: () => PluginStatus },
+        { no: 1, name: "plugin_status", kind: "message", T: () => PluginStatus },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,
-  })
+});
 
 /**
  * PluginMeta is metadata embedded in a plugin entrypoint.
@@ -269,39 +261,39 @@ export interface PluginMeta {
    *
    * @generated from field: string project_id = 1;
    */
-  projectId?: string
+  projectId?: string;
   /**
    * PluginId is the plugin identifier.
    * Must be a valid-dns-label.
    *
    * @generated from field: string plugin_id = 2;
    */
-  pluginId?: string
+  pluginId?: string;
   /**
    * PlatformId is the destination platform ID.
    *
    * @generated from field: string platform_id = 3;
    */
-  platformId?: string
+  platformId?: string;
   /**
    * BuildType is the type of build this is.
    *
    * @generated from field: string build_type = 4;
    */
-  buildType?: string
-}
+  buildType?: string;
 
-export const PluginMeta: MessageType<PluginMeta> =
-  /* @__PURE__ */ createMessageType({
-    typeName: 'bldr.plugin.PluginMeta',
+};
+
+export const PluginMeta: MessageType<PluginMeta> = /* @__PURE__ */ createMessageType({
+    typeName: "bldr.plugin.PluginMeta",
     fields: [
-      { no: 1, name: 'project_id', kind: 'scalar', T: ScalarType.STRING },
-      { no: 2, name: 'plugin_id', kind: 'scalar', T: ScalarType.STRING },
-      { no: 3, name: 'platform_id', kind: 'scalar', T: ScalarType.STRING },
-      { no: 4, name: 'build_type', kind: 'scalar', T: ScalarType.STRING },
+        { no: 1, name: "project_id", kind: "scalar", T: ScalarType.STRING },
+        { no: 2, name: "plugin_id", kind: "scalar", T: ScalarType.STRING },
+        { no: 3, name: "platform_id", kind: "scalar", T: ScalarType.STRING },
+        { no: 4, name: "build_type", kind: "scalar", T: ScalarType.STRING },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,
-  })
+});
 
 /**
  * PluginStartInfo are details passed to the plugin by the plugin host in the environment.
@@ -314,33 +306,33 @@ export interface PluginStartInfo {
    *
    * @generated from field: string instance_id = 1;
    */
-  instanceId?: string
+  instanceId?: string;
   /**
    * PluginId is the plugin identifier.
    * Must be a valid-dns-label.
    *
    * @generated from field: string plugin_id = 2;
    */
-  pluginId?: string
+  pluginId?: string;
   /**
    * InstanceKey is the instance key from the LoadPlugin request.
    * Empty for non-instanced (shared) plugins.
    *
    * @generated from field: string instance_key = 3;
    */
-  instanceKey?: string
-}
+  instanceKey?: string;
 
-export const PluginStartInfo: MessageType<PluginStartInfo> =
-  /* @__PURE__ */ createMessageType({
-    typeName: 'bldr.plugin.PluginStartInfo',
+};
+
+export const PluginStartInfo: MessageType<PluginStartInfo> = /* @__PURE__ */ createMessageType({
+    typeName: "bldr.plugin.PluginStartInfo",
     fields: [
-      { no: 1, name: 'instance_id', kind: 'scalar', T: ScalarType.STRING },
-      { no: 2, name: 'plugin_id', kind: 'scalar', T: ScalarType.STRING },
-      { no: 3, name: 'instance_key', kind: 'scalar', T: ScalarType.STRING },
+        { no: 1, name: "instance_id", kind: "scalar", T: ScalarType.STRING },
+        { no: 2, name: "plugin_id", kind: "scalar", T: ScalarType.STRING },
+        { no: 3, name: "instance_key", kind: "scalar", T: ScalarType.STRING },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,
-  })
+});
 
 /**
  * PluginContextInfo contains information about the running plugin attached to
@@ -354,14 +346,14 @@ export interface PluginContextInfo {
    *
    * @generated from field: bldr.plugin.PluginMeta plugin_meta = 1;
    */
-  pluginMeta?: PluginMeta
-}
+  pluginMeta?: PluginMeta;
 
-export const PluginContextInfo: MessageType<PluginContextInfo> =
-  /* @__PURE__ */ createMessageType({
-    typeName: 'bldr.plugin.PluginContextInfo',
+};
+
+export const PluginContextInfo: MessageType<PluginContextInfo> = /* @__PURE__ */ createMessageType({
+    typeName: "bldr.plugin.PluginContextInfo",
     fields: [
-      { no: 1, name: 'plugin_meta', kind: 'message', T: () => PluginMeta },
+        { no: 1, name: "plugin_meta", kind: "message", T: () => PluginMeta },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,
-  })
+});

--- a/bldr/plugin/plugin.proto
+++ b/bldr/plugin/plugin.proto
@@ -97,6 +97,10 @@ message GetPluginInfoResponse {
   .volume.VolumeInfo host_volume_info = 3;
   // Standalone reports that no PluginHost Resource graph is available.
   bool standalone = 4;
+  // HostStorageId is the Storage ID on the plugin host bus that this plugin
+  // instance allocates named volumes through. Empty selects the host default
+  // storage.
+  string host_storage_id = 5;
 }
 
 

--- a/bldr/plugin/plugin_srpc.pb.ts
+++ b/bldr/plugin/plugin_srpc.pb.ts
@@ -2,27 +2,11 @@
 // @generated from file github.com/s4wave/spacewave/bldr/plugin/plugin.proto (package bldr.plugin, syntax proto3)
 /* eslint-disable */
 
-import {
-  GetPluginInfoRequest,
-  GetPluginInfoResponse,
-  LoadPluginRequest,
-  LoadPluginResponse,
-  PrepareUpdateRequest,
-  PrepareUpdateResponse,
-} from './plugin.pb.js'
-import { MethodKind } from '@aptre/protobuf-es-lite'
-import {
-  ExecControllerRequest,
-  ExecControllerResponse,
-} from '@go/github.com/aperturerobotics/controllerbus/controller/exec/exec.pb.js'
-import { RpcStreamPacket } from '@go/github.com/aperturerobotics/starpc/rpcstream/rpcstream.pb.js'
-import {
-  buildDecodeMessageTransform,
-  buildEncodeMessageTransform,
-  MessageStream,
-  ProtoRpc,
-  ServerContext,
-} from 'starpc'
+import { GetPluginInfoRequest, GetPluginInfoResponse, LoadPluginRequest, LoadPluginResponse, PrepareUpdateRequest, PrepareUpdateResponse } from "./plugin.pb.js";
+import { MethodKind } from "@aptre/protobuf-es-lite";
+import { ExecControllerRequest, ExecControllerResponse } from "@go/github.com/aperturerobotics/controllerbus/controller/exec/exec.pb.js";
+import { RpcStreamPacket } from "@go/github.com/aperturerobotics/starpc/rpcstream/rpcstream.pb.js";
+import { buildDecodeMessageTransform, buildEncodeMessageTransform, MessageStream, ProtoRpc, ServerContext } from "starpc";
 
 /**
  * PluginHost is the service exposed by the plugin host.
@@ -32,7 +16,7 @@ import {
  * @generated from service bldr.plugin.PluginHost
  */
 export const PluginHostDefinition = {
-  typeName: 'bldr.plugin.PluginHost',
+  typeName: "bldr.plugin.PluginHost",
   methods: {
     /**
      * GetPluginInfo returns the information for the current plugin.
@@ -40,7 +24,7 @@ export const PluginHostDefinition = {
      * @generated from rpc bldr.plugin.PluginHost.GetPluginInfo
      */
     GetPluginInfo: {
-      name: 'GetPluginInfo',
+      name: "GetPluginInfo",
       I: GetPluginInfoRequest,
       O: GetPluginInfoResponse,
       kind: MethodKind.Unary,
@@ -51,7 +35,7 @@ export const PluginHostDefinition = {
      * @generated from rpc bldr.plugin.PluginHost.ExecController
      */
     ExecController: {
-      name: 'ExecController',
+      name: "ExecController",
       I: ExecControllerRequest,
       O: ExecControllerResponse,
       kind: MethodKind.ServerStreaming,
@@ -64,7 +48,7 @@ export const PluginHostDefinition = {
      * @generated from rpc bldr.plugin.PluginHost.LoadPlugin
      */
     LoadPlugin: {
-      name: 'LoadPlugin',
+      name: "LoadPlugin",
       I: LoadPluginRequest,
       O: LoadPluginResponse,
       kind: MethodKind.ServerStreaming,
@@ -77,7 +61,7 @@ export const PluginHostDefinition = {
      * @generated from rpc bldr.plugin.PluginHost.PluginRpc
      */
     PluginRpc: {
-      name: 'PluginRpc',
+      name: "PluginRpc",
       I: RpcStreamPacket,
       O: RpcStreamPacket,
       kind: MethodKind.BiDiStreaming,
@@ -91,13 +75,13 @@ export const PluginHostDefinition = {
      * @generated from rpc bldr.plugin.PluginHost.PluginFsRpc
      */
     PluginFsRpc: {
-      name: 'PluginFsRpc',
+      name: "PluginFsRpc",
       I: RpcStreamPacket,
       O: RpcStreamPacket,
       kind: MethodKind.BiDiStreaming,
     },
-  },
-} as const
+  }
+} as const;
 
 /**
  * PluginHost is the service exposed by the plugin host.
@@ -112,20 +96,14 @@ export interface PluginHost {
    *
    * @generated from rpc bldr.plugin.PluginHost.GetPluginInfo
    */
-  GetPluginInfo(
-    request: GetPluginInfoRequest,
-    abortSignal?: AbortSignal,
-  ): Promise<GetPluginInfoResponse>
+  GetPluginInfo(request: GetPluginInfoRequest, abortSignal?: AbortSignal): Promise<GetPluginInfoResponse>;
 
   /**
    * ExecController executes a controller configuration on the bus.
    *
    * @generated from rpc bldr.plugin.PluginHost.ExecController
    */
-  ExecController(
-    request: ExecControllerRequest,
-    abortSignal?: AbortSignal,
-  ): MessageStream<ExecControllerResponse>
+  ExecController(request: ExecControllerRequest, abortSignal?: AbortSignal): MessageStream<ExecControllerResponse>;
 
   /**
    * LoadPlugin requests to load the plugin with the given ID.
@@ -134,10 +112,7 @@ export interface PluginHost {
    *
    * @generated from rpc bldr.plugin.PluginHost.LoadPlugin
    */
-  LoadPlugin(
-    request: LoadPluginRequest,
-    abortSignal?: AbortSignal,
-  ): MessageStream<LoadPluginResponse>
+  LoadPlugin(request: LoadPluginRequest, abortSignal?: AbortSignal): MessageStream<LoadPluginResponse>;
 
   /**
    * PluginRpc forwards an RPC call to a remote plugin.
@@ -146,10 +121,7 @@ export interface PluginHost {
    *
    * @generated from rpc bldr.plugin.PluginHost.PluginRpc
    */
-  PluginRpc(
-    request: MessageStream<RpcStreamPacket>,
-    abortSignal?: AbortSignal,
-  ): MessageStream<RpcStreamPacket>
+  PluginRpc(request: MessageStream<RpcStreamPacket>, abortSignal?: AbortSignal): MessageStream<RpcStreamPacket>;
 
   /**
    * PluginFsRpc accesses a FSCursorService to access plugin assets or dist filesystems.
@@ -159,10 +131,7 @@ export interface PluginHost {
    *
    * @generated from rpc bldr.plugin.PluginHost.PluginFsRpc
    */
-  PluginFsRpc(
-    request: MessageStream<RpcStreamPacket>,
-    abortSignal?: AbortSignal,
-  ): MessageStream<RpcStreamPacket>
+  PluginFsRpc(request: MessageStream<RpcStreamPacket>, abortSignal?: AbortSignal): MessageStream<RpcStreamPacket>;
 }
 
 /**
@@ -178,22 +147,14 @@ export interface PluginHostHandler {
    *
    * @generated from rpc bldr.plugin.PluginHost.GetPluginInfo
    */
-  GetPluginInfo(
-    request: GetPluginInfoRequest,
-    abortSignal: AbortSignal,
-    context: ServerContext,
-  ): Promise<GetPluginInfoResponse>
+  GetPluginInfo(request: GetPluginInfoRequest, abortSignal: AbortSignal, context: ServerContext): Promise<GetPluginInfoResponse>;
 
   /**
    * ExecController executes a controller configuration on the bus.
    *
    * @generated from rpc bldr.plugin.PluginHost.ExecController
    */
-  ExecController(
-    request: ExecControllerRequest,
-    abortSignal: AbortSignal,
-    context: ServerContext,
-  ): MessageStream<ExecControllerResponse>
+  ExecController(request: ExecControllerRequest, abortSignal: AbortSignal, context: ServerContext): MessageStream<ExecControllerResponse>;
 
   /**
    * LoadPlugin requests to load the plugin with the given ID.
@@ -202,11 +163,7 @@ export interface PluginHostHandler {
    *
    * @generated from rpc bldr.plugin.PluginHost.LoadPlugin
    */
-  LoadPlugin(
-    request: LoadPluginRequest,
-    abortSignal: AbortSignal,
-    context: ServerContext,
-  ): MessageStream<LoadPluginResponse>
+  LoadPlugin(request: LoadPluginRequest, abortSignal: AbortSignal, context: ServerContext): MessageStream<LoadPluginResponse>;
 
   /**
    * PluginRpc forwards an RPC call to a remote plugin.
@@ -215,11 +172,7 @@ export interface PluginHostHandler {
    *
    * @generated from rpc bldr.plugin.PluginHost.PluginRpc
    */
-  PluginRpc(
-    request: MessageStream<RpcStreamPacket>,
-    abortSignal: AbortSignal,
-    context: ServerContext,
-  ): MessageStream<RpcStreamPacket>
+  PluginRpc(request: MessageStream<RpcStreamPacket>, abortSignal: AbortSignal, context: ServerContext): MessageStream<RpcStreamPacket>;
 
   /**
    * PluginFsRpc accesses a FSCursorService to access plugin assets or dist filesystems.
@@ -229,11 +182,7 @@ export interface PluginHostHandler {
    *
    * @generated from rpc bldr.plugin.PluginHost.PluginFsRpc
    */
-  PluginFsRpc(
-    request: MessageStream<RpcStreamPacket>,
-    abortSignal: AbortSignal,
-    context: ServerContext,
-  ): MessageStream<RpcStreamPacket>
+  PluginFsRpc(request: MessageStream<RpcStreamPacket>, abortSignal: AbortSignal, context: ServerContext): MessageStream<RpcStreamPacket>;
 }
 
 export const PluginHostServiceName = PluginHostDefinition.typeName
@@ -255,10 +204,7 @@ export class PluginHostClient implements PluginHost {
    *
    * @generated from rpc bldr.plugin.PluginHost.GetPluginInfo
    */
-  async GetPluginInfo(
-    request: GetPluginInfoRequest,
-    abortSignal?: AbortSignal,
-  ): Promise<GetPluginInfoResponse> {
+  async GetPluginInfo(request: GetPluginInfoRequest, abortSignal?: AbortSignal): Promise<GetPluginInfoResponse> {
     const requestMsg = GetPluginInfoRequest.create(request)
     const result = await this.rpc.request(
       this.service,
@@ -274,10 +220,7 @@ export class PluginHostClient implements PluginHost {
    *
    * @generated from rpc bldr.plugin.PluginHost.ExecController
    */
-  ExecController(
-    request: ExecControllerRequest,
-    abortSignal?: AbortSignal,
-  ): MessageStream<ExecControllerResponse> {
+  ExecController(request: ExecControllerRequest, abortSignal?: AbortSignal): MessageStream<ExecControllerResponse> {
     const requestMsg = ExecControllerRequest.create(request)
     const result = this.rpc.serverStreamingRequest(
       this.service,
@@ -295,10 +238,7 @@ export class PluginHostClient implements PluginHost {
    *
    * @generated from rpc bldr.plugin.PluginHost.LoadPlugin
    */
-  LoadPlugin(
-    request: LoadPluginRequest,
-    abortSignal?: AbortSignal,
-  ): MessageStream<LoadPluginResponse> {
+  LoadPlugin(request: LoadPluginRequest, abortSignal?: AbortSignal): MessageStream<LoadPluginResponse> {
     const requestMsg = LoadPluginRequest.create(request)
     const result = this.rpc.serverStreamingRequest(
       this.service,
@@ -316,10 +256,7 @@ export class PluginHostClient implements PluginHost {
    *
    * @generated from rpc bldr.plugin.PluginHost.PluginRpc
    */
-  PluginRpc(
-    request: MessageStream<RpcStreamPacket>,
-    abortSignal?: AbortSignal,
-  ): MessageStream<RpcStreamPacket> {
+  PluginRpc(request: MessageStream<RpcStreamPacket>, abortSignal?: AbortSignal): MessageStream<RpcStreamPacket> {
     const result = this.rpc.bidirectionalStreamingRequest(
       this.service,
       PluginHostDefinition.methods.PluginRpc.name,
@@ -337,10 +274,7 @@ export class PluginHostClient implements PluginHost {
    *
    * @generated from rpc bldr.plugin.PluginHost.PluginFsRpc
    */
-  PluginFsRpc(
-    request: MessageStream<RpcStreamPacket>,
-    abortSignal?: AbortSignal,
-  ): MessageStream<RpcStreamPacket> {
+  PluginFsRpc(request: MessageStream<RpcStreamPacket>, abortSignal?: AbortSignal): MessageStream<RpcStreamPacket> {
     const result = this.rpc.bidirectionalStreamingRequest(
       this.service,
       PluginHostDefinition.methods.PluginFsRpc.name,
@@ -356,7 +290,7 @@ export class PluginHostClient implements PluginHost {
  * @generated from service bldr.plugin.Plugin
  */
 export const PluginDefinition = {
-  typeName: 'bldr.plugin.Plugin',
+  typeName: "bldr.plugin.Plugin",
   methods: {
     /**
      * PluginRpc handles an RPC call from a remote plugin.
@@ -365,13 +299,13 @@ export const PluginDefinition = {
      * @generated from rpc bldr.plugin.Plugin.PluginRpc
      */
     PluginRpc: {
-      name: 'PluginRpc',
+      name: "PluginRpc",
       I: RpcStreamPacket,
       O: RpcStreamPacket,
       kind: MethodKind.BiDiStreaming,
     },
-  },
-} as const
+  }
+} as const;
 
 /**
  * Plugin is the service exposed by the plugin.
@@ -385,10 +319,7 @@ export interface Plugin {
    *
    * @generated from rpc bldr.plugin.Plugin.PluginRpc
    */
-  PluginRpc(
-    request: MessageStream<RpcStreamPacket>,
-    abortSignal?: AbortSignal,
-  ): MessageStream<RpcStreamPacket>
+  PluginRpc(request: MessageStream<RpcStreamPacket>, abortSignal?: AbortSignal): MessageStream<RpcStreamPacket>;
 }
 
 /**
@@ -403,11 +334,7 @@ export interface PluginHandler {
    *
    * @generated from rpc bldr.plugin.Plugin.PluginRpc
    */
-  PluginRpc(
-    request: MessageStream<RpcStreamPacket>,
-    abortSignal: AbortSignal,
-    context: ServerContext,
-  ): MessageStream<RpcStreamPacket>
+  PluginRpc(request: MessageStream<RpcStreamPacket>, abortSignal: AbortSignal, context: ServerContext): MessageStream<RpcStreamPacket>;
 }
 
 export const PluginServiceName = PluginDefinition.typeName
@@ -426,10 +353,7 @@ export class PluginClient implements Plugin {
    *
    * @generated from rpc bldr.plugin.Plugin.PluginRpc
    */
-  PluginRpc(
-    request: MessageStream<RpcStreamPacket>,
-    abortSignal?: AbortSignal,
-  ): MessageStream<RpcStreamPacket> {
+  PluginRpc(request: MessageStream<RpcStreamPacket>, abortSignal?: AbortSignal): MessageStream<RpcStreamPacket> {
     const result = this.rpc.bidirectionalStreamingRequest(
       this.service,
       PluginDefinition.methods.PluginRpc.name,
@@ -446,7 +370,7 @@ export class PluginClient implements Plugin {
  * @generated from service bldr.plugin.UpdateGuard
  */
 export const UpdateGuardDefinition = {
-  typeName: 'bldr.plugin.UpdateGuard',
+  typeName: "bldr.plugin.UpdateGuard",
   methods: {
     /**
      * Prepare waits for owned work to finish and prevents new work from starting.
@@ -455,13 +379,13 @@ export const UpdateGuardDefinition = {
      * @generated from rpc bldr.plugin.UpdateGuard.Prepare
      */
     Prepare: {
-      name: 'Prepare',
+      name: "Prepare",
       I: PrepareUpdateRequest,
       O: PrepareUpdateResponse,
       kind: MethodKind.Unary,
     },
-  },
-} as const
+  }
+} as const;
 
 /**
  * UpdateGuard is implemented by plugins whose owned work must quiesce before
@@ -476,10 +400,7 @@ export interface UpdateGuard {
    *
    * @generated from rpc bldr.plugin.UpdateGuard.Prepare
    */
-  Prepare(
-    request: PrepareUpdateRequest,
-    abortSignal?: AbortSignal,
-  ): Promise<PrepareUpdateResponse>
+  Prepare(request: PrepareUpdateRequest, abortSignal?: AbortSignal): Promise<PrepareUpdateResponse>;
 }
 
 /**
@@ -495,11 +416,7 @@ export interface UpdateGuardHandler {
    *
    * @generated from rpc bldr.plugin.UpdateGuard.Prepare
    */
-  Prepare(
-    request: PrepareUpdateRequest,
-    abortSignal: AbortSignal,
-    context: ServerContext,
-  ): Promise<PrepareUpdateResponse>
+  Prepare(request: PrepareUpdateRequest, abortSignal: AbortSignal, context: ServerContext): Promise<PrepareUpdateResponse>;
 }
 
 export const UpdateGuardServiceName = UpdateGuardDefinition.typeName
@@ -518,10 +435,7 @@ export class UpdateGuardClient implements UpdateGuard {
    *
    * @generated from rpc bldr.plugin.UpdateGuard.Prepare
    */
-  async Prepare(
-    request: PrepareUpdateRequest,
-    abortSignal?: AbortSignal,
-  ): Promise<PrepareUpdateResponse> {
+  async Prepare(request: PrepareUpdateRequest, abortSignal?: AbortSignal): Promise<PrepareUpdateResponse> {
     const requestMsg = PrepareUpdateRequest.create(request)
     const result = await this.rpc.request(
       this.service,

--- a/core/resource/testbed/testutil.go
+++ b/core/resource/testbed/testutil.go
@@ -284,7 +284,7 @@ func (t *TestbedWithQuickJS) LoadQuickJSPlugin(
 
 	// Register plugin host service for GetPluginInfo etc.
 	manifestSnapshot := &bldr_manifest.ManifestSnapshot{Manifest: manifest}
-	pluginHostSrv := bldr_plugin_host.NewPluginHostServer(ctx, t.Bus, t.Logger, pluginID, "", manifestSnapshot, nil)
+	pluginHostSrv := bldr_plugin_host.NewPluginHostServer(ctx, t.Bus, t.Logger, pluginID, "", manifestSnapshot, nil, "")
 	_ = bldr_plugin.SRPCRegisterPluginHost(hostMux, pluginHostSrv)
 
 	// Convert billy FS handles to unixfs handles for ExecutePlugin.


### PR DESCRIPTION
Plugin runtimes can select a host Storage provider for their named Volumes. Carry the selected ID through scheduler configuration, plugin initialization, and volume requests, and include it in host controller and RPC names so equal volume names in different providers remain isolated.

Verified the real host/plugin RPC path with distinct providers, the default provider, and cancellation when a selected provider is unavailable. Focused storage, entrypoint, configset, and scheduler tests pass; generated bindings and browser-target entrypoint compile pass.
