### PR TITLE
fix(auth): escape signed write-ticket header values

### DIFF
--- a/.protoc-manifest.json
+++ b/.protoc-manifest.json
@@ -1151,7 +1151,7 @@
       ]
     },
     "github.com/s4wave/spacewave/core/provider/spacewave/api": {
-      "hash": "36ffd28ac7253c8884f45f513d94ea5225fe11b28ef8500cf09efe976c31717b",
+      "hash": "fb722ead192045fb73a673009c80b1301eef860cab9fcd601952c46092603be4",
       "generatedFiles": [
         "core/provider/spacewave/api/api.pb.go",
         "core/provider/spacewave/api/api.pb.ts",

--- a/core/provider/spacewave/api/api.pb.go
+++ b/core/provider/spacewave/api/api.pb.go
@@ -2456,7 +2456,8 @@ type WriteTicketProofPayload struct {
 	ContentLength int64 `protobuf:"varint,5,opt,name=content_length,json=contentLength,proto3" json:"contentLength,omitempty"`
 	// BodyHashHex is the hex-encoded body hash associated with the proof.
 	BodyHashHex string `protobuf:"bytes,6,opt,name=body_hash_hex,json=bodyHashHex,proto3" json:"bodyHashHex,omitempty"`
-	// SignedHeaders is the sorted comma-separated "key=value" signed header pairs.
+	// SignedHeaders contains sorted comma-separated "key=value" header pairs.
+	// Values use URL query escaping, including commas, plus signs, and percent signs.
 	SignedHeaders string `protobuf:"bytes,7,opt,name=signed_headers,json=signedHeaders,proto3" json:"signedHeaders,omitempty"`
 }
 

--- a/core/provider/spacewave/api/api.pb.ts
+++ b/core/provider/spacewave/api/api.pb.ts
@@ -2918,7 +2918,8 @@ export interface WriteTicketProofPayload {
    */
   bodyHashHex?: string
   /**
-   * SignedHeaders is the sorted comma-separated "key=value" signed header pairs.
+   * SignedHeaders contains sorted comma-separated "key=value" header pairs.
+   * Values use URL query escaping, including commas, plus signs, and percent signs.
    *
    * @generated from field: string signed_headers = 7;
    */

--- a/core/provider/spacewave/api/api.proto
+++ b/core/provider/spacewave/api/api.proto
@@ -643,7 +643,8 @@ message WriteTicketProofPayload {
   int64 content_length = 5;
   // BodyHashHex is the hex-encoded body hash associated with the proof.
   string body_hash_hex = 6;
-  // SignedHeaders is the sorted comma-separated "key=value" signed header pairs.
+  // SignedHeaders contains sorted comma-separated "key=value" header pairs.
+  // Values use URL query escaping, including commas, plus signs, and percent signs.
   string signed_headers = 7;
 }
 

--- a/core/provider/spacewave/client.go
+++ b/core/provider/spacewave/client.go
@@ -141,7 +141,7 @@ func marshalWriteTicketProofPayload(
 		}
 		hdrs.WriteString(k)
 		hdrs.WriteByte('=')
-		hdrs.WriteString(fields.SignedHeaders[k])
+		hdrs.WriteString(url.QueryEscape(fields.SignedHeaders[k]))
 	}
 
 	payload := &api.WriteTicketProofPayload{

--- a/core/provider/spacewave/client_test.go
+++ b/core/provider/spacewave/client_test.go
@@ -314,9 +314,11 @@ func TestMarshalWriteTicketProofPayload(t *testing.T) {
 		ContentLength: 42,
 		BodyHashHex:   "abcd",
 		SignedHeaders: map[string]string{
-			"x-pack-id":     "pack-1",
-			"content-type":  "application/octet-stream",
-			"x-block-count": "12",
+			"x-pack-id":           "pack-1",
+			"x-replaces-pack-ids": "old-1,old-2",
+			"x-bloom-filter":      "A+/==",
+			"content-type":        "application/octet-stream",
+			"x-block-count":       "12",
 		},
 	})
 	if err != nil {
@@ -330,7 +332,7 @@ func TestMarshalWriteTicketProofPayload(t *testing.T) {
 		TimestampMs:   123456789,
 		ContentLength: 42,
 		BodyHashHex:   "abcd",
-		SignedHeaders: "content-type=application/octet-stream,x-block-count=12,x-pack-id=pack-1",
+		SignedHeaders: "content-type=application%2Foctet-stream,x-block-count=12,x-bloom-filter=A%2B%2F%3D%3D,x-pack-id=pack-1,x-replaces-pack-ids=old-1%2Cold-2",
 	}).MarshalVT()
 	if err != nil {
 		t.Fatalf("marshal want payload: %v", err)
@@ -393,7 +395,7 @@ func TestMarshalSObjectWriteTicketProofPayload(t *testing.T) {
 	if payload.GetPath() != "/api/sobject/01/op" {
 		t.Fatalf("unexpected path: %q", payload.GetPath())
 	}
-	if payload.GetSignedHeaders() != "content-type=application/octet-stream" {
+	if payload.GetSignedHeaders() != "content-type=application%2Foctet-stream" {
 		t.Fatalf("unexpected signed headers: %q", payload.GetSignedHeaders())
 	}
 	wantHash := sha256.Sum256(body)
@@ -433,7 +435,7 @@ func TestMarshalSyncPushWriteTicketProofPayload(t *testing.T) {
 	if payload.GetTicket() != "ticket-456" {
 		t.Fatalf("unexpected ticket: %q", payload.GetTicket())
 	}
-	if payload.GetSignedHeaders() != "content-type=application/octet-stream,x-block-count=12,x-bloom-filter=AQID,x-pack-id=pack-1" {
+	if payload.GetSignedHeaders() != "content-type=application%2Foctet-stream,x-block-count=12,x-bloom-filter=AQID,x-pack-id=pack-1" {
 		t.Fatalf("unexpected signed headers: %q", payload.GetSignedHeaders())
 	}
 	if payload.GetBodyHashHex() != hex.EncodeToString(bodyHash) {


### PR DESCRIPTION
Write-ticket proofs now URL-query-escape each signed header value. This preserves comma-separated replacement pack IDs and base64 values containing plus signs when the Worker parses the proof.

The corresponding Worker decoder is landed. Focused proof tests pass, and generated protocol outputs are refreshed.
