### PR TITLE
fix(sync): retain dirty writes and bound upload delay

### DIFF
--- a/.protoc-manifest.json
+++ b/.protoc-manifest.json
@@ -1138,7 +1138,7 @@
       ]
     },
     "github.com/s4wave/spacewave/core/provider/spacewave": {
-      "hash": "d53023978a8314f741f55054ec4d62cc205a49a87a2e2840442b1831c2c4c3d1",
+      "hash": "aeb427278dc6d6ce4e776f30862f87ce59a2e7f31669bb19c763fce147e2e63e",
       "generatedFiles": [
         "core/provider/spacewave/audit.pb.go",
         "core/provider/spacewave/audit.pb.ts",

--- a/core/provider/spacewave/bstore.go
+++ b/core/provider/spacewave/bstore.go
@@ -570,11 +570,11 @@ func (s *sourceTrackingStore) GetBlock(ctx context.Context, ref *block.BlockRef)
 	return data, true, nil
 }
 
-// dirtyTrackingStore wraps block.StoreOps and calls markDirty on new PutBlock.
+// dirtyTrackingStore acknowledges writes only after retaining their sync markers.
 type dirtyTrackingStore struct {
-	// store owns block writes; markDirty records newly supplied blocks.
+	// store owns block writes; markDirty durably records every supplied block.
 	store     block.StoreOps
-	markDirty func(ctx context.Context, h *hash.Hash, size int64)
+	markDirty func(ctx context.Context, h *hash.Hash, size int64) error
 }
 
 // GetHashType returns the inner store hash type.
@@ -596,58 +596,39 @@ func (d *dirtyTrackingStore) BeginReadOperation(ctx context.Context) (block.Stor
 	return &dirtyTrackingStore{store: store, markDirty: d.markDirty}, release, nil
 }
 
-// PutBlock puts a block and marks it dirty if new.
+// PutBlock stores a block and repairs its durable sync marker even on a retry.
 func (d *dirtyTrackingStore) PutBlock(ctx context.Context, data []byte, opts *block.PutOpts) (*block.BlockRef, bool, error) {
 	ref, existed, err := d.store.PutBlock(ctx, data, opts)
-	if err == nil && !existed && d.markDirty != nil {
-		d.markDirty(ctx, ref.GetHash(), int64(len(data)))
+	if err == nil && d.markDirty != nil && !ref.GetEmpty() {
+		err = d.markDirty(ctx, ref.GetHash(), int64(len(data)))
 	}
 	return ref, existed, err
 }
 
-// PutBlockBatch writes blocks and marks successful new entries dirty.
+// PutBlockBatch retains markers for every successful non-tombstone write.
+// A failed marker returns an error; repeating the batch repairs the remaining work.
 func (d *dirtyTrackingStore) PutBlockBatch(ctx context.Context, entries []*block.PutBatchEntry) error {
-	var exists []bool
-	var valid []int
-	if d.markDirty != nil {
-		refs := make([]*block.BlockRef, 0, len(entries))
-		for i, entry := range entries {
-			if entry == nil || entry.Tombstone || entry.Ref == nil || entry.Ref.GetEmpty() {
-				continue
-			}
-			valid = append(valid, i)
-			refs = append(refs, entry.Ref)
-		}
-		var err error
-		exists, err = d.store.GetBlockExistsBatch(ctx, refs)
-		if err != nil || len(exists) != len(refs) {
-			// Existence preflight is advisory; fall back to conservative dirty
-			// marking rather than failing the underlying batch write.
-			exists = nil
-		}
-	}
 	if err := d.store.PutBlockBatch(ctx, entries); err != nil {
 		return err
 	}
-	if d.markDirty != nil {
-		for j, i := range valid {
-			if exists != nil && exists[j] {
-				continue
-			}
-			entry := entries[i]
-			d.markDirty(ctx, entry.Ref.GetHash(), int64(len(entry.Data)))
+	var markErr error
+	for _, entry := range entries {
+		if entry == nil {
+			continue
 		}
-	}
-	if invalidator, ok := d.store.(decodedBlockRefInvalidator); ok {
-		// Dirty-tracking batches can wrap cache-owning stores directly; keep
-		// tombstone invalidation with the wrapper that observes the deletion.
-		for _, entry := range entries {
-			if entry != nil && entry.Tombstone {
+		if entry.Tombstone {
+			if invalidator, ok := d.store.(decodedBlockRefInvalidator); ok {
 				invalidator.InvalidateDecodedBlockRef(ctx, entry.Ref)
 			}
+			continue
+		}
+		if d.markDirty != nil && !entry.Ref.GetEmpty() {
+			if err := d.markDirty(ctx, entry.Ref.GetHash(), int64(len(entry.Data))); err != nil && markErr == nil {
+				markErr = err
+			}
 		}
 	}
-	return nil
+	return markErr
 }
 
 // GetBlock gets a block by reference.

--- a/core/provider/spacewave/bstore_test.go
+++ b/core/provider/spacewave/bstore_test.go
@@ -451,8 +451,9 @@ func TestDirtyTrackingStoreForwardsBatch(t *testing.T) {
 	var dirtyMarks int
 	store := &dirtyTrackingStore{
 		store: inner,
-		markDirty: func(_ context.Context, _ *hash.Hash, _ int64) {
+		markDirty: func(_ context.Context, _ *hash.Hash, _ int64) error {
 			dirtyMarks++
+			return nil
 		},
 	}
 
@@ -477,26 +478,27 @@ func TestDirtyTrackingStoreForwardsBatch(t *testing.T) {
 	if dirtyMarks != 2 {
 		t.Fatalf("expected 2 dirty marks, got %d", dirtyMarks)
 	}
-	if inner.existsBatchHits != 1 {
-		t.Fatalf("expected 1 advisory GetBlockExistsBatch call, got %d", inner.existsBatchHits)
+	if inner.existsBatchHits != 0 {
+		t.Fatalf("unexpected advisory existence calls: %d", inner.existsBatchHits)
 	}
 
 	if _, err := store.GetBlockExistsBatch(ctx, []*block.BlockRef{ref1}); err != nil {
 		t.Fatalf("GetBlockExistsBatch failed: %v", err)
 	}
-	if inner.existsBatchHits != 2 {
-		t.Fatalf("expected 2 GetBlockExistsBatch calls, got %d", inner.existsBatchHits)
+	if inner.existsBatchHits != 1 {
+		t.Fatalf("expected 1 explicit GetBlockExistsBatch call, got %d", inner.existsBatchHits)
 	}
 }
 
-func TestDirtyTrackingStoreBatchSkipsExistingBlocks(t *testing.T) {
+func TestDirtyTrackingStoreBatchRepairsExistingBlocks(t *testing.T) {
 	ctx := context.Background()
 	inner := newWrapperForwardTestStore("", 0)
 	var dirty []string
 	store := &dirtyTrackingStore{
 		store: inner,
-		markDirty: func(_ context.Context, h *hash.Hash, _ int64) {
+		markDirty: func(_ context.Context, h *hash.Hash, _ int64) error {
 			dirty = append(dirty, h.MarshalString())
+			return nil
 		},
 	}
 
@@ -521,10 +523,10 @@ func TestDirtyTrackingStoreBatchSkipsExistingBlocks(t *testing.T) {
 	if inner.putBlockBatchHits != 1 {
 		t.Fatalf("expected 1 PutBlockBatch call, got %d", inner.putBlockBatchHits)
 	}
-	if inner.existsBatchHits != 1 {
-		t.Fatalf("expected 1 GetBlockExistsBatch call, got %d", inner.existsBatchHits)
+	if inner.existsBatchHits != 0 {
+		t.Fatalf("unexpected GetBlockExistsBatch call, got %d", inner.existsBatchHits)
 	}
-	want := []string{fresh.GetHash().MarshalString()}
+	want := []string{existing.GetHash().MarshalString(), fresh.GetHash().MarshalString()}
 	if !slices.Equal(dirty, want) {
 		t.Fatalf("dirty marks = %v, want %v", dirty, want)
 	}
@@ -874,8 +876,9 @@ func TestNewCloudOverlayDoesNotDirtyLowerReads(t *testing.T) {
 	var dirtyMarks int
 	dirtyUpper := &dirtyTrackingStore{
 		store: upper,
-		markDirty: func(context.Context, *hash.Hash, int64) {
+		markDirty: func(context.Context, *hash.Hash, int64) error {
 			dirtyMarks++
+			return nil
 		},
 	}
 

--- a/core/provider/spacewave/spacewave.pb.go
+++ b/core/provider/spacewave/spacewave.pb.go
@@ -129,11 +129,11 @@ func (x *Config) GetSigningEnvPrefix() string {
 // SyncConfig configures block store synchronization behavior.
 type SyncConfig struct {
 	unknownFields []byte
-	// InactivityTimeoutSecs is the inactivity timeout in seconds before flushing.
-	// Default: 10.
-	InactivityTimeoutSecs uint32 `protobuf:"varint,1,opt,name=inactivity_timeout_secs,json=inactivityTimeoutSecs,proto3" json:"inactivityTimeoutSecs,omitempty"`
+	// CheckpointIntervalSecs bounds the delay from the first pending cloud change.
+	// Later changes do not reset this interval. Zero uses thirty seconds.
+	CheckpointIntervalSecs uint32 `protobuf:"varint,1,opt,name=checkpoint_interval_secs,json=checkpointIntervalSecs,proto3" json:"checkpointIntervalSecs,omitempty"`
 	// SizeThresholdBytes is the dirty size threshold in bytes before flushing.
-	// Default: 10485760 (10MB).
+	// Zero uses 48 MiB.
 	SizeThresholdBytes uint32 `protobuf:"varint,2,opt,name=size_threshold_bytes,json=sizeThresholdBytes,proto3" json:"sizeThresholdBytes,omitempty"`
 	// AutoSync enables automatic sync on block writes.
 	// Default: true.
@@ -148,9 +148,9 @@ func (x *SyncConfig) Reset() {
 
 func (*SyncConfig) ProtoMessage() {}
 
-func (x *SyncConfig) GetInactivityTimeoutSecs() uint32 {
+func (x *SyncConfig) GetCheckpointIntervalSecs() uint32 {
 	if x != nil {
-		return x.InactivityTimeoutSecs
+		return x.CheckpointIntervalSecs
 	}
 	return 0
 }
@@ -203,7 +203,7 @@ func (m *SyncConfig) CloneVT() *SyncConfig {
 		return (*SyncConfig)(nil)
 	}
 	r := new(SyncConfig)
-	r.InactivityTimeoutSecs = m.InactivityTimeoutSecs
+	r.CheckpointIntervalSecs = m.CheckpointIntervalSecs
 	r.SizeThresholdBytes = m.SizeThresholdBytes
 	r.AutoSync = m.AutoSync
 	r.SyncMode = m.SyncMode
@@ -261,7 +261,7 @@ func (this *SyncConfig) EqualVT(that *SyncConfig) bool {
 	} else if this == nil || that == nil {
 		return false
 	}
-	if this.InactivityTimeoutSecs != that.InactivityTimeoutSecs {
+	if this.CheckpointIntervalSecs != that.CheckpointIntervalSecs {
 		return false
 	}
 	if this.SizeThresholdBytes != that.SizeThresholdBytes {
@@ -426,10 +426,10 @@ func (x *SyncConfig) MarshalProtoJSON(s *json.MarshalState) {
 	}
 	s.WriteObjectStart()
 	var wroteField bool
-	if x.InactivityTimeoutSecs != 0 || s.HasField("inactivityTimeoutSecs") {
+	if x.CheckpointIntervalSecs != 0 || s.HasField("checkpointIntervalSecs") {
 		s.WriteMoreIf(&wroteField)
-		s.WriteObjectField("inactivityTimeoutSecs")
-		s.WriteUint32(x.InactivityTimeoutSecs)
+		s.WriteObjectField("checkpointIntervalSecs")
+		s.WriteUint32(x.CheckpointIntervalSecs)
 	}
 	if x.SizeThresholdBytes != 0 || s.HasField("sizeThresholdBytes") {
 		s.WriteMoreIf(&wroteField)
@@ -463,9 +463,9 @@ func (x *SyncConfig) UnmarshalProtoJSON(s *json.UnmarshalState) {
 		switch key {
 		default:
 			s.Skip() // ignore unknown field
-		case "inactivity_timeout_secs", "inactivityTimeoutSecs":
-			s.AddField("inactivity_timeout_secs")
-			x.InactivityTimeoutSecs = s.ReadUint32()
+		case "checkpoint_interval_secs", "checkpointIntervalSecs":
+			s.AddField("checkpoint_interval_secs")
+			x.CheckpointIntervalSecs = s.ReadUint32()
 		case "size_threshold_bytes", "sizeThresholdBytes":
 			s.AddField("size_threshold_bytes")
 			x.SizeThresholdBytes = s.ReadUint32()
@@ -600,8 +600,8 @@ func (m *SyncConfig) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i--
 		dAtA[i] = 0x10
 	}
-	if m.InactivityTimeoutSecs != 0 {
-		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(m.InactivityTimeoutSecs))
+	if m.CheckpointIntervalSecs != 0 {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(m.CheckpointIntervalSecs))
 		i--
 		dAtA[i] = 0x8
 	}
@@ -634,7 +634,7 @@ func (m *SyncConfig) SizeVT() (n int) {
 	}
 	var l int
 	_ = l
-	n += protobuf_go_lite.SizeVarintNonZero(1, m.InactivityTimeoutSecs)
+	n += protobuf_go_lite.SizeVarintNonZero(1, m.CheckpointIntervalSecs)
 	n += protobuf_go_lite.SizeVarintNonZero(1, m.SizeThresholdBytes)
 	n += protobuf_go_lite.SizeBoolNonZero(1, m.AutoSync)
 	n += protobuf_go_lite.SizeVarintNonZero(1, m.SyncMode)
@@ -687,9 +687,9 @@ func (x *Config) String() string {
 func (x *SyncConfig) MarshalProtoText() string {
 	var sb protobuf_go_lite.TextBuilder
 	initialLen := protobuf_go_lite.TextStartMessage(&sb, "SyncConfig")
-	if x.InactivityTimeoutSecs != 0 {
-		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "inactivity_timeout_secs")
-		protobuf_go_lite.TextWriteUint(&sb, x.InactivityTimeoutSecs)
+	if x.CheckpointIntervalSecs != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "checkpoint_interval_secs")
+		protobuf_go_lite.TextWriteUint(&sb, x.CheckpointIntervalSecs)
 	}
 	if x.SizeThresholdBytes != 0 {
 		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "size_threshold_bytes")
@@ -850,10 +850,10 @@ func (m *SyncConfig) UnmarshalVT(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field InactivityTimeoutSecs", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field CheckpointIntervalSecs", wireType)
 			}
-			m.InactivityTimeoutSecs = 0
-			m.InactivityTimeoutSecs, iNdEx, err = protobuf_go_lite.DecodeVarintUint32(dAtA, iNdEx)
+			m.CheckpointIntervalSecs = 0
+			m.CheckpointIntervalSecs, iNdEx, err = protobuf_go_lite.DecodeVarintUint32(dAtA, iNdEx)
 			if err != nil {
 				return err
 			}

--- a/core/provider/spacewave/spacewave.pb.ts
+++ b/core/provider/spacewave/spacewave.pb.ts
@@ -46,15 +46,15 @@ export const SyncMode_Enum = /* @__PURE__ */ createEnumType(
  */
 export interface SyncConfig {
   /**
-   * InactivityTimeoutSecs is the inactivity timeout in seconds before flushing.
-   * Default: 10.
+   * CheckpointIntervalSecs bounds the delay from the first pending cloud change.
+   * Later changes do not reset this interval. Zero uses thirty seconds.
    *
-   * @generated from field: uint32 inactivity_timeout_secs = 1;
+   * @generated from field: uint32 checkpoint_interval_secs = 1;
    */
-  inactivityTimeoutSecs?: number
+  checkpointIntervalSecs?: number
   /**
    * SizeThresholdBytes is the dirty size threshold in bytes before flushing.
-   * Default: 10485760 (10MB).
+   * Zero uses 48 MiB.
    *
    * @generated from field: uint32 size_threshold_bytes = 2;
    */
@@ -80,7 +80,7 @@ export const SyncConfig: MessageType<SyncConfig> =
     fields: [
       {
         no: 1,
-        name: 'inactivity_timeout_secs',
+        name: 'checkpoint_interval_secs',
         kind: 'scalar',
         T: ScalarType.UINT32,
       },

--- a/core/provider/spacewave/spacewave.proto
+++ b/core/provider/spacewave/spacewave.proto
@@ -23,11 +23,11 @@ message Config {
 
 // SyncConfig configures block store synchronization behavior.
 message SyncConfig {
-  // InactivityTimeoutSecs is the inactivity timeout in seconds before flushing.
-  // Default: 10.
-  uint32 inactivity_timeout_secs = 1;
+  // CheckpointIntervalSecs bounds the delay from the first pending cloud change.
+  // Later changes do not reset this interval. Zero uses thirty seconds.
+  uint32 checkpoint_interval_secs = 1;
   // SizeThresholdBytes is the dirty size threshold in bytes before flushing.
-  // Default: 10485760 (10MB).
+  // Zero uses 48 MiB.
   uint32 size_threshold_bytes = 2;
   // AutoSync enables automatic sync on block writes.
   // Default: true.

--- a/core/provider/spacewave/sync-persistence_test.go
+++ b/core/provider/spacewave/sync-persistence_test.go
@@ -1,0 +1,177 @@
+package provider_spacewave
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	packfile_store "github.com/s4wave/spacewave/core/provider/spacewave/packfile/store"
+	"github.com/s4wave/spacewave/db/block"
+	"github.com/s4wave/spacewave/net/hash"
+	"github.com/sirupsen/logrus"
+)
+
+// TestDirtyTrackingRetriesPersistedBlocks repairs a marker failure after payload storage.
+func TestDirtyTrackingRetriesPersistedBlocks(t *testing.T) {
+	for _, batch := range []bool{false, true} {
+		name := "single"
+		if batch {
+			name = "batch"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx := t.Context()
+			metadata := newSyncTestKvStore()
+			syncer := &syncController{store: metadata}
+			payload := []byte("accepted local bytes")
+			ref, err := block.BuildBlockRef(payload, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			injected := errors.New("metadata unavailable")
+			fail := true
+			store := &dirtyTrackingStore{store: newSyncTestBlockStore(), markDirty: func(ctx context.Context, h *hash.Hash, size int64) error {
+				if fail {
+					return injected
+				}
+				return syncer.MarkDirty(ctx, h, size)
+			}}
+			put := func() error {
+				if batch {
+					return store.PutBlockBatch(ctx, []*block.PutBatchEntry{{Ref: ref, Data: payload}})
+				}
+				_, _, err := store.PutBlock(ctx, payload, &block.PutOpts{ForceBlockRef: ref})
+				return err
+			}
+
+			// Returning success before this marker would lose the upload on restart.
+			if err := put(); !errors.Is(err, injected) {
+				t.Fatalf("failed marker was acknowledged: %v", err)
+			}
+			fail = false
+			if err := put(); err != nil {
+				t.Fatal(err)
+			}
+			first, size, _ := syncer.pendingSnapshot()
+			if first.IsZero() || size != int64(len(payload)) {
+				t.Fatalf("missing recovered queue: first=%v size=%d", first, size)
+			}
+
+			// Concurrent identical retries retain one block and the original deadline.
+			results := make(chan error, 24)
+			for range 24 {
+				go func() { results <- put() }()
+			}
+			for range 24 {
+				if err := <-results; err != nil {
+					t.Fatal(err)
+				}
+			}
+			reopened := &syncController{store: metadata}
+			if err := reopened.recalcDirtySize(ctx); err != nil {
+				t.Fatal(err)
+			}
+			gotFirst, gotSize, _ := reopened.pendingSnapshot()
+			if !gotFirst.Equal(first) || gotSize != size {
+				t.Fatalf("reopened queue changed: first=%v size=%d", gotFirst, gotSize)
+			}
+
+			// Acknowledging the last block resets the deadline before the next write.
+			candidates, err := reopened.scanDirtyCandidates(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := reopened.cleanupDirtyCandidates(ctx, candidates); err != nil {
+				t.Fatal(err)
+			}
+			if next, size, _ := reopened.pendingSnapshot(); !next.IsZero() || size != 0 {
+				t.Fatal("acknowledged queue retained its deadline")
+			}
+			if err := reopened.MarkDirty(ctx, ref.GetHash(), int64(len(payload))); err != nil {
+				t.Fatal(err)
+			}
+			if next, _, _ := reopened.pendingSnapshot(); !next.After(first) {
+				t.Fatal("new queue inherited the previous deadline")
+			}
+		})
+	}
+}
+
+// TestSyncDeadlineSurvivesContinuousWrites exercises the real pack and HTTP path.
+func TestSyncDeadlineSurvivesContinuousWrites(t *testing.T) {
+	uploaded := make(chan time.Time, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		select {
+		case uploaded <- time.Now():
+		default:
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	key, pid := generateTestKeypair(t)
+	client := NewSessionClient(server.Client(), server.URL, DefaultSigningEnvPrefix, key, pid.String())
+	client.executeWriteTicketAudience = func(_ context.Context, _ string, _ writeTicketAudience, submit func(string) error) error {
+		return submit("test-ticket")
+	}
+	syncer := newDirtySyncExecuteTestController(t, client, nil)
+	syncer.conf.SizeThresholdBytes = 0
+	candidates, err := syncer.scanDirtyCandidates(t.Context())
+	if err != nil || len(candidates) != 1 {
+		t.Fatalf("initial queue: %v (%d blocks)", err, len(candidates))
+	}
+	first, _, _ := syncer.pendingSnapshot()
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- syncer.Execute(ctx) }()
+	defer func() {
+		cancel()
+		if err := <-done; err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// The configured one-second interval remains fixed while writes keep arriving.
+	writes := time.NewTicker(50 * time.Millisecond)
+	defer writes.Stop()
+	deadline := time.NewTimer(2 * time.Second)
+	defer deadline.Stop()
+	for {
+		select {
+		case <-writes.C:
+			if err := syncer.MarkDirty(ctx, candidates[0].hash, candidates[0].size); err != nil {
+				t.Fatal(err)
+			}
+		case at := <-uploaded:
+			if at.Before(first.Add(time.Second)) {
+				t.Fatal("ordinary upload bypassed its configured interval")
+			}
+			return
+		case <-deadline.C:
+			t.Fatal("continuous writes postponed the first-pending deadline")
+		}
+	}
+}
+
+// TestSyncMissingDirtyBlockPreservesPending rejects an incomplete local payload set.
+func TestSyncMissingDirtyBlockPreservesPending(t *testing.T) {
+	syncer := &syncController{
+		le: logrus.NewEntry(logrus.New()), store: newSyncTestKvStore(),
+		upper: newSyncTestBlockStore(), lower: packfile_store.NewPackfileStore(nil, nil),
+	}
+	ref, err := block.BuildBlockRef([]byte("missing payload"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := syncer.MarkDirty(t.Context(), ref.GetHash(), 15); err != nil {
+		t.Fatal(err)
+	}
+	if err := syncer.FlushNowUnordered(t.Context()); !errors.Is(err, block.ErrNotFound) {
+		t.Fatalf("missing payload was acknowledged: %v", err)
+	}
+	pending, err := syncer.scanDirtyCandidates(t.Context())
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("failed upload lost its marker: %v (%d blocks)", err, len(pending))
+	}
+}

--- a/core/provider/spacewave/sync.go
+++ b/core/provider/spacewave/sync.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
 	cbackoff "github.com/aperturerobotics/util/backoff/cbackoff"
 	"github.com/aperturerobotics/util/broadcast"
+	"github.com/aperturerobotics/util/csync"
 	"github.com/pkg/errors"
 	packfile "github.com/s4wave/spacewave/core/provider/spacewave/packfile"
 	"github.com/s4wave/spacewave/core/provider/spacewave/packfile/identity"
@@ -31,6 +32,9 @@ import (
 const syncPushRetryTimeout = 30 * time.Second
 
 const syncNoProgressBackoff = time.Second
+
+// syncPendingSinceKey retains the first dirty-block deadline across restart.
+const syncPendingSinceKey = "sync/pending-since"
 
 const defaultSyncSizeThresholdBytes = 48 * 1024 * 1024
 
@@ -60,9 +64,13 @@ type syncController struct {
 	skipPull          bool
 	remotePullRoutine *coalescedTriggerRoutine
 
-	// dirtySize is guarded by bcast.
-	dirtySize int64
-	bcast     broadcast.Broadcast
+	// dirtySize and dirtyPendingAt project durable dirty records under bcast.
+	dirtySize      int64
+	dirtyPendingAt time.Time
+	// bcast wakes the scheduler when the durable dirty queue changes.
+	bcast broadcast.Broadcast
+	// dirtyMtx orders durable dirty mutations and their in-memory projection.
+	dirtyMtx csync.Mutex
 
 	// flushMtx serializes foreground and background flush operations.
 	flushMtx sync.Mutex
@@ -74,7 +82,9 @@ type syncController struct {
 // Must be called before Execute.
 func (s *syncController) Init(ctx context.Context) error {
 	s.cleanStaleTempFiles()
-	s.recalcDirtySize(ctx)
+	if err := s.recalcDirtySize(ctx); err != nil {
+		return err
+	}
 
 	if s.skipPull {
 		s.lower.UpdateManifest(s.mergedManifestEntries())
@@ -121,120 +131,88 @@ func (s *syncController) mergedManifestEntries() []*packfile.PackfileEntry {
 	return out
 }
 
-// Execute runs the sync controller loop.
+// pendingSnapshot reads the durable queue projection and its notification together.
+func (s *syncController) pendingSnapshot() (time.Time, int64, <-chan struct{}) {
+	var first time.Time
+	var dirty int64
+	var changed <-chan struct{}
+	s.bcast.HoldLock(func(_ func(), getWait func() <-chan struct{}) {
+		first, dirty, changed = s.dirtyPendingAt, s.dirtySize, getWait()
+	})
+	return first, dirty, changed
+}
+
+// Execute dispatches from the first pending change, without extending its deadline.
 func (s *syncController) Execute(ctx context.Context) error {
 	if s.remotePullRoutine != nil && !s.skipPull {
 		s.remotePullRoutine.SetContext(ctx)
 		defer s.remotePullRoutine.ClearContext()
 	}
 
+	// Keep the existing pressure and pack limits independent of the time boundary.
 	bo := providerBackoff.Construct()
 	threshold := int64(s.conf.GetSizeThresholdBytes())
 	if threshold == 0 {
 		threshold = defaultSyncSizeThresholdBytes
 	}
-
-	timeout := time.Duration(s.conf.GetInactivityTimeoutSecs()) * time.Second
-	if timeout == 0 {
-		timeout = 10 * time.Second
+	interval := time.Duration(s.conf.GetCheckpointIntervalSecs()) * time.Second
+	if interval == 0 {
+		interval = 30 * time.Second
 	}
 
-	for {
-		if err := ctx.Err(); err != nil {
-			return nil
-		}
-
-		var ch <-chan struct{}
-		var dirty int64
-		s.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
-			ch = getWaitCh()
-			dirty = s.dirtySize
-		})
-
-		if dirty >= threshold {
-			if err := s.FlushNow(ctx); err != nil {
-				if ctx.Err() != nil {
-					return nil
-				}
-				if isDirtySyncGatedCloudError(err) {
-					bo.Reset()
-					s.le.WithError(err).Warn("flush gated, waiting for account state change")
-					if err := s.waitDirtySyncGate(ctx); err != nil {
-						return nil
-					}
-					continue
-				}
-				s.le.WithError(err).Warn("flush failed")
-				delay := nextProviderRetryDelay(bo, err)
-				s.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
-					ch = getWaitCh()
-				})
-				if err := waitDirtySyncRetry(ctx, ch, delay); err != nil {
-					return nil
-				}
-				continue
-			}
-
+	for ctx.Err() == nil {
+		first, dirty, changed := s.pendingSnapshot()
+		if first.IsZero() && dirty < threshold {
 			bo.Reset()
-			var nextDirty int64
-			s.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
-				nextDirty = s.dirtySize
-			})
-			if nextDirty >= dirty && nextDirty > 0 {
-				s.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
-					ch = getWaitCh()
-				})
-				select {
-				case <-ctx.Done():
-					return nil
-				case <-ch:
-				case <-time.After(syncNoProgressBackoff):
-				}
-			}
-			continue
-		}
-
-		if dirty > 0 {
 			select {
 			case <-ctx.Done():
 				return nil
-			case <-ch:
+			case <-changed:
 				continue
-			case <-time.After(timeout):
-				if err := s.FlushNow(ctx); err != nil {
-					if ctx.Err() != nil {
-						return nil
-					}
-					if isDirtySyncGatedCloudError(err) {
-						bo.Reset()
-						s.le.WithError(err).Warn("flush on timeout gated, waiting for account state change")
-						if err := s.waitDirtySyncGate(ctx); err != nil {
-							return nil
-						}
-						continue
-					}
-					s.le.WithError(err).Warn("flush on timeout failed")
-					delay := nextProviderRetryDelay(bo, err)
-					s.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
-						ch = getWaitCh()
-					})
-					if werr := waitDirtySyncRetry(ctx, ch, delay); werr != nil {
-						return nil
-					}
-					continue
-				}
+			}
+		}
+
+		// A later edit wakes this wait but keeps the original persisted deadline.
+		if delay := time.Until(first.Add(interval)); dirty < threshold && delay > 0 {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-changed:
+				continue
+			case <-time.After(delay):
+			}
+		}
+
+		if err := s.FlushNow(ctx); err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			if isDirtySyncGatedCloudError(err) {
 				bo.Reset()
+				s.le.WithError(err).Warn("block upload gated, waiting for account state change")
+				if err := s.waitDirtySyncGate(ctx); err != nil {
+					return nil
+				}
+				continue
+			}
+			s.le.WithError(err).Warn("block upload failed")
+			_, _, changed = s.pendingSnapshot()
+			if err := waitDirtySyncRetry(ctx, changed, nextProviderRetryDelay(bo, err)); err != nil {
+				return nil
 			}
 			continue
 		}
 
+		// A flush with no progress must not spin on an expired deadline.
 		bo.Reset()
-		select {
-		case <-ctx.Done():
-			return nil
-		case <-ch:
+		next, _, changed := s.pendingSnapshot()
+		if !next.IsZero() && !next.After(first) {
+			if err := waitDirtySyncRetry(ctx, changed, syncNoProgressBackoff); err != nil {
+				return nil
+			}
 		}
 	}
+	return nil
 }
 
 func waitDirtySyncRetry(ctx context.Context, ch <-chan struct{}, delay time.Duration) error {
@@ -258,13 +236,8 @@ func waitDirtySyncRetry(ctx context.Context, ch <-chan struct{}, delay time.Dura
 
 func (s *syncController) waitDirtySyncGate(ctx context.Context) error {
 	for {
-		var dirty int64
-		var dirtyCh <-chan struct{}
-		s.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
-			dirty = s.dirtySize
-			dirtyCh = getWaitCh()
-		})
-		if dirty == 0 {
+		first, dirty, dirtyCh := s.pendingSnapshot()
+		if first.IsZero() && dirty == 0 {
 			return nil
 		}
 		if s.gateBcast == nil {
@@ -364,66 +337,115 @@ func (s *syncController) pushPackfile(
 	return pushFn(retryCtx, packID, blockCount)
 }
 
-// MarkDirty marks a block as dirty for sync.
-func (s *syncController) MarkDirty(ctx context.Context, h *hash.Hash, size int64) {
-	key := []byte("dirty/" + h.MarshalString())
-	sizeBytes := []byte(strconv.FormatInt(size, 10))
-	err := kvtx.RunTransaction(ctx, true,
-		func(ctx context.Context) (kvtx.Tx, error) {
-			return s.store.NewTransaction(ctx, true)
-		},
-		func(ctx context.Context, tx kvtx.Tx) error {
-			return tx.Set(ctx, key, sizeBytes)
-		},
-	)
+// MarkDirty durably schedules a block before its caller can acknowledge the write.
+// Repeating a write repairs a failed marker without double-counting pending bytes.
+func (s *syncController) MarkDirty(ctx context.Context, h *hash.Hash, size int64) error {
+	release, err := s.dirtyMtx.Lock(ctx)
 	if err != nil {
-		s.le.WithError(err).Warn("failed to mark dirty")
-		return
+		return err
 	}
-	s.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
-		s.dirtySize += size
-		broadcast()
-	})
-	s.telemetrySafeCall(func(t *ProviderAccount, id string) {
-		t.addSyncTelemetryDirty(id, size)
-	})
-}
+	defer release()
 
-// recalcDirtySize recalculates the dirty size from the object store on startup.
-func (s *syncController) recalcDirtySize(ctx context.Context) {
-	var total int64
-	var count int
-	err := kvtx.RunTransaction(ctx, false,
-		func(ctx context.Context) (kvtx.Tx, error) {
-			return s.store.NewTransaction(ctx, false)
-		},
+	// The marker and first-pending timestamp share the metadata transaction.
+	key := []byte("dirty/" + h.MarshalString())
+	var added bool
+	var first time.Time
+	err = kvtx.RunTransaction(ctx, true,
+		func(ctx context.Context) (kvtx.Tx, error) { return s.store.NewTransaction(ctx, true) },
 		func(ctx context.Context, tx kvtx.Tx) error {
-			var attemptTotal int64
-			var attemptCount int
-			err := tx.ScanPrefix(ctx, []byte("dirty/"), func(_, v []byte) error {
-				attemptTotal += parseDirtySize(v)
-				attemptCount++
-				return nil
-			})
-			if err == nil {
-				total = attemptTotal
-				count = attemptCount
+			_, found, err := tx.Get(ctx, key)
+			if err != nil {
+				return err
 			}
+			added = !found
+			if added {
+				if err := tx.Set(ctx, key, []byte(strconv.FormatInt(size, 10))); err != nil {
+					return err
+				}
+			}
+			first, err = readDirtyPendingTime(ctx, tx)
 			return err
 		},
 	)
 	if err != nil {
-		s.le.WithError(err).Warn("failed to recalculate dirty size")
-		return
+		return errors.Wrap(err, "retain pending block")
 	}
 
+	// Publish only the committed projection, ordered with startup and cleanup scans.
 	s.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
-		s.dirtySize = total
+		if added {
+			s.dirtySize += size
+		}
+		s.dirtyPendingAt = first
 		broadcast()
 	})
-	s.telemetrySafeCall(func(t *ProviderAccount, id string) {
-		t.setSyncTelemetryPending(id, total, count)
+	if added {
+		s.telemetrySafeCall(func(t *ProviderAccount, id string) { t.addSyncTelemetryDirty(id, size) })
+	}
+	return nil
+}
+
+// readDirtyPendingTime retains the first dirty time for current and preexisting work.
+// The caller holds a writable metadata transaction containing at least one marker.
+func readDirtyPendingTime(ctx context.Context, tx kvtx.Tx) (time.Time, error) {
+	value, found, err := tx.Get(ctx, []byte(syncPendingSinceKey))
+	if err != nil {
+		return time.Time{}, err
+	}
+	if found {
+		return time.Parse(time.RFC3339Nano, string(value))
+	}
+	first := time.Now().UTC()
+	return first, tx.Set(ctx, []byte(syncPendingSinceKey), []byte(first.Format(time.RFC3339Nano)))
+}
+
+// recalcDirtySize reconciles the durable queue and clears its deadline only when empty.
+func (s *syncController) recalcDirtySize(ctx context.Context, flushed ...dirtyCandidate) error {
+	release, err := s.dirtyMtx.Lock(ctx)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	// Startup and successful cleanup use one transaction for count and deadline.
+	var total int64
+	var count int
+	var first time.Time
+	err = kvtx.RunTransaction(ctx, true,
+		func(ctx context.Context) (kvtx.Tx, error) { return s.store.NewTransaction(ctx, true) },
+		func(ctx context.Context, tx kvtx.Tx) error {
+			total, count, first = 0, 0, time.Time{}
+			for _, candidate := range flushed {
+				if err := tx.Delete(ctx, candidate.key); err != nil {
+					return err
+				}
+			}
+			if err := tx.ScanPrefix(ctx, []byte("dirty/"), func(_, value []byte) error {
+				total += parseDirtySize(value)
+				count++
+				return nil
+			}); err != nil {
+				return err
+			}
+			if count == 0 {
+				return tx.Delete(ctx, []byte(syncPendingSinceKey))
+			}
+			var err error
+			first, err = readDirtyPendingTime(ctx, tx)
+			return err
+		},
+	)
+	if err != nil {
+		return errors.Wrap(err, "read pending blocks")
+	}
+
+	// Readers observe counts and their matching timer together.
+	s.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		s.dirtySize, s.dirtyPendingAt = total, first
+		broadcast()
 	})
+	s.telemetrySafeCall(func(t *ProviderAccount, id string) { t.setSyncTelemetryPending(id, total, count) })
+	return nil
 }
 
 // dirtyCandidate is the metadata needed to decide which dirty blocks belong in
@@ -469,25 +491,9 @@ func (s *syncController) packBlocks(w io.Writer, blocks []dirtyBlock) (*writer.P
 	return result, hashWriter.Sum(nil), nil
 }
 
-// cleanupDirtyCandidates removes flushed dirty keys from the object store.
+// cleanupDirtyCandidates removes acknowledged markers and resets an empty queue's deadline atomically.
 func (s *syncController) cleanupDirtyCandidates(ctx context.Context, blocks []dirtyCandidate) error {
-	err := kvtx.RunTransaction(ctx, true,
-		func(ctx context.Context) (kvtx.Tx, error) {
-			return s.store.NewTransaction(ctx, true)
-		},
-		func(ctx context.Context, tx kvtx.Tx) error {
-			for _, b := range blocks {
-				if err := tx.Delete(ctx, b.key); err != nil {
-					return errors.Wrap(err, "deleting dirty key")
-				}
-			}
-			return nil
-		},
-	)
-	if err != nil {
-		return errors.Wrap(err, "cleaning dirty candidates")
-	}
-	return nil
+	return s.recalcDirtySize(ctx, blocks...)
 }
 
 // orderDirtyBlocks orders dirty block metadata for pack locality before
@@ -638,7 +644,7 @@ func (s *syncController) loadDirtyBlocks(ctx context.Context, candidates []dirty
 			return nil, errors.Wrap(err, "getting dirty block")
 		}
 		if !found {
-			continue
+			return nil, errors.Wrap(block.ErrNotFound, candidate.hash.MarshalString())
 		}
 		if int64(len(data)) > writer.DefaultMaxPackBytes {
 			return nil, errors.Errorf(
@@ -790,8 +796,7 @@ func (s *syncController) flush(ctx context.Context, orderBlocks bool) error {
 		return err
 	}
 	if len(blocks) == 0 {
-		s.recalcDirtySize(ctx)
-		return nil
+		return s.recalcDirtySize(ctx)
 	}
 
 	s.le.WithField("dirty-blocks", len(blocks)).
@@ -801,15 +806,10 @@ func (s *syncController) flush(ctx context.Context, orderBlocks bool) error {
 
 	blocks, dedupedBlocks, err := s.filterDuplicateDirtyBlocks(ctx, blocks)
 	if err != nil {
-		s.recalcDirtySize(ctx)
 		return errors.Wrap(err, "filtering duplicate dirty blocks")
 	}
 	if len(blocks) == 0 {
-		if err := s.cleanupDirtyCandidates(ctx, dedupedBlocks); err != nil {
-			return err
-		}
-		s.recalcDirtySize(ctx)
-		return nil
+		return s.cleanupDirtyCandidates(ctx, dedupedBlocks)
 	}
 
 	if orderBlocks && len(blocks) > syncOrderDirtyBlocksLimit {
@@ -826,7 +826,6 @@ func (s *syncController) flush(ctx context.Context, orderBlocks bool) error {
 			WithField("duration", time.Since(started)).
 			Debug("ordered dirty blocks")
 		if err != nil {
-			s.recalcDirtySize(ctx)
 			return errors.Wrap(err, "ordering dirty blocks")
 		}
 	}
@@ -839,22 +838,14 @@ func (s *syncController) flush(ctx context.Context, orderBlocks bool) error {
 	for start < len(blocks) {
 		end, err := nextDirtyCandidateChunk(blocks, start, syncFlushMaxPackBytes, maxChunkBlocks)
 		if err != nil {
-			s.recalcDirtySize(ctx)
 			return err
 		}
 
 		loadedBlocks, err := s.loadDirtyBlocks(ctx, blocks[start:end])
 		if err != nil {
-			s.recalcDirtySize(ctx)
 			return err
 		}
-		if len(loadedBlocks) == 0 {
-			start = end
-			continue
-		}
-
 		if err := s.flushLoadedBlocks(ctx, loadedBlocks, &entries, &flushedBlocks); err != nil {
-			s.recalcDirtySize(ctx)
 			return err
 		}
 		start = end
@@ -867,17 +858,8 @@ func (s *syncController) flush(ctx context.Context, orderBlocks bool) error {
 		s.lower.UpdateManifest(s.mergedManifestEntries())
 	}
 
-	if len(flushedBlocks) != 0 {
-		if err := s.cleanupDirtyCandidates(ctx, flushedBlocks); err != nil {
-			return err
-		}
-	}
-
-	// Recalculate dirty size from the store so concurrent markDirty calls that
-	// raced with this flush are preserved for the next cycle.
-	s.recalcDirtySize(ctx)
-
-	return nil
+	// Reconcile cleanup with concurrent writes in the same metadata transaction.
+	return s.cleanupDirtyCandidates(ctx, flushedBlocks)
 }
 
 // pull fetches new packfile entries from the server since the last pull.

--- a/core/provider/spacewave/sync_test.go
+++ b/core/provider/spacewave/sync_test.go
@@ -1190,7 +1190,7 @@ func newDirtySyncExecuteTestController(
 		mfst:       mfst,
 		lower:      packfile_store.NewPackfileStore(nil, nil),
 		upper:      upper,
-		conf:       &SyncConfig{SizeThresholdBytes: 1, InactivityTimeoutSecs: 1},
+		conf:       &SyncConfig{SizeThresholdBytes: 1, CheckpointIntervalSecs: 1},
 		gateBcast:  gate,
 	}
 	s.recalcDirtySize(ctx)


### PR DESCRIPTION
Block writes could succeed after their upload marker failed, and later retries skipped that marker because the payload already existed. Continuous edits could also keep resetting the background upload timer. Retain a durable, idempotent marker before acknowledging each write and persist the first pending timestamp so later edits and restarts preserve the upload deadline.

Use a thirty-second default interval, retain the existing size and pack limits, and return a missing-block error without clearing pending work. Marker cleanup and deadline reset share one transaction. This change covers block upload scheduling; SharedObject operation and root publication keep their existing behavior.

Validation: focused sync, dirty-store, retry, restart, continuous-write, missing-block, and overlay tests passed with the race detector. Protocol generation and repository commit hooks passed. The final review checked persisted queue ownership, cleanup ordering, cancellation, and error propagation.
