### PR TITLE
feat(sync): retain local writes and coalesce cloud checkpoints

### DIFF
--- a/.protoc-manifest.json
+++ b/.protoc-manifest.json
@@ -1161,7 +1161,7 @@
       ]
     },
     "github.com/s4wave/spacewave/core/provider/spacewave/api": {
-      "hash": "fb722ead192045fb73a673009c80b1301eef860cab9fcd601952c46092603be4",
+      "hash": "66744131a99ecde622d902bf76fcfd6c443e785d4427a6cfe5a29ccf214175bb",
       "generatedFiles": [
         "core/provider/spacewave/api/api.pb.go",
         "core/provider/spacewave/api/api.pb.ts",

--- a/core/provider/spacewave/api/api.pb.go
+++ b/core/provider/spacewave/api/api.pb.go
@@ -894,6 +894,26 @@ func (x *SOStateDeltaEntry) GetChangeData() []byte {
 	return nil
 }
 
+// PostOpsRequest is one bounded, atomic cloud operation checkpoint.
+type PostOpsRequest struct {
+	unknownFields []byte
+	// Operations contains at most 50 signed operations and 1 MiB of encoded data.
+	Operations []*sobject.SOOperation `protobuf:"bytes,1,rep,name=operations,proto3" json:"operations,omitempty"`
+}
+
+func (x *PostOpsRequest) Reset() {
+	*x = PostOpsRequest{}
+}
+
+func (*PostOpsRequest) ProtoMessage() {}
+
+func (x *PostOpsRequest) GetOperations() []*sobject.SOOperation {
+	if x != nil {
+		return x.Operations
+	}
+	return nil
+}
+
 // PostRootRequest is the binary payload for POST /sobject/:id/root.
 type PostRootRequest struct {
 	unknownFields []byte
@@ -5528,6 +5548,12 @@ type VerifiedSOStateCache struct {
 	PeerState *sobject.SOState `protobuf:"bytes,6,opt,name=peer_state,json=peerState,proto3" json:"peerState,omitempty"`
 	// ConfigHistory retains authenticated transitions for peer catch-up.
 	ConfigHistory []*sobject.SOConfigChange `protobuf:"bytes,7,rep,name=config_history,json=configHistory,proto3" json:"configHistory,omitempty"`
+	// PendingPublication retains locally accepted work until cloud acknowledgment.
+	PendingPublication *PendingSOPublication `protobuf:"bytes,8,opt,name=pending_publication,json=pendingPublication,proto3" json:"pendingPublication,omitempty"`
+	// CloudState is the authenticated base for cloud deltas, separate from peers.
+	CloudState *sobject.SOState `protobuf:"bytes,9,opt,name=cloud_state,json=cloudState,proto3" json:"cloudState,omitempty"`
+	// CloudSequence is the changelog cursor belonging to CloudState.
+	CloudSequence uint64 `protobuf:"varint,10,opt,name=cloud_sequence,json=cloudSequence,proto3" json:"cloudSequence,omitempty"`
 }
 
 func (x *VerifiedSOStateCache) Reset() {
@@ -5583,6 +5609,74 @@ func (x *VerifiedSOStateCache) GetConfigHistory() []*sobject.SOConfigChange {
 		return x.ConfigHistory
 	}
 	return nil
+}
+
+func (x *VerifiedSOStateCache) GetPendingPublication() *PendingSOPublication {
+	if x != nil {
+		return x.PendingPublication
+	}
+	return nil
+}
+
+func (x *VerifiedSOStateCache) GetCloudState() *sobject.SOState {
+	if x != nil {
+		return x.CloudState
+	}
+	return nil
+}
+
+func (x *VerifiedSOStateCache) GetCloudSequence() uint64 {
+	if x != nil {
+		return x.CloudSequence
+	}
+	return 0
+}
+
+// PendingSOPublication survives process loss without moving its first deadline.
+type PendingSOPublication struct {
+	unknownFields []byte
+	// Root is the newest locally validated checkpoint awaiting cloud acceptance.
+	Root *sobject.SORoot `protobuf:"bytes,1,opt,name=root,proto3" json:"root,omitempty"`
+	// Operations are signed local writes not yet acknowledged by the cloud.
+	Operations []*sobject.SOOperation `protobuf:"bytes,2,rep,name=operations,proto3" json:"operations,omitempty"`
+	// Rejections are signed outcomes accompanying the coalesced root.
+	Rejections []*sobject.SOOperationRejection `protobuf:"bytes,3,rep,name=rejections,proto3" json:"rejections,omitempty"`
+	// FirstPendingUnixMilli starts the bounded cloud-checkpoint interval.
+	FirstPendingUnixMilli int64 `protobuf:"varint,4,opt,name=first_pending_unix_milli,json=firstPendingUnixMilli,proto3" json:"firstPendingUnixMilli,omitempty"`
+}
+
+func (x *PendingSOPublication) Reset() {
+	*x = PendingSOPublication{}
+}
+
+func (*PendingSOPublication) ProtoMessage() {}
+
+func (x *PendingSOPublication) GetRoot() *sobject.SORoot {
+	if x != nil {
+		return x.Root
+	}
+	return nil
+}
+
+func (x *PendingSOPublication) GetOperations() []*sobject.SOOperation {
+	if x != nil {
+		return x.Operations
+	}
+	return nil
+}
+
+func (x *PendingSOPublication) GetRejections() []*sobject.SOOperationRejection {
+	if x != nil {
+		return x.Rejections
+	}
+	return nil
+}
+
+func (x *PendingSOPublication) GetFirstPendingUnixMilli() int64 {
+	if x != nil {
+		return x.FirstPendingUnixMilli
+	}
+	return 0
 }
 
 // TicketResponse is the response body for POST /session/ticket.
@@ -10579,6 +10673,22 @@ func (m *SOStateDeltaEntry) CloneMessageVT() protobuf_go_lite.CloneMessage {
 	return m.CloneVT()
 }
 
+func (m *PostOpsRequest) CloneVT() *PostOpsRequest {
+	if m == nil {
+		return (*PostOpsRequest)(nil)
+	}
+	r := new(PostOpsRequest)
+	r.Operations = protobuf_go_lite.CloneVTSlice(m.Operations)
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = slices.Clone(m.unknownFields)
+	}
+	return r
+}
+
+func (m *PostOpsRequest) CloneMessageVT() protobuf_go_lite.CloneMessage {
+	return m.CloneVT()
+}
+
 func (m *PostRootRequest) CloneVT() *PostRootRequest {
 	if m == nil {
 		return (*PostRootRequest)(nil)
@@ -12844,12 +12954,15 @@ func (m *VerifiedSOStateCache) CloneVT() *VerifiedSOStateCache {
 	}
 	r := new(VerifiedSOStateCache)
 	r.VerifiedConfigChainSeqno = m.VerifiedConfigChainSeqno
+	r.CloudSequence = m.CloudSequence
 	r.GenesisHash = protobuf_go_lite.CloneBytes(m.GenesisHash)
 	r.VerifiedConfigChainHash = protobuf_go_lite.CloneBytes(m.VerifiedConfigChainHash)
 	r.KeyEpochs = protobuf_go_lite.CloneVTSlice(m.KeyEpochs)
 	r.CurrentConfig = protobuf_go_lite.CloneVTValue(m.CurrentConfig)
 	r.PeerState = protobuf_go_lite.CloneVTValue(m.PeerState)
 	r.ConfigHistory = protobuf_go_lite.CloneVTSlice(m.ConfigHistory)
+	r.PendingPublication = protobuf_go_lite.CloneVTValue(m.PendingPublication)
+	r.CloudState = protobuf_go_lite.CloneVTValue(m.CloudState)
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = slices.Clone(m.unknownFields)
 	}
@@ -12857,6 +12970,25 @@ func (m *VerifiedSOStateCache) CloneVT() *VerifiedSOStateCache {
 }
 
 func (m *VerifiedSOStateCache) CloneMessageVT() protobuf_go_lite.CloneMessage {
+	return m.CloneVT()
+}
+
+func (m *PendingSOPublication) CloneVT() *PendingSOPublication {
+	if m == nil {
+		return (*PendingSOPublication)(nil)
+	}
+	r := new(PendingSOPublication)
+	r.FirstPendingUnixMilli = m.FirstPendingUnixMilli
+	r.Root = protobuf_go_lite.CloneVTValue(m.Root)
+	r.Operations = protobuf_go_lite.CloneVTSlice(m.Operations)
+	r.Rejections = protobuf_go_lite.CloneVTSlice(m.Rejections)
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = slices.Clone(m.unknownFields)
+	}
+	return r
+}
+
+func (m *PendingSOPublication) CloneMessageVT() protobuf_go_lite.CloneMessage {
 	return m.CloneVT()
 }
 
@@ -15912,6 +16044,26 @@ func (this *SOStateDeltaEntry) EqualVT(that *SOStateDeltaEntry) bool {
 
 func (this *SOStateDeltaEntry) EqualMessageVT(thatMsg any) bool {
 	that, ok := thatMsg.(*SOStateDeltaEntry)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+
+func (this *PostOpsRequest) EqualVT(that *PostOpsRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !protobuf_go_lite.EqualVTSliceImplicit(this.Operations, that.Operations, func() *sobject.SOOperation { return &sobject.SOOperation{} }) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *PostOpsRequest) EqualMessageVT(thatMsg any) bool {
+	that, ok := thatMsg.(*PostOpsRequest)
 	if !ok {
 		return false
 	}
@@ -19164,11 +19316,49 @@ func (this *VerifiedSOStateCache) EqualVT(that *VerifiedSOStateCache) bool {
 	if !protobuf_go_lite.EqualVTSliceImplicit(this.ConfigHistory, that.ConfigHistory, func() *sobject.SOConfigChange { return &sobject.SOConfigChange{} }) {
 		return false
 	}
+	if !protobuf_go_lite.IsEqualVT(this.PendingPublication, that.PendingPublication) {
+		return false
+	}
+	if !protobuf_go_lite.IsEqualVT(this.CloudState, that.CloudState) {
+		return false
+	}
+	if this.CloudSequence != that.CloudSequence {
+		return false
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
 func (this *VerifiedSOStateCache) EqualMessageVT(thatMsg any) bool {
 	that, ok := thatMsg.(*VerifiedSOStateCache)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+
+func (this *PendingSOPublication) EqualVT(that *PendingSOPublication) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !protobuf_go_lite.IsEqualVT(this.Root, that.Root) {
+		return false
+	}
+	if !protobuf_go_lite.EqualVTSliceImplicit(this.Operations, that.Operations, func() *sobject.SOOperation { return &sobject.SOOperation{} }) {
+		return false
+	}
+	if !protobuf_go_lite.EqualVTSliceImplicit(this.Rejections, that.Rejections, func() *sobject.SOOperationRejection { return &sobject.SOOperationRejection{} }) {
+		return false
+	}
+	if this.FirstPendingUnixMilli != that.FirstPendingUnixMilli {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *PendingSOPublication) EqualMessageVT(thatMsg any) bool {
+	that, ok := thatMsg.(*PendingSOPublication)
 	if !ok {
 		return false
 	}
@@ -23901,6 +24091,69 @@ func (x *SOStateDeltaEntry) UnmarshalProtoJSON(s *json.UnmarshalState) {
 
 // UnmarshalJSON unmarshals the SOStateDeltaEntry from JSON.
 func (x *SOStateDeltaEntry) UnmarshalJSON(b []byte) error {
+	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
+}
+
+// MarshalProtoJSON marshals the PostOpsRequest message to JSON.
+func (x *PostOpsRequest) MarshalProtoJSON(s *json.MarshalState) {
+	if x == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteObjectStart()
+	var wroteField bool
+	if len(x.Operations) > 0 || s.HasField("operations") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("operations")
+		s.WriteArrayStart()
+		var wroteElement bool
+		for _, element := range x.Operations {
+			s.WriteMoreIf(&wroteElement)
+			element.MarshalProtoJSON(s.WithField("operations"))
+		}
+		s.WriteArrayEnd()
+	}
+	s.WriteObjectEnd()
+}
+
+// MarshalJSON marshals the PostOpsRequest to JSON.
+func (x *PostOpsRequest) MarshalJSON() ([]byte, error) {
+	return json.DefaultMarshalerConfig.Marshal(x)
+}
+
+// UnmarshalProtoJSON unmarshals the PostOpsRequest message from JSON.
+func (x *PostOpsRequest) UnmarshalProtoJSON(s *json.UnmarshalState) {
+	if s.ReadNil() {
+		return
+	}
+	s.ReadObject(func(key string) {
+		switch key {
+		default:
+			s.Skip() // ignore unknown field
+		case "operations":
+			s.AddField("operations")
+			if s.ReadNil() {
+				x.Operations = nil
+				return
+			}
+			s.ReadArray(func() {
+				if s.ReadNil() {
+					x.Operations = append(x.Operations, nil)
+					return
+				}
+				v := &sobject.SOOperation{}
+				v.UnmarshalProtoJSON(s.WithField("operations", false))
+				if s.Err() != nil {
+					return
+				}
+				x.Operations = append(x.Operations, v)
+			})
+		}
+	})
+}
+
+// UnmarshalJSON unmarshals the PostOpsRequest from JSON.
+func (x *PostOpsRequest) UnmarshalJSON(b []byte) error {
 	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
 }
 
@@ -31199,6 +31452,21 @@ func (x *VerifiedSOStateCache) MarshalProtoJSON(s *json.MarshalState) {
 		}
 		s.WriteArrayEnd()
 	}
+	if x.PendingPublication != nil || s.HasField("pendingPublication") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("pendingPublication")
+		x.PendingPublication.MarshalProtoJSON(s.WithField("pendingPublication"))
+	}
+	if x.CloudState != nil || s.HasField("cloudState") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("cloudState")
+		x.CloudState.MarshalProtoJSON(s.WithField("cloudState"))
+	}
+	if x.CloudSequence != 0 || s.HasField("cloudSequence") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("cloudSequence")
+		s.WriteUint64(x.CloudSequence)
+	}
 	s.WriteObjectEnd()
 }
 
@@ -31275,12 +31543,141 @@ func (x *VerifiedSOStateCache) UnmarshalProtoJSON(s *json.UnmarshalState) {
 				}
 				x.ConfigHistory = append(x.ConfigHistory, v)
 			})
+		case "pending_publication", "pendingPublication":
+			if s.ReadNil() {
+				x.PendingPublication = nil
+				return
+			}
+			x.PendingPublication = &PendingSOPublication{}
+			x.PendingPublication.UnmarshalProtoJSON(s.WithField("pending_publication", true))
+		case "cloud_state", "cloudState":
+			if s.ReadNil() {
+				x.CloudState = nil
+				return
+			}
+			x.CloudState = &sobject.SOState{}
+			x.CloudState.UnmarshalProtoJSON(s.WithField("cloud_state", true))
+		case "cloud_sequence", "cloudSequence":
+			s.AddField("cloud_sequence")
+			x.CloudSequence = s.ReadUint64()
 		}
 	})
 }
 
 // UnmarshalJSON unmarshals the VerifiedSOStateCache from JSON.
 func (x *VerifiedSOStateCache) UnmarshalJSON(b []byte) error {
+	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
+}
+
+// MarshalProtoJSON marshals the PendingSOPublication message to JSON.
+func (x *PendingSOPublication) MarshalProtoJSON(s *json.MarshalState) {
+	if x == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteObjectStart()
+	var wroteField bool
+	if x.Root != nil || s.HasField("root") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("root")
+		x.Root.MarshalProtoJSON(s.WithField("root"))
+	}
+	if len(x.Operations) > 0 || s.HasField("operations") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("operations")
+		s.WriteArrayStart()
+		var wroteElement bool
+		for _, element := range x.Operations {
+			s.WriteMoreIf(&wroteElement)
+			element.MarshalProtoJSON(s.WithField("operations"))
+		}
+		s.WriteArrayEnd()
+	}
+	if len(x.Rejections) > 0 || s.HasField("rejections") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("rejections")
+		s.WriteArrayStart()
+		var wroteElement bool
+		for _, element := range x.Rejections {
+			s.WriteMoreIf(&wroteElement)
+			element.MarshalProtoJSON(s.WithField("rejections"))
+		}
+		s.WriteArrayEnd()
+	}
+	if x.FirstPendingUnixMilli != 0 || s.HasField("firstPendingUnixMilli") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("firstPendingUnixMilli")
+		s.WriteInt64(x.FirstPendingUnixMilli)
+	}
+	s.WriteObjectEnd()
+}
+
+// MarshalJSON marshals the PendingSOPublication to JSON.
+func (x *PendingSOPublication) MarshalJSON() ([]byte, error) {
+	return json.DefaultMarshalerConfig.Marshal(x)
+}
+
+// UnmarshalProtoJSON unmarshals the PendingSOPublication message from JSON.
+func (x *PendingSOPublication) UnmarshalProtoJSON(s *json.UnmarshalState) {
+	if s.ReadNil() {
+		return
+	}
+	s.ReadObject(func(key string) {
+		switch key {
+		default:
+			s.Skip() // ignore unknown field
+		case "root":
+			if s.ReadNil() {
+				x.Root = nil
+				return
+			}
+			x.Root = &sobject.SORoot{}
+			x.Root.UnmarshalProtoJSON(s.WithField("root", true))
+		case "operations":
+			s.AddField("operations")
+			if s.ReadNil() {
+				x.Operations = nil
+				return
+			}
+			s.ReadArray(func() {
+				if s.ReadNil() {
+					x.Operations = append(x.Operations, nil)
+					return
+				}
+				v := &sobject.SOOperation{}
+				v.UnmarshalProtoJSON(s.WithField("operations", false))
+				if s.Err() != nil {
+					return
+				}
+				x.Operations = append(x.Operations, v)
+			})
+		case "rejections":
+			s.AddField("rejections")
+			if s.ReadNil() {
+				x.Rejections = nil
+				return
+			}
+			s.ReadArray(func() {
+				if s.ReadNil() {
+					x.Rejections = append(x.Rejections, nil)
+					return
+				}
+				v := &sobject.SOOperationRejection{}
+				v.UnmarshalProtoJSON(s.WithField("rejections", false))
+				if s.Err() != nil {
+					return
+				}
+				x.Rejections = append(x.Rejections, v)
+			})
+		case "first_pending_unix_milli", "firstPendingUnixMilli":
+			s.AddField("first_pending_unix_milli")
+			x.FirstPendingUnixMilli = s.ReadInt64()
+		}
+	})
+}
+
+// UnmarshalJSON unmarshals the PendingSOPublication from JSON.
+func (x *PendingSOPublication) UnmarshalJSON(b []byte) error {
 	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
 }
 
@@ -39707,6 +40104,50 @@ func (m *SOStateDeltaEntry) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *PostOpsRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *PostOpsRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *PostOpsRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	if len(m.Operations) > 0 {
+		for iNdEx := len(m.Operations) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.Operations[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *PostRootRequest) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -45712,6 +46153,31 @@ func (m *VerifiedSOStateCache) MarshalToSizedBufferVT(dAtA []byte) (int, error) 
 	if m.unknownFields != nil {
 		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
 	}
+	if m.CloudSequence != 0 {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(m.CloudSequence))
+		i--
+		dAtA[i] = 0x50
+	}
+	if m.CloudState != nil {
+		size, err := m.CloudState.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x4a
+	}
+	if m.PendingPublication != nil {
+		size, err := m.PendingPublication.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x42
+	}
 	if len(m.ConfigHistory) > 0 {
 		for iNdEx := len(m.ConfigHistory) - 1; iNdEx >= 0; iNdEx-- {
 			size, err := m.ConfigHistory[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
@@ -45768,6 +46234,77 @@ func (m *VerifiedSOStateCache) MarshalToSizedBufferVT(dAtA []byte) (int, error) 
 	}
 	if len(m.GenesisHash) > 0 {
 		i = protobuf_go_lite.EncodeBytes(dAtA, i, m.GenesisHash)
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *PendingSOPublication) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *PendingSOPublication) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *PendingSOPublication) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	if m.FirstPendingUnixMilli != 0 {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(m.FirstPendingUnixMilli))
+		i--
+		dAtA[i] = 0x20
+	}
+	if len(m.Rejections) > 0 {
+		for iNdEx := len(m.Rejections) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.Rejections[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if len(m.Operations) > 0 {
+		for iNdEx := len(m.Operations) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.Operations[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if m.Root != nil {
+		size, err := m.Root.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(size))
 		i--
 		dAtA[i] = 0xa
 	}
@@ -52644,6 +53181,20 @@ func (m *SOStateDeltaEntry) SizeVT() (n int) {
 	return n
 }
 
+func (m *PostOpsRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	for _, e := range m.Operations {
+		l = e.SizeVT()
+		n += protobuf_go_lite.SizeMessage(1, l)
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *PostRootRequest) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -54462,6 +55013,38 @@ func (m *VerifiedSOStateCache) SizeVT() (n int) {
 		l = e.SizeVT()
 		n += protobuf_go_lite.SizeMessage(1, l)
 	}
+	if m.PendingPublication != nil {
+		l = m.PendingPublication.SizeVT()
+		n += protobuf_go_lite.SizeMessage(1, l)
+	}
+	if m.CloudState != nil {
+		l = m.CloudState.SizeVT()
+		n += protobuf_go_lite.SizeMessage(1, l)
+	}
+	n += protobuf_go_lite.SizeVarintNonZero(1, m.CloudSequence)
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *PendingSOPublication) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Root != nil {
+		l = m.Root.SizeVT()
+		n += protobuf_go_lite.SizeMessage(1, l)
+	}
+	for _, e := range m.Operations {
+		l = e.SizeVT()
+		n += protobuf_go_lite.SizeMessage(1, l)
+	}
+	for _, e := range m.Rejections {
+		l = e.SizeVT()
+		n += protobuf_go_lite.SizeMessage(1, l)
+	}
+	n += protobuf_go_lite.SizeVarintNonZero(1, m.FirstPendingUnixMilli)
 	n += len(m.unknownFields)
 	return n
 }
@@ -56914,6 +57497,28 @@ func (x *SOStateDeltaEntry) MarshalProtoText() string {
 }
 
 func (x *SOStateDeltaEntry) String() string {
+	return x.MarshalProtoText()
+}
+
+func (x *PostOpsRequest) MarshalProtoText() string {
+	var sb protobuf_go_lite.TextBuilder
+	initialLen := protobuf_go_lite.TextStartMessage(&sb, "PostOpsRequest")
+	if len(x.Operations) > 0 {
+		protobuf_go_lite.TextWriteListStart(&sb, initialLen, "operations")
+		for i, v := range x.Operations {
+			protobuf_go_lite.TextWriteListSeparator(&sb, i)
+			if v == nil {
+				protobuf_go_lite.TextWriteTextMarshaler(&sb, &sobject.SOOperation{})
+			} else {
+				protobuf_go_lite.TextWriteTextMarshaler(&sb, v)
+			}
+		}
+		protobuf_go_lite.TextWriteListEnd(&sb)
+	}
+	return protobuf_go_lite.TextFinishMessage(&sb)
+}
+
+func (x *PostOpsRequest) String() string {
 	return x.MarshalProtoText()
 }
 
@@ -59687,10 +60292,64 @@ func (x *VerifiedSOStateCache) MarshalProtoText() string {
 		}
 		protobuf_go_lite.TextWriteListEnd(&sb)
 	}
+	if x.PendingPublication != nil {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "pending_publication")
+		protobuf_go_lite.TextWriteTextMarshaler(&sb, x.PendingPublication)
+	}
+	if x.CloudState != nil {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "cloud_state")
+		protobuf_go_lite.TextWriteTextMarshaler(&sb, x.CloudState)
+	}
+	if x.CloudSequence != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "cloud_sequence")
+		protobuf_go_lite.TextWriteUint(&sb, x.CloudSequence)
+	}
 	return protobuf_go_lite.TextFinishMessage(&sb)
 }
 
 func (x *VerifiedSOStateCache) String() string {
+	return x.MarshalProtoText()
+}
+
+func (x *PendingSOPublication) MarshalProtoText() string {
+	var sb protobuf_go_lite.TextBuilder
+	initialLen := protobuf_go_lite.TextStartMessage(&sb, "PendingSOPublication")
+	if x.Root != nil {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "root")
+		protobuf_go_lite.TextWriteTextMarshaler(&sb, x.Root)
+	}
+	if len(x.Operations) > 0 {
+		protobuf_go_lite.TextWriteListStart(&sb, initialLen, "operations")
+		for i, v := range x.Operations {
+			protobuf_go_lite.TextWriteListSeparator(&sb, i)
+			if v == nil {
+				protobuf_go_lite.TextWriteTextMarshaler(&sb, &sobject.SOOperation{})
+			} else {
+				protobuf_go_lite.TextWriteTextMarshaler(&sb, v)
+			}
+		}
+		protobuf_go_lite.TextWriteListEnd(&sb)
+	}
+	if len(x.Rejections) > 0 {
+		protobuf_go_lite.TextWriteListStart(&sb, initialLen, "rejections")
+		for i, v := range x.Rejections {
+			protobuf_go_lite.TextWriteListSeparator(&sb, i)
+			if v == nil {
+				protobuf_go_lite.TextWriteTextMarshaler(&sb, &sobject.SOOperationRejection{})
+			} else {
+				protobuf_go_lite.TextWriteTextMarshaler(&sb, v)
+			}
+		}
+		protobuf_go_lite.TextWriteListEnd(&sb)
+	}
+	if x.FirstPendingUnixMilli != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "first_pending_unix_milli")
+		protobuf_go_lite.TextWriteInt(&sb, x.FirstPendingUnixMilli)
+	}
+	return protobuf_go_lite.TextFinishMessage(&sb)
+}
+
+func (x *PendingSOPublication) String() string {
 	return x.MarshalProtoText()
 }
 
@@ -63565,6 +64224,62 @@ func (m *SOStateDeltaEntry) UnmarshalVT(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
+		default:
+			iNdEx = preIndex
+			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protobuf_go_lite.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+
+func (m *PostOpsRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	var err error
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		wire, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+		if err != nil {
+			return err
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: PostOpsRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: PostOpsRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Operations", wireType)
+			}
+			msgStart, postIndex, err := protobuf_go_lite.DecodeLengthDelimited(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.Operations = append(m.Operations, &sobject.SOOperation{})
+			if err := m.Operations[len(m.Operations)-1].UnmarshalVT(dAtA[msgStart:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
@@ -72473,6 +73188,138 @@ func (m *VerifiedSOStateCache) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PendingPublication", wireType)
+			}
+			msgStart, postIndex, err := protobuf_go_lite.DecodeLengthDelimited(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			if m.PendingPublication == nil {
+				m.PendingPublication = &PendingSOPublication{}
+			}
+			if err := m.PendingPublication.UnmarshalVT(dAtA[msgStart:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 9:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CloudState", wireType)
+			}
+			msgStart, postIndex, err := protobuf_go_lite.DecodeLengthDelimited(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			if m.CloudState == nil {
+				m.CloudState = &sobject.SOState{}
+			}
+			if err := m.CloudState.UnmarshalVT(dAtA[msgStart:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 10:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CloudSequence", wireType)
+			}
+			m.CloudSequence = 0
+			m.CloudSequence, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protobuf_go_lite.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+
+func (m *PendingSOPublication) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	var err error
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		wire, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+		if err != nil {
+			return err
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: PendingSOPublication: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: PendingSOPublication: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Root", wireType)
+			}
+			msgStart, postIndex, err := protobuf_go_lite.DecodeLengthDelimited(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			if m.Root == nil {
+				m.Root = &sobject.SORoot{}
+			}
+			if err := m.Root.UnmarshalVT(dAtA[msgStart:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Operations", wireType)
+			}
+			msgStart, postIndex, err := protobuf_go_lite.DecodeLengthDelimited(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.Operations = append(m.Operations, &sobject.SOOperation{})
+			if err := m.Operations[len(m.Operations)-1].UnmarshalVT(dAtA[msgStart:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Rejections", wireType)
+			}
+			msgStart, postIndex, err := protobuf_go_lite.DecodeLengthDelimited(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.Rejections = append(m.Rejections, &sobject.SOOperationRejection{})
+			if err := m.Rejections[len(m.Rejections)-1].UnmarshalVT(dAtA[msgStart:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field FirstPendingUnixMilli", wireType)
+			}
+			m.FirstPendingUnixMilli = 0
+			m.FirstPendingUnixMilli, iNdEx, err = protobuf_go_lite.DecodeVarintInt64(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])

--- a/core/provider/spacewave/api/api.pb.ts
+++ b/core/provider/spacewave/api/api.pb.ts
@@ -23,6 +23,7 @@ import {
   SOJoinResponse,
   SOKeyEpoch,
   SOMutationKey,
+  SOOperation,
   SOOperationRejection,
   SOReceiptState_Enum,
   SORoot,
@@ -964,6 +965,35 @@ export const SOStateMessage: MessageType<SOStateMessage> =
         name: 'receipt_protocol_epoch',
         kind: 'scalar',
         T: ScalarType.UINT32,
+      },
+    ] satisfies readonly PartialFieldInfo[],
+    packedByDefault: true,
+  })
+
+/**
+ * PostOpsRequest is one bounded, atomic cloud operation checkpoint.
+ *
+ * @generated from message provider.spacewave.api.PostOpsRequest
+ */
+export interface PostOpsRequest {
+  /**
+   * Operations contains at most 50 signed operations and 1 MiB of encoded data.
+   *
+   * @generated from field: repeated sobject.SOOperation operations = 1;
+   */
+  operations?: SOOperation[]
+}
+
+export const PostOpsRequest: MessageType<PostOpsRequest> =
+  /* @__PURE__ */ createMessageType({
+    typeName: 'provider.spacewave.api.PostOpsRequest',
+    fields: [
+      {
+        no: 1,
+        name: 'operations',
+        kind: 'message',
+        T: () => SOOperation,
+        repeated: true,
       },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,
@@ -5961,6 +5991,67 @@ export const AccountStateCache: MessageType<AccountStateCache> =
   })
 
 /**
+ * PendingSOPublication survives process loss without moving its first deadline.
+ *
+ * @generated from message provider.spacewave.api.PendingSOPublication
+ */
+export interface PendingSOPublication {
+  /**
+   * Root is the newest locally validated checkpoint awaiting cloud acceptance.
+   *
+   * @generated from field: sobject.SORoot root = 1;
+   */
+  root?: SORoot
+  /**
+   * Operations are signed local writes not yet acknowledged by the cloud.
+   *
+   * @generated from field: repeated sobject.SOOperation operations = 2;
+   */
+  operations?: SOOperation[]
+  /**
+   * Rejections are signed outcomes accompanying the coalesced root.
+   *
+   * @generated from field: repeated sobject.SOOperationRejection rejections = 3;
+   */
+  rejections?: SOOperationRejection[]
+  /**
+   * FirstPendingUnixMilli starts the bounded cloud-checkpoint interval.
+   *
+   * @generated from field: int64 first_pending_unix_milli = 4;
+   */
+  firstPendingUnixMilli?: bigint
+}
+
+export const PendingSOPublication: MessageType<PendingSOPublication> =
+  /* @__PURE__ */ createMessageType({
+    typeName: 'provider.spacewave.api.PendingSOPublication',
+    fields: [
+      { no: 1, name: 'root', kind: 'message', T: () => SORoot },
+      {
+        no: 2,
+        name: 'operations',
+        kind: 'message',
+        T: () => SOOperation,
+        repeated: true,
+      },
+      {
+        no: 3,
+        name: 'rejections',
+        kind: 'message',
+        T: () => SOOperationRejection,
+        repeated: true,
+      },
+      {
+        no: 4,
+        name: 'first_pending_unix_milli',
+        kind: 'scalar',
+        T: ScalarType.INT64,
+      },
+    ] satisfies readonly PartialFieldInfo[],
+    packedByDefault: true,
+  })
+
+/**
  * VerifiedSOStateCache is the trusted local cache of verified SO config state.
  *
  * @generated from message provider.spacewave.api.VerifiedSOStateCache
@@ -6008,6 +6099,24 @@ export interface VerifiedSOStateCache {
    * @generated from field: repeated sobject.SOConfigChange config_history = 7;
    */
   configHistory?: SOConfigChange[]
+  /**
+   * PendingPublication retains locally accepted work until cloud acknowledgment.
+   *
+   * @generated from field: provider.spacewave.api.PendingSOPublication pending_publication = 8;
+   */
+  pendingPublication?: PendingSOPublication
+  /**
+   * CloudState is the authenticated base for cloud deltas, separate from peers.
+   *
+   * @generated from field: sobject.SOState cloud_state = 9;
+   */
+  cloudState?: SOState
+  /**
+   * CloudSequence is the changelog cursor belonging to CloudState.
+   *
+   * @generated from field: uint64 cloud_sequence = 10;
+   */
+  cloudSequence?: bigint
 }
 
 export const VerifiedSOStateCache: MessageType<VerifiedSOStateCache> =
@@ -6048,6 +6157,14 @@ export const VerifiedSOStateCache: MessageType<VerifiedSOStateCache> =
         T: () => SOConfigChange,
         repeated: true,
       },
+      {
+        no: 8,
+        name: 'pending_publication',
+        kind: 'message',
+        T: () => PendingSOPublication,
+      },
+      { no: 9, name: 'cloud_state', kind: 'message', T: () => SOState },
+      { no: 10, name: 'cloud_sequence', kind: 'scalar', T: ScalarType.UINT64 },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,
   })

--- a/core/provider/spacewave/api/api.proto
+++ b/core/provider/spacewave/api/api.proto
@@ -163,6 +163,12 @@ message SOStateDeltaEntry {
   bytes change_data = 3;
 }
 
+// PostOpsRequest is one bounded, atomic cloud operation checkpoint.
+message PostOpsRequest {
+  // Operations contains at most 50 signed operations and 1 MiB of encoded data.
+  repeated .sobject.SOOperation operations = 1;
+}
+
 // PostRootRequest is the binary payload for POST /sobject/:id/root.
 message PostRootRequest {
   // Root is the next signed root state.
@@ -1563,6 +1569,24 @@ message VerifiedSOStateCache {
   .sobject.SOState peer_state = 6;
   // ConfigHistory retains authenticated transitions for peer catch-up.
   repeated .sobject.SOConfigChange config_history = 7;
+  // PendingPublication retains locally accepted work until cloud acknowledgment.
+  PendingSOPublication pending_publication = 8;
+  // CloudState is the authenticated base for cloud deltas, separate from peers.
+  .sobject.SOState cloud_state = 9;
+  // CloudSequence is the changelog cursor belonging to CloudState.
+  uint64 cloud_sequence = 10;
+}
+
+// PendingSOPublication survives process loss without moving its first deadline.
+message PendingSOPublication {
+  // Root is the newest locally validated checkpoint awaiting cloud acceptance.
+  .sobject.SORoot root = 1;
+  // Operations are signed local writes not yet acknowledged by the cloud.
+  repeated .sobject.SOOperation operations = 2;
+  // Rejections are signed outcomes accompanying the coalesced root.
+  repeated .sobject.SOOperationRejection rejections = 3;
+  // FirstPendingUnixMilli starts the bounded cloud-checkpoint interval.
+  int64 first_pending_unix_milli = 4;
 }
 
 // TicketResponse is the response body for POST /session/ticket.

--- a/core/provider/spacewave/bstore-retention.go
+++ b/core/provider/spacewave/bstore-retention.go
@@ -1,0 +1,38 @@
+package provider_spacewave
+
+import (
+	"context"
+
+	"github.com/aperturerobotics/util/csync"
+	"github.com/s4wave/spacewave/db/kvtx"
+)
+
+// blockPublicationRetention belongs to the local block cache. Removing cached
+// bytes invalidates its graph proofs before deletion can become durable.
+type blockPublicationRetention struct {
+	mu    csync.Mutex
+	store kvtx.Store
+}
+
+// invalidate excludes graph retention until the caller finishes deleting bytes.
+// A failure leaves the bytes intact. A crash after invalidation requires a fresh
+// graph walk, even when the physical deletion never completed.
+func (r *blockPublicationRetention) invalidate(ctx context.Context) (func(), error) {
+	if r == nil {
+		return func() {}, nil
+	}
+	release, err := r.mu.Lock(ctx)
+	if err != nil {
+		return nil, err
+	}
+	err = kvtx.RunTransaction(ctx, true, func(ctx context.Context) (kvtx.Tx, error) {
+		return r.store.NewTransaction(ctx, true)
+	}, func(ctx context.Context, tx kvtx.Tx) error {
+		return tx.ScanPrefixKeys(ctx, nil, func(key []byte) error { return tx.Delete(ctx, key) })
+	})
+	if err != nil {
+		release()
+		return nil, err
+	}
+	return release, nil
+}

--- a/core/provider/spacewave/bstore-retention_test.go
+++ b/core/provider/spacewave/bstore-retention_test.go
@@ -1,0 +1,53 @@
+package provider_spacewave
+
+import (
+	"context"
+	"testing"
+
+	"github.com/s4wave/spacewave/db/block"
+	block_mock "github.com/s4wave/spacewave/db/block/mock"
+	block_store "github.com/s4wave/spacewave/db/block/store"
+	"github.com/s4wave/spacewave/db/kvtx"
+)
+
+// TestBlockDeletionInvalidatesPublicationProofs checks both deletion entry points
+// against the proof store shared by ordinary and scoped block handles.
+func TestBlockDeletionInvalidatesPublicationProofs(t *testing.T) {
+	for _, batch := range []bool{false, true} {
+		t.Run(map[bool]string{false: "remove", true: "batch"}[batch], func(t *testing.T) {
+			ctx := t.Context()
+			cache := newSyncTestKvStore()
+			store := &BlockStore{
+				store:     block_store.NewStore("test", block_mock.NewMockStore(0)),
+				retention: &blockPublicationRetention{store: cache},
+			}
+			ref, _, err := store.PutBlock(ctx, []byte("retained"), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := kvtx.RunTransaction(ctx, true, func(ctx context.Context) (kvtx.Tx, error) {
+				return cache.NewTransaction(ctx, true)
+			}, func(ctx context.Context, tx kvtx.Tx) error {
+				return tx.Set(ctx, []byte("complete-parent"), []byte{1})
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if batch {
+				err = store.PutBlockBatch(ctx, []*block.PutBatchEntry{{Ref: ref, Tombstone: true}})
+			} else {
+				err = store.RmBlock(ctx, ref)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			tx, err := cache.NewTransaction(ctx, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer tx.Discard()
+			if _, found, err := tx.Get(ctx, []byte("complete-parent")); err != nil || found {
+				t.Fatalf("deletion retained a false closure proof: found=%v, err=%v", found, err)
+			}
+		})
+	}
+}

--- a/core/provider/spacewave/bstore.go
+++ b/core/provider/spacewave/bstore.go
@@ -26,6 +26,7 @@ import (
 	block_store_controller "github.com/s4wave/spacewave/db/block/store/controller"
 	"github.com/s4wave/spacewave/db/bucket"
 	lookup_concurrent "github.com/s4wave/spacewave/db/bucket/lookup/concurrent"
+	kvtx_prefixer "github.com/s4wave/spacewave/db/kvtx/prefixer"
 	"github.com/s4wave/spacewave/db/volume"
 	kvtx_volume "github.com/s4wave/spacewave/db/volume/common/kvtx"
 	"github.com/s4wave/spacewave/net/hash"
@@ -60,6 +61,10 @@ type BlockStore struct {
 	decodedBlocks *block.DecodedBlockCache
 	// forceSync flushes pending dirty blocks to the cloud immediately.
 	forceSync func(ctx context.Context) error
+	// syncer coalesces block uploads with mounted SharedObject publications.
+	syncer *syncController
+	// retention shares graph proofs and deletion exclusion across scoped handles.
+	retention *blockPublicationRetention
 	// refreshRemote pulls remote packfile metadata into the local read manifest.
 	refreshRemote func(ctx context.Context) error
 	// remoteSequence returns the local manifest's last-seen remote sequence.
@@ -110,6 +115,8 @@ func (b *BlockStore) BeginReadOperation(ctx context.Context) (block.StoreOps, fu
 		store:          scopedStore,
 		decodedBlocks:  b.decodedBlocks,
 		forceSync:      b.forceSync,
+		syncer:         b.syncer,
+		retention:      b.retention,
 		refreshRemote:  b.refreshRemote,
 		remoteSequence: b.remoteSequence,
 	}, release, nil
@@ -122,6 +129,16 @@ func (b *BlockStore) PutBlock(ctx context.Context, data []byte, opts *block.PutO
 
 // PutBlockBatch forwards batched writes to the inner store.
 func (b *BlockStore) PutBlockBatch(ctx context.Context, entries []*block.PutBatchEntry) error {
+	for _, entry := range entries {
+		if entry != nil && entry.Tombstone {
+			release, err := b.retention.invalidate(ctx)
+			if err != nil {
+				return err
+			}
+			defer release()
+			break
+		}
+	}
 	// Tombstone publication and the decoded cache are separate lower stores;
 	// invalidate on both sides so in-flight decoded stores cannot cross the
 	// mutation boundary.
@@ -150,6 +167,11 @@ func (b *BlockStore) GetBlockExistsBatch(ctx context.Context, refs []*block.Bloc
 
 // RmBlock forwards to the inner store.
 func (b *BlockStore) RmBlock(ctx context.Context, ref *block.BlockRef) error {
+	release, err := b.retention.invalidate(ctx)
+	if err != nil {
+		return err
+	}
+	defer release()
 	// Delete publication and the decoded cache are separate lower stores;
 	// invalidate on both sides so in-flight decoded stores cannot cross the
 	// mutation boundary.
@@ -364,6 +386,9 @@ func (t *bstoreTracker) executeBlockStoreTracker(rctx context.Context) error {
 		decodedBlocks: decodedBlocks,
 		cacheStore:    sourceUpper,
 		cloudStore:    sourceLower,
+		retention: &blockPublicationRetention{
+			store: kvtx_prefixer.NewPrefixer(objStore, []byte("publication-retention/")),
+		},
 	}
 
 	// Build and register block store controller on the bus.
@@ -413,6 +438,7 @@ func (t *bstoreTracker) executeBlockStoreTracker(rctx context.Context) error {
 
 	// Wire dirty tracking from PutBlock to syncController.
 	dirtyUpper.markDirty = sc.MarkDirty
+	bstoreHandle.syncer = sc
 	bstoreHandle.forceSync = sc.FlushNowUnordered
 	bstoreHandle.refreshRemote = sc.PullNow
 	bstoreHandle.remoteSequence = sc.LastPullSequence

--- a/core/provider/spacewave/client.go
+++ b/core/provider/spacewave/client.go
@@ -1630,6 +1630,28 @@ func (c *SessionClient) PostOp(ctx context.Context, soID string, opData []byte) 
 	return errors.Wrap(err, "post op")
 }
 
+// PostOps posts one bounded atomic operation checkpoint using its write ticket.
+func (c *SessionClient) PostOps(ctx context.Context, soID string, operations []*sobject.SOOperation) error {
+	if len(operations) == 0 || len(operations) > 50 {
+		return errors.New("operation checkpoint must contain 1 to 50 operations")
+	}
+	body, err := (&api.PostOpsRequest{Operations: operations}).MarshalVT()
+	if err != nil {
+		return err
+	}
+	if len(body) > 1<<20 {
+		return errors.New("operation checkpoint exceeds 1 MiB")
+	}
+	return c.executeRequiredWriteTicketAudience(ctx, soID, writeTicketAudienceSOOp, func(ticket string) error {
+		data, err := c.postSObjectWriteWithTicket(ctx, soID, "ops", body, ticket)
+		if err != nil {
+			return err
+		}
+		var response api.SubmitOpResponse
+		return response.UnmarshalVT(data)
+	})
+}
+
 // PostRoot posts a root state update to a shared object.
 func (c *SessionClient) PostRoot(
 	ctx context.Context,

--- a/core/provider/spacewave/cloud-publication.go
+++ b/core/provider/spacewave/cloud-publication.go
@@ -1,0 +1,270 @@
+package provider_spacewave
+
+import (
+	"bytes"
+	"cmp"
+	"context"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	api "github.com/s4wave/spacewave/core/provider/spacewave/api"
+	"github.com/s4wave/spacewave/core/sobject"
+)
+
+// retainPublication commits accepted state and its cloud obligation atomically.
+// The caller holds acceptMu. No watched local success precedes this transaction.
+func (h *cloudSOHost) retainPublication(ctx context.Context, state *sobject.SOState, operation *sobject.SOOperation, root bool) error {
+	if operation != nil && (&api.PostOpsRequest{Operations: []*sobject.SOOperation{operation}}).SizeVT() > 1<<20 {
+		return errors.New("operation exceeds the cloud checkpoint limit")
+	}
+	if h.syncer != nil {
+		fenced, err := h.syncer.upper.Sync(ctx)
+		if err != nil {
+			return err
+		}
+		if !fenced {
+			return errors.New("local block store has no durability fence")
+		}
+	}
+	cache := h.buildVerifiedStateCache()
+	if cache == nil || h.persistVerifiedStateCache == nil {
+		return errors.New("local publication requires durable verified state")
+	}
+	pending := cache.GetPendingPublication()
+	if pending == nil {
+		pending = &api.PendingSOPublication{FirstPendingUnixMilli: time.Now().UnixMilli()}
+	}
+	if operation != nil {
+		pending.Operations = append(pending.Operations, operation.CloneVT())
+	}
+	if root {
+		pending.Root = state.GetRoot().CloneVT()
+		pending.Rejections = append(pending.Rejections, diffSOOperationRejections(h.stateCtr.GetValue(), state)...)
+		pending.Operations = sobject.FilterResolvedOperations(pending.Operations, pending.Root.GetAccountNonces(), nil, state.GetOpRejections())
+	}
+	cache.PeerState = state.CloneVT()
+	cache.PendingPublication = pending
+	if err := h.persistVerifiedStateCache(ctx, cache); err != nil {
+		return err
+	}
+	h.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		h.peerState = cache.PeerState
+		h.pending = pending
+		h.stateCtr.SetValue(state)
+		broadcast()
+	})
+	if h.syncer != nil {
+		h.syncer.setPublication(h, pending)
+	}
+	return nil
+}
+
+// pendingPublication snapshots durable work before its block flush begins.
+func (h *cloudSOHost) pendingPublication() *api.PendingSOPublication {
+	var pending *api.PendingSOPublication
+	h.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) { pending = h.pending.CloneVT() })
+	return pending
+}
+
+// publishCheckpoint sends only work captured before the corresponding block
+// fence. Newer local writes keep their own obligation through acknowledgment.
+func (h *cloudSOHost) publishCheckpoint(ctx context.Context, sent *api.PendingSOPublication) error {
+	if sent == nil {
+		return nil
+	}
+	var config *sobject.SharedObjectConfig
+	h.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) { config = h.verifiedConfig.CloneVT() })
+	if config == nil {
+		return sobject.ErrConfigHistoryUnavailable
+	}
+	if sent.GetRoot() != nil {
+		valid, err := sent.Root.ValidateSignatures(h.soID, config.GetParticipants())
+		if err != nil {
+			return err
+		}
+		if err := sobject.CheckConsensusAcceptance(config.GetConsensusMode(), valid); err != nil {
+			return err
+		}
+		if err := h.client.PostRoot(ctx, h.soID, sent.Root, sent.Rejections); err != nil {
+			return err
+		}
+	}
+	var batch []*sobject.SOOperation
+	for _, operation := range sent.GetOperations() {
+		if err := operation.ValidateSignature(h.soID, config.GetParticipants()); err != nil {
+			return err
+		}
+		candidate := append(batch, operation)
+		if len(candidate) > 50 || (&api.PostOpsRequest{Operations: candidate}).SizeVT() > 1<<20 {
+			if err := h.client.PostOps(ctx, h.soID, batch); err != nil {
+				return err
+			}
+			batch = nil
+		}
+		batch = append(batch, operation)
+	}
+	if len(batch) != 0 {
+		if err := h.client.PostOps(ctx, h.soID, batch); err != nil {
+			return err
+		}
+	}
+
+	// A lost acknowledgment leaves the same signed request available for retry.
+	release, err := h.acceptMu.Lock(ctx)
+	if err != nil {
+		return err
+	}
+	defer release()
+	cache := h.buildVerifiedStateCache()
+	if cache == nil || h.persistVerifiedStateCache == nil {
+		return sobject.ErrConfigHistoryUnavailable
+	}
+	pending := cache.GetPendingPublication()
+	if pending == nil {
+		return nil
+	}
+	if pending.GetRoot().EqualVT(sent.GetRoot()) {
+		pending.Root = nil
+	}
+	pending.Operations = slices.DeleteFunc(pending.Operations, func(op *sobject.SOOperation) bool {
+		return slices.ContainsFunc(sent.Operations, func(other *sobject.SOOperation) bool { return op.EqualVT(other) })
+	})
+	pending.Rejections = slices.DeleteFunc(pending.Rejections, func(rejection *sobject.SOOperationRejection) bool {
+		return slices.ContainsFunc(sent.Rejections, func(other *sobject.SOOperationRejection) bool { return rejection.EqualVT(other) })
+	})
+	if pending.GetRoot() == nil && len(pending.Operations) == 0 && len(pending.Rejections) == 0 {
+		pending = nil
+	}
+	cache.PendingPublication = pending
+	if err := h.persistVerifiedStateCache(ctx, cache); err != nil {
+		return err
+	}
+	h.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		h.pending = pending
+		broadcast()
+	})
+	if h.syncer != nil {
+		h.syncer.setPublication(h, pending)
+	}
+	return nil
+}
+
+// setPublication projects durable obligations into the existing sync scheduler.
+func (s *syncController) setPublication(h *cloudSOHost, pending *api.PendingSOPublication) {
+	s.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		if pending == nil {
+			delete(s.publications, h)
+		} else {
+			if s.publications == nil {
+				s.publications = make(map[*cloudSOHost]time.Time)
+			}
+			s.publications[h] = time.UnixMilli(pending.GetFirstPendingUnixMilli())
+		}
+		if s.telemetry != nil {
+			s.telemetry.syncTelemetry.SetPendingPublications(s.resourceID, len(s.publications))
+		}
+		broadcast()
+	})
+}
+
+// flushCheckpoint runs under flushMtx. Snapshotting roots before blocks prevents
+// a concurrent edit from publishing a root whose dependencies missed this flush.
+func (s *syncController) flushCheckpoint(ctx context.Context, orderBlocks bool) (retErr error) {
+	if s.telemetry != nil {
+		defer func() { s.telemetry.syncTelemetry.RecordError(s.resourceID, retErr) }()
+	}
+	var hosts []*cloudSOHost
+	s.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		for host := range s.publications {
+			hosts = append(hosts, host)
+		}
+	})
+	pending := make([]*api.PendingSOPublication, len(hosts))
+	for i, host := range hosts {
+		pending[i] = host.pendingPublication()
+	}
+	if err := s.flush(ctx, orderBlocks); err != nil {
+		return err
+	}
+	for i, host := range hosts {
+		if err := host.publishCheckpoint(ctx, pending[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// acceptCloudSnapshot keeps the cloud cursor paired with its authenticated base,
+// while preserving newer peer roots and unresolved local operations. The caller
+// holds acceptMu and has verified both cloud signatures and changelog progression.
+func (h *cloudSOHost) acceptCloudSnapshot(ctx context.Context, cloud *sobject.SOState, sequence uint64) error {
+	previous := h.stateCtr.GetValue()
+	next := cloud.CloneVT()
+	other := previous
+	if previous.GetRoot().GetInnerSeqno() > cloud.GetRoot().GetInnerSeqno() {
+		next = h.stateWithVerifiedConfig(previous, cloud.GetConfig())
+		other = cloud
+	} else if previous.GetRoot().GetInnerSeqno() == cloud.GetRoot().GetInnerSeqno() && previous.GetRoot() != nil && !previous.GetRoot().EqualVT(cloud.GetRoot()) {
+		return errors.New("cloud root conflicts with accepted peer root")
+	}
+
+	// Rebuild admissible work against the selected root. Its committed nonces
+	// discard resolved operations; signed rejection identities remain available.
+	for _, rejection := range diffSOOperationRejections(next, other) {
+		inner, err := rejection.ValidateSignature(h.soID, next.GetConfig().GetParticipants())
+		if err != nil {
+			continue
+		}
+		group := slices.IndexFunc(next.OpRejections, func(group *sobject.SOPeerOpRejections) bool { return group.GetPeerId() == inner.GetPeerId() })
+		if group == -1 {
+			next.OpRejections = append(next.OpRejections, &sobject.SOPeerOpRejections{PeerId: inner.GetPeerId(), Rejections: []*sobject.SOOperationRejection{rejection.CloneVT()}})
+		} else {
+			next.OpRejections[group].Rejections = append(next.OpRejections[group].Rejections, rejection.CloneVT())
+		}
+	}
+	slices.SortFunc(next.OpRejections, func(a, b *sobject.SOPeerOpRejections) int { return strings.Compare(a.GetPeerId(), b.GetPeerId()) })
+	operations := append(next.Ops, cloneVTSlice(other.GetOps())...)
+	operations = sobject.FilterResolvedOperations(operations, next.GetRoot().GetAccountNonces(), nil, next.GetOpRejections())
+	slices.SortStableFunc(operations, func(a, b *sobject.SOOperation) int {
+		aa, _ := a.UnmarshalInner()
+		bb, _ := b.UnmarshalInner()
+		if cmp := strings.Compare(aa.GetPeerId(), bb.GetPeerId()); cmp != 0 {
+			return cmp
+		}
+		return cmp.Compare(aa.GetNonce(), bb.GetNonce())
+	})
+	next.Ops = nil
+	next.QueuedAccountNonces = nil
+	for _, operation := range operations {
+		// Duplicate, committed, or revoked work is not admissible in this state.
+		_ = next.QueueOperation(h.soID, operation)
+	}
+
+	cache := h.buildVerifiedStateCache()
+	if cache != nil && h.persistVerifiedStateCache != nil {
+		cache.PeerState = next.CloneVT()
+		cache.CloudState = cloud.CloneVT()
+		cache.CloudSequence = sequence
+		if err := h.persistVerifiedStateCache(ctx, cache); err != nil {
+			return err
+		}
+	}
+	var configChanged bool
+	h.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		h.peerState = next.CloneVT()
+		h.cloudState = cloud.CloneVT()
+		h.lastSeqno = sequence
+		h.initialStateErr = nil
+		configHash := cloud.GetConfig().GetConfigChainHash()
+		configChanged = len(configHash) != 0 && !bytes.Equal(configHash, h.lastConfigChainHash)
+		h.stateCtr.SetValue(next)
+		broadcast()
+	})
+	if configChanged {
+		h.triggerConfigChanged()
+	}
+	h.logNewOpRejections(previous, next, "cloud-checkpoint")
+	return nil
+}

--- a/core/provider/spacewave/cloud-sohost-operation_test.go
+++ b/core/provider/spacewave/cloud-sohost-operation_test.go
@@ -2,70 +2,249 @@ package provider_spacewave
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 
 	"github.com/aperturerobotics/util/ccontainer"
-	"github.com/pkg/errors"
+	api "github.com/s4wave/spacewave/core/provider/spacewave/api"
 	"github.com/s4wave/spacewave/core/sobject"
+	"github.com/s4wave/spacewave/db/block"
 	"github.com/sirupsen/logrus"
 )
 
-// TestCloudSOHostUploadsBeforeOperation keeps referenced blocks available when
-// the cloud receives an operation, without waiting for background sync.
-func TestCloudSOHostUploadsBeforeOperation(t *testing.T) {
-	for _, tc := range []struct {
-		name       string
-		failUpload bool
-	}{
-		{name: "uploaded"},
-		{name: "upload-failed", failUpload: true},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			// Only the cloud HTTP boundary is substituted; the operation owner and
-			// signed operation use their production implementations.
-			var uploaded, posted atomic.Bool
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				posted.Store(true)
-				if !uploaded.Load() {
-					t.Error("operation reached the cloud before its blocks were uploaded")
-				}
-				w.WriteHeader(http.StatusOK)
-			}))
-			t.Cleanup(server.Close)
-			key, peerID := generateTestKeypair(t)
-			client := NewSessionClient(server.Client(), server.URL, DefaultSigningEnvPrefix, key, peerID.String())
-			client.executeWriteTicketAudience = func(ctx context.Context, resourceID string, audience writeTicketAudience, submit func(string) error) error {
-				return submit("test-ticket")
+// TestCloudPublicationSurvivesRestart exercises signed local acceptance, failed
+// persistence, cloud loss, coalescing, and blocks-before-root acknowledgment.
+func TestCloudPublicationSurvivesRestart(t *testing.T) {
+	var requests, roots, uploads atomic.Int32
+	var unavailable atomic.Bool
+	unavailable.Store(true)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if unavailable.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, "/sync/push") {
+			uploads.Add(1)
+		} else if strings.HasSuffix(r.URL.Path, "/root") {
+			if uploads.Load() == 0 {
+				t.Error("root reached the cloud before its blocks")
 			}
-			uploadErr := errors.New("upload unavailable")
-			host := &cloudSOHost{
-				le:       logrus.New().WithField("test", t.Name()),
-				client:   client,
-				soID:     testSharedObjectID,
-				stateCtr: ccontainer.NewCContainer(&sobject.SOState{}),
-				forceBlockSync: func(context.Context) error {
-					if tc.failUpload {
-						return uploadErr
-					}
-					uploaded.Store(true)
-					return nil
-				},
-			}
-
-			// Failed uploads must not publish an operation whose inputs are absent.
-			err := host.QueueOperation(t.Context(), peerID, func(nonce uint64) (*sobject.SOOperation, error) {
-				return sobject.BuildSOOperation(testSharedObjectID, key, []byte("operation"), nonce, sobject.NewSOOperationLocalID())
-			})
-			if tc.failUpload {
-				if !errors.Is(err, uploadErr) || posted.Load() {
-					t.Fatalf("failed upload submitted operation: err=%v posted=%v", err, posted.Load())
-				}
-			} else if err != nil || !uploaded.Load() || !posted.Load() {
-				t.Fatalf("operation did not upload then submit: err=%v uploaded=%v posted=%v", err, uploaded.Load(), posted.Load())
-			}
+			roots.Add(1)
+		} else {
+			t.Errorf("unexpected publication route: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/protobuf")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+	key, peerID := generateTestKeypair(t)
+	client := NewSessionClient(server.Client(), server.URL, DefaultSigningEnvPrefix, key, peerID.String())
+	client.executeWriteTicketAudience = func(ctx context.Context, resourceID string, audience writeTicketAudience, submit func(string) error) error {
+		return submit("test-ticket")
+	}
+	syncer := newDirtySyncExecuteTestController(t, client, nil)
+	account := &ProviderAccount{objStore: newSyncTestKvStore()}
+	config := &sobject.SharedObjectConfig{
+		ConfigChainHash: []byte("verified history"),
+		ConsensusMode:   sobject.SOConsensusMode_SO_CONSENSUS_MODE_SINGLE_VALIDATOR,
+		Participants:    []*sobject.SOParticipantConfig{{PeerId: peerID.String(), Role: sobject.SOParticipantRole_SOParticipantRole_OWNER}},
+	}
+	initial := &sobject.SOState{Config: config, Root: buildTestSORoot(t, key, 1, nil)}
+	persistErr := errors.New("metadata unavailable")
+	failPersist := true
+	persist := func(ctx context.Context, cache *api.VerifiedSOStateCache) error {
+		if failPersist {
+			return persistErr
+		}
+		return account.writeVerifiedSOStateCache(ctx, testSharedObjectID, cache)
+	}
+	host := &cloudSOHost{
+		le: logrus.New().WithField("test", t.Name()), client: client,
+		soID: testSharedObjectID, peerID: peerID, stateCtr: ccontainer.NewCContainer(initial),
+		verifiedConfig: config, lastConfigChainHash: config.ConfigChainHash,
+		cloudState: initial.CloneVT(), persistVerifiedStateCache: persist, syncer: syncer,
+	}
+	queue := func() error {
+		return host.QueueOperation(t.Context(), peerID, func(nonce uint64) (*sobject.SOOperation, error) {
+			return sobject.BuildSOOperation(testSharedObjectID, key, []byte("operation"), nonce, sobject.NewSOOperationLocalID())
 		})
+	}
+	if err := queue(); !errors.Is(err, persistErr) || len(host.stateCtr.GetValue().GetOps()) != 0 {
+		t.Fatalf("failed persistence acknowledged local work: %v", err)
+	}
+	failPersist = false
+	for range 2 {
+		if err := queue(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if requests.Load() != 0 {
+		t.Fatal("ordinary local acceptance contacted the cloud")
+	}
+	first := host.pending.GetFirstPendingUnixMilli()
+
+	// Validator acceptance coalesces both operations into one signed checkpoint.
+	state := host.stateCtr.GetValue().CloneVT()
+	root := buildTestSORoot(t, key, 2, []*sobject.SOAccountNonce{{PeerId: peerID.String(), Nonce: 2}})
+	if err := state.UpdateRootState(testSharedObjectID, root, peerID.String(), nil, state.Ops); err != nil {
+		t.Fatal(err)
+	}
+	if err := host.acceptLocalState(t.Context(), state); err != nil {
+		t.Fatal(err)
+	}
+	if len(host.pending.Operations) != 0 || host.pending.GetFirstPendingUnixMilli() != first {
+		t.Fatal("coalescing retained resolved operations or extended the deadline")
+	}
+
+	// Restart from serialized storage, retaining the cloud delta base and timer.
+	cache, err := account.loadVerifiedSOStateCache(t.Context(), testSharedObjectID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reopened := &cloudSOHost{
+		le: host.le, client: client, soID: testSharedObjectID, peerID: peerID,
+		stateCtr: ccontainer.NewCContainer[*sobject.SOState](nil), persistVerifiedStateCache: persist, syncer: syncer,
+	}
+	reopened.hydrateVerifiedStateCache(cache)
+	syncer.setPublication(host, nil)
+	syncer.setPublication(reopened, reopened.pending)
+	if reopened.stateCtr.GetValue() == nil || reopened.pending.GetFirstPendingUnixMilli() != first {
+		t.Fatal("restart lost accepted state or first-pending deadline")
+	}
+	if err := reopened.verifyPulledState(initial); err != nil {
+		t.Fatal(err)
+	}
+	if err := reopened.acceptCloudSnapshot(t.Context(), initial, 1); err != nil {
+		t.Fatal(err)
+	}
+	if reopened.stateCtr.GetValue().GetRoot().GetInnerSeqno() != 2 {
+		t.Fatal("cloud lag rolled back accepted local state")
+	}
+
+	if err := syncer.FlushNowUnordered(t.Context()); err == nil {
+		t.Fatal("cloud outage was acknowledged")
+	}
+	if reopened.pending == nil || roots.Load() != 0 {
+		t.Fatal("failed upload lost publication or exposed its root")
+	}
+	unavailable.Store(false)
+	if err := syncer.FlushNowUnordered(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if roots.Load() != 1 || reopened.pending != nil {
+		t.Fatal("checkpoint did not acknowledge exactly one coalesced root")
+	}
+	cache, err = account.loadVerifiedSOStateCache(t.Context(), testSharedObjectID)
+	if err != nil || cache.GetPendingPublication() != nil {
+		t.Fatalf("acknowledgment was not durable: %v", err)
+	}
+}
+
+// TestCloudPublicationMissingBlockCannotPublish keeps root visibility behind the
+// complete dirty-block fence even when all state metadata is already durable.
+func TestCloudPublicationMissingBlockCannotPublish(t *testing.T) {
+	syncer := newDirtySyncExecuteTestController(t, nil, nil)
+	ref, err := block.BuildBlockRef([]byte("unavailable dependency"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := syncer.MarkDirty(t.Context(), ref.GetHash(), 22); err != nil {
+		t.Fatal(err)
+	}
+	host := &cloudSOHost{pending: &api.PendingSOPublication{FirstPendingUnixMilli: 1}}
+	syncer.setPublication(host, host.pending)
+	if err := syncer.FlushNowUnordered(t.Context()); !errors.Is(err, block.ErrNotFound) {
+		t.Fatalf("missing dependency fence: %v", err)
+	}
+}
+
+// TestCloudPublicationConcurrentAcceptance preserves work accepted during a
+// checkpoint and fences retained work when the writer loses publication rights.
+func TestCloudPublicationConcurrentAcceptance(t *testing.T) {
+	started := make(chan struct{})
+	resume := make(chan struct{})
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/ops") {
+			t.Errorf("unexpected route: %s", r.URL.Path)
+		}
+		if calls.Add(1) == 1 {
+			close(started)
+			select {
+			case <-resume:
+			case <-r.Context().Done():
+				return
+			}
+		}
+		w.Header().Set("Content-Type", "application/protobuf")
+	}))
+	t.Cleanup(server.Close)
+	key, peerID := generateTestKeypair(t)
+	client := NewSessionClient(server.Client(), server.URL, DefaultSigningEnvPrefix, key, peerID.String())
+	client.executeWriteTicketAudience = func(ctx context.Context, resourceID string, audience writeTicketAudience, submit func(string) error) error {
+		return submit("test-ticket")
+	}
+	account := &ProviderAccount{objStore: newSyncTestKvStore()}
+	config := &sobject.SharedObjectConfig{
+		ConfigChainHash: []byte("verified history"),
+		ConsensusMode:   sobject.SOConsensusMode_SO_CONSENSUS_MODE_SINGLE_VALIDATOR,
+		Participants:    []*sobject.SOParticipantConfig{{PeerId: peerID.String(), Role: sobject.SOParticipantRole_SOParticipantRole_OWNER}},
+	}
+	host := &cloudSOHost{
+		le: logrus.New().WithField("test", t.Name()), client: client,
+		soID: testSharedObjectID, peerID: peerID,
+		stateCtr:       ccontainer.NewCContainer(&sobject.SOState{Config: config}),
+		verifiedConfig: config, lastConfigChainHash: config.ConfigChainHash,
+		persistVerifiedStateCache: func(ctx context.Context, cache *api.VerifiedSOStateCache) error {
+			return account.writeVerifiedSOStateCache(ctx, testSharedObjectID, cache)
+		},
+	}
+	queue := func() {
+		t.Helper()
+		if err := host.QueueOperation(t.Context(), peerID, func(nonce uint64) (*sobject.SOOperation, error) {
+			return sobject.BuildSOOperation(testSharedObjectID, key, []byte("operation"), nonce, sobject.NewSOOperationLocalID())
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	queue()
+	sent := host.pendingPublication()
+	done := make(chan error, 1)
+	go func() { done <- host.publishCheckpoint(t.Context(), sent) }()
+	select {
+	case <-started:
+	case <-t.Context().Done():
+		t.Fatal(t.Context().Err())
+	}
+	queue()
+	close(resume)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	cache, err := account.loadVerifiedSOStateCache(t.Context(), testSharedObjectID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pending := cache.GetPendingPublication()
+	if len(pending.GetOperations()) != 1 || pending.GetFirstPendingUnixMilli() != sent.GetFirstPendingUnixMilli() {
+		t.Fatal("acknowledgment lost concurrent work or extended its deadline")
+	}
+	inner, err := pending.Operations[0].UnmarshalInner()
+	if err != nil || inner.GetNonce() != 2 {
+		t.Fatalf("wrong pending operation: %v", err)
+	}
+	revoked := config.CloneVT()
+	revoked.Participants[0].Role = sobject.SOParticipantRole_SOParticipantRole_READER
+	host.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) { host.verifiedConfig = revoked })
+	if err := host.publishCheckpoint(t.Context(), host.pendingPublication()); err == nil {
+		t.Fatal("revoked writer published retained work")
+	}
+	if calls.Load() != 1 || len(host.pendingPublication().GetOperations()) != 1 {
+		t.Fatal("revocation contacted the cloud or discarded retained work")
 	}
 }

--- a/core/provider/spacewave/cloud-sohost-sync.go
+++ b/core/provider/spacewave/cloud-sohost-sync.go
@@ -66,26 +66,6 @@ func (h *cloudSOHost) readConfigHistory(ctx context.Context, _ string, base, tar
 	})
 }
 
-// retainPeerState advances an existing durable snapshot before cloud publication.
-// The caller holds acceptMu and publishes next only after this returns success.
-func (h *cloudSOHost) retainPeerState(ctx context.Context, next *sobject.SOState) error {
-	if h.peerState == nil {
-		return nil
-	}
-	cache := h.buildVerifiedStateCache()
-	if cache == nil || h.persistVerifiedStateCache == nil {
-		return sobject.ErrConfigHistoryUnavailable
-	}
-	cache.PeerState = next.CloneVT()
-	if err := h.persistVerifiedStateCache(ctx, cache); err != nil {
-		return err
-	}
-	h.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
-		h.peerState = cache.PeerState
-	})
-	return nil
-}
-
 // stateWithVerifiedConfig preserves the accepted root while fencing capabilities
 // and queued work that no longer have authority in the verified configuration.
 func (h *cloudSOHost) stateWithVerifiedConfig(state *sobject.SOState, config *sobject.SharedObjectConfig) *sobject.SOState {

--- a/core/provider/spacewave/cloud-sohost.go
+++ b/core/provider/spacewave/cloud-sohost.go
@@ -3,7 +3,6 @@ package provider_spacewave
 import (
 	"bytes"
 	"context"
-	"time"
 
 	"github.com/aperturerobotics/util/broadcast"
 	"github.com/aperturerobotics/util/ccontainer"
@@ -72,6 +71,12 @@ type cloudSOHost struct {
 	historyIndex map[string]*sobject.SOConfigChange
 	// peerState is the durable peer snapshot retained across cache-only updates.
 	peerState *sobject.SOState
+	// pending retains only work accepted locally for cloud publication.
+	pending *api.PendingSOPublication
+	// cloudState is the authenticated cloud-delta base, independent of live peers.
+	cloudState *sobject.SOState
+	// syncer owns this host's block and root checkpoint lifetime.
+	syncer *syncController
 	// writeMu serializes local writes to prevent self-nonce conflicts.
 	writeMu csync.Mutex
 	// pullRoutine runs coalesced gap-recovery state pulls.
@@ -95,8 +100,6 @@ type cloudSOHost struct {
 	// onPeerRevoked is called when a peer is removed from the config chain with
 	// RevocationInfo. Called with the revoked peer ID string.
 	onPeerRevoked func(peerIDStr string)
-	// forceBlockSync uploads referenced blocks before publishing operations or roots.
-	forceBlockSync func(ctx context.Context) error
 	// refreshBlockManifest pulls remote packfile metadata before publishing
 	// remote SO state that may reference newly-pushed blocks.
 	refreshBlockManifest func(ctx context.Context) error
@@ -120,7 +123,7 @@ func newCloudSOHost(
 	sfs *block_transform.StepFactorySet,
 	verifiedCache *api.VerifiedSOStateCache,
 	persistVerifiedStateCache func(context.Context, *api.VerifiedSOStateCache) error,
-	forceBlockSync func(ctx context.Context) error,
+	syncer *syncController,
 ) *cloudSOHost {
 	// Construct state containers and background routines before exposing the host.
 	h := &cloudSOHost{
@@ -135,7 +138,7 @@ func newCloudSOHost(
 		stateCtr:                  ccontainer.NewCContainer[*sobject.SOState](nil),
 		snapCtr:                   ccontainer.NewCContainer[sobject.SharedObjectStateSnapshot](nil),
 		persistVerifiedStateCache: persistVerifiedStateCache,
-		forceBlockSync:            forceBlockSync,
+		syncer:                    syncer,
 	}
 	h.pullRoutine = newCoalescedTriggerRoutine(le, "so-state-pull", h.pullOnTrigger)
 	h.snapDeriver = newNamedRoutineContainer(le, "so-snapshot-deriver")
@@ -149,7 +152,7 @@ func newCloudSOHost(
 	}
 
 	// lockFn acquires the local write mutex and reads from the cached stateCtr.
-	// WriteSOState does HTTP POST with 409 retry.
+	// WriteSOState persists accepted local work before peer notification.
 	lockFn := func(ctx context.Context, sharedObjectID string) (sobject.SOStateLock, error) {
 		// Serialize local writers until their returned state lock is released.
 		relLock, err := h.writeMu.Lock(ctx)
@@ -169,14 +172,14 @@ func newCloudSOHost(
 			return nil, errors.New("no state available after pull")
 		}
 
-		// Bind the local snapshot to cloud publication and the acquired write lock.
+		// Bind the local snapshot to durable acceptance and the acquired write lock.
 		initialState := state.CloneVT()
 		writeFn := func(ctx context.Context, state *sobject.SOState, changes ...*sobject.SOConfigChange) error {
 			// Cloud configuration mutations use the server's config-state transaction.
 			if len(changes) != 0 {
 				return errors.New("configuration changes require cloud config-state publication")
 			}
-			return h.writeStateWithRetry(ctx, state)
+			return h.acceptLocalState(ctx, state)
 		}
 
 		return sobject.NewSOStateLock(initialState, writeFn, relLock), nil
@@ -380,34 +383,7 @@ func (h *cloudSOHost) pullState(ctx context.Context, reason SeedReason) error {
 		return err
 	}
 
-	if err := h.retainPeerState(ctx, state); err != nil {
-		return err
-	}
-
-	// Publish only after the accepted snapshot has been retained successfully.
-	var configHashChanged bool
-	var prevState *sobject.SOState
-	h.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
-		prevState = h.stateCtr.GetValue()
-		h.initialStateErr = nil
-		if lastSeqno > h.lastSeqno {
-			h.lastSeqno = lastSeqno
-		}
-		newHash := state.GetConfig().GetConfigChainHash()
-		if !bytes.Equal(newHash, h.lastConfigChainHash) && len(newHash) > 0 {
-			configHashChanged = true
-		}
-		h.stateCtr.SetValue(state)
-		broadcast()
-	})
-	h.logNewOpRejections(prevState, state, "state-pull")
-
-	// If the config chain hash changed, trigger verification.
-	if configHashChanged {
-		h.triggerConfigChanged()
-	}
-
-	return nil
+	return h.acceptCloudSnapshot(ctx, state, lastSeqno)
 }
 
 // noteInitialStateRejection records a rejected cold-seed verification outcome
@@ -476,17 +452,27 @@ func (h *cloudSOHost) verifyChangeLogSeqno(snapshotSeqno uint64) error {
 // verifyPulledState performs client-side verification on a pulled SOState.
 // Checks config chain hash continuity and root signature validity.
 func (h *cloudSOHost) verifyPulledState(state *sobject.SOState) error {
+	var held *sobject.SOState
+	h.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		held = h.cloudState
+		if held == nil && h.pending == nil && h.peerState == nil {
+			held = h.stateCtr.GetValue()
+		}
+	})
+	return h.verifyStateAgainst(state, held)
+}
+
+// verifyStateAgainst binds signatures and root progression to the given origin.
+func (h *cloudSOHost) verifyStateAgainst(state, held *sobject.SOState) error {
 	// Snapshot the trusted head and accepted root before comparing the response.
 	root := state.GetRoot()
 	var lastConfigHash []byte
 	var trustedConfig *sobject.SharedObjectConfig
 	var trustedSeqno uint64
-	var held *sobject.SOState
 	h.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
 		lastConfigHash = h.lastConfigChainHash
 		trustedConfig = h.verifiedConfig
 		trustedSeqno = h.verifiedConfigChainSeqno
-		held = h.stateCtr.GetValue()
 	})
 
 	// D3/D4: Reject state if its config chain hash differs from the last
@@ -675,22 +661,7 @@ func (h *cloudSOHost) handleStateDelta(ctx context.Context, msg *api.SOStateMess
 		if err := h.verifyPulledState(snap); err != nil {
 			return errors.Wrap(err, "verify inline snapshot")
 		}
-		if err := h.retainPeerState(ctx, snap); err != nil {
-			return err
-		}
-
-		// Publish the retained snapshot and its changelog cursor together.
-		var prevState *sobject.SOState
-		h.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
-			prevState = h.stateCtr.GetValue()
-			if msg.GetSeqno() >= h.lastSeqno {
-				h.stateCtr.SetValue(snap)
-				h.lastSeqno = msg.GetSeqno()
-				broadcast()
-			}
-		})
-		h.logNewOpRejections(prevState, snap, "inline-snapshot")
-		return nil
+		return h.acceptCloudSnapshot(ctx, snap, msg.GetSeqno())
 
 	case msg.GetDelta() != nil:
 		// Read the delta and the held base needed to apply it.
@@ -705,7 +676,10 @@ func (h *cloudSOHost) handleStateDelta(ctx context.Context, msg *api.SOStateMess
 			lastSeqno uint64
 		)
 		h.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
-			cached = h.stateCtr.GetValue()
+			cached = h.cloudState
+			if cached == nil && h.pending == nil {
+				cached = h.stateCtr.GetValue()
+			}
 			lastSeqno = h.lastSeqno
 		})
 
@@ -754,25 +728,7 @@ func (h *cloudSOHost) handleStateDelta(ctx context.Context, msg *api.SOStateMess
 			return errors.Wrap(err, "verify state after delta apply")
 		}
 
-		if err := h.retainPeerState(ctx, next); err != nil {
-			return err
-		}
-
-		// Publish the retained delta only if its base is still current.
-		newSeqno := entries[len(entries)-1].GetSeqno()
-		var prevState *sobject.SOState
-		h.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
-			// Re-check under lock to avoid clobbering a concurrent update.
-			if h.lastSeqno != lastSeqno {
-				return
-			}
-			prevState = h.stateCtr.GetValue()
-			h.stateCtr.SetValue(next)
-			h.lastSeqno = newSeqno
-			broadcast()
-		})
-		h.logNewOpRejections(prevState, next, "inline-delta")
-		return nil
+		return h.acceptCloudSnapshot(ctx, next, entries[len(entries)-1].GetSeqno())
 
 	case msg.GetConfigChanged() != nil:
 		h.triggerConfigChanged()
@@ -797,6 +753,21 @@ func applyChangeLogEntry(
 	entry *api.SOStateDeltaEntry,
 ) error {
 	switch entry.GetChangeType() {
+	case "ops":
+		batch := &api.PostOpsRequest{}
+		if err := batch.UnmarshalVT(entry.GetChangeData()); err != nil {
+			return err
+		}
+		for _, operation := range batch.GetOperations() {
+			data, err := operation.MarshalVT()
+			if err != nil {
+				return err
+			}
+			if err := applyChangeLogEntry(sharedObjectID, state, &api.SOStateDeltaEntry{ChangeType: "op", ChangeData: data}); err != nil {
+				return err
+			}
+		}
+		return nil
 	case "op":
 		// Decode the operation and discard any already-queued duplicate.
 		op := &sobject.SOOperation{}
@@ -965,101 +936,20 @@ func (h *cloudSOHost) logNewOpRejections(
 	}
 }
 
-// writeStateWithRetry posts the root state to the server.
-// On 409 (seqno conflict): pull fresh state, rebuild, retry up to maxWriteRetries times.
-func (h *cloudSOHost) writeStateWithRetry(ctx context.Context, state *sobject.SOState) error {
-	for attempt := range maxWriteRetries {
-		if h.forceBlockSync != nil {
-			started := time.Now()
-			h.le.WithField("attempt", attempt+1).Debug("flushing block store before root write")
-			if err := h.forceBlockSync(ctx); err != nil {
-				return errors.Wrap(err, "flush block store before root write")
-			}
-			h.le.WithField("attempt", attempt+1).
-				WithField("duration", time.Since(started)).
-				Debug("flushed block store before root write")
-		}
-
-		// Submit the root only after its referenced blocks are available remotely.
-		prevState := h.stateCtr.GetValue()
-		rejectedOps := diffSOOperationRejections(prevState, state)
-
-		started := time.Now()
-		err := h.client.PostRoot(ctx, h.soID, state.GetRoot(), rejectedOps)
-		if err == nil {
-			h.le.WithField("attempt", attempt+1).
-				WithField("duration", time.Since(started)).
-				WithField("so-seqno", state.GetRoot().GetInnerSeqno()).
-				Debug("posted root state")
-
-			// Recheck the accepted state after HTTP before publishing this local write.
-			release, err := h.acceptMu.Lock(ctx)
-			if err != nil {
-				return err
-			}
-			defer release()
-			if err := h.verifyPulledState(state); err != nil {
-				return err
-			}
-
-			if err := h.retainPeerState(ctx, state); err != nil {
-				return err
-			}
-
-			// Update cached state on successful write.
-			h.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
-				h.stateCtr.SetValue(state)
-				broadcast()
-			})
-			h.logNewOpRejections(prevState, state, "root-write")
-			return nil
-		}
-
-		// Retry only sequence conflicts after refreshing the held state.
-		var ce *cloudError
-		if !errors.As(err, &ce) || ce.StatusCode != 409 {
-			return err
-		}
-
-		h.le.WithField("attempt", attempt+1).Debug("seqno conflict, pulling fresh state for retry")
-		if pullErr := h.pullStateSingleflight(ctx, SeedReasonGapRecovery); pullErr != nil {
-			return errors.Wrap(pullErr, "pull state after 409")
-		}
-	}
-	return errors.New("write failed after max retries due to seqno conflicts")
-}
-
-// applyQueuedOperation updates the cached state with a newly accepted queued op.
-// It avoids an immediate read-after-write pull in the common success case.
-func (h *cloudSOHost) applyQueuedOperation(ctx context.Context, op *sobject.SOOperation) {
-	// Serialize the optimistic projection with cloud and peer acceptance.
+// acceptLocalState durably accepts a validated root for the checkpoint scheduler.
+func (h *cloudSOHost) acceptLocalState(ctx context.Context, state *sobject.SOState) error {
 	release, err := h.acceptMu.Lock(ctx)
 	if err != nil {
-		return
+		return err
 	}
 	defer release()
-	state := h.stateCtr.GetValue()
-	if state == nil {
-		return
+	if err := h.verifyStateAgainst(state, h.stateCtr.GetValue()); err != nil {
+		return err
 	}
-
-	// Revalidate the server-accepted operation against the latest held state.
-	next := state.CloneVT()
-	if err := next.QueueOperation(h.soID, op); err != nil {
-		h.le.WithError(err).Debug("failed to optimistically apply queued operation")
-		return
+	if err := state.Validate(h.soID); err != nil {
+		return err
 	}
-	if err := h.retainPeerState(ctx, next); err != nil {
-		h.le.WithError(err).Warn("failed to retain accepted cloud operation")
-		h.triggerPull()
-		return
-	}
-
-	// Publish the retained optimistic projection.
-	h.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
-		h.stateCtr.SetValue(next)
-		broadcast()
-	})
+	return h.retainPublication(ctx, state, nil, true)
 }
 
 // applyKeyEpoch updates the cached key-epoch state after a successful write.
@@ -1205,68 +1095,33 @@ func (h *cloudSOHost) applyConfigMutation(
 	return nil
 }
 
-// QueueOperation uploads pending blocks before submitting an operation to the cloud.
+// QueueOperation signs and durably accepts local work before live peer delivery.
 func (h *cloudSOHost) QueueOperation(ctx context.Context, peerID peer.ID, cb func(nonce uint64) (*sobject.SOOperation, error)) error {
-	// Keep nonce selection and publication under the existing local write lock.
-	relLock, err := h.writeMu.Lock(ctx)
+	releaseWrite, err := h.writeMu.Lock(ctx)
 	if err != nil {
 		return err
 	}
-	defer relLock()
-
-	for attempt := range maxWriteRetries {
-		// Refresh the accepted state before deriving an operation nonce.
-		if err := h.ensureInitialState(ctx, SeedReasonColdSeed); err != nil {
-			return errors.Wrap(err, "initial state pull for op queue")
-		}
-		state := h.stateCtr.GetValue()
-		if state == nil {
-			return errors.New("no state available after pull")
-		}
-
-		// Construct and encode the signed operation against that state.
-		op, err := cb(state.GetNextAccountNonce(peerID.String()))
-		if err != nil {
-			return err
-		}
-		if err := op.Validate(); err != nil {
-			return err
-		}
-
-		opData, err := op.MarshalVT()
-		if err != nil {
-			return errors.Wrap(err, "marshal operation")
-		}
-
-		// A remote validator must be able to read the operation's referenced
-		// blocks immediately, without waiting for the background upload timer.
-		if h.forceBlockSync != nil {
-			started := time.Now()
-			if err := h.forceBlockSync(ctx); err != nil {
-				return errors.Wrap(err, "upload blocks before operation")
-			}
-			h.le.WithField("duration", time.Since(started)).Debug("uploaded blocks before operation")
-		}
-		if err := h.client.PostOp(ctx, h.soID, opData); err != nil {
-			var ce *cloudError
-			if !errors.As(err, &ce) || ce.StatusCode != 409 || attempt+1 == maxWriteRetries {
-				return err
-			}
-			h.le.WithFields(logrus.Fields{
-				"attempt": attempt + 1,
-				"code":    ce.Code,
-			}).Debug("op conflict, pulling fresh state for retry")
-			if pullErr := h.pullStateSingleflight(ctx, SeedReasonGapRecovery); pullErr != nil {
-				return errors.Wrap(pullErr, "pull state after op conflict")
-			}
-			continue
-		}
-
-		// Project the server-accepted operation without an immediate read-after-write.
-		h.applyQueuedOperation(ctx, op)
-		return nil
+	defer releaseWrite()
+	if err := h.ensureInitialState(ctx, SeedReasonColdSeed); err != nil {
+		return err
 	}
-	return errors.New("queue operation failed after max retries due to write conflicts")
+	release, err := h.acceptMu.Lock(ctx)
+	if err != nil {
+		return err
+	}
+	defer release()
+	state := h.stateCtr.GetValue().CloneVT()
+	if state == nil {
+		return errors.New("no accepted shared object state")
+	}
+	operation, err := cb(state.GetNextAccountNonce(peerID.String()))
+	if err != nil {
+		return err
+	}
+	if err := state.QueueOperation(h.soID, operation); err != nil {
+		return err
+	}
+	return h.retainPublication(ctx, state, operation, false)
 }
 
 // AccessSharedObjectState returns the raw SOState container.
@@ -1677,6 +1532,9 @@ func (h *cloudSOHost) buildVerifiedStateCache() *api.VerifiedSOStateCache {
 			KeyEpochs:                cloneVTSlice(h.keyEpochs),
 			PeerState:                h.peerState.CloneVT(),
 			ConfigHistory:            cloneVTSlice(h.configHistory),
+			PendingPublication:       h.pending.CloneVT(),
+			CloudState:               h.cloudState.CloneVT(),
+			CloudSequence:            h.lastSeqno,
 		}
 		config := h.verifiedConfig
 		if config == nil {
@@ -1725,6 +1583,9 @@ func (h *cloudSOHost) hydrateVerifiedStateCache(cache *api.VerifiedSOStateCache)
 	h.configHistory = cloneVTSlice(cache.GetConfigHistory())
 	h.historyIndex = indexConfigHistory(h.configHistory)
 	h.peerState = cache.GetPeerState().CloneVT()
+	h.pending = cache.GetPendingPublication().CloneVT()
+	h.cloudState = cache.GetCloudState().CloneVT()
+	h.lastSeqno = cache.GetCloudSequence()
 	if h.peerState != nil && sobject.EqualSOConfigs(h.peerState.GetConfig(), cache.GetCurrentConfig()) && h.peerState.Validate(h.soID) == nil {
 		h.stateCtr.SetValue(h.peerState.CloneVT())
 	}

--- a/core/provider/spacewave/peer-import_test.go
+++ b/core/provider/spacewave/peer-import_test.go
@@ -115,16 +115,18 @@ func TestCloudPeerImportCommitsWithoutPublication(t *testing.T) {
 	// A cloud response prepared before the import cannot roll back its root or authority.
 	stale := initial.CloneVT()
 	stale.Config = candidate.Config.CloneVT()
-	if err := reopened.handleStateDelta(ctx, &api.SOStateMessage{Seqno: 99, Content: &api.SOStateMessage_Snapshot{Snapshot: stale}}); err == nil {
-		t.Fatal("accepted stale cloud root after peer import")
+	if err := reopened.handleStateDelta(ctx, &api.SOStateMessage{Seqno: 99, Content: &api.SOStateMessage_Snapshot{Snapshot: stale}}); err != nil {
+		t.Fatal(err)
 	}
 	if !reopened.stateCtr.GetValue().EqualVT(candidate) {
 		t.Fatal("stale cloud response changed accepted peer state")
 	}
 	// Hold peer persistence while a cloud completion tries to publish an older root.
 	persisting, allowCommit := make(chan struct{}), make(chan struct{})
+	var blocked bool
 	reopened.persistVerifiedStateCache = func(ctx context.Context, cache *api.VerifiedSOStateCache) error {
-		if cache.GetPeerState().GetRoot().GetInnerSeqno() == 9 {
+		if cache.GetPeerState().GetRoot().GetInnerSeqno() == 9 && !blocked {
+			blocked = true
 			close(persisting)
 			select {
 			case <-allowCommit:
@@ -164,8 +166,11 @@ func TestCloudPeerImportCommitsWithoutPublication(t *testing.T) {
 	if err := <-peerDone; err != nil {
 		t.Fatal(err)
 	}
-	if err := <-cloudDone; err == nil {
-		t.Fatal("delayed cloud completion overwrote the peer winner")
+	if err := <-cloudDone; err != nil {
+		t.Fatal(err)
+	}
+	if !reopened.stateCtr.GetValue().EqualVT(newer) || reopened.pending != nil {
+		t.Fatal("delayed cloud completion overwrote the peer winner or created a publication")
 	}
 
 	// Later valid cloud progress also advances the durable root used on restart.

--- a/core/provider/spacewave/sobject.go
+++ b/core/provider/spacewave/sobject.go
@@ -18,6 +18,7 @@ import (
 	"github.com/s4wave/spacewave/core/space"
 	block_gc "github.com/s4wave/spacewave/db/block/gc"
 	"github.com/s4wave/spacewave/db/kvtx"
+	kvtx_prefixer "github.com/s4wave/spacewave/db/kvtx/prefixer"
 	"github.com/s4wave/spacewave/db/volume"
 	kvtx_volume "github.com/s4wave/spacewave/db/volume/common/kvtx"
 	"github.com/s4wave/spacewave/net/crypto"
@@ -67,8 +68,28 @@ func (s *SharedObject) GetBackingVolume() volume.Volume {
 
 // AccessLocalStateStore accesses a kvtx ops for a local state store with the given ID.
 func (s *SharedObject) AccessLocalStateStore(ctx context.Context, storeID string, released func()) (kvtx.Store, func(), error) {
-	// For cloud provider, local state store is not yet implemented.
-	return nil, nil, errors.New("local state store not available for cloud provider")
+	if s.tkr.a.objStore == nil {
+		return nil, nil, errors.New("account object store not ready")
+	}
+	store := kvtx_prefixer.NewPrefixer(s.tkr.a.objStore, []byte("so-local/"+s.tkr.id+"/"+storeID+"/"))
+	if released == nil {
+		return store, func() {}, nil
+	}
+	stop := context.AfterFunc(ctx, released)
+	return store, func() { stop() }, nil
+}
+
+// AccessPublicationRetention retains completion proofs for cloud-bound graphs.
+func (s *SharedObject) AccessPublicationRetention(ctx context.Context) (kvtx.Store, func(), error) {
+	store, ok := s.blkStore.(*BlockStore)
+	if !ok || store.retention == nil {
+		return nil, nil, errors.New("cloud block retention unavailable")
+	}
+	release, err := store.retention.mu.Lock(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return store.retention.store, release, nil
 }
 
 // GetSharedObjectState returns a snapshot of the shared object state.
@@ -394,9 +415,13 @@ func (t *sobjectTracker) executeSharedObjectTracker(rctx context.Context) (rerr 
 		func(ctx context.Context, cache *api.VerifiedSOStateCache) error {
 			return t.a.writeVerifiedSOStateCache(ctx, sharedObjectID, cache)
 		},
-		cloudBlkStore.ForceSync,
+		cloudBlkStore.syncer,
 	)
 	host.refreshBlockManifest = cloudBlkStore.RefreshRemote
+	if host.syncer != nil {
+		host.syncer.setPublication(host, host.pending)
+		defer host.syncer.setPublication(host, nil)
+	}
 	host.blockManifestSequence = cloudBlkStore.RemoteSequence
 	host.stateObserved = func(state *sobject.SOState) {
 		if state == nil || state.GetRoot() == nil {

--- a/core/provider/spacewave/sobject_test.go
+++ b/core/provider/spacewave/sobject_test.go
@@ -146,7 +146,7 @@ func TestPostOp_UsesWriteTicketWhenConfigured(t *testing.T) {
 		if payload.GetBodyHashHex() != hex.EncodeToString(wantHash[:]) {
 			t.Errorf("unexpected proof body hash: %q", payload.GetBodyHashHex())
 		}
-		if payload.GetSignedHeaders() != "content-type=application/octet-stream" {
+		if payload.GetSignedHeaders() != "content-type=application%2Foctet-stream" {
 			t.Errorf("unexpected proof signed headers: %q", payload.GetSignedHeaders())
 		}
 
@@ -799,7 +799,7 @@ func TestPostInitState_UsesWriteTicketWhenConfigured(t *testing.T) {
 		if payload.GetBodyHashHex() != hex.EncodeToString(wantHash[:]) {
 			t.Errorf("unexpected proof body hash: %q", payload.GetBodyHashHex())
 		}
-		if payload.GetSignedHeaders() != "content-type=application/octet-stream" {
+		if payload.GetSignedHeaders() != "content-type=application%2Foctet-stream" {
 			t.Errorf("unexpected proof signed headers: %q", payload.GetSignedHeaders())
 		}
 

--- a/core/provider/spacewave/sync.go
+++ b/core/provider/spacewave/sync.go
@@ -67,6 +67,8 @@ type syncController struct {
 	// dirtySize and dirtyPendingAt project durable dirty records under bcast.
 	dirtySize      int64
 	dirtyPendingAt time.Time
+	// publications tracks mounted hosts with durable pending cloud work.
+	publications map[*cloudSOHost]time.Time
 	// bcast wakes the scheduler when the durable dirty queue changes.
 	bcast broadcast.Broadcast
 	// dirtyMtx orders durable dirty mutations and their in-memory projection.
@@ -138,6 +140,11 @@ func (s *syncController) pendingSnapshot() (time.Time, int64, <-chan struct{}) {
 	var changed <-chan struct{}
 	s.bcast.HoldLock(func(_ func(), getWait func() <-chan struct{}) {
 		first, dirty, changed = s.dirtyPendingAt, s.dirtySize, getWait()
+		for _, pendingAt := range s.publications {
+			if first.IsZero() || pendingAt.Before(first) {
+				first = pendingAt
+			}
+		}
 	})
 	return first, dirty, changed
 }
@@ -267,14 +274,14 @@ func (s *syncController) waitDirtySyncGate(ctx context.Context) error {
 func (s *syncController) FlushNow(ctx context.Context) error {
 	s.flushMtx.Lock()
 	defer s.flushMtx.Unlock()
-	return s.flush(ctx, true)
+	return s.flushCheckpoint(ctx, true)
 }
 
 // FlushNowUnordered flushes dirty blocks without refgraph locality ordering.
 func (s *syncController) FlushNowUnordered(ctx context.Context) error {
 	s.flushMtx.Lock()
 	defer s.flushMtx.Unlock()
-	return s.flush(ctx, false)
+	return s.flushCheckpoint(ctx, false)
 }
 
 // PullNow serializes an immediate remote packfile manifest pull.

--- a/core/provider/spacewave/sync_test.go
+++ b/core/provider/spacewave/sync_test.go
@@ -224,7 +224,7 @@ func TestSyncPush_UsesWriteTicketWhenConfigured(t *testing.T) {
 		if payload.GetBodyHashHex() != hex.EncodeToString(h[:]) {
 			t.Errorf("unexpected proof body hash: %q", payload.GetBodyHashHex())
 		}
-		if payload.GetSignedHeaders() != "content-type=application/octet-stream,x-block-count=42,x-bloom-filter="+base64.StdEncoding.EncodeToString(bloomFilter)+",x-pack-id=test-pack-id" {
+		if payload.GetSignedHeaders() != "content-type=application%2Foctet-stream,x-block-count=42,x-bloom-filter="+base64.StdEncoding.EncodeToString(bloomFilter)+",x-pack-id=test-pack-id" {
 			t.Errorf("unexpected proof signed headers: %q", payload.GetSignedHeaders())
 		}
 

--- a/core/provider/spacewave/synctelemetry/store.go
+++ b/core/provider/spacewave/synctelemetry/store.go
@@ -200,6 +200,7 @@ type state struct {
 
 	pendingUploadBytes        int64
 	pendingUploadCount        int
+	pendingPublications       int
 	activeUploadBytes         int64
 	activeUploadSent          int64
 	inFlightPushes            int
@@ -296,6 +297,15 @@ func (s *Store) SetPending(bstoreID string, bytes int64, count int) {
 	})
 }
 
+// SetPendingPublications keeps metadata awaiting cloud acknowledgment visible
+// after all payload blocks have uploaded.
+func (s *Store) SetPendingPublications(bstoreID string, count int) {
+	s.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		s.getOrCreateStateLocked(bstoreID).pendingPublications = max(count, 0)
+		broadcast()
+	})
+}
+
 // AddDirty records newly dirty upload bytes.
 func (s *Store) AddDirty(bstoreID string, bytes int64) {
 	if bytes < 0 {
@@ -376,16 +386,18 @@ func (s *Store) FinishPush(bstoreID string, bytes int64, err error) {
 	})
 }
 
-// RecordError records a sync error that happened outside an active push/pull.
+// RecordError records a sync error outside an active push/pull. A successful
+// checkpoint clears the previous error without counting another payload push.
 func (s *Store) RecordError(bstoreID string, err error) {
-	if err == nil {
-		return
-	}
 	now := time.Now()
 	s.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
 		state := s.getOrCreateStateLocked(bstoreID)
-		state.lastPushError = err.Error()
-		state.lastPushErrorAt = now
+		state.lastPushError = ""
+		state.lastPushErrorAt = time.Time{}
+		if err != nil {
+			state.lastPushError = err.Error()
+			state.lastPushErrorAt = now
+		}
 		state.lastActivityAt = now
 		broadcast()
 	})
@@ -502,7 +514,7 @@ func BuildSnapshot(states []state) Snapshot {
 			CloudRemoteSequence:       state.cloudRemoteSequence,
 		})
 		snap.PendingUploadBytes += state.pendingUploadBytes
-		snap.PendingUploadCount += state.pendingUploadCount
+		snap.PendingUploadCount += state.pendingUploadCount + state.pendingPublications
 		snap.ActiveUploadBytes += state.activeUploadBytes
 		snap.ActiveUploadTransferredBytes += state.activeUploadSent
 		snap.InFlightPushes += state.inFlightPushes

--- a/core/provider/spacewave/testdata/checkpoint-vectors.go
+++ b/core/provider/spacewave/testdata/checkpoint-vectors.go
@@ -1,0 +1,54 @@
+//go:build ignore
+
+// Regenerate with go run -tags purego ./core/provider/spacewave/testdata/checkpoint-vectors.go.
+// The fixed key is public test material and must never identify a real account.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	api "github.com/s4wave/spacewave/core/provider/spacewave/api"
+	"github.com/s4wave/spacewave/core/sobject"
+	"github.com/s4wave/spacewave/net/crypto"
+	"github.com/s4wave/spacewave/net/hash"
+	"github.com/s4wave/spacewave/net/peer"
+)
+
+func main() {
+	const objectID = "checkpoint-protocol"
+	key, _, err := crypto.GenerateEd25519Key(bytes.NewReader(bytes.Repeat([]byte{42}, 32)))
+	must(err)
+	peerID, err := peer.IDFromPrivateKey(key)
+	must(err)
+	var operations []*sobject.SOOperation
+	for nonce := uint64(1); nonce <= 50; nonce++ {
+		operation, err := sobject.BuildSOOperation(objectID, key, []byte(fmt.Sprintf("edit %d", nonce)), nonce, fmt.Sprintf("01j0000000%016d", nonce))
+		must(err)
+		operations = append(operations, operation)
+	}
+	batch, err := (&api.PostOpsRequest{Operations: operations}).MarshalVT()
+	must(err)
+	rejection, err := sobject.BuildSOOperationRejection(key, objectID, peerID, 50, fmt.Sprintf("01j0000000%016d", 50), nil)
+	must(err)
+	inner, err := (&sobject.SORootInner{Seqno: 51, StateData: []byte("coalesced checkpoint")}).MarshalVT()
+	must(err)
+	root := &sobject.SORoot{Inner: inner, InnerSeqno: 51, AccountNonces: []*sobject.SOAccountNonce{{PeerId: peerID.String(), Nonce: 50}}}
+	must(root.SignInnerData(key, objectID, 51, hash.RecommendedHashType))
+	request, err := (&api.PostRootRequest{Root: root, RejectedOps: []*sobject.SOOperationRejection{rejection}}).MarshalVT()
+	must(err)
+	must(json.NewEncoder(os.Stdout).Encode(struct {
+		ObjectID string `json:"objectId"`
+		PeerID   string `json:"peerId"`
+		Batch    []byte `json:"batch"`
+		Root     []byte `json:"root"`
+	}{objectID, peerID.String(), batch, request}))
+}
+
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}

--- a/core/sobject/sobject.go
+++ b/core/sobject/sobject.go
@@ -86,6 +86,13 @@ type SharedObject interface {
 	ProcessOperations(ctx context.Context, watch bool, cb ProcessOpsFunc) error
 }
 
+// PublicationRetention is implemented by providers that publish local state
+// asynchronously. Its store retains graph-completion proofs for the mounted
+// block store; World consumers fence all dependencies before accepting a write.
+type PublicationRetention interface {
+	AccessPublicationRetention(context.Context) (kvtx.Store, func(), error)
+}
+
 // SharedObjectHealthAccessor exposes SharedObject health directly from a mounted object.
 type SharedObjectHealthAccessor interface {
 	// AccessSharedObjectHealth adds a reference to SharedObject health and returns the state container.

--- a/core/sobject/world/engine/retain-world.go
+++ b/core/sobject/world/engine/retain-world.go
@@ -1,0 +1,125 @@
+package sobject_world_engine
+
+import (
+	"context"
+	"time"
+
+	"github.com/aperturerobotics/controllerbus/controller"
+	"github.com/pkg/errors"
+	"github.com/s4wave/spacewave/core/sobject"
+	"github.com/s4wave/spacewave/db/block"
+	block_transform "github.com/s4wave/spacewave/db/block/transform"
+	"github.com/s4wave/spacewave/db/blocktype"
+	"github.com/s4wave/spacewave/db/bucket"
+	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
+	"github.com/s4wave/spacewave/db/kvtx"
+	"github.com/s4wave/spacewave/db/world"
+	world_block "github.com/s4wave/spacewave/db/world/block"
+)
+
+// retainPublicationWorld fences all candidate dependencies before local authority
+// accepts the operation or root. Completed immutable subtrees are retained in the
+// SharedObject's local store, with at most 1024 new completion records in memory.
+func (c *Controller) retainPublicationWorld(ctx context.Context, so sobject.SharedObject, head *bucket.ObjectRef) error {
+	retention, ok := so.(sobject.PublicationRetention)
+	if !ok {
+		return nil
+	}
+	if head.GetRootRef().GetEmpty() {
+		return nil
+	}
+	store := so.GetBlockStore()
+	local, release, err := retention.AccessPublicationRetention(ctx)
+	if err != nil {
+		return err
+	}
+	defer release()
+	xfrm, err := block_transform.NewTransformer(controller.ConstructOpts{Logger: c.le}, c.sfs, head.GetTransformConf())
+	if err != nil {
+		return err
+	}
+	bucketID := store.GetID()
+	localRef := head.CloneVT()
+	localRef.BucketId = bucketID
+	cursor := bucket_lookup.NewCursor(ctx, so.GetBus(), c.le, c.sfs, store, xfrm, localRef, &bucket.BucketOpArgs{BucketId: bucketID, VolumeId: bucketID}, head.GetTransformConf())
+	cursor.SetBucketIDOverride(bucketID)
+	defer cursor.Release()
+	ws, err := world_block.BuildWorldStateFromCursor(ctx, c.le, false, cursor, world.NewWorldStorageFromCursor(cursor), nil, false)
+	if err != nil {
+		return err
+	}
+	defer ws.Discard()
+
+	// Fence bytes before recording proofs. Failure may preserve complete
+	// subtrees, but never records a parent whose descendants failed.
+	pending := make(map[string]struct{})
+	flush := func() error {
+		fenced, err := store.Sync(ctx)
+		if err != nil {
+			return err
+		}
+		if !fenced {
+			return errors.New("local block store has no durability fence")
+		}
+		err = kvtx.RunTransaction(ctx, true, func(ctx context.Context) (kvtx.Tx, error) {
+			return local.NewTransaction(ctx, true)
+		}, func(ctx context.Context, tx kvtx.Tx) error {
+			for key := range pending {
+				if err := tx.Set(ctx, []byte(key), []byte{1}); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err == nil {
+			clear(pending)
+		}
+		return err
+	}
+	key := func(domain string, ref *block.BlockRef) string {
+		return "world-publication/" + bucketID + "/" + domain + "/" + ref.MarshalString()
+	}
+	err = ws.WalkBlocks(ctx, func(ctx context.Context, typeID string) (block.Ctor, error) {
+		lookupCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		info, release, err := blocktype.ExLookupBlockType(lookupCtx, so.GetBus(), typeID)
+		if release != nil {
+			defer release.Release()
+		}
+		if err != nil {
+			return nil, err
+		}
+		if info == nil {
+			return nil, errors.Errorf("block type unavailable: %s", typeID)
+		}
+		return info.Constructor, nil
+	}, func(ref *block.BlockRef, data []byte) error {
+		_, _, err := store.PutBlock(ctx, data, &block.PutOpts{ForceBlockRef: ref})
+		return err
+	}, &world_block.WalkBlocksOptions{
+		Known: func(domain string, ref *block.BlockRef) (bool, error) {
+			k := key(domain, ref)
+			if _, ok := pending[k]; ok {
+				return true, nil
+			}
+			tx, err := local.NewTransaction(ctx, false)
+			if err != nil {
+				return false, err
+			}
+			defer tx.Discard()
+			_, found, err := tx.Get(ctx, []byte(k))
+			return found, err
+		},
+		Complete: func(domain string, ref *block.BlockRef) error {
+			pending[key(domain, ref)] = struct{}{}
+			if len(pending) >= 1024 {
+				return flush()
+			}
+			return nil
+		},
+	})
+	if err != nil {
+		return err
+	}
+	return flush()
+}

--- a/core/sobject/world/engine/retain-world_test.go
+++ b/core/sobject/world/engine/retain-world_test.go
@@ -1,0 +1,108 @@
+package sobject_world_engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aperturerobotics/controllerbus/bus"
+	"github.com/s4wave/spacewave/db/block"
+	block_mock "github.com/s4wave/spacewave/db/block/mock"
+	"github.com/s4wave/spacewave/db/blocktype"
+	blocktype_controller "github.com/s4wave/spacewave/db/blocktype/controller"
+	"github.com/s4wave/spacewave/db/bucket"
+	"github.com/s4wave/spacewave/db/kvtx"
+	"github.com/s4wave/spacewave/db/testbed"
+	world_block "github.com/s4wave/spacewave/db/world/block"
+	world_types "github.com/s4wave/spacewave/db/world/types"
+	"github.com/sirupsen/logrus"
+)
+
+// TestRetainPublicationWorldRecoversPeerDependencies exercises the engine's
+// retention boundary with a peer-only nested payload and a separate local cache.
+func TestRetainPublicationWorldRecoversPeerDependencies(t *testing.T) {
+	ctx := t.Context()
+	le := logrus.NewEntry(logrus.New())
+	remote, err := testbed.NewTestbed(ctx, le)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(remote.Release)
+	local, err := testbed.NewTestbed(ctx, le)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(local.Release)
+	source, err := remote.BuildEmptyCursor(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(source.Release)
+	target, err := local.BuildEmptyCursor(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(target.Release)
+	ws, err := world_block.BuildMockWorldState(ctx, le, true, source, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(ws.Discard)
+	leaf, _, err := block.PutBlock(ctx, source.GetBucket(), &block_mock.Example{Msg: "peer-only payload"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, _, err := block.PutBlock(ctx, source.GetBucket(), &block_mock.Root{ExampleSubBlock: &block_mock.SubBlock{ExamplePtr: leaf}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ws.CreateObject(ctx, "content", &bucket.ObjectRef{RootRef: root}); err != nil {
+		t.Fatal(err)
+	}
+	if err := world_types.SetObjectType(ctx, ws, "content", "test/nested"); err != nil {
+		t.Fatal(err)
+	}
+	if err := ws.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	release, err := local.Bus.AddController(ctx, blocktype_controller.NewController(func(context.Context, string) (blocktype.BlockType, error) {
+		return blocktype.NewBlockType("test/nested", block_mock.NewRootBlock), nil
+	}), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(release)
+
+	// The same overlay used by cloud stores exposes remote bytes on demand.
+	overlay := block.NewOverlay(ctx, le, source.GetBucket(), target.GetBucket(), block.OverlayMode_UPPER_WRITE_CACHE, 0, nil)
+	shared := &publicationTestSharedObject{
+		testSharedObject: testSharedObject{blockStore: newTestBlockStore("publication-test", overlay)},
+		bus:              local.Bus, retained: newTestRejectedCandidateStore(),
+	}
+	c := &Controller{le: le, bus: local.Bus, sfs: local.StepFactorySet}
+	head := &bucket.ObjectRef{RootRef: ws.GetRootRef()}
+	if err := c.retainPublicationWorld(ctx, shared, head); err != nil {
+		t.Fatal(err)
+	}
+	if _, found, err := target.GetBucket().GetBlock(ctx, leaf); err != nil || !found {
+		t.Fatalf("peer dependency was not retained: found=%v, err=%v", found, err)
+	}
+
+	// Remove the peer path. The retained graph remains usable and a repeat
+	// checkpoint resolves entirely from local storage and completion records.
+	shared.blockStore = newTestBlockStore("publication-test", target.GetBucket())
+	if err := c.retainPublicationWorld(ctx, shared, head); err != nil {
+		t.Fatalf("peer loss invalidated the retained checkpoint: %v", err)
+	}
+}
+
+type publicationTestSharedObject struct {
+	testSharedObject
+	bus      bus.Bus
+	retained kvtx.Store
+}
+
+func (s *publicationTestSharedObject) GetBus() bus.Bus { return s.bus }
+
+func (s *publicationTestSharedObject) AccessPublicationRetention(context.Context) (kvtx.Store, func(), error) {
+	return s.retained, func() {}, nil
+}

--- a/core/sobject/world/engine/tx.go
+++ b/core/sobject/world/engine/tx.go
@@ -126,6 +126,9 @@ func (t *soEngineWriteTx) Commit(ctx context.Context) error {
 	baseStoredObjRef.BucketId = ""
 	nextStoredObjRef := nextObjRef.CloneVT()
 	nextStoredObjRef.BucketId = ""
+	if err := t.eng.c.retainPublicationWorld(ctx, t.eng.so, nextStoredObjRef); err != nil {
+		return err
+	}
 
 	// Bind the finalization packet to the encoded operation.
 	contentID, err := bifhash.Sum(bifhash.HashType_HashType_SHA256, opData)

--- a/core/sobject/world/engine/validator.go
+++ b/core/sobject/world/engine/validator.go
@@ -116,6 +116,11 @@ func (c *Controller) executeProcessOpsAsValidator(ctx context.Context, so sobjec
 				return nil, opResults, nil
 			}
 
+			// Retain replayed dependencies before accepting the next signed root.
+			if err := c.retainPublicationWorld(ctx, so, headState.GetHeadRef()); err != nil {
+				return nil, nil, err
+			}
+
 			// Marshal the next state
 			nextStateData, err := headState.MarshalVT()
 			if err != nil {

--- a/db/bucket/lookup/object-walk-depth.go
+++ b/db/bucket/lookup/object-walk-depth.go
@@ -1,0 +1,91 @@
+package bucket_lookup
+
+import (
+	"context"
+	"slices"
+
+	"github.com/s4wave/spacewave/db/block"
+	"github.com/s4wave/spacewave/db/bucket"
+)
+
+// WalkObjectGraph visits a block graph depth first with memory bounded by depth.
+// visit may prune a previously completed subtree or supply a dynamic decoder.
+// complete runs only after visit and every descendant succeed. A caller can
+// durably record that boundary to avoid traversing immutable subtrees again.
+// Callbacks are sequential and must not retain mutable entries after returning.
+func WalkObjectGraph(
+	ctx context.Context,
+	root *WalkObjectBlocksEntry,
+	visit WalkObjectBlocksCb,
+	complete func(*WalkObjectBlocksEntry) error,
+	store bucket.BucketOps,
+	xfrm block.Transformer,
+) error {
+	if root == nil {
+		return nil
+	}
+	var walk func(*WalkObjectBlocksEntry) error
+	walk = func(entry *WalkObjectBlocksEntry) error {
+		// Load one immutable node while retaining only its ancestors.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if !entry.Found && entry.Err == nil && !entry.IsSubBlock && !entry.Ref.GetEmpty() {
+			entry.Data, entry.Found, entry.Err = store.GetBlock(ctx, entry.Ref)
+		}
+		if entry.Err == nil && entry.Found && !entry.IsSubBlock {
+			entry.Err = entry.decodeBlock(false, xfrm)
+		}
+		if visit != nil {
+			proceed, err := visit(entry)
+			if err != nil || !proceed {
+				return err
+			}
+		} else if entry.Err != nil {
+			return entry.Err
+		}
+
+		// Resolve children only after the callback has supplied dynamic state.
+		var children []*WalkObjectBlocksEntry
+		if sub, ok := entry.Blk.(block.BlockWithSubBlocks); ok {
+			for id, child := range sub.GetSubBlocks() {
+				if child != nil && !child.IsNil() {
+					children = append(children, &WalkObjectBlocksEntry{RefID: id, Ref: entry.Ref, Blk: child, IsSubBlock: true, Found: true})
+				}
+			}
+		}
+		if refs, ok := entry.Blk.(block.BlockWithRefs); ok {
+			childrenRefs, err := refs.GetBlockRefs()
+			if err != nil {
+				return err
+			}
+			for id, ref := range childrenRefs {
+				if !ref.GetEmpty() {
+					children = append(children, &WalkObjectBlocksEntry{RefID: id, Ref: ref, Ctor: refs.GetBlockRefCtor(id)})
+				}
+			}
+		}
+		slices.SortStableFunc(children, func(a, b *WalkObjectBlocksEntry) int {
+			if a.RefID < b.RefID {
+				return -1
+			}
+			if a.RefID > b.RefID {
+				return 1
+			}
+			return 0
+		})
+
+		// Complete a parent only after all referenced descendants completed.
+		for _, child := range children {
+			child.Depth = entry.Depth + 1
+			if err := walk(child); err != nil {
+				return err
+			}
+		}
+		if complete != nil {
+			return complete(entry)
+		}
+		return nil
+	}
+	return walk(root)
+}

--- a/db/world/block/world-walk.go
+++ b/db/world/block/world-walk.go
@@ -10,19 +10,26 @@ import (
 	world_types "github.com/s4wave/spacewave/db/world/types"
 )
 
-// WalkBlocks visits the persisted World metadata and each current object's full
-// block graph. resolve supplies the object's root decoder; unknown types fail
-// instead of treating an opaque root as a complete object. The callback is
-// sequential and can copy each block to durable storage. External bucket and
-// transform references are resolved by the World storage.
-// Like other WorldState operations, the caller serializes access to the state.
-func (t *WorldState) WalkBlocks(ctx context.Context, resolve func(context.Context, string) (block.Ctor, error), visit func(*block.BlockRef, []byte) error) error {
-	seen := make(map[string]struct{})
-	walk := func(ref *block.BlockRef, ctor block.Ctor, store block.StoreOps, xfrm block.Transformer) error {
-		if ref.GetEmpty() {
-			return nil
-		}
-		return bucket_lookup.WalkObjectBlocks(ctx, bucket_lookup.NewWalkObjectBlocksWithRef(ref, ctor), func(entry *bucket_lookup.WalkObjectBlocksEntry) (bool, error) {
+// WalkBlocksOptions retains immutable subtrees separately for each decoding
+// domain. Known is valid only while the corresponding bytes remain durable.
+// Complete runs after every dependency in that domain has been visited.
+type WalkBlocksOptions struct {
+	Known    func(domain string, ref *block.BlockRef) (bool, error)
+	Complete func(domain string, ref *block.BlockRef) error
+}
+
+// WalkBlocks visits World metadata and each current object's complete block graph.
+// resolve supplies dynamic object decoders; an unknown type prevents completion.
+// Callbacks are sequential. Completion records prune unchanged Merkle branches.
+// The caller serializes World access and keeps retained bytes through later walks.
+func (t *WorldState) WalkBlocks(ctx context.Context, resolve func(context.Context, string) (block.Ctor, error), visit func(*block.BlockRef, []byte) error, options ...*WalkBlocksOptions) error {
+	var opts *WalkBlocksOptions
+	if len(options) != 0 {
+		opts = options[0]
+	}
+	var walk func(*bucket_lookup.WalkObjectBlocksEntry, block.StoreOps, block.Transformer, string) error
+	walk = func(root *bucket_lookup.WalkObjectBlocksEntry, store block.StoreOps, xfrm block.Transformer, domain string) error {
+		return bucket_lookup.WalkObjectGraph(ctx, root, func(entry *bucket_lookup.WalkObjectBlocksEntry) (bool, error) {
 			if entry.Err != nil {
 				return false, entry.Err
 			}
@@ -32,56 +39,76 @@ func (t *WorldState) WalkBlocks(ctx context.Context, resolve func(context.Contex
 			if !entry.Found {
 				return false, errors.Wrap(block.ErrNotFound, entry.Ref.MarshalString())
 			}
-			// An opaque metadata reference can later be visited with its object
-			// decoder. Deduplicate writes without skipping that traversal.
-			key := entry.Ref.MarshalString()
-			if _, found := seen[key]; !found {
-				if err := visit(entry.Ref, entry.Data); err != nil {
+			if opts != nil && opts.Known != nil {
+				known, err := opts.Known(domain, entry.Ref)
+				if err != nil || known {
 					return false, err
 				}
-				seen[key] = struct{}{}
 			}
-			return true, nil
-		}, store, xfrm, 1, false)
-	}
-	if err := walk(t.GetRootRef(), NewWorldBlock, t.store, t.xfrm); err != nil {
-		return err
-	}
+			if err := visit(entry.Ref, entry.Data); err != nil {
+				return false, err
+			}
+			if domain != "objects" || entry.Ctor != nil {
+				return true, nil
+			}
 
-	objects := t.IterateObjects(ctx, "", false)
-	defer objects.Close()
-	for objects.Next() {
-		object, found, err := t.GetObject(ctx, objects.Key())
-		if err != nil {
-			return err
-		}
-		if !found {
-			return world.ErrObjectNotFound
-		}
-		err = func() error {
+			// Object-index leaves are opaque to the generic key/value decoder.
+			// Resolve their complete payload here, independent of the changelog.
+			data := entry.Data
+			if xfrm != nil {
+				var err error
+				data, err = xfrm.DecodeBlock(data)
+				if err != nil {
+					return false, err
+				}
+			}
+			objectBlock := &Object{}
+			if err := objectBlock.UnmarshalVT(data); err != nil {
+				return false, err
+			}
+			object, found, err := t.GetObject(ctx, objectBlock.GetKey())
+			if err != nil {
+				return false, err
+			}
+			if !found {
+				return false, world.ErrObjectNotFound
+			}
 			defer world.ReleaseObjectState(object)
-			ref, _, err := object.GetRootRef(ctx)
-			if err != nil || ref.GetRootRef().GetEmpty() {
-				return err
+			objectRef, _, err := object.GetRootRef(ctx)
+			if err != nil || objectRef.GetRootRef().GetEmpty() {
+				return err == nil, err
 			}
 			typeID, err := world_types.GetObjectType(ctx, t, object.GetKey())
 			if err != nil {
-				return err
+				return false, err
 			}
 			ctor, err := resolve(ctx, typeID)
 			if err != nil {
-				return err
+				return false, err
 			}
 			if ctor == nil {
-				return errors.Errorf("block decoder unavailable for object %s (%s)", object.GetKey(), typeID)
+				return false, errors.Errorf("block decoder unavailable for object %s (%s)", object.GetKey(), typeID)
 			}
-			return object.AccessWorldState(ctx, nil, func(cursor *bucket_lookup.Cursor) error {
-				return walk(ref.GetRootRef(), ctor, cursor.GetBucket(), cursor.GetTransformer())
+			err = object.AccessWorldState(ctx, nil, func(cursor *bucket_lookup.Cursor) error {
+				return walk(bucket_lookup.NewWalkObjectBlocksWithRef(objectRef.GetRootRef(), ctor), cursor.GetBucket(), cursor.GetTransformer(), "type/"+typeID)
 			})
-		}()
-		if err != nil {
-			return err
-		}
+			return err == nil, err
+		}, func(entry *bucket_lookup.WalkObjectBlocksEntry) error {
+			if opts != nil && opts.Complete != nil && !entry.IsSubBlock && !entry.Ref.GetEmpty() {
+				return opts.Complete(domain, entry.Ref)
+			}
+			return nil
+		}, store, xfrm)
 	}
-	return objects.Err()
+
+	// Metadata and dynamic object graphs have distinct completion domains: a
+	// copied opaque value does not prove that its typed descendants were copied.
+	if err := walk(bucket_lookup.NewWalkObjectBlocksWithRef(t.GetRootRef(), NewWorldBlock), t.store, t.xfrm, "metadata"); err != nil {
+		return err
+	}
+	root, err := t.GetRoot(ctx)
+	if err != nil {
+		return err
+	}
+	return walk(bucket_lookup.NewWalkObjectBlocksWithSubBlock(root.GetObjectKeyValue()), t.store, t.xfrm, "objects")
 }

--- a/db/world/block/world-walk_test.go
+++ b/db/world/block/world-walk_test.go
@@ -17,6 +17,11 @@ import (
 // TestWalkBlocksCopiesObjectDescendants uses separate stores and an opaque World
 // object root. Copying metadata alone cannot recover the nested payload.
 func TestWalkBlocksCopiesObjectDescendants(t *testing.T) {
+	t.Run("with changelog", func(t *testing.T) { testWalkBlocksCopiesObjectDescendants(t, false) })
+	t.Run("without changelog", func(t *testing.T) { testWalkBlocksCopiesObjectDescendants(t, true) })
+}
+
+func testWalkBlocksCopiesObjectDescendants(t *testing.T, disableChangelog bool) {
 	ctx := t.Context()
 	le := logrus.NewEntry(logrus.New())
 	source, err := testbed.NewTestbed(ctx, le)
@@ -32,6 +37,13 @@ func TestWalkBlocksCopiesObjectDescendants(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer cursor.Release()
+	if disableChangelog {
+		root, _, err := block.PutBlock(ctx, cursor.GetBucket(), world_block.NewWorld(true))
+		if err != nil {
+			t.Fatal(err)
+		}
+		cursor.SetRootRef(root)
+	}
 	target, err := receiver.BuildEmptyCursor(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -85,13 +97,38 @@ func TestWalkBlocksCopiesObjectDescendants(t *testing.T) {
 		t.Fatalf("unexpected payload: %q", value.GetMsg())
 	}
 
+	// An unchanged graph needs no repeated payload copies or object decoding.
+	complete := make(map[string]bool)
+	options := &world_block.WalkBlocksOptions{
+		Known: func(domain string, ref *block.BlockRef) (bool, error) {
+			return complete[domain+ref.MarshalString()], nil
+		},
+		Complete: func(domain string, ref *block.BlockRef) error {
+			complete[domain+ref.MarshalString()] = true
+			return nil
+		},
+	}
+	if err := ws.WalkBlocks(ctx, resolve, copyBlock, options); err != nil {
+		t.Fatal(err)
+	}
+	if err := ws.WalkBlocks(ctx, resolve, func(*block.BlockRef, []byte) error {
+		t.Error("unchanged completed graph copied again")
+		return nil
+	}, options); err != nil {
+		t.Fatal(err)
+	}
+
 	if err := ws.WalkBlocks(ctx, func(context.Context, string) (block.Ctor, error) { return nil, nil }, copyBlock); err == nil {
 		t.Fatal("unknown object decoder must prevent completion")
 	}
 	if err := cursor.GetBucket().RmBlock(ctx, leaf); err != nil {
 		t.Fatal(err)
 	}
-	if err := ws.WalkBlocks(ctx, resolve, copyBlock); !errors.Is(err, block.ErrNotFound) {
+	clear(complete)
+	if err := ws.WalkBlocks(ctx, resolve, copyBlock, options); !errors.Is(err, block.ErrNotFound) {
 		t.Fatalf("missing descendant must prevent completion: %v", err)
+	}
+	if complete["type/test/nested"+root.MarshalString()] {
+		t.Fatal("failed descendant retained a completion claim for its parent")
 	}
 }


### PR DESCRIPTION
Local writes currently wait for cloud publication. Retain accepted signed state and its pending publication together, then let the existing sync controller coalesce operations and roots behind the block durability fence. Cloud acknowledgments clear only the captured work; concurrent edits and newer peer state remain intact through restart and cloud lag.

World publication retains typed object dependencies and records completed immutable subtrees. Block deletion invalidates those records. Pending roots and checkpoint failures remain visible after payload uploads finish.

Validation: native provider and sync telemetry race suites; World engine and block packages; focused peer-only nested-payload retention, concurrent acknowledgment, revocation, restart, missing-block, and deletion checks. Browser validation remains blocked by existing GoScript benchmark and Vitest declaration type errors.
