### PR TITLE
fix(storage): retry bucket creation and report failures

### DIFF
--- a/app/session/dashboard/SessionDashboard.e2e.test.tsx
+++ b/app/session/dashboard/SessionDashboard.e2e.test.tsx
@@ -45,7 +45,8 @@ vi.mock('@s4wave/web/router/router.js', () => ({
   useNavigate: () => mockNavigate,
 }))
 
-vi.mock('@s4wave/web/state/persist.js', () => ({
+vi.mock('@s4wave/web/state/persist.js', async (importOriginal) => ({
+  ...(await importOriginal()),
   useStateNamespace: () => ['session-settings'],
   useStateAtom: () => ['/', mockSetStateAtom],
 }))

--- a/core/provider/spacewave/session-link_test.go
+++ b/core/provider/spacewave/session-link_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/s4wave/spacewave/core/session"
 )
 
+// TestLinkSessionUsesAuthorizerAndReceivingIdentity verifies the enrollment identities.
 func TestLinkSessionUsesAuthorizerAndReceivingIdentity(t *testing.T) {
+	// Record the signed request sent to the account service.
 	sourceKey, sourcePeer := generateTestKeypair(t)
 	_, receivingPeer := generateTestKeypair(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -43,13 +45,17 @@ func TestLinkSessionUsesAuthorizerAndReceivingIdentity(t *testing.T) {
 		_, _ = w.Write(response)
 	}))
 	defer server.Close()
+
+	// Enroll the receiving Session through the authorizer's client.
 	client := NewSessionClient(server.Client(), server.URL, DefaultSigningEnvPrefix, sourceKey, sourcePeer.String())
 	if _, err := client.LinkSession(context.Background(), receivingPeer, "Receiving client"); err != nil {
 		t.Fatal(err)
 	}
 }
 
+// TestMountHandoffSessionVerifiesAccountBeforePersistence rejects a different account.
 func TestMountHandoffSessionVerifiesAccountBeforePersistence(t *testing.T) {
+	// Route the provider through the test server in native and browser runtimes.
 	key, _ := generateTestKeypair(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		data, _ := (&api.AccountInfoResponse{AccountId: "other-account"}).MarshalVT()
@@ -57,6 +63,9 @@ func TestMountHandoffSessionVerifiesAccountBeforePersistence(t *testing.T) {
 	}))
 	defer server.Close()
 	account := NewTestProviderAccount(t, server.URL)
+	account.p.httpCli = server.Client()
+
+	// Validation must finish before any Session state can be persisted.
 	_, err := account.p.MountHandoffSession(context.Background(), "selected-account", key, nil)
 	if err == nil || !strings.Contains(err.Error(), "belongs to another account") {
 		t.Fatalf("unexpected handoff validation result: %v", err)

--- a/core/provider/spacewave/sobject_test.go
+++ b/core/provider/spacewave/sobject_test.go
@@ -349,6 +349,7 @@ func TestCreateSharedObject_ServerError(t *testing.T) {
 	}
 }
 
+// TestGetSharedObjectDisplayName uses the cached shared object name.
 func TestGetSharedObjectDisplayName(t *testing.T) {
 	soMeta, err := space.NewSharedObjectMeta("My Space")
 	if err != nil {
@@ -366,6 +367,7 @@ func TestGetSharedObjectDisplayName(t *testing.T) {
 	}
 }
 
+// TestEnsureAccountSettingsSharedObject_AlreadyExists reuses the existing settings object.
 func TestEnsureAccountSettingsSharedObject_AlreadyExists(t *testing.T) {
 	var calls []string
 	const soID = "so-123"
@@ -418,6 +420,7 @@ func TestEnsureAccountSettingsSharedObject_AlreadyExists(t *testing.T) {
 	}
 }
 
+// TestEnsureAccountSettingsSharedObject_UsesReadyBindingFromAccountState reuses the ready account binding.
 func TestEnsureAccountSettingsSharedObject_UsesReadyBindingFromAccountState(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatalf("unexpected path: %s", r.URL.Path)
@@ -442,6 +445,7 @@ func TestEnsureAccountSettingsSharedObject_UsesReadyBindingFromAccountState(t *t
 	}
 }
 
+// TestDeleteSharedObjectRemovesMetadataAndListCaches invalidates both object caches after deletion.
 func TestDeleteSharedObjectRemovesMetadataAndListCaches(t *testing.T) {
 	var calls []string
 	const soID = "so-123"
@@ -492,6 +496,7 @@ func TestDeleteSharedObjectRemovesMetadataAndListCaches(t *testing.T) {
 	}
 }
 
+// TestFetchSharedObjectListPreservesCreatedCacheEntry retains locally created entries during list refresh.
 func TestFetchSharedObjectListPreservesCreatedCacheEntry(t *testing.T) {
 	const soID = "so-created"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -531,6 +536,7 @@ func TestFetchSharedObjectListPreservesCreatedCacheEntry(t *testing.T) {
 	}
 }
 
+// TestEnsureSharedObjectListLoaded_NoSubscriptionSkipsFetch avoids fetching without account access.
 func TestEnsureSharedObjectListLoaded_NoSubscriptionSkipsFetch(t *testing.T) {
 	var listCalls int
 
@@ -565,6 +571,7 @@ func TestEnsureSharedObjectListLoaded_NoSubscriptionSkipsFetch(t *testing.T) {
 	}
 }
 
+// TestEnsureSharedObjectListLoaded_InvalidationRefetchesOnce coalesces invalidated list reads.
 func TestEnsureSharedObjectListLoaded_InvalidationRefetchesOnce(t *testing.T) {
 	var listCalls int
 
@@ -607,6 +614,7 @@ func TestEnsureSharedObjectListLoaded_InvalidationRefetchesOnce(t *testing.T) {
 	}
 }
 
+// TestGetAccountStateEnablesSharedObjectListAccess enables list reads after account access arrives.
 func TestGetAccountStateEnablesSharedObjectListAccess(t *testing.T) {
 	var listCalls int
 
@@ -649,6 +657,7 @@ func TestGetAccountStateEnablesSharedObjectListAccess(t *testing.T) {
 	}
 }
 
+// TestRefreshSharedObjectListRefreshesAccountAccess refreshes account access before listing objects.
 func TestRefreshSharedObjectListRefreshesAccountAccess(t *testing.T) {
 	var accountStateCalls int
 	var listCalls int

--- a/core/provider/spacewave/sync_test.go
+++ b/core/provider/spacewave/sync_test.go
@@ -528,6 +528,7 @@ func TestSyncPush_ServerError(t *testing.T) {
 	}
 }
 
+// TestSyncPushData_MissingBloomFilter rejects uploads without a bloom filter.
 func TestSyncPushData_MissingBloomFilter(t *testing.T) {
 	packData := []byte("inline-pack-data")
 	h := sha256.Sum256(packData)
@@ -592,6 +593,7 @@ func TestSyncPushData_MissingWriteTicketExecutor(t *testing.T) {
 	}
 }
 
+// TestSyncControllerPushPackfileRetriesCanceledPush retries a canceled upload with the same pack.
 func TestSyncControllerPushPackfileRetriesCanceledPush(t *testing.T) {
 	s := &syncController{}
 
@@ -630,6 +632,7 @@ func TestSyncControllerPushPackfileRetriesCanceledPush(t *testing.T) {
 	}
 }
 
+// TestSyncControllerExecuteExitsOnCanceledThresholdContext stops execution when its context is canceled.
 func TestSyncControllerExecuteExitsOnCanceledThresholdContext(t *testing.T) {
 	s := &syncController{
 		conf: &SyncConfig{SizeThresholdBytes: 1},
@@ -654,6 +657,7 @@ func TestSyncControllerExecuteExitsOnCanceledThresholdContext(t *testing.T) {
 	}
 }
 
+// TestSyncControllerInitSkipsPullForRemoteManifest uses an existing remote manifest without pulling.
 func TestSyncControllerInitSkipsPullForRemoteManifest(t *testing.T) {
 	ctx := context.Background()
 	pullRequests := make(chan struct{}, 1)
@@ -704,6 +708,7 @@ func TestSyncControllerInitSkipsPullForRemoteManifest(t *testing.T) {
 	}
 }
 
+// TestSyncControllerPullNowRecordsLatestSequenceFromEmptyPull retains sequence progress from empty responses.
 func TestSyncControllerPullNowRecordsLatestSequenceFromEmptyPull(t *testing.T) {
 	ctx := context.Background()
 	respData := mustMarshalVT(t, &packfile.PullResponse{LatestSequence: 9})
@@ -751,6 +756,7 @@ func TestSyncControllerPullNowRecordsLatestSequenceFromEmptyPull(t *testing.T) {
 	}
 }
 
+// TestSyncControllerInitReturnsAccessGatedPullError propagates access failures during initialization.
 func TestSyncControllerInitReturnsAccessGatedPullError(t *testing.T) {
 	ctx := context.Background()
 	errResp := &api.ErrorResponse{
@@ -806,6 +812,7 @@ func TestSyncControllerInitReturnsAccessGatedPullError(t *testing.T) {
 	}
 }
 
+// TestSyncControllerExecuteHonorsRetryAfterBackoff delays retries for the server backoff interval.
 func TestSyncControllerExecuteHonorsRetryAfterBackoff(t *testing.T) {
 	errResp := &api.ErrorResponse{
 		Code:      "rate_limited",
@@ -873,6 +880,7 @@ func TestSyncControllerExecuteHonorsRetryAfterBackoff(t *testing.T) {
 	}
 }
 
+// TestSyncControllerExecuteGatesAccessDeniedFlushFailures waits for access changes after denied writes.
 func TestSyncControllerExecuteGatesAccessDeniedFlushFailures(t *testing.T) {
 	errResp := &api.ErrorResponse{
 		Code:      "account_read_only",
@@ -949,19 +957,23 @@ func TestSyncControllerExecuteGatesAccessDeniedFlushFailures(t *testing.T) {
 	}
 }
 
+// syncPackTransport serves packed fixture bytes.
 type syncPackTransport struct {
 	data []byte
 }
 
+// syncErrorTransport returns a configured read failure.
 type syncErrorTransport struct {
 	err error
 }
 
+// syncCountingBlockStore observes upper-store block reads.
 type syncCountingBlockStore struct {
 	block.StoreOps
 	onGet func(*block.BlockRef)
 }
 
+// Fetch reads a bounded range of fixture bytes.
 func (t *syncPackTransport) Fetch(_ context.Context, off int64, length int) ([]byte, error) {
 	if off >= int64(len(t.data)) {
 		return nil, io.EOF
@@ -970,10 +982,12 @@ func (t *syncPackTransport) Fetch(_ context.Context, off int64, length int) ([]b
 	return bytes.Clone(t.data[off:end]), nil
 }
 
+// Fetch returns the configured failure.
 func (t *syncErrorTransport) Fetch(context.Context, int64, int) ([]byte, error) {
 	return nil, t.err
 }
 
+// GetBlock observes the read before forwarding it.
 func (s *syncCountingBlockStore) GetBlock(ctx context.Context, ref *block.BlockRef) ([]byte, bool, error) {
 	if s.onGet != nil {
 		s.onGet(ref)
@@ -981,10 +995,12 @@ func (s *syncCountingBlockStore) GetBlock(ctx context.Context, ref *block.BlockR
 	return s.StoreOps.GetBlock(ctx, ref)
 }
 
+// newSyncTestBlockStore constructs the provider block test store.
 func newSyncTestBlockStore() block.StoreOps {
 	return newProviderSpacewaveTestBlockStore(hash.RecommendedHashType)
 }
 
+// newSyncTestLowerPackfileStore packs fixture blocks into a readable lower store.
 func newSyncTestLowerPackfileStore(t *testing.T, blocks map[string][]byte) *packfile_store.PackfileStore {
 	t.Helper()
 	var items []struct {
@@ -1038,6 +1054,7 @@ func newSyncTestLowerPackfileStore(t *testing.T, blocks map[string][]byte) *pack
 	return lower
 }
 
+// newSyncTestErrorLowerPackfileStore constructs a lower store whose reads fail.
 func newSyncTestErrorLowerPackfileStore() *packfile_store.PackfileStore {
 	lower := packfile_store.NewPackfileStore(
 		func(packID string, size int64) (*packfile_store.PackReader, error) {
@@ -1060,11 +1077,13 @@ func newSyncTestErrorLowerPackfileStore() *packfile_store.PackfileStore {
 	return lower
 }
 
+// syncTestRefGraph stores directed block references.
 type syncTestRefGraph struct {
 	out map[string][]string
 	in  map[string][]string
 }
 
+// newSyncTestRefGraph constructs an empty reference graph.
 func newSyncTestRefGraph() *syncTestRefGraph {
 	return &syncTestRefGraph{
 		out: make(map[string][]string),
@@ -1072,23 +1091,28 @@ func newSyncTestRefGraph() *syncTestRefGraph {
 	}
 }
 
+// add inserts a directed reference.
 func (g *syncTestRefGraph) add(subject, object string) {
 	g.out[subject] = append(g.out[subject], object)
 	g.in[object] = append(g.in[object], subject)
 }
 
+// GetOutgoingRefs returns references originating at the node.
 func (g *syncTestRefGraph) GetOutgoingRefs(_ context.Context, node string) ([]string, error) {
 	return slices.Clone(g.out[node]), nil
 }
 
+// GetIncomingRefs returns references targeting the node.
 func (g *syncTestRefGraph) GetIncomingRefs(_ context.Context, node string) ([]string, error) {
 	return slices.Clone(g.in[node]), nil
 }
 
+// newSyncTestKvStore constructs a transactional in-memory store.
 func newSyncTestKvStore() kvtx.Store {
 	return hashmap.NewHashmapKvtx(hashmap.NewHashmap[[]byte]())
 }
 
+// assertSyncPackEntryMetadata checks uploaded pack discovery metadata.
 func assertSyncPackEntryMetadata(t *testing.T, entries []*packfile.PackfileEntry) {
 	t.Helper()
 	for i, entry := range entries {
@@ -1104,6 +1128,7 @@ func assertSyncPackEntryMetadata(t *testing.T, entries []*packfile.PackfileEntry
 	}
 }
 
+// readPackPhysicalKeys returns block keys in physical pack order.
 func readPackPhysicalKeys(t *testing.T, body []byte) []string {
 	t.Helper()
 	reader, err := kvfile.BuildReader(bytes.NewReader(body), uint64(len(body)))
@@ -1134,6 +1159,7 @@ func readPackPhysicalKeys(t *testing.T, body []byte) []string {
 	return keys
 }
 
+// addSyncDirtyBlock stores a block and queues it for upload.
 func addSyncDirtyBlock(
 	t *testing.T,
 	ctx context.Context,
@@ -1157,6 +1183,7 @@ func addSyncDirtyBlock(
 	return ref
 }
 
+// newDirtySyncExecuteTestController constructs a controller with pending upload work.
 func newDirtySyncExecuteTestController(
 	t *testing.T,
 	cli *SessionClient,
@@ -1197,6 +1224,7 @@ func newDirtySyncExecuteTestController(
 	return s
 }
 
+// TestSyncControllerFlushChunksLargeDirtySet uploads bounded packs before reading all dirty data.
 func TestSyncControllerFlushChunksLargeDirtySet(t *testing.T) {
 	ctx := context.Background()
 
@@ -1325,6 +1353,7 @@ func TestSyncControllerFlushChunksLargeDirtySet(t *testing.T) {
 	}
 }
 
+// TestSyncControllerFlushDedupesLowerBlocks filters stored blocks before reading upper data.
 func TestSyncControllerFlushDedupesLowerBlocks(t *testing.T) {
 	ctx := context.Background()
 
@@ -1444,6 +1473,7 @@ func TestSyncControllerFlushDedupesLowerBlocks(t *testing.T) {
 	}
 }
 
+// TestSyncControllerFlushAllDuplicateDirtyBlocksSkipsPush clears duplicate work without uploading.
 func TestSyncControllerFlushAllDuplicateDirtyBlocksSkipsPush(t *testing.T) {
 	ctx := context.Background()
 
@@ -1538,6 +1568,7 @@ func TestSyncControllerFlushAllDuplicateDirtyBlocksSkipsPush(t *testing.T) {
 	}
 }
 
+// TestSyncControllerFlushDuplicateProbeErrorPreservesDirty retains dirty work when deduplication fails.
 func TestSyncControllerFlushDuplicateProbeErrorPreservesDirty(t *testing.T) {
 	ctx := context.Background()
 
@@ -1593,6 +1624,7 @@ func TestSyncControllerFlushDuplicateProbeErrorPreservesDirty(t *testing.T) {
 	}
 }
 
+// TestSyncControllerFlushOrdersBlocksByGCGraph writes parent blocks before their children.
 func TestSyncControllerFlushOrdersBlocksByGCGraph(t *testing.T) {
 	ctx := context.Background()
 
@@ -1673,6 +1705,7 @@ func TestSyncControllerFlushOrdersBlocksByGCGraph(t *testing.T) {
 	}
 }
 
+// TestSyncControllerFlushChunksBlockCountCeiling splits packs at the wire block limit.
 func TestSyncControllerFlushChunksBlockCountCeiling(t *testing.T) {
 	ctx := context.Background()
 

--- a/core/space/migration/builtins.go
+++ b/core/space/migration/builtins.go
@@ -3,6 +3,7 @@ package space_migration
 import (
 	bldr_manifest_world "github.com/s4wave/spacewave/bldr/manifest/world"
 	forge_dashboard "github.com/s4wave/spacewave/core/forge/dashboard"
+	volume_world "github.com/s4wave/spacewave/db/volume/world"
 	forge_cluster "github.com/s4wave/spacewave/forge/cluster"
 	forge_execution "github.com/s4wave/spacewave/forge/execution"
 	forge_job "github.com/s4wave/spacewave/forge/job"
@@ -29,10 +30,12 @@ import (
 	s4wave_vm_world "github.com/s4wave/spacewave/sdk/vm/world"
 )
 
+// spaceSettingsTypeID identifies the Space settings payload.
 const spaceSettingsTypeID = "github.com/s4wave/spacewave/core/space/world.SpaceSettings"
 
 // BuiltInRegistry returns the complete built-in ObjectType classification.
 func BuiltInRegistry() (*Registry, error) {
+	// Classify every built-in payload before exposing the registry to planners.
 	registry := NewRegistry()
 	handlers := []*TypedHandler{
 		NewSchemaHandler(spaceSettingsTypeID, ClassificationRewrite, true, false, false, false, false, inspectSpaceSettings, rewriteSpaceSettings),
@@ -42,6 +45,7 @@ func BuiltInRegistry() (*Registry, error) {
 		NewSchemaHandler(s4wave_git_world.GitWorktreeTypeID, ClassificationRewrite, true, false, false, true, false, inspectGitWorktree, rewriteGitWorktree),
 		NewSchemaHandler(s4wave_canvas_world.CanvasTypeID, ClassificationRewrite, true, false, true, true, false, inspectCanvas, rewriteCanvas),
 		NewSchemaHandler(s4wave_kv_world.KvStoreTypeID, ClassificationSpaceLocalOpaque, false, false, false, false, false, inspectKV, rewriteKV),
+		NewSchemaRefusalHandler(volume_world.ObjectTypeID, ClassificationNonMigratable, "Volume backing contains installation identity and requires an installation-aware migration"),
 		NewSchemaHandler(forge_cluster.ClusterTypeID, ClassificationRewrite, false, false, false, true, false, inspectForgeCluster, rewriteForgeCluster),
 		NewSchemaHandler(forge_job.JobTypeID, ClassificationRewrite, false, false, false, true, false, inspectForgeJob, rewriteForgeJob),
 		NewSchemaHandler(forge_task.TaskTypeID, ClassificationRewrite, true, false, false, true, true, inspectForgeTask, rewriteForgeTask),
@@ -61,6 +65,8 @@ func BuiltInRegistry() (*Registry, error) {
 		NewSchemaHandler(s4wave_secret_world.SecretTypeID, ClassificationRewrite, false, true, false, false, true, inspectSecret, rewriteSecret),
 		NewSchemaRefusalHandler(bldr_manifest_world.ManifestTypeID, ClassificationExternalRef, "manifest payload is external and not admitted for rewrite"),
 	}
+
+	// Reject duplicate registrations before returning the complete inventory.
 	for _, handler := range handlers {
 		if err := registry.Register(handler); err != nil {
 			return nil, err

--- a/core/space/migration/registry_test.go
+++ b/core/space/migration/registry_test.go
@@ -8,9 +8,12 @@ import (
 
 	space_migration "github.com/s4wave/spacewave/core/space/migration"
 	objecttypes "github.com/s4wave/spacewave/core/space/world/objecttypes"
+	volume_world "github.com/s4wave/spacewave/db/volume/world"
 )
 
+// TestBuiltInsAreClassifiedAndBoundToCentralInventory verifies complete migration coverage.
 func TestBuiltInsAreClassifiedAndBoundToCentralInventory(t *testing.T) {
+	// Compare the migration registry with the application inventory.
 	registry, err := space_migration.BuiltInRegistry()
 	if err != nil {
 		t.Fatal(err)
@@ -19,6 +22,8 @@ func TestBuiltInsAreClassifiedAndBoundToCentralInventory(t *testing.T) {
 	if !slices.Equal(central, registry.TypeIDs()) {
 		t.Fatalf("migration registry diverges from central ObjectType inventory: central=%v migration=%v", central, registry.TypeIDs())
 	}
+
+	// Require a policy for each type and preserve installation identity boundaries.
 	for _, typeID := range central {
 		handler := registry.Lookup(typeID)
 		if handler == nil {
@@ -27,14 +32,21 @@ func TestBuiltInsAreClassifiedAndBoundToCentralInventory(t *testing.T) {
 		if handler.Classification() == space_migration.ClassificationUnclassified {
 			t.Fatalf("built-in type %q is unclassified", typeID)
 		}
+		if typeID == volume_world.ObjectTypeID && handler.Classification() != space_migration.ClassificationNonMigratable {
+			t.Fatal("Volume backing must not migrate installation identity as an ordinary object")
+		}
 	}
 }
 
+// TestSchemaHandlersRejectSyntheticMetadata requires the live source payload.
 func TestSchemaHandlersRejectSyntheticMetadata(t *testing.T) {
+	// Resolve handlers with real payload requirements.
 	registry, err := space_migration.BuiltInRegistry()
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// Caller-provided references cannot substitute for a stored payload.
 	for _, typeID := range []string{"spacewave/secret", "canvas"} {
 		handler := registry.Lookup(typeID)
 		if handler == nil {

--- a/db/store/kvtx/bucket.go
+++ b/db/store/kvtx/bucket.go
@@ -31,7 +31,7 @@ func (k *KVTx) loadBucketConfig(ctx context.Context, tx kvtx.Tx, key []byte) (*b
 // ApplyBucketConfig applies a bucket configuration.
 // Returns the previous and current (updated) configurations.
 // The current configuration may be nil if the volume rejects the bucket.
-// If outdated, prev == curr.
+// If outdated, prev == curr. Invalid storage snapshots retry the complete update.
 func (k *KVTx) ApplyBucketConfig(ctx context.Context, conf *bucket.Config) (
 	updated bool,
 	prev, curr *bucket.Config,
@@ -47,33 +47,31 @@ func (k *KVTx) ApplyBucketConfig(ctx context.Context, conf *bucket.Config) (
 	}
 
 	key := k.kvkey.GetBucketConfigKey(conf.GetId())
-	tx, err := k.store.NewTransaction(ctx, true)
+	err = kvtx.RunTransaction(ctx, true,
+		func(ctx context.Context) (kvtx.Tx, error) {
+			return k.store.NewTransaction(ctx, true)
+		},
+		func(ctx context.Context, tx kvtx.Tx) error {
+			updated, prev, curr = false, nil, nil
+			existing, err := k.loadBucketConfig(ctx, tx, key)
+			if err != nil {
+				return err
+			}
+			if existing != nil && existing.GetRev() >= conf.GetRev() {
+				prev, curr = existing, existing
+				return nil
+			}
+
+			if err := tx.Set(ctx, key, dat); err != nil {
+				return err
+			}
+			updated, prev, curr = true, existing, conf
+			return nil
+		})
 	if err != nil {
 		return false, nil, nil, err
 	}
-	defer tx.Discard()
-
-	// 1. lookup the existing config
-	econf, err := k.loadBucketConfig(ctx, tx, key)
-	if err != nil {
-		return false, nil, nil, err
-	}
-
-	if econf != nil {
-		if econf.GetRev() >= conf.GetRev() {
-			return false, econf, econf, nil
-		}
-	}
-
-	if err := tx.Set(ctx, key, dat); err != nil {
-		return false, nil, nil, err
-	}
-
-	if err := tx.Commit(ctx); err != nil {
-		return false, nil, nil, err
-	}
-
-	return true, econf, conf, nil
+	return updated, prev, curr, nil
 }
 
 // GetBucketInfo returns bucket information by string.

--- a/db/store/kvtx/bucket_test.go
+++ b/db/store/kvtx/bucket_test.go
@@ -1,0 +1,38 @@
+package store_kvtx
+
+import (
+	"testing"
+
+	"github.com/s4wave/spacewave/db/bucket"
+	kvtx_kvtest "github.com/s4wave/spacewave/db/kvtx/kvtest"
+	store_kvkey "github.com/s4wave/spacewave/db/store/kvkey"
+	store_kvtx_inmem "github.com/s4wave/spacewave/db/store/kvtx/inmem"
+)
+
+// TestApplyBucketConfigRetriesInvalidSnapshot preserves bucket revisions after a commit conflict.
+func TestApplyBucketConfigRetriesInvalidSnapshot(t *testing.T) {
+	ctx := t.Context()
+	store := kvtx_kvtest.NewFaultStore(store_kvtx_inmem.NewStore(), kvtx_kvtest.FaultBeforeCommit)
+	k := &KVTx{kvkey: store_kvkey.NewDefaultKVKey(), store: store}
+	conf := &bucket.Config{Id: "space", Rev: 2}
+	updated, previous, current, err := k.ApplyBucketConfig(ctx, conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !updated || previous != nil || !current.EqualVT(conf) {
+		t.Fatalf("create returned updated=%v previous=%v current=%v", updated, previous, current)
+	}
+	if store.Opened() != 2 || store.Discarded() != 2 {
+		t.Fatalf("transaction attempts: opened=%d discarded=%d", store.Opened(), store.Discarded())
+	}
+	persisted, err := k.GetBucketConfig(ctx, conf.Id)
+	if err != nil || !persisted.EqualVT(conf) {
+		t.Fatalf("persisted config=%v error=%v", persisted, err)
+	}
+
+	// An older revision cannot replace the configuration committed by the retry.
+	updated, previous, current, err = k.ApplyBucketConfig(ctx, &bucket.Config{Id: conf.Id, Rev: 1})
+	if err != nil || updated || !previous.EqualVT(conf) || !current.EqualVT(conf) {
+		t.Fatalf("older revision returned updated=%v previous=%v current=%v error=%v", updated, previous, current, err)
+	}
+}

--- a/db/volume/controller/apply-bucket-conf.go
+++ b/db/volume/controller/apply-bucket-conf.go
@@ -2,6 +2,7 @@ package volume_controller
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/aperturerobotics/controllerbus/directive"
@@ -9,7 +10,7 @@ import (
 	"github.com/s4wave/spacewave/db/bucket"
 )
 
-// applyBucketConfigResolver resolves ApplyBucketConfig directives
+// applyBucketConfigResolver resolves ApplyBucketConfig directives.
 type applyBucketConfigResolver struct {
 	c   *Controller
 	dir bucket.ApplyBucketConfig
@@ -41,16 +42,22 @@ func (o *applyBucketConfigResolver) Resolve(ctx context.Context, handler directi
 	}
 
 	ts := timestamp.Now()
-	var errStr string
 	updated, prev, curr, err := vol.ApplyBucketConfig(ctx, o.dir.ApplyBucketConfigBucketConf())
 	if err != nil {
-		if err == context.Canceled {
+		if errors.Is(err, context.Canceled) {
 			return err
 		}
-		errStr = err.Error()
+		o.applied = true
+		handler.AddValue(&bucket.ApplyBucketConfigResult{
+			VolumeId:  vol.GetID(),
+			BucketId:  o.dir.ApplyBucketConfigBucketConf().GetId(),
+			Timestamp: ts,
+			Error:     err.Error(),
+		})
+		return nil
 	}
 
-	// no effect and no bucket data -> no value
+	// An unchanged bucket rejected by the Volume has no value.
 	if !updated && curr.GetId() == "" {
 		if prev != nil {
 			curr = prev
@@ -84,7 +91,6 @@ func (o *applyBucketConfigResolver) Resolve(ctx context.Context, handler directi
 		OldBucketConf: prev,
 		Timestamp:     ts,
 		Updated:       updated,
-		Error:         errStr,
 	})
 	return nil
 }
@@ -95,7 +101,7 @@ func (c *Controller) resolveApplyBucketConf(
 	di directive.Instance,
 	dir bucket.ApplyBucketConfig,
 ) (directive.Resolver, error) {
-	// check if we can immediately reject this directive or not
+	// Reject a directive that cannot match the current Volume.
 	if vb := c.volume.GetValue(); vb != nil {
 		if !bucket.CheckApplyBucketConfigMatchesVolume(dir, vb.vol.GetID(), c.config.GetVolumeIdAlias()) {
 			return nil, nil
@@ -106,5 +112,5 @@ func (c *Controller) resolveApplyBucketConf(
 	return &applyBucketConfigResolver{c: c, dir: dir}, nil
 }
 
-// _ is a type assertion
+// _ asserts the resolver contract.
 var _ directive.Resolver = (*applyBucketConfigResolver)(nil)

--- a/db/volume/controller/apply-bucket-conf_test.go
+++ b/db/volume/controller/apply-bucket-conf_test.go
@@ -1,0 +1,69 @@
+package volume_controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aperturerobotics/controllerbus/directive"
+	"github.com/aperturerobotics/util/ccontainer"
+	"github.com/s4wave/spacewave/db/bucket"
+	"github.com/s4wave/spacewave/db/volume"
+)
+
+// TestApplyBucketConfigPublishesStorageError prevents failed creation from leaving callers waiting.
+func TestApplyBucketConfigPublishesStorageError(t *testing.T) {
+	ctx := t.Context()
+	failure := errors.New("bucket storage failed")
+	ctrl := &Controller{
+		config: &Config{},
+		volume: ccontainer.NewCContainer(&volumeCtxPair{
+			vol: &failedBucketVolume{failure: failure},
+			ctx: ctx,
+		}),
+	}
+	resolver := &applyBucketConfigResolver{
+		c:   ctrl,
+		dir: bucket.NewApplyBucketConfigToVolume(&bucket.Config{Id: "space", Rev: 1}, "volume"),
+	}
+	handler := &bucketConfigResultHandler{}
+	if err := resolver.Resolve(ctx, handler); err != nil {
+		t.Fatal(err)
+	}
+	if len(handler.results) != 1 {
+		t.Fatalf("published %d results, want one storage error", len(handler.results))
+	}
+	result := handler.results[0]
+	if result.GetError() != failure.Error() || result.GetBucketId() != "space" || result.GetVolumeId() != "volume" {
+		t.Fatalf("failure result=%v", result)
+	}
+	if result.GetUpdated() || result.GetBucketConf() != nil {
+		t.Fatalf("failure published a successful update: %v", result)
+	}
+}
+
+// failedBucketVolume fails creation before any bucket configuration exists.
+type failedBucketVolume struct {
+	volume.Volume
+	failure error
+}
+
+// GetID returns the fixture volume identity.
+func (v *failedBucketVolume) GetID() string { return "volume" }
+
+// ApplyBucketConfig returns the configured storage failure.
+func (v *failedBucketVolume) ApplyBucketConfig(context.Context, *bucket.Config) (bool, *bucket.Config, *bucket.Config, error) {
+	return false, nil, nil, v.failure
+}
+
+// bucketConfigResultHandler captures the resolver's published results.
+type bucketConfigResultHandler struct {
+	directive.ResolverHandler
+	results []*bucket.ApplyBucketConfigResult
+}
+
+// AddValue retains each published result.
+func (h *bucketConfigResultHandler) AddValue(value directive.Value) (uint32, bool) {
+	h.results = append(h.results, value.(*bucket.ApplyBucketConfigResult))
+	return uint32(len(h.results)), true
+}

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/aperturerobotics/cayley v0.15.1-0.20260824110931-e6b102492e31 // master
 	github.com/aperturerobotics/cli v1.1.0 // v1.1.0
 	github.com/aperturerobotics/common v0.35.4 // master
-	github.com/aperturerobotics/controllerbus v0.53.5 // master
+	github.com/aperturerobotics/controllerbus v0.53.6-0.20260910010448-62281fa2684f // master
 	github.com/aperturerobotics/cpp-yamux v0.0.0-20260223122921-58339cfd0e5d
 	github.com/aperturerobotics/esbuild v0.24.1-0.20260219011422-6d4b923e2023 // https://github.com/evanw/esbuild/pull/3413 [rejected]
 	github.com/aperturerobotics/fastjson v0.1.2-0.20260705010846-94f343f5bb34
@@ -61,7 +61,7 @@ require (
 	github.com/fatih/color v1.19.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-git/go-billy/v6 v6.0.0-alpha.2.0.20260818093742-7bd059496705 // main
-	github.com/go-git/go-git/v6 v6.0.0-alpha.5.0.20260908152337-c3e96df0c369 // main
+	github.com/go-git/go-git/v6 v6.0.0-alpha.5.0.20260910092924-d15c624290f1 // main
 	github.com/go-sql-driver/mysql v1.10.1
 	github.com/goccy/go-json v0.10.6
 	github.com/gomodule/redigo v2.0.0+incompatible
@@ -85,7 +85,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/quic-go/quic-go v0.62.0
 	github.com/restic/chunker v0.5.0
-	github.com/s4wave/goscript v0.2.32-0.20260910005250-c96596b81552
+	github.com/s4wave/goscript v0.2.32-0.20260910104619-c3332db76d5b
 	github.com/sasha-s/go-deadlock v0.3.9
 	github.com/satori/go.uuid v1.2.0
 	github.com/sergi/go-diff v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/aperturerobotics/common v0.35.4 h1:MQgSHHIad71KIwV0pFqNTKm47QW93/kWJ4
 github.com/aperturerobotics/common v0.35.4/go.mod h1:eqVzmvTuSCoS31uwheXjILMcfx+jhl3VClGCT5ZxruI=
 github.com/aperturerobotics/controllerbus v0.53.5 h1:mSZQltMn2G1qjELMnsRWOb3jjyFAn/+gjuqbaOrBOIQ=
 github.com/aperturerobotics/controllerbus v0.53.5/go.mod h1:oMdVjwUwfKUo9XgnO7GbDk6cVMvrlnVaRDp/epb7ydU=
+github.com/aperturerobotics/controllerbus v0.53.6-0.20260910010448-62281fa2684f h1:qEuo1mmxCkpL5kR9rNiIHSW+hfdHog5nJjlEtTMwX50=
+github.com/aperturerobotics/controllerbus v0.53.6-0.20260910010448-62281fa2684f/go.mod h1:oMdVjwUwfKUo9XgnO7GbDk6cVMvrlnVaRDp/epb7ydU=
 github.com/aperturerobotics/cpp-yamux v0.0.0-20260223122921-58339cfd0e5d h1:TVae+YDmMmtutvNKC5d64yXx5Woa3QIq3Ndn11J1IPQ=
 github.com/aperturerobotics/cpp-yamux v0.0.0-20260223122921-58339cfd0e5d/go.mod h1:z43wdjwvCS9HJwxnqEtWgedAqWpeK6c5vozJoGXtUug=
 github.com/aperturerobotics/esbuild v0.24.1-0.20260219011422-6d4b923e2023 h1:OFfw+2XQglhiej7liQM/YQneJTkJvENZLfR/H4zmZ8Q=
@@ -315,6 +317,12 @@ github.com/rogpeppe/go-internal v1.16.0 h1:O9DK+vNMDVGLr2BeZqmpLeMjiMNkuXfcqntWb
 github.com/rogpeppe/go-internal v1.16.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
 github.com/s4wave/goscript v0.2.32-0.20260910005250-c96596b81552 h1:EZ+gP9qiG7IEcQaLxjjdGo997vQdF7RTIL6sfjig9uE=
 github.com/s4wave/goscript v0.2.32-0.20260910005250-c96596b81552/go.mod h1:2PkLvl4v5IXRzAh+HpOQymrS7Z6mNmAOKY89EoAhv8A=
+github.com/s4wave/goscript v0.2.32-0.20260910103058-9808ca17edd8 h1:c5FNS0p9M8egt2msRyrOuGsP04onZLAV/5XDbq2qZBA=
+github.com/s4wave/goscript v0.2.32-0.20260910103058-9808ca17edd8/go.mod h1:2PkLvl4v5IXRzAh+HpOQymrS7Z6mNmAOKY89EoAhv8A=
+github.com/s4wave/goscript v0.2.32-0.20260910103758-609b2dac09b3 h1:HXEZmfVMm+8+KVN+Wf3pyQdc5Mw+NuENyY+U02tkXyI=
+github.com/s4wave/goscript v0.2.32-0.20260910103758-609b2dac09b3/go.mod h1:2PkLvl4v5IXRzAh+HpOQymrS7Z6mNmAOKY89EoAhv8A=
+github.com/s4wave/goscript v0.2.32-0.20260910104619-c3332db76d5b h1:/i1m1rhtCI0WoJyYfRq7S1KPl7ONAP4/GwS9FGV7jHk=
+github.com/s4wave/goscript v0.2.32-0.20260910104619-c3332db76d5b/go.mod h1:2PkLvl4v5IXRzAh+HpOQymrS7Z6mNmAOKY89EoAhv8A=
 github.com/sasha-s/go-deadlock v0.3.9 h1:fiaT9rB7g5sr5ddNZvlwheclN9IP86eFW9WgqlEQV+w=
 github.com/sasha-s/go-deadlock v0.3.9/go.mod h1:KuZj51ZFmx42q/mPaYbRk0P1xcwe697zsJKE03vD4/Y=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=


### PR DESCRIPTION
New Space creation could wait forever after a concurrent write invalidated its bucket-configuration snapshot. Retry the full configuration transaction through the existing KVTx helper and publish storage failures to waiting callers. Revision ordering remains intact and existing stored data is unchanged.

Classify installation-backed volumes explicitly in the migration inventory, preserve real persistence exports in the dashboard mock, and inject the synthetic HTTP client into the handoff test. Update GoScript for precise persisted timestamps, constructor-based nested struct assignment, closed-channel scheduling, FileServer directory behavior, and bigint unary-plus lowering.

Focused migration and provider tests pass, both storage regressions pass under the race detector, and the real retained Drive-open scenario passes. Full compiler integration and repository CI are required before merge.
