### PR TITLE
Show accepted billing prices and correct DMCA restoration terms

### DIFF
--- a/.protoc-manifest.json
+++ b/.protoc-manifest.json
@@ -1161,7 +1161,7 @@
       ]
     },
     "github.com/s4wave/spacewave/core/provider/spacewave/api": {
-      "hash": "2bf5a8c782c8b21ab7617b6d36d1a6341a84cb3a370c30065bb1849fe563805d",
+      "hash": "5dabb48a2d4bc6c1b6ce80cc63e046ca816d6169b5efec9ebf70b52ef625d173",
       "generatedFiles": [
         "core/provider/spacewave/api/api.pb.go",
         "core/provider/spacewave/api/api.pb.ts",
@@ -3688,7 +3688,7 @@
       ]
     },
     "github.com/s4wave/spacewave/sdk/provider/spacewave": {
-      "hash": "3d36393bda2d2801a14d1d69bf2fb86238243ee5aa0c88589831c18b91167889",
+      "hash": "8c28a380e7b3e5a172f8fc276833f24c5950fc8405937a1ed673691d35c42d41",
       "generatedFiles": [
         "sdk/provider/spacewave/spacewave.pb.go",
         "sdk/provider/spacewave/spacewave.pb.ts",

--- a/app/billing/UsageBars.test.tsx
+++ b/app/billing/UsageBars.test.tsx
@@ -14,6 +14,11 @@ const mockBillingState = vi.hoisted(() => ({
       readOps: 225_000n,
       readOpsBaseline: 250_000n,
       overageLimitCents: 1000,
+      monthlyPriceCents: 900,
+      writeMicrodollars: 30,
+      readMicrodollars: 15,
+      offerVersion: 'cloud-monthly-v2',
+      policyVersion: '2026-09-10',
       accruedOverageMicrodollars: 2_000_000n,
       reservedOverageMicrodollars: 500_000n,
       currentPeriodStart: 1_800_000_000_000n,
@@ -40,6 +45,9 @@ describe('UsageBars', () => {
       ),
     ).toBeDefined()
     expect(screen.getByText(/Subscription period:/)).toBeDefined()
+    expect(screen.getByText(/Service maximum: \$19.00/)).toBeDefined()
+    expect(screen.getByText(/Extra writes cost \$0.30/)).toBeDefined()
+    expect(screen.getByText(/Extra uncached reads cost \$0.15/)).toBeDefined()
     expect(screen.getByText(/Peer-only traffic and cached reads/)).toBeDefined()
     expect(screen.queryByText('Extra storage')).toBeNull()
   })

--- a/app/billing/UsageBars.tsx
+++ b/app/billing/UsageBars.tsx
@@ -3,10 +3,7 @@ import { cn } from '@s4wave/web/style/utils.js'
 import { formatBytes } from '@s4wave/web/transform/TransformConfigDisplay.js'
 import { SessionContext } from '@s4wave/web/contexts/contexts.js'
 import { useBillingConsent } from '../provider/spacewave/useBillingConsent.js'
-import {
-  CLOUD_OFFER,
-  OVERAGE_EXPLANATION,
-} from '../provider/spacewave/pricing.js'
+import { CLOUD_OFFER } from '../provider/spacewave/pricing.js'
 import { useBillingStateContext } from './BillingStateProvider.js'
 
 const SOFT_USAGE_ALERT_RATIO = 0.8
@@ -69,9 +66,25 @@ export function UsageBars(props: { actions?: ReactNode }) {
   const periodStart = Number(usage.currentPeriodStart ?? 0n)
   const periodEnd = Number(usage.currentPeriodEnd ?? 0n)
 
+  const offer = {
+    ...CLOUD_OFFER,
+    version: usage.offerVersion ?? CLOUD_OFFER.version,
+    policyVersion: usage.policyVersion ?? CLOUD_OFFER.policyVersion,
+    monthlyPriceCents: usage.monthlyPriceCents ?? CLOUD_OFFER.monthlyPriceCents,
+    writeMicrodollars: usage.writeMicrodollars ?? CLOUD_OFFER.writeMicrodollars,
+    readMicrodollars: usage.readMicrodollars ?? CLOUD_OFFER.readMicrodollars,
+    storageBytes: storageBaseline,
+    writeOperations: writeBaseline,
+    readOperations: readBaseline,
+  }
+
   async function changeLimit() {
     if (!session || saving) return
-    const consent = await requestConsent(usage?.overageLimitCents ?? 0, true)
+    const consent = await requestConsent(
+      usage?.overageLimitCents ?? 0,
+      true,
+      offer,
+    )
     if (!consent) return
     setSaving(true)
     setError(null)
@@ -149,8 +162,8 @@ export function UsageBars(props: { actions?: ReactNode }) {
             ? `${formatCurrency(overageLimit)} monthly maximum`
             : 'off'}
           . Service maximum:{' '}
-          {formatCurrency(CLOUD_OFFER.monthlyPriceCents / 100 + overageLimit)}{' '}
-          before tax.
+          {formatCurrency(offer.monthlyPriceCents / 100 + overageLimit)} before
+          tax.
         </div>
         <div>
           Accrued: {formatCurrency(accrued)} · Reserved:{' '}
@@ -164,7 +177,13 @@ export function UsageBars(props: { actions?: ReactNode }) {
             {new Date(periodEnd).toLocaleString()}.
           </div>
         )}
-        <p>{OVERAGE_EXPLANATION}</p>
+        <p>
+          Extra writes cost ${(offer.writeMicrodollars / 100).toFixed(2)} per
+          10,000. Extra uncached reads cost $
+          {(offer.readMicrodollars / 100).toFixed(2)} per 10,000. Charges accrue
+          proportionally. Change or turn off the monthly extra-usage maximum
+          below.
+        </p>
         <p>
           A cloud write is a successful sync upload or billed cloud mutation.
           Many edits can share one upload. Peer-only traffic and cached reads do

--- a/app/landing/DMCA.tsx
+++ b/app/landing/DMCA.tsx
@@ -32,7 +32,7 @@ export function DMCA() {
               <p>Registration number: DMCA-1070193</p>
               <div className="bg-background/50 border-border/50 rounded-lg border p-4">
                 <p className="text-foreground mb-2 text-sm font-medium">
-                  Copyright Compliance Manager
+                  Christian Stewart, Designated Agent
                 </p>
                 <p>Aperture Robotics, LLC.</p>
                 <p>PO Box 692</p>
@@ -140,11 +140,21 @@ export function DMCA() {
                 </li>
               </ol>
               <p>
-                Upon receipt of a valid counter-notification, we will forward it
-                to the complaining party. If the complaining party does not file
-                a court action seeking to restrain the allegedly infringing
-                activity within ten (10) business days, we will restore the
-                removed material.
+                We promptly forward a valid counter-notification to the
+                complaining party and inform them that we intend to restore the
+                material after ten business days. We restore it no earlier than
+                ten and no later than fourteen business days after we receive
+                the valid counter-notification, unless our designated agent
+                receives notice of a court action seeking an order restraining
+                the subscriber from the alleged infringement.
+              </p>
+              <p>
+                Our operational calendar uses America/Los_Angeles dates and
+                excludes weekends and observed U.S. federal holidays. Later
+                administrative entry, review, or forwarding does not restart the
+                original receipt period. Other unresolved notices may keep the
+                material disabled. A withdrawal or acknowledged mistake may be
+                resolved sooner.
               </p>
             </div>
           </div>

--- a/app/provider/spacewave/NoActiveBillingAccountPage.test.tsx
+++ b/app/provider/spacewave/NoActiveBillingAccountPage.test.tsx
@@ -286,7 +286,7 @@ describe('NoActiveBillingAccountPage', () => {
           {
             id: 'ba_1',
             displayName: 'Billing Account',
-            subscriptionStatus: 'trialing',
+            subscriptionStatus: 'active',
             lifecycleState: 'active',
             assignees: [{ ownerType: 'account', ownerId: 'acct_1' }],
           },

--- a/app/provider/spacewave/useBillingConsent.tsx
+++ b/app/provider/spacewave/useBillingConsent.tsx
@@ -12,27 +12,28 @@ import { CLOUD_OFFER } from './pricing.js'
 // BillingConsentForm binds the visible terms and spending choice to one action.
 export function BillingConsentForm({
   onAccept,
-  initialLimit = CLOUD_OFFER.defaultOverageLimitCents,
+  offer = CLOUD_OFFER,
+  initialLimit = offer.defaultOverageLimitCents,
   spendingOnly = false,
   disabled = false,
 }: {
+  offer?: typeof CLOUD_OFFER
   onAccept: (consent: BillingConsent) => void
   initialLimit?: number
   spendingOnly?: boolean
   disabled?: boolean
 }) {
   const [limit, setLimit] = useState(initialLimit)
-  const monthlyPrice = CLOUD_OFFER.monthlyPriceCents / 100
+  const monthlyPrice = offer.monthlyPriceCents / 100
   const label = spendingOnly
     ? 'Save extra-usage maximum'
     : `Subscribe for $${monthlyPrice}/month`
   return (
     <div className="space-y-4 text-sm">
       <p className="text-foreground-alt text-xs">
-        Extra writes: ${(CLOUD_OFFER.writeMicrodollars / 100).toFixed(2)} per
-        10,000. Extra uncached reads: $
-        {(CLOUD_OFFER.readMicrodollars / 100).toFixed(2)} per 10,000. Charges
-        accrue proportionally.
+        Extra writes: ${(offer.writeMicrodollars / 100).toFixed(2)} per 10,000.
+        Extra uncached reads: ${(offer.readMicrodollars / 100).toFixed(2)} per
+        10,000. Charges accrue proportionally.
       </p>
       <label className="grid gap-2">
         Extra-usage cap
@@ -42,7 +43,7 @@ export function BillingConsentForm({
           disabled={disabled}
           onChange={(event) => setLimit(Number(event.target.value))}
         >
-          {CLOUD_OFFER.overageLimitsCents.map((value) => (
+          {offer.overageLimitsCents.map((value) => (
             <option key={value} value={value}>
               {value === 0 ? 'Off' : `$${value / 100}/month`}
             </option>
@@ -77,8 +78,8 @@ export function BillingConsentForm({
         disabled={disabled}
         onClick={() =>
           onAccept({
-            offerVersion: CLOUD_OFFER.version,
-            policyVersion: CLOUD_OFFER.policyVersion,
+            offerVersion: offer.version,
+            policyVersion: offer.policyVersion,
             renewalAccepted: !spendingOnly,
             overageAccepted: limit > 0,
             overageLimitCents: limit,
@@ -98,6 +99,7 @@ export function useBillingConsent() {
   const [choice, setChoice] = useState<{
     limit: number
     spendingOnly: boolean
+    offer: typeof CLOUD_OFFER
   } | null>(null)
 
   const finish = useCallback((consent?: BillingConsent) => {
@@ -119,9 +121,10 @@ export function useBillingConsent() {
     (
       currentLimit = CLOUD_OFFER.defaultOverageLimitCents,
       spendingOnly = false,
+      offer = CLOUD_OFFER,
     ) => {
       pending.current?.()
-      setChoice({ limit: currentLimit, spendingOnly })
+      setChoice({ limit: currentLimit, spendingOnly, offer })
       return new Promise<BillingConsent | undefined>((resolve) => {
         pending.current = resolve
       })
@@ -129,6 +132,7 @@ export function useBillingConsent() {
     [],
   )
 
+  const offer = choice?.offer ?? CLOUD_OFFER
   const consentDialog = (
     <Dialog
       open={choice !== null}
@@ -141,14 +145,15 @@ export function useBillingConsent() {
           {choice?.spendingOnly ? 'Extra-usage maximum' : 'Cloud monthly offer'}
         </DialogTitle>
         <DialogDescription>
-          ${CLOUD_OFFER.monthlyPriceCents / 100}/month before tax. Includes{' '}
-          {CLOUD_OFFER.storageBytes / 2 ** 30} GiB of encrypted cloud storage,{' '}
-          {CLOUD_OFFER.writeOperations.toLocaleString()} cloud writes, and{' '}
-          {CLOUD_OFFER.readOperations.toLocaleString()} uncached cloud reads per
+          ${offer.monthlyPriceCents / 100}/month before tax. Includes{' '}
+          {offer.storageBytes / 2 ** 30} GiB of encrypted cloud storage,{' '}
+          {offer.writeOperations.toLocaleString()} cloud writes, and{' '}
+          {offer.readOperations.toLocaleString()} uncached cloud reads per
           subscription month.
         </DialogDescription>
         {choice && (
           <BillingConsentForm
+            offer={choice.offer}
             initialLimit={choice.limit}
             spendingOnly={choice.spendingOnly}
             onAccept={finish}

--- a/core/provider/spacewave/api/api.pb.go
+++ b/core/provider/spacewave/api/api.pb.go
@@ -2824,6 +2824,14 @@ type BillingUsageResponse struct {
 	ReservedOverageMicrodollars int64 `protobuf:"varint,18,opt,name=reserved_overage_microdollars,json=reservedOverageMicrodollars,proto3" json:"reservedOverageMicrodollars,omitempty"`
 	// OfferVersion identifies the applied offer.
 	OfferVersion string `protobuf:"bytes,19,opt,name=offer_version,json=offerVersion,proto3" json:"offerVersion,omitempty"`
+	// MonthlyPriceCents is the accepted recurring base price before tax.
+	MonthlyPriceCents uint32 `protobuf:"varint,20,opt,name=monthly_price_cents,json=monthlyPriceCents,proto3" json:"monthlyPriceCents,omitempty"`
+	// WriteMicrodollars is the accepted charge for one extra write.
+	WriteMicrodollars uint32 `protobuf:"varint,21,opt,name=write_microdollars,json=writeMicrodollars,proto3" json:"writeMicrodollars,omitempty"`
+	// ReadMicrodollars is the accepted charge for one extra uncached read.
+	ReadMicrodollars uint32 `protobuf:"varint,22,opt,name=read_microdollars,json=readMicrodollars,proto3" json:"readMicrodollars,omitempty"`
+	// PolicyVersion identifies the policy applying to the current offer.
+	PolicyVersion string `protobuf:"bytes,23,opt,name=policy_version,json=policyVersion,proto3" json:"policyVersion,omitempty"`
 }
 
 func (x *BillingUsageResponse) Reset() {
@@ -2919,6 +2927,34 @@ func (x *BillingUsageResponse) GetReservedOverageMicrodollars() int64 {
 func (x *BillingUsageResponse) GetOfferVersion() string {
 	if x != nil {
 		return x.OfferVersion
+	}
+	return ""
+}
+
+func (x *BillingUsageResponse) GetMonthlyPriceCents() uint32 {
+	if x != nil {
+		return x.MonthlyPriceCents
+	}
+	return 0
+}
+
+func (x *BillingUsageResponse) GetWriteMicrodollars() uint32 {
+	if x != nil {
+		return x.WriteMicrodollars
+	}
+	return 0
+}
+
+func (x *BillingUsageResponse) GetReadMicrodollars() uint32 {
+	if x != nil {
+		return x.ReadMicrodollars
+	}
+	return 0
+}
+
+func (x *BillingUsageResponse) GetPolicyVersion() string {
+	if x != nil {
+		return x.PolicyVersion
 	}
 	return ""
 }
@@ -11653,6 +11689,10 @@ func (m *BillingUsageResponse) CloneVT() *BillingUsageResponse {
 	r.CurrentPeriodEnd = m.CurrentPeriodEnd
 	r.ReservedOverageMicrodollars = m.ReservedOverageMicrodollars
 	r.OfferVersion = m.OfferVersion
+	r.MonthlyPriceCents = m.MonthlyPriceCents
+	r.WriteMicrodollars = m.WriteMicrodollars
+	r.ReadMicrodollars = m.ReadMicrodollars
+	r.PolicyVersion = m.PolicyVersion
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = slices.Clone(m.unknownFields)
 	}
@@ -17427,6 +17467,18 @@ func (this *BillingUsageResponse) EqualVT(that *BillingUsageResponse) bool {
 		return false
 	}
 	if this.OfferVersion != that.OfferVersion {
+		return false
+	}
+	if this.MonthlyPriceCents != that.MonthlyPriceCents {
+		return false
+	}
+	if this.WriteMicrodollars != that.WriteMicrodollars {
+		return false
+	}
+	if this.ReadMicrodollars != that.ReadMicrodollars {
+		return false
+	}
+	if this.PolicyVersion != that.PolicyVersion {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -26999,6 +27051,26 @@ func (x *BillingUsageResponse) MarshalProtoJSON(s *json.MarshalState) {
 		s.WriteObjectField("offerVersion")
 		s.WriteString(x.OfferVersion)
 	}
+	if x.MonthlyPriceCents != 0 || s.HasField("monthlyPriceCents") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("monthlyPriceCents")
+		s.WriteUint32(x.MonthlyPriceCents)
+	}
+	if x.WriteMicrodollars != 0 || s.HasField("writeMicrodollars") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("writeMicrodollars")
+		s.WriteUint32(x.WriteMicrodollars)
+	}
+	if x.ReadMicrodollars != 0 || s.HasField("readMicrodollars") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("readMicrodollars")
+		s.WriteUint32(x.ReadMicrodollars)
+	}
+	if x.PolicyVersion != "" || s.HasField("policyVersion") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("policyVersion")
+		s.WriteString(x.PolicyVersion)
+	}
 	s.WriteObjectEnd()
 }
 
@@ -27055,6 +27127,18 @@ func (x *BillingUsageResponse) UnmarshalProtoJSON(s *json.UnmarshalState) {
 		case "offer_version", "offerVersion":
 			s.AddField("offer_version")
 			x.OfferVersion = s.ReadString()
+		case "monthly_price_cents", "monthlyPriceCents":
+			s.AddField("monthly_price_cents")
+			x.MonthlyPriceCents = s.ReadUint32()
+		case "write_microdollars", "writeMicrodollars":
+			s.AddField("write_microdollars")
+			x.WriteMicrodollars = s.ReadUint32()
+		case "read_microdollars", "readMicrodollars":
+			s.AddField("read_microdollars")
+			x.ReadMicrodollars = s.ReadUint32()
+		case "policy_version", "policyVersion":
+			s.AddField("policy_version")
+			x.PolicyVersion = s.ReadString()
 		}
 	})
 }
@@ -42512,6 +42596,34 @@ func (m *BillingUsageResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) 
 	if m.unknownFields != nil {
 		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
 	}
+	if len(m.PolicyVersion) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.PolicyVersion)
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xba
+	}
+	if m.ReadMicrodollars != 0 {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(m.ReadMicrodollars))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xb0
+	}
+	if m.WriteMicrodollars != 0 {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(m.WriteMicrodollars))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xa8
+	}
+	if m.MonthlyPriceCents != 0 {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(m.MonthlyPriceCents))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xa0
+	}
 	if len(m.OfferVersion) > 0 {
 		i = protobuf_go_lite.EncodeString(dAtA, i, m.OfferVersion)
 		i--
@@ -53845,6 +53957,10 @@ func (m *BillingUsageResponse) SizeVT() (n int) {
 	n += protobuf_go_lite.SizeVarintNonZero(2, m.CurrentPeriodEnd)
 	n += protobuf_go_lite.SizeVarintNonZero(2, m.ReservedOverageMicrodollars)
 	n += protobuf_go_lite.SizeStringNonEmpty(2, m.OfferVersion)
+	n += protobuf_go_lite.SizeVarintNonZero(2, m.MonthlyPriceCents)
+	n += protobuf_go_lite.SizeVarintNonZero(2, m.WriteMicrodollars)
+	n += protobuf_go_lite.SizeVarintNonZero(2, m.ReadMicrodollars)
+	n += protobuf_go_lite.SizeStringNonEmpty(2, m.PolicyVersion)
 	n += len(m.unknownFields)
 	return n
 }
@@ -58464,6 +58580,22 @@ func (x *BillingUsageResponse) MarshalProtoText() string {
 	if x.OfferVersion != "" {
 		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "offer_version")
 		protobuf_go_lite.TextWriteString(&sb, x.OfferVersion)
+	}
+	if x.MonthlyPriceCents != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "monthly_price_cents")
+		protobuf_go_lite.TextWriteUint(&sb, x.MonthlyPriceCents)
+	}
+	if x.WriteMicrodollars != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "write_microdollars")
+		protobuf_go_lite.TextWriteUint(&sb, x.WriteMicrodollars)
+	}
+	if x.ReadMicrodollars != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "read_microdollars")
+		protobuf_go_lite.TextWriteUint(&sb, x.ReadMicrodollars)
+	}
+	if x.PolicyVersion != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "policy_version")
+		protobuf_go_lite.TextWriteString(&sb, x.PolicyVersion)
 	}
 	return protobuf_go_lite.TextFinishMessage(&sb)
 }
@@ -67747,6 +67879,43 @@ func (m *BillingUsageResponse) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			m.OfferVersion = v
+		case 20:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MonthlyPriceCents", wireType)
+			}
+			m.MonthlyPriceCents = 0
+			m.MonthlyPriceCents, iNdEx, err = protobuf_go_lite.DecodeVarintUint32(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+		case 21:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field WriteMicrodollars", wireType)
+			}
+			m.WriteMicrodollars = 0
+			m.WriteMicrodollars, iNdEx, err = protobuf_go_lite.DecodeVarintUint32(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+		case 22:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ReadMicrodollars", wireType)
+			}
+			m.ReadMicrodollars = 0
+			m.ReadMicrodollars, iNdEx, err = protobuf_go_lite.DecodeVarintUint32(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+		case 23:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PolicyVersion", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.PolicyVersion = v
 		default:
 			iNdEx = preIndex
 			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])

--- a/core/provider/spacewave/api/api.pb.ts
+++ b/core/provider/spacewave/api/api.pb.ts
@@ -3330,6 +3330,30 @@ export interface BillingUsageResponse {
    * @generated from field: string offer_version = 19;
    */
   offerVersion?: string
+  /**
+   * MonthlyPriceCents is the accepted recurring base price before tax.
+   *
+   * @generated from field: uint32 monthly_price_cents = 20;
+   */
+  monthlyPriceCents?: number
+  /**
+   * WriteMicrodollars is the accepted charge for one extra write.
+   *
+   * @generated from field: uint32 write_microdollars = 21;
+   */
+  writeMicrodollars?: number
+  /**
+   * ReadMicrodollars is the accepted charge for one extra uncached read.
+   *
+   * @generated from field: uint32 read_microdollars = 22;
+   */
+  readMicrodollars?: number
+  /**
+   * PolicyVersion identifies the policy applying to the current offer.
+   *
+   * @generated from field: string policy_version = 23;
+   */
+  policyVersion?: string
 }
 
 export const BillingUsageResponse: MessageType<BillingUsageResponse> =
@@ -3394,6 +3418,25 @@ export const BillingUsageResponse: MessageType<BillingUsageResponse> =
         T: ScalarType.INT64,
       },
       { no: 19, name: 'offer_version', kind: 'scalar', T: ScalarType.STRING },
+      {
+        no: 20,
+        name: 'monthly_price_cents',
+        kind: 'scalar',
+        T: ScalarType.UINT32,
+      },
+      {
+        no: 21,
+        name: 'write_microdollars',
+        kind: 'scalar',
+        T: ScalarType.UINT32,
+      },
+      {
+        no: 22,
+        name: 'read_microdollars',
+        kind: 'scalar',
+        T: ScalarType.UINT32,
+      },
+      { no: 23, name: 'policy_version', kind: 'scalar', T: ScalarType.STRING },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,
   })

--- a/core/provider/spacewave/api/api.proto
+++ b/core/provider/spacewave/api/api.proto
@@ -784,6 +784,14 @@ message BillingUsageResponse {
   int64 reserved_overage_microdollars = 18;
   // OfferVersion identifies the applied offer.
   string offer_version = 19;
+  // MonthlyPriceCents is the accepted recurring base price before tax.
+  uint32 monthly_price_cents = 20;
+  // WriteMicrodollars is the accepted charge for one extra write.
+  uint32 write_microdollars = 21;
+  // ReadMicrodollars is the accepted charge for one extra uncached read.
+  uint32 read_microdollars = 22;
+  // PolicyVersion identifies the policy applying to the current offer.
+  string policy_version = 23;
 }
 
 // CheckoutStatusMessage is a JSON message from the checkout status WebSocket.

--- a/core/resource/session/sessioninfo/info.go
+++ b/core/resource/session/sessioninfo/info.go
@@ -30,6 +30,10 @@ func BuildEmptyBillingUsageInfo() *s4wave_provider_spacewave.BillingUsageInfo {
 		WriteOpsBaseline:     int64(offer.WriteOperations),
 		ReadOpsBaseline:      int64(offer.ReadOperations),
 		OfferVersion:         offer.Version,
+		MonthlyPriceCents:    offer.MonthlyPriceCents,
+		WriteMicrodollars:    offer.WriteMicrodollars,
+		ReadMicrodollars:     offer.ReadMicrodollars,
+		PolicyVersion:        offer.PolicyVersion,
 	}
 }
 
@@ -52,5 +56,9 @@ func BuildBillingUsageInfo(usage *api.BillingUsageResponse) *s4wave_provider_spa
 		CurrentPeriodEnd:            usage.GetCurrentPeriodEnd(),
 		ReservedOverageMicrodollars: usage.GetReservedOverageMicrodollars(),
 		OfferVersion:                usage.GetOfferVersion(),
+		MonthlyPriceCents:           usage.GetMonthlyPriceCents(),
+		WriteMicrodollars:           usage.GetWriteMicrodollars(),
+		ReadMicrodollars:            usage.GetReadMicrodollars(),
+		PolicyVersion:               usage.GetPolicyVersion(),
 	}
 }

--- a/core/resource/session/sessioninfo/info_test.go
+++ b/core/resource/session/sessioninfo/info_test.go
@@ -73,8 +73,12 @@ func TestBuildBillingUsageInfoPreservesSpendingConsent(t *testing.T) {
 		StorageBytes: 123, StorageBaselineBytes: 107374182400,
 		WriteOps: 50001, WriteOpsBaseline: 50000, ReadOps: 250000, ReadOpsBaseline: 250000,
 		OverageLimitCents: 500, AccruedOverageMicrodollars: 20, ReservedOverageMicrodollars: 10,
-		CurrentPeriodStart: 1776900000000, CurrentPeriodEnd: 1779492000000, OfferVersion: "cloud-monthly-v1",
+		CurrentPeriodStart: 1776900000000, CurrentPeriodEnd: 1779492000000, OfferVersion: "cloud-monthly-v2",
+		MonthlyPriceCents: 900, WriteMicrodollars: 30, ReadMicrodollars: 15, PolicyVersion: "2026-09-10",
 	})
+	if usage.GetMonthlyPriceCents() != 900 || usage.GetWriteMicrodollars() != 30 || usage.GetReadMicrodollars() != 15 || usage.GetPolicyVersion() != "2026-09-10" {
+		t.Fatalf("billing projection lost accepted prices: %+v", usage)
+	}
 	if usage.GetAccruedOverageMicrodollars() != 20 || usage.GetOverageLimitCents() != 500 || usage.GetReservedOverageMicrodollars() != 10 {
 		t.Fatalf("spending projection lost exact ledger units: %+v", usage)
 	}

--- a/sdk/provider/spacewave/spacewave.pb.go
+++ b/sdk/provider/spacewave/spacewave.pb.go
@@ -3554,6 +3554,14 @@ type BillingUsageInfo struct {
 	ReservedOverageMicrodollars int64 `protobuf:"varint,18,opt,name=reserved_overage_microdollars,json=reservedOverageMicrodollars,proto3" json:"reservedOverageMicrodollars,omitempty"`
 	// OfferVersion identifies the applied offer.
 	OfferVersion string `protobuf:"bytes,19,opt,name=offer_version,json=offerVersion,proto3" json:"offerVersion,omitempty"`
+	// MonthlyPriceCents is the accepted recurring base price before tax.
+	MonthlyPriceCents uint32 `protobuf:"varint,20,opt,name=monthly_price_cents,json=monthlyPriceCents,proto3" json:"monthlyPriceCents,omitempty"`
+	// WriteMicrodollars is the accepted charge for one extra write.
+	WriteMicrodollars uint32 `protobuf:"varint,21,opt,name=write_microdollars,json=writeMicrodollars,proto3" json:"writeMicrodollars,omitempty"`
+	// ReadMicrodollars is the accepted charge for one extra uncached read.
+	ReadMicrodollars uint32 `protobuf:"varint,22,opt,name=read_microdollars,json=readMicrodollars,proto3" json:"readMicrodollars,omitempty"`
+	// PolicyVersion identifies the policy applying to the current offer.
+	PolicyVersion string `protobuf:"bytes,23,opt,name=policy_version,json=policyVersion,proto3" json:"policyVersion,omitempty"`
 }
 
 func (x *BillingUsageInfo) Reset() {
@@ -3649,6 +3657,34 @@ func (x *BillingUsageInfo) GetReservedOverageMicrodollars() int64 {
 func (x *BillingUsageInfo) GetOfferVersion() string {
 	if x != nil {
 		return x.OfferVersion
+	}
+	return ""
+}
+
+func (x *BillingUsageInfo) GetMonthlyPriceCents() uint32 {
+	if x != nil {
+		return x.MonthlyPriceCents
+	}
+	return 0
+}
+
+func (x *BillingUsageInfo) GetWriteMicrodollars() uint32 {
+	if x != nil {
+		return x.WriteMicrodollars
+	}
+	return 0
+}
+
+func (x *BillingUsageInfo) GetReadMicrodollars() uint32 {
+	if x != nil {
+		return x.ReadMicrodollars
+	}
+	return 0
+}
+
+func (x *BillingUsageInfo) GetPolicyVersion() string {
+	if x != nil {
+		return x.PolicyVersion
 	}
 	return ""
 }
@@ -10028,6 +10064,10 @@ func (m *BillingUsageInfo) CloneVT() *BillingUsageInfo {
 	r.CurrentPeriodEnd = m.CurrentPeriodEnd
 	r.ReservedOverageMicrodollars = m.ReservedOverageMicrodollars
 	r.OfferVersion = m.OfferVersion
+	r.MonthlyPriceCents = m.MonthlyPriceCents
+	r.WriteMicrodollars = m.WriteMicrodollars
+	r.ReadMicrodollars = m.ReadMicrodollars
+	r.PolicyVersion = m.PolicyVersion
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = slices.Clone(m.unknownFields)
 	}
@@ -15050,6 +15090,18 @@ func (this *BillingUsageInfo) EqualVT(that *BillingUsageInfo) bool {
 		return false
 	}
 	if this.OfferVersion != that.OfferVersion {
+		return false
+	}
+	if this.MonthlyPriceCents != that.MonthlyPriceCents {
+		return false
+	}
+	if this.WriteMicrodollars != that.WriteMicrodollars {
+		return false
+	}
+	if this.ReadMicrodollars != that.ReadMicrodollars {
+		return false
+	}
+	if this.PolicyVersion != that.PolicyVersion {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -23696,6 +23748,26 @@ func (x *BillingUsageInfo) MarshalProtoJSON(s *json.MarshalState) {
 		s.WriteObjectField("offerVersion")
 		s.WriteString(x.OfferVersion)
 	}
+	if x.MonthlyPriceCents != 0 || s.HasField("monthlyPriceCents") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("monthlyPriceCents")
+		s.WriteUint32(x.MonthlyPriceCents)
+	}
+	if x.WriteMicrodollars != 0 || s.HasField("writeMicrodollars") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("writeMicrodollars")
+		s.WriteUint32(x.WriteMicrodollars)
+	}
+	if x.ReadMicrodollars != 0 || s.HasField("readMicrodollars") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("readMicrodollars")
+		s.WriteUint32(x.ReadMicrodollars)
+	}
+	if x.PolicyVersion != "" || s.HasField("policyVersion") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("policyVersion")
+		s.WriteString(x.PolicyVersion)
+	}
 	s.WriteObjectEnd()
 }
 
@@ -23752,6 +23824,18 @@ func (x *BillingUsageInfo) UnmarshalProtoJSON(s *json.UnmarshalState) {
 		case "offer_version", "offerVersion":
 			s.AddField("offer_version")
 			x.OfferVersion = s.ReadString()
+		case "monthly_price_cents", "monthlyPriceCents":
+			s.AddField("monthly_price_cents")
+			x.MonthlyPriceCents = s.ReadUint32()
+		case "write_microdollars", "writeMicrodollars":
+			s.AddField("write_microdollars")
+			x.WriteMicrodollars = s.ReadUint32()
+		case "read_microdollars", "readMicrodollars":
+			s.AddField("read_microdollars")
+			x.ReadMicrodollars = s.ReadUint32()
+		case "policy_version", "policyVersion":
+			s.AddField("policy_version")
+			x.PolicyVersion = s.ReadString()
 		}
 	})
 }
@@ -35997,6 +36081,34 @@ func (m *BillingUsageInfo) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
 	}
+	if len(m.PolicyVersion) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.PolicyVersion)
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xba
+	}
+	if m.ReadMicrodollars != 0 {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(m.ReadMicrodollars))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xb0
+	}
+	if m.WriteMicrodollars != 0 {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(m.WriteMicrodollars))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xa8
+	}
+	if m.MonthlyPriceCents != 0 {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(m.MonthlyPriceCents))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xa0
+	}
 	if len(m.OfferVersion) > 0 {
 		i = protobuf_go_lite.EncodeString(dAtA, i, m.OfferVersion)
 		i--
@@ -44134,6 +44246,10 @@ func (m *BillingUsageInfo) SizeVT() (n int) {
 	n += protobuf_go_lite.SizeVarintNonZero(2, m.CurrentPeriodEnd)
 	n += protobuf_go_lite.SizeVarintNonZero(2, m.ReservedOverageMicrodollars)
 	n += protobuf_go_lite.SizeStringNonEmpty(2, m.OfferVersion)
+	n += protobuf_go_lite.SizeVarintNonZero(2, m.MonthlyPriceCents)
+	n += protobuf_go_lite.SizeVarintNonZero(2, m.WriteMicrodollars)
+	n += protobuf_go_lite.SizeVarintNonZero(2, m.ReadMicrodollars)
+	n += protobuf_go_lite.SizeStringNonEmpty(2, m.PolicyVersion)
 	n += len(m.unknownFields)
 	return n
 }
@@ -47943,6 +48059,22 @@ func (x *BillingUsageInfo) MarshalProtoText() string {
 	if x.OfferVersion != "" {
 		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "offer_version")
 		protobuf_go_lite.TextWriteString(&sb, x.OfferVersion)
+	}
+	if x.MonthlyPriceCents != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "monthly_price_cents")
+		protobuf_go_lite.TextWriteUint(&sb, x.MonthlyPriceCents)
+	}
+	if x.WriteMicrodollars != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "write_microdollars")
+		protobuf_go_lite.TextWriteUint(&sb, x.WriteMicrodollars)
+	}
+	if x.ReadMicrodollars != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "read_microdollars")
+		protobuf_go_lite.TextWriteUint(&sb, x.ReadMicrodollars)
+	}
+	if x.PolicyVersion != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "policy_version")
+		protobuf_go_lite.TextWriteString(&sb, x.PolicyVersion)
 	}
 	return protobuf_go_lite.TextFinishMessage(&sb)
 }
@@ -56944,6 +57076,43 @@ func (m *BillingUsageInfo) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			m.OfferVersion = v
+		case 20:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MonthlyPriceCents", wireType)
+			}
+			m.MonthlyPriceCents = 0
+			m.MonthlyPriceCents, iNdEx, err = protobuf_go_lite.DecodeVarintUint32(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+		case 21:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field WriteMicrodollars", wireType)
+			}
+			m.WriteMicrodollars = 0
+			m.WriteMicrodollars, iNdEx, err = protobuf_go_lite.DecodeVarintUint32(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+		case 22:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ReadMicrodollars", wireType)
+			}
+			m.ReadMicrodollars = 0
+			m.ReadMicrodollars, iNdEx, err = protobuf_go_lite.DecodeVarintUint32(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+		case 23:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PolicyVersion", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.PolicyVersion = v
 		default:
 			iNdEx = preIndex
 			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])

--- a/sdk/provider/spacewave/spacewave.pb.ts
+++ b/sdk/provider/spacewave/spacewave.pb.ts
@@ -3773,6 +3773,30 @@ export interface BillingUsageInfo {
    * @generated from field: string offer_version = 19;
    */
   offerVersion?: string
+  /**
+   * MonthlyPriceCents is the accepted recurring base price before tax.
+   *
+   * @generated from field: uint32 monthly_price_cents = 20;
+   */
+  monthlyPriceCents?: number
+  /**
+   * WriteMicrodollars is the accepted charge for one extra write.
+   *
+   * @generated from field: uint32 write_microdollars = 21;
+   */
+  writeMicrodollars?: number
+  /**
+   * ReadMicrodollars is the accepted charge for one extra uncached read.
+   *
+   * @generated from field: uint32 read_microdollars = 22;
+   */
+  readMicrodollars?: number
+  /**
+   * PolicyVersion identifies the policy applying to the current offer.
+   *
+   * @generated from field: string policy_version = 23;
+   */
+  policyVersion?: string
 }
 
 export const BillingUsageInfo: MessageType<BillingUsageInfo> =
@@ -3832,6 +3856,25 @@ export const BillingUsageInfo: MessageType<BillingUsageInfo> =
         T: ScalarType.INT64,
       },
       { no: 19, name: 'offer_version', kind: 'scalar', T: ScalarType.STRING },
+      {
+        no: 20,
+        name: 'monthly_price_cents',
+        kind: 'scalar',
+        T: ScalarType.UINT32,
+      },
+      {
+        no: 21,
+        name: 'write_microdollars',
+        kind: 'scalar',
+        T: ScalarType.UINT32,
+      },
+      {
+        no: 22,
+        name: 'read_microdollars',
+        kind: 'scalar',
+        T: ScalarType.UINT32,
+      },
+      { no: 23, name: 'policy_version', kind: 'scalar', T: ScalarType.STRING },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,
   })

--- a/sdk/provider/spacewave/spacewave.proto
+++ b/sdk/provider/spacewave/spacewave.proto
@@ -965,6 +965,14 @@ message BillingUsageInfo {
   int64 reserved_overage_microdollars = 18;
   // OfferVersion identifies the applied offer.
   string offer_version = 19;
+  // MonthlyPriceCents is the accepted recurring base price before tax.
+  uint32 monthly_price_cents = 20;
+  // WriteMicrodollars is the accepted charge for one extra write.
+  uint32 write_microdollars = 21;
+  // ReadMicrodollars is the accepted charge for one extra uncached read.
+  uint32 read_microdollars = 22;
+  // PolicyVersion identifies the policy applying to the current offer.
+  string policy_version = 23;
 }
 
 // BillingConsent captures the customer's affirmative offer and spending choice.


### PR DESCRIPTION
Billing usage and spending consent now display the subscriber's accepted base price and operation rates, carried through the generated Worker and SDK contracts. Public DMCA text uses original provider receipt and the ten-to-fourteen-business-day restoration rule.

Validation: 30 focused UI tests, billing projection Go tests, TypeScript checking, JavaScript lint, and the changed Go package's lint passed. An obsolete onboarding fixture now uses an active paid subscription. Two existing JavaScript test warnings remain.
