### PR TITLE
fix(sync): typecheck the standalone worker source

### DIFF
--- a/core/sync/node/worker.ts
+++ b/core/sync/node/worker.ts
@@ -1,16 +1,26 @@
 import { isMainThread, parentPort, workerData } from 'node:worker_threads'
 import { createHandler, createMux, Server } from 'starpc'
-import { ValueOf } from '@goscript/syscall/js/index.js'
 
 import { SqliteNodeServer } from '../../../db/sql/sqlite-node/server.js'
 import { SqliteBridgeDefinition } from '../../../db/sql/sqlite-wasm/rpc/sqlite-bridge_srpc.pb.js'
 import { messagePortPacketStream } from '../../../bldr/web/entrypoint/browser/message-port-packet-stream.js'
-import { Open } from '@goscript/github.com/s4wave/spacewave/core/sync/node/runtime.gs.js'
 import { acquireDirectoryLock } from '../../../db/sql/sqlite-node/lock.js'
 import { RuntimeInit, RuntimeMessage, RuntimeMessage_Kind } from './node.pb.js'
 
+// EngineRuntime is the compiled engine capability supplied by the build entrypoint.
+interface EngineRuntime {
+  accept(port: MessagePort): Promise<void>
+  close(): Promise<void>
+}
+
+// OpenRuntime binds the compiled engine to this Worker's private SQL-port opener.
+type OpenRuntime = (
+  directory: string,
+  openSQLPort: () => MessagePort,
+) => Promise<EngineRuntime>
+
 // openEngine connects the compiled engine to SQLite within this Worker.
-export async function openEngine(directory: string) {
+async function openEngine(directory: string, openRuntime: OpenRuntime) {
   const sqlite = new SqliteNodeServer()
   const mux = createMux()
   mux.register(createHandler(SqliteBridgeDefinition, sqlite))
@@ -21,9 +31,7 @@ export async function openEngine(directory: string) {
     return port2
   }
   try {
-    const [runtime, error] = await Open(directory, ValueOf(openPort))
-    if (error) throw new Error(await error.Error())
-    if (!runtime) throw new Error('Sync engine returned no runtime')
+    const runtime = await openRuntime(directory, openPort)
     return { runtime, sqlite }
   } catch (error) {
     sqlite.close()
@@ -31,15 +39,15 @@ export async function openEngine(directory: string) {
   }
 }
 
-// runWorker publishes readiness only after SQLite and the World are available.
-async function runWorker(): Promise<void> {
+// serveWorker publishes readiness only after SQLite and the World are available.
+async function serveWorker(openRuntime: OpenRuntime): Promise<void> {
   if (!parentPort) throw new Error('Sync engine requires a Worker parent')
   const parent = parentPort
   const init = RuntimeInit.fromBinary(workerData)
   const lock = acquireDirectoryLock(init.directory ?? '')
   let opened: Awaited<ReturnType<typeof openEngine>> | undefined
   try {
-    opened = await openEngine(lock.directory)
+    opened = await openEngine(lock.directory, openRuntime)
     const { runtime, sqlite } = opened
     let closing: Promise<void> | undefined
     parent.on(
@@ -51,17 +59,12 @@ async function runWorker(): Promise<void> {
             frame.port.close()
             return
           }
-          void Promise.resolve(runtime.Accept(ValueOf(frame.port)))
-            .then((error) => {
-              if (error) frame.port?.close()
-            })
-            .catch(() => frame.port?.close())
+          void runtime.accept(frame.port).catch(() => frame.port?.close())
         } else if (message.kind === RuntimeMessage_Kind.CLOSE) {
           closing ??= (async () => {
             let failure = ''
             try {
-              const error = await runtime.Close()
-              if (error) throw new Error(await error.Error())
+              await runtime.close()
             } catch (error) {
               failure = error instanceof Error ? error.message : String(error)
             } finally {
@@ -111,8 +114,10 @@ async function runWorker(): Promise<void> {
   }
 }
 
-if (!isMainThread) {
-  void runWorker().catch((error: unknown) => {
+// runWorker starts the host after the generated entrypoint supplies its compiled binding.
+export function runWorker(openRuntime: OpenRuntime): void {
+  if (isMainThread) throw new Error('Sync engine requires a Worker')
+  void serveWorker(openRuntime).catch((error: unknown) => {
     parentPort?.postMessage(
       RuntimeMessage.toBinary({
         kind: RuntimeMessage_Kind.FAILED,

--- a/scripts/sync-library/main.go
+++ b/scripts/sync-library/main.go
@@ -58,6 +58,10 @@ func build(ctx context.Context, le *logrus.Entry, output string, skipCompile boo
 			return err
 		}
 	}
+	entrypoint := filepath.Join(working, "engine-worker.ts")
+	if err := os.WriteFile(entrypoint, []byte(workerEntrypoint), 0o644); err != nil {
+		return err
+	}
 	result, err := rolldown.Build(ctx, le, working, filepath.Join(root, "bldr"), &rolldown.BuildRequest{
 		WorkingDir: working, SourceRoot: root, OutputRoot: output,
 		BldrDistRoot: filepath.Join(root, "bldr"),
@@ -68,7 +72,7 @@ func build(ctx context.Context, le *logrus.Entry, output string, skipCompile boo
 		CleanOutputDir: true,
 		Defines:        map[string]string{"process.env.WS_NO_BUFFER_UTIL": "true", "process.env.WS_NO_UTF_8_VALIDATE": "true"},
 		Entrypoints: []*rolldown.Entrypoint{
-			{Name: "engine-worker", InputPath: filepath.Join(root, "core/sync/node/worker.ts")},
+			{Name: "engine-worker", InputPath: entrypoint},
 			{Name: "server", InputPath: filepath.Join(root, "packages/spacewave/server.ts")},
 		},
 		Goscript: &rolldown.GoScriptPolicy{OutputRoot: compiled},
@@ -119,3 +123,26 @@ func build(ctx context.Context, le *logrus.Entry, output string, skipCompile boo
 	notices.Stderr = os.Stderr
 	return notices.Run()
 }
+
+// workerEntrypoint adapts generated Go values to the typed Worker host contract.
+// Its relative host import is rooted at the build's .tmp/sync-library directory.
+const workerEntrypoint = `import { ValueOf } from '@goscript/syscall/js/index.js'
+import { Open } from '@goscript/github.com/s4wave/spacewave/core/sync/node/runtime.gs.js'
+import { runWorker } from '../../core/sync/node/worker.js'
+
+runWorker(async (directory, openSQLPort) => {
+  const [runtime, error] = await Open(directory, ValueOf(openSQLPort))
+  if (error) throw new Error(await error.Error())
+  if (!runtime) throw new Error('Sync engine returned no runtime')
+  return {
+    async accept(port) {
+      const error = await runtime.Accept(ValueOf(port))
+      if (error) throw new Error(await error.Error())
+    },
+    async close() {
+      const error = await runtime.Close()
+      if (error) throw new Error(await error.Error())
+    },
+  }
+})
+`

--- a/scripts/sync-library/qualify.ts
+++ b/scripts/sync-library/qualify.ts
@@ -67,8 +67,10 @@ assert.match(
   'Set SYNC_NODE_BINARY to supported Node 24.15 or later within 24.x',
 )
 assert.ok(Number(version.split('.')[1]) >= 15)
-if (!process.argv.includes('--skip-build'))
+if (!process.argv.includes('--skip-build')) {
+  await run('source-types', [bun, 'run', 'typecheck'])
   await run('build', ['go', 'run', './scripts/sync-library'])
+}
 const metadata = JSON.parse(
   await readFile('packages/spacewave/dist/build.json', 'utf8'),
 )

--- a/sdk/sync/json.test.ts
+++ b/sdk/sync/json.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'vitest'
-import { canonicalJSON, decodeJSON, encodeJSON } from './json.js'
+import {
+  canonicalJSON,
+  decodeJSON,
+  encodeJSON,
+  type JsonValue,
+} from './json.js'
 
 describe('canonicalJSON', () => {
   test('null round-trips and stays distinct from absent', () => {
@@ -101,14 +106,13 @@ describe('canonicalJSON', () => {
   })
 
   test('rejects enumerable symbol keys', () => {
-    const v: Record<string, unknown> = { a: 1 }
+    const v: Record<PropertyKey, unknown> = { a: 1 }
     v[Symbol('s')] = 2
     expect(() => canonicalJSON(v)).toThrow(TypeError)
   })
 
   test('rejects extra enumerable array properties', () => {
-    const v: unknown[] = [1, 2]
-    ;(v as Record<string, unknown>).extra = 3
+    const v = Object.assign([1, 2], { extra: 3 })
     expect(() => canonicalJSON(v)).toThrow(TypeError)
   })
 


### PR DESCRIPTION
The standalone Worker imported GoScript modules that only exist after compilation, so a clean source typecheck failed. Generate that binding in the bundle entrypoint and pass a typed engine capability to the Worker host. This preserves the existing SQLite, readiness, and shutdown ownership.

Correct the JSON codec fixtures' symbol-key and array-property types, and run the source typecheck as part of package qualification.

Validation: source typecheck and focused lint pass; 31 codec/key tests pass; the complete installed-tarball qualification passes, including Node persistence and Worker failure handling, transaction and migration checks, public declaration checks, Chromium/WebKit journeys, React lifecycle, and the packaged examples.
