### PR TITLE
feat(sync): document use cases and publish qualified npm releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: npm release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: npm-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Qualify npm package
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.27.1'
+          cache: false
+      - uses: oven-sh/setup-bun@v2
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24.x'
+          package-manager-cache: false
+      - name: Install build dependencies
+        run: |
+          bun install --frozen-lockfile --ignore-scripts
+          bun install --cwd bldr/dist/deps --frozen-lockfile --ignore-scripts
+          go mod vendor
+      - name: Install browser test runtimes
+        run: bunx playwright install --with-deps chromium webkit
+      - name: Build and qualify the package
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            bun run qualify:sync --release-tag "${GITHUB_REF_NAME}"
+          else
+            bun run qualify:sync
+          fi
+      - name: Upload qualified package
+        uses: actions/upload-artifact@v7
+        with:
+          name: spacewave-npm
+          path: |
+            .bldr-dist/sync-library/*.tgz
+            .bldr-dist/sync-library/*.tgz.sha256
+            .bldr-dist/sync-library/qualification.json
+          if-no-files-found: error
+      - name: Upload qualification logs
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: spacewave-npm-logs
+          path: .tmp/sync-qualification/*.log
+          if-no-files-found: ignore
+
+  publish:
+    name: Publish to npm
+    needs: build
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24.x'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+      - name: Install npm with trusted publishing support
+        run: npm install --global npm@11 --ignore-scripts
+      - uses: actions/download-artifact@v8
+        with:
+          name: spacewave-npm
+          path: package
+      - name: Verify and publish the qualified tarball
+        working-directory: package
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          archive="spacewave-${version}.tgz"
+          sha256sum --check "${archive}.sha256"
+          dist_tag=latest
+          if [[ "${version}" == *-* ]]; then
+            dist_tag=next
+          fi
+          npm publish "./${archive}" --tag "${dist_tag}" --access public --ignore-scripts

--- a/packages/spacewave/AGENTS.md
+++ b/packages/spacewave/AGENTS.md
@@ -1,15 +1,82 @@
 # Building with Spacewave
 
-Start from `examples/task-board`. Keep one browser-safe schema module containing the application ID, version, Standard Schema validators, and declared mutation inputs and outputs. Import it from the server and clients. Keep authentication, authorization, and mutation handlers in server files.
+Use this guide when adding the `spacewave` npm package to an application. Start with the [README](README.md) for setup and the [API reference](API.md) for signatures and error codes. The [task board](examples/task-board) is a complete integration with vanilla TypeScript and React clients sharing one server.
 
-Use the public entries `spacewave`, `spacewave/server`, and optional `spacewave/react`. Run Node 24.15 or later within 24.x. Install the RC tarball directly; no Go compiler or package install scripts are required. Server type checking needs `@types/node` 24.x and `types: ["node"]`; React requires its corresponding peers and types.
+## Package and runtime
 
-Create one server per dataset directory. `createServer` completes startup and maintenance before returning. Use `server.listen()` to own a listener, or `server.attach(http)` to add sync to an existing HTTP server. Close the returned attachment and server at shutdown. An attachment does not own the supplied HTTP server.
+Install with `npm install spacewave`, or use `spacewave@next` for a prerelease. Use ESM and Node.js `>=24.15.0 <25` for the server. The package contains its compiled engine; consuming it requires no Go compiler or installation scripts.
 
-Return a stable `subject` and `scope` from your real token verifier. Provide expiry or a revocation signal when available. Grant collection actions through `authorize`. Read and write permissions are separate; a prefix is a query, not an authorization boundary. Use `wss` when serving an HTTPS application. Keep tokens out of URLs.
+| Import | Use |
+| --- | --- |
+| `spacewave` | `defineSchema`, `connect`, `SyncError`, and public types |
+| `spacewave/server` | `createServer` and server configuration types; Node only |
+| `spacewave/react` | Optional `createSyncContext(schema)` bindings for React `>=19.2.0 <20` |
 
-Await `connect` before using the database. Render subscription data and freshness together. Unsubscribe when a view leaves; close the database when its application lifetime ends. A React provider receives an existing database and does not close it on unmount.
+Use these public entry points. Package internals and generated engine files are implementation details.
 
-Choose stable request IDs for writes that may need recovery. On `UNCERTAIN`, preserve the exact input and request ID and offer a retry. Do not generate a replacement ID for that retry. Avoid side effects outside the transaction inside mutation handlers: rollback and accepted receipts cover collection data, not unrelated external systems.
+For server type checking, install `@types/node` 24.x and include `"node"` in `compilerOptions.types`. React applications also need their matching React types. Check the application against the installed package so repository aliases cannot hide missing dependencies or exports.
 
-Validate the actual installed package with strict TypeScript, two clients plus a server writer, reconnect, denied operations, and close/reopen persistence. Use the example's vanilla and React pages to exercise the same schema and dataset. Handle typed errors from the API reference. Size prefix queries for the data the view needs; snapshots are complete and bounded.
+## Shared schema
+
+Keep one browser-safe schema module containing the application ID, version, collection validators, and declared mutation inputs and outputs. Import it from clients and the server. Keep token verification, authorization, and mutation handlers in server modules.
+
+Use a Standard Schema v1 validator, such as Zod. Collection writes take validator inputs; reads return stored validator outputs. Store strict JSON: null, booleans, finite numbers, strings, arrays, and plain objects. A missing record is `undefined`; a stored `null` is a value.
+
+Treat the schema ID and version as the persisted application's compatibility contract. To change an existing dataset's schema, supply an explicit migration from its stored version. `createServer` completes that maintenance transaction before admitting clients. See [Migration](API.md#migration).
+
+## Server and access
+
+Create one server per dataset directory. `createServer({ directory, schema, authenticate, authorize, mutations })` opens durable storage and returns after startup and maintenance finish.
+
+- Return a stable `subject` and `scope` from the application's real token verifier. The scope selects the caller's dataset. Supply `expiresAt` or a revocation `signal` when available.
+- Grant collection actions through `authorize({ principal, scope, collection, action })`. Read and write permissions are separate, and subscription deliveries recheck read permission. A prefix is a query selector, not an authorization boundary; this RC has no row-level authorization.
+- Use `server.as(principal)` for server-side work that follows the same policy. Reserve `server.admin(scope)` for deliberate privileged operations; it bypasses collection authorization.
+- Use `server.listen()` for a listener Spacewave owns, or `server.attach(http)` to add sync to an existing HTTP server. Set `allowedOrigins` for the frontend and use `wss://` with HTTPS. Pass tokens through `getAccessToken`, keeping them out of URLs.
+- Call `await server.close()` during shutdown. It closes its attachments, application, and storage. When using `attach(http)`, close the supplied HTTP server separately.
+
+The example's `local-demo` verifier is only for local development. Replace it before serving other users.
+
+## Client and React lifetime
+
+Await `connect({ url, schema, getAccessToken })` before using the database. Admission includes authentication and schema compatibility checks. `getAccessToken(signal)` runs for each connection attempt; obtain the current token there. The client manages reconnection.
+
+Keep a database for the application's intended connection lifetime. Use `collection(name).subscribe()` or `.watch()` for changing state, and render freshness alongside the data:
+
+| Status | Meaning |
+| --- | --- |
+| `loading` | Waiting for the first snapshot |
+| `current` | Latest received snapshot on a live connection |
+| `stale` | Last received snapshot while reconnecting |
+| `error` | Subscription ended with a failure |
+
+Snapshots contain all matching `{ key, value }` records, ordered by key. They replace the previous snapshot. A query supports only `{ prefix?: string }`; it has no SQL, pagination, row filters, or deltas.
+
+Forward cancellation signals to operations. Release subscriptions when views leave and close the database with `await db.close()` when its application lifetime ends.
+
+For React, call `createSyncContext(schema)` once at module scope. Its `SyncProvider` receives an existing database; `useCollection` manages the component's subscription and `useDatabase` exposes the database for writes. The application closes the database. Keep top-level calls to `connect()` in client startup modules; importing a package entry alone is safe during server rendering.
+
+## Writes, transactions, and recovery
+
+Use collection `put` and `delete` for single-record changes. For an operation spanning records, declare a named mutation and implement its handler with `context.collection(name)` so its reads and writes share one transaction. The server validates mutation inputs and outputs.
+
+Keep external side effects out of mutation handlers. Transaction rollback and acceptance receipts cover collection data and the returned result; they cannot roll back an email, payment, or unrelated HTTP request.
+
+Each write has a request ID. When recovery matters, choose the ID before dispatch and keep the exact input available. Handle `SyncError` by its stable `code`:
+
+- On `UNCERTAIN`, acceptance is unknown. Offer a retry of the same operation with the same request ID and exact input. An accepted duplicate returns the original result, including after a server restart.
+- On `CONFLICT`, the request ID was reused with different input. Correct the caller's request handling.
+- On `UNAVAILABLE`, the server or storage cannot currently serve the operation. Preserve the user's intent and let the application decide when to retry.
+
+Receipts remain for the dataset lifetime. The client has no durable offline replica, offline write queue, or optimistic updates. Render accepted server snapshots and keep any pending form input separate from them. See [Uncertain writes](API.md#uncertain-writes) for a concrete retry example.
+
+## Verify the integration
+
+Run the application against the installed artifact and check the behavior the change affects:
+
+- Type-check shared schema, server code, and client code with strict TypeScript.
+- Connect two clients in the same scope and a server writer. Confirm accepted changes reach both clients, then close and reopen the server to verify persistence.
+- Exercise rejected tokens, denied operations, and separate scopes. Confirm each caller sees only its authorized dataset.
+- Interrupt and restore the connection. Check stale state, recovery, and reuse of the original request ID for an uncertain write.
+- Unmount subscribed views and close clients and servers. Confirm subscriptions and processes finish.
+
+Keep queries sized for the view: defaults cap them at 10,000 records and 8 MiB per snapshot, with 256 KiB per record. Changes produce complete snapshots, so record count alone does not describe the workload. Measure scan and delivery time, memory, and storage growth with representative data before raising limits. See the [README's current scope](README.md#current-scope).

--- a/packages/spacewave/API.md
+++ b/packages/spacewave/API.md
@@ -344,3 +344,21 @@ const http = createHTTPServer((request, response) => response.end())
 server.attach(http, { path: '/sync', allowedOrigins: ['https://example.com'] })
 http.listen(3000)
 ```
+
+## Limits and performance
+
+Queries return complete, ordered snapshots of a collection or prefix. Defaults bound a query to 10,000 records and 8 MiB of encoded keys and values, and a record to 256 KiB. Exceeding a bound produces `QUERY_LIMIT`. These are safety bounds, not throughput guarantees.
+
+A qualification workload on Node 24.21.0 and macOS arm64 used 1,000 numeric records, three subscribers, and ten writes. Identical queries shared one producer.
+
+| Measurement | Observed sample |
+| --- | --- |
+| Write acceptance, p50 / p95 | 234 / 242 ms |
+| Delivery to all subscribers, p50 / p95 | 947 / 1,041 ms |
+| Initial bulk seeding | 13.57 seconds |
+| RSS when ready / after the workload | 336 MB / 1.10 GB |
+| Encoded snapshot | 28.9 KB |
+
+Each changed revision still requires a complete scan. RSS includes the compiled runtime and is not a retained-heap measurement. These observations describe one workload; measure representative scan and delivery time, memory, and storage growth before raising limits. Acceptance receipts and World history accumulate for the dataset lifetime.
+
+A qualified release artifact's `qualification.json` records its own sample, source revision, package sizes, and checksum. See the [README](README.md) for supported runtimes and current release scope.

--- a/packages/spacewave/README.md
+++ b/packages/spacewave/README.md
@@ -1,90 +1,349 @@
+<div align="center">
+
 # Spacewave
 
-Typed live collections for TypeScript applications. Define a shared schema, run a Node server, and subscribe from browsers or React. Accepted writes persist in a Spacewave World backed by SQLite; other connected clients receive the resulting state.
+**Live data for TypeScript applications.**
 
-This release candidate supports Node 24.15–24.x and ESM. React is optional and requires React 19.2–19.x. Browser clients use the native WebSocket API. The package includes its compiled engine; installation needs neither Go nor lifecycle scripts.
+[![npm](https://img.shields.io/npm/v/spacewave)](https://www.npmjs.com/package/spacewave)
+[![Node.js 24](https://img.shields.io/badge/node-%3E%3D24.15%20%3C25-5FA04E)](#getting-started)
+[![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 
-## Try the task board
+[Get started](#getting-started) · [Showcase](#showcase) · [API reference](API.md) · [Task board](examples/task-board) · [Contributing](#contributing)
 
-Install the release-candidate tarball, then copy its complete example:
+</div>
+
+Spacewave keeps application data in sync between a Node.js server and TypeScript clients. Define your data with a shared schema, read and write typed collections, and subscribe to changes from the browser or React.
+
+Build shared task boards, chat feeds, job dashboards, and settings that follow users between tabs. Accepted writes persist in SQLite, mutations run in transactions, and your authentication and authorization functions control access. You run the server and keep the data in your own application.
 
 ```sh
-npm install ./spacewave-0.1.0-rc.1.tgz
+npm install spacewave
+```
+
+## Showcase
+
+These examples share a schema and a connected client named `db`. Server examples use `server`, created with that same schema. The [setup below](#getting-started) defines their collections and connects them.
+
+### Shared task lists
+
+Write a task in one tab and watch it appear in another. Collection names and record values are checked by TypeScript.
+
+```ts
+const todos = db.collection('todos')
+
+const unsubscribe = todos.subscribe(
+  {},
+  {
+    next: ({ status, data }) => console.log(status, data),
+  },
+)
+
+await todos.put('welcome', { title: 'Try Spacewave', done: false })
+await todos.put('welcome', { title: 'Try Spacewave', done: true })
+```
+
+Subscriptions deliver complete snapshots ordered by key. Call `unsubscribe()` when the view leaves; the client handles reconnection.
+
+### Chat feeds
+
+Use a key prefix to subscribe to one room's messages. Timestamp-prefixed keys keep the feed in key order; a UUID distinguishes messages sent at the same time.
+
+```ts
+const messages = db.collection('messages')
+const room = 'general/'
+
+const unsubscribe = messages.subscribe(
+  { prefix: room },
+  {
+    next: ({ data }) => console.table(data.map(({ value }) => value)),
+  },
+)
+
+await messages.put(
+  `${room}${new Date().toISOString()}/${crypto.randomUUID()}`,
+  {
+    text: 'Anyone up for a quick demo?',
+  },
+)
+```
+
+Messages persist across server restarts. A prefix selects the feed; collection permissions and the authenticated scope control access. This example orders messages by client timestamp, not server arrival time.
+
+### Background job progress
+
+A worker can write through the same collection API that browsers use. Here a server-side job reports its progress after processing a batch:
+
+```ts
+const jobs = server
+  .as({ subject: 'import-worker', scope: 'demo' })
+  .collection('jobs')
+
+await jobs.put('import/contacts', { completed: 50, total: 100 })
+```
+
+Subscribe from the dashboard to receive progress as it changes:
+
+```ts
+const unsubscribe = db.collection('jobs').subscribe(
+  { prefix: 'import/' },
+  {
+    next: ({ data }) => console.table(data),
+  },
+)
+```
+
+`server.as(principal)` applies the same authorization policy as client operations. Grant the worker access to the collections its job needs.
+
+### Shared settings
+
+Keep a team's preferences in one record. Connected settings views can subscribe to changes; a one-time read uses `get()`.
+
+```ts
+const settings = db.collection('settings')
+
+await settings.put('appearance', { theme: 'dark', compact: true })
+const appearance = await settings.get('appearance')
+console.log(appearance?.theme) // 'dark'
+```
+
+### Separate team datasets
+
+Each authenticated scope has its own collection data. The same record key can hold different values for different teams:
+
+```ts
+const teamA = server.as({ subject: 'service', scope: 'team-a' })
+const teamB = server.as({ subject: 'service', scope: 'team-b' })
+
+await teamA
+  .collection('todos')
+  .put('welcome', { title: 'Plan the launch', done: false })
+await teamB
+  .collection('todos')
+  .put('welcome', { title: 'Review the design', done: false })
+```
+
+Your server's verifier assigns the caller's scope, and its policy grants access. The setup below permits the example scopes; use your application's token verification and team membership rules before serving users.
+
+### Atomic counters
+
+When a change depends on existing data, use a named mutation. Its reads and writes run in one server transaction. Add this handler to the server's `mutations` option:
+
+```ts
+import type { MutationHandlers, Principal } from 'spacewave'
+
+const mutations: MutationHandlers<typeof schema, Principal> = {
+  increment: async (context, { key }) => {
+    const counters = context.collection('counters')
+    const value = ((await counters.get(key)) ?? 0) + 1
+    await counters.put(key, value)
+    return value
+  },
+}
+```
+
+Then call it from a client:
+
+```ts
+const views = await db.mutate('increment', { key: 'page-views' })
+```
+
+The schema declares the input and output types. A mutation can also update several records or collections in the same transaction.
+
+### Live React views
+
+The optional React entry binds hooks to your schema. Pass an existing connection to the provider and read live collections inside it:
+
+```tsx
+import { createSyncContext } from 'spacewave/react'
+
+const { SyncProvider, useCollection } = createSyncContext(schema)
+
+function Tasks() {
+  const todos = useCollection('todos')
+  if (todos.status === 'loading') return <p>Loading tasks…</p>
+  if (todos.status === 'error')
+    return <p role="alert">{todos.error?.message}</p>
+
+  return (
+    <>
+      {todos.status === 'stale' && (
+        <p>Reconnecting. Showing the last saved view.</p>
+      )}
+      <ul>
+        {todos.data.map(({ key, value }) => (
+          <li key={key}>{value.title}</li>
+        ))}
+      </ul>
+    </>
+  )
+}
+
+export function App() {
+  return (
+    <SyncProvider db={db}>
+      <Tasks />
+    </SyncProvider>
+  )
+}
+```
+
+`useCollection` cleans up with the component. `useDatabase` gives components the same typed database for writes. The application owns and closes the connection. See the [React task board](examples/task-board/react.tsx) for forms, connection feedback, and write recovery.
+
+### Retry without repeating a change
+
+A connection can fail after the server accepts a write but before the client receives its result. If the call reports `UNCERTAIN`, retry the exact operation with its original request ID and input:
+
+```ts
+import { SyncError } from 'spacewave'
+
+const requestId = crypto.randomUUID()
+const input = { key: 'page-views' }
+
+try {
+  await db.mutate('increment', input, { requestId })
+} catch (error) {
+  if (!(error instanceof SyncError) || error.code !== 'UNCERTAIN') throw error
+  await db.mutate('increment', input, { requestId })
+}
+```
+
+An accepted duplicate returns the original result, including after a server restart. Reusing the ID with different input fails with `CONFLICT`. The [retry reference](API.md#uncertain-writes) explains how to retain unresolved writes for later recovery.
+
+## Motivation
+
+Adding live data often means writing the same contract in several places: database models, API handlers, client types, subscription messages, and UI state. Every new feature has to keep those pieces in agreement.
+
+Spacewave gives that work a shared starting point. Define collections and mutations once with [Standard Schema](https://standardschema.dev/) validators, such as Zod. The server validates writes, TypeScript infers the client API, and subscriptions deliver accepted state to each view. Your application chooses its authentication provider, access policy, and interface.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    Browser[Browser or React] <-->|WebSocket| Server[Node.js server]
+    Jobs[Server-side code] -->|Collection API| Server
+    Server <-->|Transactions| Storage[SQLite-backed World]
+```
+
+The Node server authenticates connections, selects each caller's scope, and checks collection permissions on operations and subscription deliveries. Accepted writes commit to a Spacewave World, the engine's durable dataset stored in SQLite. Each dataset directory permits one server writer.
+
+Clients receive whole-collection or prefix snapshots with `loading`, `current`, `stale`, or `error` status. Reconnection refreshes subscriptions; durable write receipts support recovery when acceptance is uncertain.
+
+The npm package includes its compiled engine, which runs in a dedicated Node worker. Installing it requires no Go toolchain or lifecycle scripts. See the [API reference](API.md) for the storage, access, and connection contracts.
+
+## Getting started
+
+Use **Node.js `>=24.15.0 <25`** for the server and **ESM** for your application. Browser clients use the native WebSocket API. The optional React bindings require React 19.2 or later within 19.x and its matching type packages.
+
+For a complete application, install Spacewave and copy the bundled task board:
+
+```sh
+npm install spacewave
 cp -R node_modules/spacewave/examples/task-board ./task-board
 cd task-board
-npm install ../spacewave-0.1.0-rc.1.tgz
+npm install
 npm start
 ```
 
-Open `http://127.0.0.1:8787` for vanilla TypeScript or `/react` for React. Open both pages, add a task in one, and complete it in the other. Restart the server to reopen the same `.data` directory. The example's `local-demo` token is a local identity; replace its verifier before exposing the server to other users.
+Open [the vanilla board](http://127.0.0.1:8787) and [the React board](http://127.0.0.1:8787/react). Add a task in one and complete it in the other. Restart the server to see the saved tasks from its `.data` directory.
 
-The [shared schema](examples/task-board/schema.ts), [server](examples/task-board/server.ts), [vanilla client](examples/task-board/vanilla.ts), and [React client](examples/task-board/react.tsx) form one application. The server also writes through the same collection API.
+For your own application, the following setup supports the showcase examples. Install Zod with `npm install zod`. Server TypeScript projects also need `@types/node` 24.x and `"node"` in `compilerOptions.types`.
 
-## Share a contract
+<details>
+<summary><strong>Shared schema, server, and client setup</strong></summary>
+
+**`schema.ts`** defines the contract imported by both server and client:
 
 ```ts
 import { defineSchema } from 'spacewave'
 import { z } from 'zod'
 
 export const schema = defineSchema({
-  id: 'notes',
+  id: 'showcase',
   version: 1,
-  collections: { notes: z.object({ text: z.string() }) },
-  mutations: {},
+  collections: {
+    todos: z.object({ title: z.string(), done: z.boolean() }),
+    messages: z.object({ text: z.string() }),
+    jobs: z.object({ completed: z.number(), total: z.number() }),
+    settings: z.object({
+      theme: z.enum(['light', 'dark']),
+      compact: z.boolean(),
+    }),
+    counters: z.number().int(),
+  },
+  mutations: {
+    increment: {
+      input: z.object({ key: z.string() }),
+      output: z.number().int(),
+    },
+  },
 })
 ```
 
-Any Standard Schema v1 validator can supply runtime validation and inferred TypeScript types. Writes accept validator inputs; reads return stored validator outputs. Values must be strict JSON. Missing records return `undefined`; stored `null` remains `null`.
+**`server.ts`** opens storage and a WebSocket endpoint. Place the `mutations` declaration from the atomic counter example in this module before `createServer`:
 
 ```ts
-import { connect } from 'spacewave'
-import { schema } from './schema.js'
-
-const db = await connect({
-  url: 'ws://localhost:8787/sync',
-  schema,
-  getAccessToken: () => 'local-demo',
-})
-const notes = db.collection('notes')
-const unsubscribe = notes.subscribe({}, {
-  next: ({ status, data }) => console.log(status, data),
-})
-await notes.put('welcome', { text: 'Hello from Spacewave' })
-// At application shutdown:
-unsubscribe()
-await db.close()
-```
-
-```ts
-import { createServer } from 'spacewave/server'
 import { SyncError } from 'spacewave'
+import { createServer } from 'spacewave/server'
+
 import { schema } from './schema.js'
 
 const server = await createServer({
   directory: './data',
   schema,
   authenticate: async (token) => {
-    if (token !== 'local-demo') throw new SyncError('AUTHENTICATION', 'Sign in again')
-    return { subject: 'local-user', scope: 'local' }
+    if (token !== 'local-demo')
+      throw new SyncError('AUTHENTICATION', 'Sign in again')
+    return { subject: 'demo-user', scope: 'demo' }
   },
-  authorize: ({ scope }) => scope === 'local',
-  mutations: {},
+  authorize: ({ scope }) => ['demo', 'team-a', 'team-b'].includes(scope),
+  mutations,
 })
-await server.listen({ port: 8787 })
+
+await server.listen({
+  port: 8787,
+  allowedOrigins: ['http://localhost:5173', 'http://127.0.0.1:5173'],
+})
 ```
 
-Import `createSyncContext(schema)` from `spacewave/react` for `SyncProvider`, `useDatabase`, and `useCollection`. The provider accepts an existing database; unmounting releases subscriptions, and the application closes its database. Importing any package entry during SSR starts no connections or workers.
+Replace the local demo verifier and policy before serving other users. Set `allowedOrigins` to your frontend's origin and use `wss://` with HTTPS. You can also attach sync to an [existing HTTP server](API.md#hosting-and-lifetime).
 
-For server TypeScript projects, install `@types/node` 24.x and include `node` in `compilerOptions.types`. React projects also need the matching React type packages. Public declarations resolve inside this package and its declared dependencies.
+**`db.ts`** opens the client connection:
 
-## Behavior and limits
+```ts
+import { connect } from 'spacewave'
 
-- The server owns accepted state. A subscription delivers complete, ordered prefix snapshots with `loading`, `current`, `stale`, or `error` status. Reconnection refreshes the snapshot. Slow consumers retain the latest pending snapshot.
-- Policies grant collection reads or writes within an authenticated scope. Each operation and each subscription delivery checks authority. Tokens travel in the authentication exchange, and never in the URL.
-- Collection writes and named mutations commit with a durable acceptance receipt. On `UNCERTAIN`, retain the request ID and exact input. Retrying returns the accepted result without executing the write again; conflicting reuse fails. Receipts remain for the dataset lifetime.
-- There is no durable offline replica, offline write queue, optimistic state, row-level authorization, or SQL query interface in this RC. Schema changes require an explicit maintenance migration before admission.
-- Defaults bound queries to 10,000 records and 8 MiB of encoded keys and values, and each record to 256 KiB. These are safety bounds, not throughput claims. One server writer owns each dataset directory.
+import { schema } from './schema.js'
 
-A qualification workload on Node 24.21.0, macOS arm64 used 1,000 numeric records, three subscribers, and ten writes. With a shared producer for identical queries, all-subscriber delivery p50/p95 was 947/1,041 ms and acceptance was 234/242 ms. Ready RSS was 336 MB and RSS after the workload was 1.10 GB. The 28.9 KB snapshot still requires a complete scan per changed revision. Bulk seeding took 13.57 seconds. This RC is suitable for evaluating small live datasets; larger workloads need measurement. RSS includes the compiled runtime and is not a retained-heap measurement. The release artifact's `qualification.json` records its exact sample, sizes, and checksum.
+export const db = await connect({
+  url: 'ws://127.0.0.1:8787/sync',
+  schema,
+  getAccessToken: () => 'local-demo',
+})
+```
 
-Read the [API reference](API.md), [agent setup guide](AGENTS.md), and [release notes](CHANGELOG.md).
+Import `db` and `schema` into the client examples that use them. Compile with your application's TypeScript setup and run the server output with Node.js. Call `await db.close()` and `await server.close()` at their respective application shutdowns. Importing package entries is safe during server rendering; keep calls to `connect()` in client startup code.
+
+</details>
+
+Prereleases are available with `npm install spacewave@next`. To build a tarball yourself, follow the [repository setup](../../README.md), then run `bun run build:sync` and `bun run pack:sync` from the repository root.
+
+## Current scope
+
+The sync API is in early development and is intended for evaluating small live datasets:
+
+- Queries return complete collection or prefix snapshots. Defaults cap them at 10,000 records and 8 MiB per snapshot, with 256 KiB per record.
+- Clients retain their last snapshot in memory while reconnecting. Writes require the server; durable offline replicas, offline queues, and optimistic updates are outside this release.
+- Access policies grant reads and writes per collection within a scope. Row-level authorization and SQL queries are outside this release.
+- Schema changes require an explicit migration. Write receipts remain for the dataset lifetime.
+
+Read the [measured workload results](API.md#limits-and-performance) before growing a dataset, and the [release notes](CHANGELOG.md) for current capabilities.
+
+## Contributing
+
+Bug reports, small reproductions, and feedback on the API are welcome in [GitHub issues](https://github.com/s4wave/spacewave/issues). Include your package and Node versions, the error code, and enough code to reproduce the behavior.
+
+For code changes, follow the [repository setup](../../README.md). Run `bun run build:sync` to build the package. `bun run qualify:sync` checks an installed tarball, persistence, reconnection, and the Chromium and WebKit examples. The [agent guide](AGENTS.md) covers integration rules for coding assistants.
+
+## License
+
+[Apache-2.0](LICENSE). Distributed packages include third-party notices in `dist/THIRD_PARTY_NOTICES.txt`.

--- a/packages/spacewave/examples/task-board/react.html
+++ b/packages/spacewave/examples/task-board/react.html
@@ -1,9 +1,17 @@
 <!doctype html>
 <html lang="en">
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Task board · Spacewave React</title>
-  <link rel="stylesheet" href="/style.css" />
-  <main id="app"><p role="status">Connecting…</p></main>
-  <script type="module" src="/react.js"></script>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Task board · Spacewave React</title>
+    <link rel="stylesheet" href="/style.css" />
+  </head>
+
+  <body>
+    <main id="app">
+      <p role="status">Connecting…</p>
+    </main>
+
+    <script type="module" src="/react.js"></script>
+  </body>
 </html>

--- a/packages/spacewave/examples/task-board/react.tsx
+++ b/packages/spacewave/examples/task-board/react.tsx
@@ -1,13 +1,18 @@
-import { useCallback, useEffect, useState, type FormEvent } from 'react'
+import {
+  useCallback,
+  useState,
+  useSyncExternalStore,
+  type FormEvent,
+} from 'react'
 import { createRoot } from 'react-dom/client'
 import { connect, SyncError, type ConnectionState } from 'spacewave'
 import { createSyncContext } from 'spacewave/react'
+
 import { schema } from './schema.ts'
 
 const { SyncProvider, useDatabase, useCollection } = createSyncContext(schema)
 
-// UncertainWrite keeps the exact original write closure and requestId so Retry
-// resubmits the identical operation; no offline queue is kept.
+/** UncertainWrite retains the original input and request ID for an explicit retry. */
 interface UncertainWrite {
   requestId: string
   message: string
@@ -20,28 +25,32 @@ const connectionLabels: Record<ConnectionState['status'], string> = {
   closed: 'Disconnected',
 }
 
-// TaskBoard renders the live task list and issues every write against the
-// supplied db. Record state comes only from useCollection; a write never
-// inserts a row before the server accepts it.
+/** TaskBoard renders accepted tasks and keeps pending form input separate. */
 function TaskBoard() {
+  // Read task and connection state from the database's existing subscriptions.
   const db = useDatabase()
   const todos = useCollection('todos')
-  const [connection, setConnection] = useState<ConnectionState>(
-    db.connection.current,
+  const connection = useSyncExternalStore(
+    db.connection.subscribe,
+    () => db.connection.current,
+    () => db.connection.current,
   )
+
+  // Keep editable input and unresolved writes outside the accepted task snapshot.
   const [title, setTitle] = useState('')
   const [pending, setPending] = useState(false)
   const [uncertain, setUncertain] = useState<UncertainWrite | null>(null)
   const [writeError, setWriteError] = useState<string | null>(null)
 
-  useEffect(() => db.connection.subscribe(setConnection), [db])
-
-  // runWrite runs one write at a time and reports UNCERTAIN with its retry.
+  /** runWrite exposes an uncertain write's original operation for a later retry. */
   const runWrite = useCallback(
     async (run: () => Promise<unknown>, requestId: string): Promise<void> => {
+      // Suspend new edits and clear the previous write's feedback.
       setPending(true)
       setUncertain(null)
       setWriteError(null)
+
+      // Keep failed writes recoverable without inserting unaccepted task rows.
       try {
         await run()
       } catch (error) {
@@ -63,10 +72,14 @@ function TaskBoard() {
     [],
   )
 
+  /** addTask preserves the title and generated IDs until the write is accepted. */
   const addTask = (event: FormEvent<HTMLFormElement>) => {
+    // Accept a nonempty title only while connected and ready for another write.
     event.preventDefault()
     const trimmed = title.trim()
     if (!trimmed || pending || connection.status !== 'ready') return
+
+    // Capture the write once so Retry submits the same input with the same ID.
     const id = crypto.randomUUID()
     const requestId = crypto.randomUUID()
     void runWrite(async () => {
@@ -77,6 +90,7 @@ function TaskBoard() {
     }, requestId)
   }
 
+  /** completeTask invokes the server mutation with a recoverable request ID. */
   const completeTask = (id: string) => {
     const requestId = crypto.randomUUID()
     void runWrite(
@@ -85,6 +99,7 @@ function TaskBoard() {
     )
   }
 
+  // Describe the snapshot's freshness without treating stale data as current.
   const todosStatus =
     todos.status === 'loading'
       ? 'Loading tasks…'
@@ -94,6 +109,7 @@ function TaskBoard() {
           }`
         : 'Showing the last saved view while reconnecting…'
 
+  // Render connection feedback, write controls, and the accepted task list.
   return (
     <>
       <h1>Task board</h1>
@@ -101,6 +117,7 @@ function TaskBoard() {
         Two tabs share one server: the <a href="/">Vanilla</a> example and this{' '}
         <a href="/react">React</a> example.
       </p>
+
       <p className="status">
         {`Connection: ${connectionLabels[connection.status]}`}
         {connection.error ? `: ${connection.error.message}` : ''}
@@ -112,6 +129,7 @@ function TaskBoard() {
       ) : (
         <p className="status">{todosStatus}</p>
       )}
+
       <form onSubmit={addTask}>
         <label htmlFor="new-task">
           Add a task
@@ -132,6 +150,7 @@ function TaskBoard() {
           Add task
         </button>
       </form>
+
       {writeError ? <p className="notice">{writeError}</p> : null}
       {uncertain ? (
         <p className="notice">
@@ -147,6 +166,7 @@ function TaskBoard() {
           </button>
         </p>
       ) : null}
+
       <ul className="tasks">
         {todos.data.map((entry) => (
           <li className="task" key={entry.key} data-done={entry.value.done}>
@@ -168,10 +188,13 @@ function TaskBoard() {
   )
 }
 
-// start connects, mounts the board into #app, and registers pagehide teardown.
+/** start connects the board and releases its React tree and database on pagehide. */
 async function start(): Promise<void> {
+  // Require the page's mount point before opening a connection.
   const container = document.getElementById('app')
   if (!container) throw new Error('Missing #app mount point')
+
+  // Connect to the sync endpoint served alongside this page.
   const url = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${
     location.host
   }/sync`
@@ -180,12 +203,16 @@ async function start(): Promise<void> {
     schema,
     getAccessToken: () => 'local-demo',
   })
+
+  // Supply the admitted database to every task-board component.
   const root = createRoot(container)
   root.render(
     <SyncProvider db={db}>
       <TaskBoard />
     </SyncProvider>,
   )
+
+  // Unmount subscriptions before closing the database they use.
   window.addEventListener(
     'pagehide',
     () => {
@@ -196,6 +223,7 @@ async function start(): Promise<void> {
   )
 }
 
+// Replace the loading view with a readable failure if startup cannot finish.
 start().catch((error: unknown) => {
   const container = document.getElementById('app') ?? document.body
   const notice = document.createElement('p')

--- a/packages/spacewave/examples/task-board/schema.ts
+++ b/packages/spacewave/examples/task-board/schema.ts
@@ -1,7 +1,13 @@
 import { defineSchema } from 'spacewave'
 import { z } from 'zod'
 
-const todo = z.object({ title: z.string().min(1).max(120), done: z.boolean() })
+/** todo validates stored tasks and the result of completing a task. */
+const todo = z.object({
+  title: z.string().min(1).max(120),
+  done: z.boolean(),
+})
+
+/** schema is the shared contract for the server, vanilla client, and React client. */
 export const schema = defineSchema({
   id: 'task-board',
   version: 1,

--- a/packages/spacewave/examples/task-board/server.ts
+++ b/packages/spacewave/examples/task-board/server.ts
@@ -1,12 +1,14 @@
-import { createServer as createHTTPServer } from 'node:http'
 import { readFile } from 'node:fs/promises'
+import { createServer as createHTTPServer } from 'node:http'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { build } from 'esbuild'
 import { SyncError } from 'spacewave'
 import { createServer } from 'spacewave/server'
+
 import { schema } from './schema.ts'
 
+// Build both browser entry points before accepting page requests.
 const directory = dirname(fileURLToPath(import.meta.url))
 await build({
   absWorkingDir: directory,
@@ -19,21 +21,31 @@ await build({
   define: { 'process.env.NODE_ENV': '"production"' },
 })
 
+// Open the persistent task dataset and admit only the local demo identity.
 const server = await createServer({
   directory: process.env.DATA_DIRECTORY ?? join(directory, '.data'),
   schema,
-  // Replace the local demo identity with your application's token verifier.
+
+  // Replace this verifier with the application's real authentication provider.
   authenticate: async (token) => {
-    if (token !== 'local-demo')
+    if (token !== 'local-demo') {
       throw new SyncError('AUTHENTICATION', 'Sign in again')
+    }
     return { subject: 'demo-user', scope: 'demo' }
   },
   authorize: ({ scope }) => scope === 'demo',
+
+  // Mutations read and write through one server transaction.
   mutations: {
     completeTodo: async (context, { id }) => {
+      // Read the task before changing its completion state.
       const todos = context.collection('todos')
       const todo = await todos.get(id)
-      if (!todo) throw new SyncError('VALIDATION', 'This task no longer exists')
+      if (!todo) {
+        throw new SyncError('VALIDATION', 'This task no longer exists')
+      }
+
+      // Update the task within this transaction and return its value.
       const updated = { ...todo, done: true }
       await todos.put(id, updated)
       return updated
@@ -41,6 +53,7 @@ const server = await createServer({
   },
 })
 
+// Seed the board through the same authorized collection API used by clients.
 const tasks = server
   .as({ subject: 'demo-user', scope: 'demo' })
   .collection('todos')
@@ -51,6 +64,7 @@ if (!(await tasks.get('welcome'))) {
   })
 }
 
+// Serve only the example's page, bundle, and stylesheet routes.
 const files = new Map([
   ['/', ['vanilla.html', 'text/html']],
   ['/react', ['react.html', 'text/html']],
@@ -59,6 +73,7 @@ const files = new Map([
   ['/style.css', ['style.css', 'text/css']],
 ])
 const http = createHTTPServer((request, response) => {
+  // Resolve the request through the fixed route map.
   const path = new URL(request.url ?? '/', 'http://localhost').pathname
   const file = files.get(path)
   if (!file) {
@@ -66,9 +81,12 @@ const http = createHTTPServer((request, response) => {
     response.end()
     return
   }
-  void readFile(join(directory, file[0])).then(
+
+  // Send the matching asset or report a read failure.
+  const [filename, contentType] = file
+  void readFile(join(directory, filename)).then(
     (data) => {
-      response.setHeader('Content-Type', file[1])
+      response.setHeader('Content-Type', contentType)
       response.end(data)
     },
     () => {
@@ -77,6 +95,8 @@ const http = createHTTPServer((request, response) => {
     },
   )
 })
+
+// Share the HTTP listener between pages and the sync endpoint.
 server.attach(http)
 const port = Number(process.env.PORT ?? 8787)
 await new Promise<void>((resolve, reject) => {
@@ -84,17 +104,25 @@ await new Promise<void>((resolve, reject) => {
   http.listen(port, '127.0.0.1', resolve)
 })
 const address = http.address()
-if (address && typeof address !== 'string')
+if (address && typeof address !== 'string') {
   console.log(`Task board: http://127.0.0.1:${address.port}`)
+}
 
+// Repeated shutdown signals share one close operation.
 let closing: Promise<void> | undefined
-const close = () =>
-  (closing ??= (async () => {
+
+/** close releases sync connections and storage, then the HTTP server we supplied. */
+function close(): Promise<void> {
+  closing ??= (async () => {
     await server.close()
     await new Promise<void>((resolve, reject) =>
       http.close((error) => (error ? reject(error) : resolve())),
     )
-  })())
+  })()
+  return closing
+}
+
+// Let both normal interruption and service termination finish cleanup.
 for (const signal of ['SIGINT', 'SIGTERM'] as const) {
   process.once(signal, () => {
     void close().catch((error: unknown) => {

--- a/packages/spacewave/examples/task-board/style.css
+++ b/packages/spacewave/examples/task-board/style.css
@@ -1,39 +1,48 @@
+/* Page layout and typography. */
 :root {
   color-scheme: light;
   font-family: system-ui, sans-serif;
   color: #18282d;
   background: #f3f6f4;
 }
+
 * {
   box-sizing: border-box;
 }
+
 body {
   margin: 0;
 }
+
 main {
   width: min(720px, 100%);
   padding: 36px 24px;
   margin: 4vh auto;
 }
+
 nav {
   display: flex;
   gap: 18px;
   margin-bottom: 32px;
 }
+
 a {
   color: #285f4d;
   text-underline-offset: 4px;
 }
+
 h1 {
   font-size: clamp(2rem, 6vw, 3rem);
   line-height: 1.1;
   margin-bottom: 12px;
   letter-spacing: -0.04em;
 }
+
 p {
   line-height: 1.6;
   color: #4c6065;
 }
+
 .status {
   display: inline-block;
   font-size: 0.85rem;
@@ -41,17 +50,21 @@ p {
   padding: 5px 12px;
   border-radius: 24px;
 }
+
+/* Input controls and their interaction states. */
 form {
   display: flex;
   gap: 10px;
   align-items: end;
   margin: 30px 0;
 }
+
 label {
   flex: 1;
   font-size: 0.9rem;
   font-weight: 600;
 }
+
 input {
   display: block;
   width: 100%;
@@ -62,6 +75,7 @@ input {
   border-radius: 8px;
   background: white;
 }
+
 button,
 .button {
   font: inherit;
@@ -72,19 +86,24 @@ button,
   border-radius: 8px;
   cursor: pointer;
 }
+
 button:disabled {
   opacity: 0.55;
   cursor: default;
 }
+
 :focus-visible {
   outline: 3px solid #2b7dbe;
   outline-offset: 3px;
 }
+
+/* Accepted task rows and write feedback. */
 .tasks {
   list-style: none;
   padding: 0;
   border-top: 1px solid #cddbd3;
 }
+
 .task {
   display: flex;
   gap: 16px;
@@ -93,33 +112,42 @@ button:disabled {
   padding: 18px 0;
   border-bottom: 1px solid #cddbd3;
 }
+
 .task span {
   overflow-wrap: anywhere;
 }
+
 .task[data-done='true'] span {
   text-decoration: line-through;
   color: #63756b;
 }
+
 .notice {
   padding: 16px;
   background: #fff0d2;
   border-radius: 8px;
   overflow-wrap: anywhere;
 }
+
 .notice button {
   margin-top: 10px;
 }
+
+/* Keep the form usable on narrow screens. */
 @media (max-width: 460px) {
   main {
     padding: 24px 16px;
     margin-top: 0;
   }
+
   form {
     flex-wrap: wrap;
   }
+
   form label {
     flex-basis: 100%;
   }
+
   form button {
     width: 100%;
   }

--- a/packages/spacewave/examples/task-board/vanilla.html
+++ b/packages/spacewave/examples/task-board/vanilla.html
@@ -1,9 +1,17 @@
 <!doctype html>
 <html lang="en">
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Task board · Spacewave</title>
-  <link rel="stylesheet" href="/style.css" />
-  <main id="app"><p role="status">Connecting…</p></main>
-  <script type="module" src="/vanilla.js"></script>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Task board · Spacewave</title>
+    <link rel="stylesheet" href="/style.css" />
+  </head>
+
+  <body>
+    <main id="app">
+      <p role="status">Connecting…</p>
+    </main>
+
+    <script type="module" src="/vanilla.js"></script>
+  </body>
 </html>

--- a/packages/spacewave/examples/task-board/vanilla.ts
+++ b/packages/spacewave/examples/task-board/vanilla.ts
@@ -1,24 +1,90 @@
 import { connect, SyncError } from 'spacewave'
+
 import { schema } from './schema.ts'
 
+// Keep the fixed page scaffold separate from task values rendered with textContent.
 const app = document.querySelector<HTMLElement>('#app')!
-app.innerHTML =
-  '<nav><a href="/">Vanilla</a><a href="/react">React</a></nav><h1>Task board</h1><p>Open two tabs. Add or complete a task and watch both boards update.</p><div class="status" role="status">Connecting…</div><form><label>Add a task<input name="title" required maxlength="120" autocomplete="off"></label><button class="button">Add task</button></form><div class="notice" role="alert" hidden></div><p id="freshness" role="status"></p><ul class="tasks"></ul>'
+app.innerHTML = `
+  <nav>
+    <a href="/">Vanilla</a>
+    <a href="/react">React</a>
+  </nav>
+
+  <h1>Task board</h1>
+  <p>Open two tabs. Add or complete a task and watch both boards update.</p>
+  <div class="status" role="status">Connecting…</div>
+
+  <form>
+    <label>
+      Add a task
+      <input name="title" required maxlength="120" autocomplete="off">
+    </label>
+    <button class="button">Add task</button>
+  </form>
+
+  <div class="notice" role="alert" hidden></div>
+  <p id="freshness" role="status"></p>
+  <ul class="tasks"></ul>
+`
+
+// Bind the controls used by connection, write, and subscription callbacks.
 const form = app.querySelector<HTMLFormElement>('form')!
 const input = app.querySelector<HTMLInputElement>('input')!
 const status = app.querySelector<HTMLElement>('.status')!
 const notice = app.querySelector<HTMLElement>('.notice')!
 const freshness = app.querySelector<HTMLElement>('#freshness')!
 const list = app.querySelector<HTMLElement>('.tasks')!
+
+// Pending form work stays separate from the accepted collection snapshot.
 let pending = false
 let ready = false
-const updateButtons = () => {
+
+/** updateButtons permits edits only while connected and without a pending write. */
+function updateButtons(): void {
   for (const button of app.querySelectorAll<HTMLButtonElement>('button')) {
     button.disabled = pending || !ready || button.dataset.done === 'true'
   }
 }
 
+/** runWrite retains the original write closure so Retry preserves its input and ID. */
+async function runWrite(write: () => Promise<unknown>): Promise<void> {
+  // Suspend edits while the server decides this write's result.
+  pending = true
+  notice.hidden = true
+  updateButtons()
+
+  // Show failures without changing the accepted task rows.
+  try {
+    await write()
+  } catch (error) {
+    notice.hidden = false
+    notice.replaceChildren(
+      document.createTextNode(
+        error instanceof Error
+          ? error.message
+          : 'The change could not complete',
+      ),
+    )
+
+    // Retrying an uncertain write reuses its original input and request ID.
+    if (error instanceof SyncError && error.code === 'UNCERTAIN') {
+      notice.append(document.createTextNode(` Request: ${error.requestId}. `))
+      const retry = document.createElement('button')
+      retry.textContent = 'Retry'
+      retry.onclick = () => {
+        void runWrite(write)
+      }
+      notice.append(retry)
+    }
+  } finally {
+    pending = false
+    updateButtons()
+  }
+}
+
+/** start connects the board and releases its subscriptions when the page leaves. */
 async function start(): Promise<void> {
+  // Open one connection for the page and use its typed task collection.
   const url = new URL('/sync', location.href)
   url.protocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
   const db = await connect({
@@ -27,6 +93,8 @@ async function start(): Promise<void> {
     getAccessToken: () => 'local-demo',
   })
   const todos = db.collection('todos')
+
+  // Keep connection feedback and edit availability in sync.
   const stopConnection = db.connection.subscribe((connection) => {
     ready = connection.status === 'ready'
     status.textContent =
@@ -37,39 +105,13 @@ async function start(): Promise<void> {
           : 'Connection closed'
     updateButtons()
   })
-  const runWrite = async (write: () => Promise<unknown>) => {
-    pending = true
-    notice.hidden = true
-    updateButtons()
-    try {
-      await write()
-    } catch (error) {
-      notice.hidden = false
-      notice.replaceChildren(
-        document.createTextNode(
-          error instanceof Error
-            ? error.message
-            : 'The change could not complete',
-        ),
-      )
-      if (error instanceof SyncError && error.code === 'UNCERTAIN') {
-        notice.append(document.createTextNode(` Request: ${error.requestId}. `))
-        const retry = document.createElement('button')
-        retry.textContent = 'Retry'
-        retry.onclick = () => {
-          void runWrite(write)
-        }
-        notice.append(retry)
-      }
-    } finally {
-      pending = false
-      updateButtons()
-    }
-  }
+
+  // Replace the rendered list with each complete server snapshot.
   const stop = todos.subscribe(
     {},
     {
       next: (state) => {
+        // Describe freshness separately from the retained task values.
         freshness.textContent =
           state.status === 'loading'
             ? 'Loading tasks…'
@@ -80,13 +122,18 @@ async function start(): Promise<void> {
                 : state.data.length
                   ? 'All changes saved'
                   : 'No tasks yet'
+
+        // Render task titles as text and wire each row's completion action.
         list.replaceChildren(
           ...state.data.map(({ key, value }) => {
+            // Build the row from the accepted task value.
             const row = document.createElement('li')
             row.className = 'task'
             row.dataset.done = String(value.done)
             const title = document.createElement('span')
             title.textContent = value.title
+
+            // Keep a completion request's ID stable if the user retries it.
             const complete = document.createElement('button')
             complete.textContent = value.done ? 'Completed' : 'Complete'
             complete.dataset.done = String(value.done)
@@ -104,10 +151,15 @@ async function start(): Promise<void> {
       },
     },
   )
+
+  // Capture a new task's input once so recovery can repeat the exact write.
   form.onsubmit = (event) => {
+    // Accept a nonempty title only when edits are available.
     event.preventDefault()
     const title = input.value.trim()
     if (!title || pending || !ready) return
+
+    // Clear the input after acceptance, preserving the IDs inside the closure.
     const key = crypto.randomUUID()
     const requestId = crypto.randomUUID()
     void runWrite(async () => {
@@ -115,6 +167,8 @@ async function start(): Promise<void> {
       input.value = ''
     })
   }
+
+  // Release both subscriptions before closing the page's database.
   window.addEventListener(
     'pagehide',
     () => {
@@ -125,6 +179,8 @@ async function start(): Promise<void> {
     { once: true },
   )
 }
+
+// Disable edits until admission succeeds and make startup failures visible.
 updateButtons()
 void start().catch((error: unknown) => {
   status.textContent = 'Connection failed'

--- a/packages/spacewave/package.json
+++ b/packages/spacewave/package.json
@@ -2,6 +2,13 @@
   "name": "spacewave",
   "version": "0.1.0-rc.1",
   "description": "Typed live collections backed by a durable Spacewave World",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/s4wave/spacewave.git",
+    "directory": "packages/spacewave"
+  },
+  "homepage": "https://github.com/s4wave/spacewave/tree/master/packages/spacewave#readme",
+  "bugs": "https://github.com/s4wave/spacewave/issues",
   "type": "module",
   "engines": {
     "node": ">=24.15.0 <25"

--- a/scripts/sync-library/qualify.ts
+++ b/scripts/sync-library/qualify.ts
@@ -9,12 +9,22 @@ import {
   writeFile,
 } from 'node:fs/promises'
 import { dirname, join, relative, resolve } from 'node:path'
+import { parseArgs } from 'node:util'
 import { gzipSync } from 'node:zlib'
 import { parseSync } from 'oxc-parser'
 
 // Qualification installs one tarball and exercises only its public consumer APIs.
+const { values: options } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    'skip-build': { type: 'boolean' },
+    'allow-dirty': { type: 'boolean' },
+    'release-tag': { type: 'string' },
+  },
+})
 const root = process.cwd()
 const working = join(root, '.tmp/sync-qualification')
+const packageDirectory = join(working, 'package')
 const consumer = join(working, 'consumer')
 const artifacts = resolve(
   process.env.SYNC_ARTIFACT_DIRECTORY ?? '.bldr-dist/sync-library',
@@ -22,16 +32,31 @@ const artifacts = resolve(
 const node = resolve(process.env.SYNC_NODE_BINARY ?? Bun.which('node') ?? '')
 const bun = process.execPath
 const checks: { name: string; elapsedMs: number }[] = []
+
+// Bind release metadata to the application version before building anything.
+const releaseTag = options['release-tag']
+if (releaseTag) {
+  assert.match(releaseTag, /^v\d+\.\d+\.\d+(?:-[\dA-Za-z.-]+)?$/)
+  assert.equal(
+    releaseTag,
+    'v' + (await readFile('core/appversion/version.txt', 'utf8')).trim(),
+    'The npm release tag must match the application version',
+  )
+}
+
+// Recreate the isolated consumer while retaining completed release artifacts.
 await mkdir(artifacts, { recursive: true })
 await rm(working, { recursive: true, force: true })
 await mkdir(consumer, { recursive: true })
 
+/** run records a check's output and duration, rejecting unsuccessful commands. */
 async function run(
   name: string,
   cmd: string[],
   cwd = root,
   env: Record<string, string> = {},
 ): Promise<string> {
+  // Start the command with a dedicated log and the requested environment.
   const started = performance.now()
   const log = join(working, name + '.log')
   await writeFile(log, '')
@@ -41,6 +66,8 @@ async function run(
     stdout: 'pipe',
     stderr: 'pipe',
   })
+
+  // Drain both streams while retaining their text for failure diagnostics.
   async function consume(stream: ReadableStream<Uint8Array>): Promise<string> {
     const parts: Uint8Array[] = []
     for await (const chunk of stream) {
@@ -54,12 +81,17 @@ async function run(
     consume(child.stderr),
     child.exited,
   ])
-  if (code) throw new Error(`${name} failed (${code}):\n${stdout}\n${stderr}`)
+  if (code) {
+    throw new Error(`${name} failed (${code}):\n${stdout}\n${stderr}`)
+  }
+
+  // Include only successful checks in the qualification report.
   checks.push({ name, elapsedMs: performance.now() - started })
   console.log(`Passed ${name}`)
   return stdout
 }
 
+// Build the library using its supported Node runtime and the current source.
 const version = (await run('node-version', [node, '--version'])).trim()
 assert.match(
   version,
@@ -67,19 +99,51 @@ assert.match(
   'Set SYNC_NODE_BINARY to supported Node 24.15 or later within 24.x',
 )
 assert.ok(Number(version.split('.')[1]) >= 15)
-if (!process.argv.includes('--skip-build')) {
+if (!options['skip-build']) {
   await run('source-types', [bun, 'run', 'typecheck'])
   await run('build', ['go', 'run', './scripts/sync-library'])
 }
+
+// Require reproducible source metadata unless this is an explicit development run.
 const metadata = JSON.parse(
   await readFile('packages/spacewave/dist/build.json', 'utf8'),
 )
-if (!process.argv.includes('--allow-dirty'))
+if (!options['allow-dirty']) {
   assert.equal(
     metadata.dirty,
     false,
     'Release qualification requires a clean source revision',
   )
+}
+
+// Stage versioned metadata without changing the source revision being qualified.
+await cp(join(root, 'packages/spacewave'), packageDirectory, {
+  recursive: true,
+})
+if (releaseTag) {
+  // Stamp the staged library with the application release version.
+  const packageVersion = releaseTag.slice(1)
+  await run(
+    'release-version',
+    [
+      'npm',
+      'version',
+      packageVersion,
+      '--no-git-tag-version',
+      '--allow-same-version',
+      '--ignore-scripts',
+    ],
+    packageDirectory,
+  )
+
+  // Make the bundled example install this same published version.
+  const examplePath = join(packageDirectory, 'examples/task-board/package.json')
+  const example = JSON.parse(await readFile(examplePath, 'utf8'))
+  example.dependencies.spacewave = packageVersion
+  await writeFile(examplePath, JSON.stringify(example, null, 2) + '\n')
+}
+
+// Pack once so every consumer check and publication use identical bytes.
 const packed = JSON.parse(
   await run(
     'pack',
@@ -91,14 +155,24 @@ const packed = JSON.parse(
       '--pack-destination',
       artifacts,
     ],
-    join(root, 'packages/spacewave'),
+    packageDirectory,
   ),
-)[0] as { filename: string; size: number; unpackedSize: number }
+)[0] as {
+  filename: string
+  version: string
+  size: number
+  unpackedSize: number
+}
+if (releaseTag) assert.equal(packed.version, releaseTag.slice(1))
+
+// Record the archive digest before installing it into the consumer.
 const tarball = join(artifacts, packed.filename)
 const sha256 = createHash('sha256')
   .update(await readFile(tarball))
   .digest('hex')
 await writeFile(tarball + '.sha256', `${sha256}  ${packed.filename}\n`)
+
+// Install public dependencies without workspace aliases or lifecycle scripts.
 await writeFile(
   join(consumer, 'package.json'),
   JSON.stringify(
@@ -124,6 +198,8 @@ await writeFile(
   ),
 )
 await run('install', [bun, 'install', '--ignore-scripts'], consumer)
+
+// Verify package provenance and SSR imports without Go on the consumer's PATH.
 const distribution = join(consumer, 'node_modules/spacewave/dist')
 assert.deepEqual(
   JSON.parse(await readFile(join(distribution, 'build.json'), 'utf8')),
@@ -142,6 +218,7 @@ await run(
   noGo,
 )
 
+/** bundle compiles a test fixture while keeping its consumer package imports external. */
 async function bundle(
   source: string,
   target: string,
@@ -157,6 +234,8 @@ async function bundle(
     ...external.flatMap((name) => ['--external', name]),
   ])
 }
+
+// Exercise public APIs through independent server and client processes.
 await bundle('scripts/sync-library/consumer.test.ts', 'consumer.test.mjs')
 await bundle('scripts/sync-library/live.test.ts', 'live.test.mjs')
 await run(
@@ -166,6 +245,7 @@ await run(
   noGo,
 )
 
+// Check transaction guarantees against the engine shipped in the tarball.
 const internal = join(working, 'internal')
 await cp(distribution, internal, { recursive: true })
 await run('bundle-internal', [
@@ -182,6 +262,7 @@ await run(
   noGo,
 )
 
+// Type-check consumers against the package's declarations and optional React API.
 await cp(
   'scripts/sync-library/types.test.tsx',
   join(consumer, 'types.test.tsx'),
@@ -208,6 +289,8 @@ await writeFile(
   ),
 )
 await run('consumer-types', [bun, 'x', 'tsgo', '-p', 'tsconfig.json'], consumer)
+
+// Exercise browser and React subscriptions in Chromium and WebKit.
 await bundle('e2e/sync-library/browser.ts', 'browser.mjs', true, ['spacewave'])
 await cp('e2e/sync-library/react.tsx', join(consumer, 'react-fixture.tsx'))
 await cp('e2e/sync-library/schema.ts', join(consumer, 'schema.ts'))
@@ -230,6 +313,7 @@ await run(
   noGo,
 )
 
+// Copy the published example and confirm that it selects this package version.
 const example = join(working, 'example')
 await cp(
   join(consumer, 'node_modules/spacewave/examples/task-board'),
@@ -239,6 +323,9 @@ await cp(
 const exampleManifest = JSON.parse(
   await readFile(join(example, 'package.json'), 'utf8'),
 )
+assert.equal(exampleManifest.dependencies.spacewave, packed.version)
+
+// Run the example against the exact archive before it reaches the registry.
 exampleManifest.dependencies.spacewave = `file:${tarball}`
 await writeFile(
   join(example, 'package.json'),
@@ -252,31 +339,44 @@ await run('example-browser', [node, '--test', 'example.test.mjs'], consumer, {
   SYNC_EXAMPLE_DIRECTORY: example,
 })
 
-// Entry closures expose accidental Node, React, or workspace imports in the client.
+/** closure measures an entry point and follows its static imports within the package. */
 async function closure(entry: string): Promise<{
   files: string[]
   bytes: number
   gzipBytes: number
   external: string[]
 }> {
+  // Count each module once, retaining external imports for boundary checks.
   const files = new Set<string>()
   const external = new Set<string>()
   let bytes = 0
   let gzipBytes = 0
+
+  /** visit accumulates one module and recursively follows its relative imports. */
   async function visit(path: string): Promise<void> {
+    // Skip modules already reached through another import.
     if (files.has(path)) return
     files.add(path)
+
+    // Account for this module's source and compressed size.
     const text = await readFile(path, 'utf8')
     bytes += Buffer.byteLength(text)
     gzipBytes += gzipSync(text).length
+
+    // Traverse package imports and retain external dependency names.
     const parsed = parseSync(path, text)
     assert.equal(parsed.errors.length, 0)
     for (const imported of parsed.module.staticImports) {
       const name = imported.moduleRequest.value
-      if (name.startsWith('.')) await visit(resolve(dirname(path), name))
-      else external.add(name)
+      if (name.startsWith('.')) {
+        await visit(resolve(dirname(path), name))
+      } else {
+        external.add(name)
+      }
     }
   }
+
+  // Return package-relative paths so reports remain portable across runners.
   await visit(join(distribution, entry + '.mjs'))
   return {
     files: [...files].map((file) => relative(distribution, file)),
@@ -285,6 +385,8 @@ async function closure(entry: string): Promise<{
     external: [...external].sort(),
   }
 }
+
+// Measure each public entry point and the worker it loads.
 const bundles = Object.fromEntries(
   await Promise.all(
     ['index', 'react', 'server', 'engine-worker'].map(async (name) => [
@@ -293,6 +395,8 @@ const bundles = Object.fromEntries(
     ]),
   ),
 )
+
+// Reject application-only Go packages in the embedded sync engine.
 const buildReport = JSON.parse(
   await readFile('.tmp/sync-library/build-report.json', 'utf8'),
 ) as { inputs: string[] }
@@ -317,6 +421,8 @@ assert.ok(
     forbidden.every((prefix) => !(path + '/').startsWith(prefix)),
   ),
 )
+
+// Keep Node and React dependencies confined to their declared entry points.
 assert.deepEqual(bundles.index.external, [])
 assert.ok(
   bundles.react.external.every(
@@ -331,6 +437,8 @@ assert.ok(
     name.startsWith('node:'),
   ),
 )
+
+// Measure one bounded workload through the installed public package.
 await bundle('scripts/sync-library/workload.ts', 'workload.mjs')
 const workloadLog = await run(
   'workload',
@@ -344,8 +452,11 @@ const workload = JSON.parse(
     .split('\n')
     .findLast((line) => line.startsWith('{'))!,
 )
+
+// Retain build identity, package boundaries, timings, and workload evidence.
 const report = {
   artifact: packed.filename,
+  version: packed.version,
   sha256,
   ...metadata,
   node: version,


### PR DESCRIPTION
The npm package now introduces live collections through eight short use cases, a shared setup, and a complete task board. Its integration guide covers schema, access, connection lifetime, and write recovery. The examples use readable code paragraphs and React's existing external-store subscription API.

Release tags build and qualify one package archive, stamp its version and the bundled example from the application version, then publish that exact archive through npm trusted publishing. Stable tags select `latest`; prereleases select `next`. Manual workflow runs qualify without publishing.

Validation: installed-package qualification on Node 24, including public API and transaction checks, consumer types, SSR imports, persistence and reconnect journeys, and the vanilla/React task board in Chromium and WebKit. All README TypeScript snippets type-check against installed package exports. Workflow validation passes with actionlint.
