### PR TITLE
fix(bldr): preserve the configured Go module proxy

### DIFF
--- a/bldr/util/gocompiler/env_test.go
+++ b/bldr/util/gocompiler/env_test.go
@@ -1,0 +1,24 @@
+package gocompiler
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestGoCompilerPreservesModuleProxy checks the effective child-process setting.
+func TestGoCompilerPreservesModuleProxy(t *testing.T) {
+	// Preserve an explicit offline policy when launching the Go compiler.
+	t.Setenv("GOPROXY", "off")
+	cmd := NewGoCompilerCmd(t.Context(), "go", "env", "GOPROXY")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Compiler defaults must not replace the caller's module transport.
+	if got := strings.TrimSpace(out.String()); got != "off" {
+		t.Fatalf("GOPROXY = %q, want off", got)
+	}
+}

--- a/bldr/util/gocompiler/gocompiler.go
+++ b/bldr/util/gocompiler/gocompiler.go
@@ -32,7 +32,7 @@ const SQLLiteBuildTag = "sql_lite"
 // package artifact cache.
 const GoScriptCompilerCacheRootEnv = "BLDR_GOSCRIPT_COMPILER_CACHE_ROOT"
 
-// GetDefaultArgs are the set of args we usually pass to the compiler.
+// GetDefaultArgs returns compiler flags that preserve the module manifest.
 func GetDefaultArgs() []string {
 	return []string{
 		"-v",
@@ -41,7 +41,7 @@ func GetDefaultArgs() []string {
 	}
 }
 
-// GetDefaultTinygoLlvmFeatures are the set of additional features to enable or disable.
+// GetDefaultTinygoLlvmFeatures returns the WebAssembly features enabled for TinyGo.
 func GetDefaultTinygoLlvmFeatures() []string {
 	// https://github.com/llvm/llvm-project/blob/91423d71938d7a1dba27188e6d854148a750a3dd/clang/lib/Basic/Targets/WebAssembly.cpp#L150
 	// https://github.com/llvm/llvm-project/blob/91423d71938d7a1dba27188e6d854148a750a3dd/clang/lib/Basic/Targets/WebAssembly.cpp#L180
@@ -66,17 +66,16 @@ func GetDefaultTinygoLlvmFeatures() []string {
 	}
 }
 
-// GetDefaultEnv are the set of args we usually pass to the compiler.
+// GetDefaultEnv selects module mode without changing the configured module proxy.
 func GetDefaultEnv() []string {
 	return []string{
 		"GO111MODULE=on",
-		"GOPROXY=direct",
-		// required for -mod=vendor
+		// Vendored builds require module isolation from workspace configuration.
 		"GOWORK=off",
 	}
 }
 
-// NewGoCompilerCmd builds an exec.Cmd for the Go compiler with the default env.
+// NewGoCompilerCmd builds a compiler command with module defaults and the caller's environment.
 func NewGoCompilerCmd(ctx context.Context, cmd string, args ...string) *exec.Cmd {
 	ecmd := uexec.NewCmd(ctx, cmd, args...)
 	ecmd.Env = os.Environ()
@@ -102,13 +101,13 @@ func NewBuildTags(buildType bldr_manifest.BuildType, enableCgo bool) []string {
 
 // GetWasmExecPath gets the path to wasm_exec.js and ensures it exists.
 func GetWasmExecPath(ctx context.Context, le *logrus.Entry, useTinygo bool) (string, error) {
+	// Query the selected compiler's installation root.
 	var goc *exec.Cmd
 	if useTinygo {
 		goc = NewGoCompilerCmd(ctx, "tinygo", "env", "TINYGOROOT")
 	} else {
 		goc = NewGoCompilerCmd(ctx, "go", "env", "GOROOT")
 	}
-
 	var gocBuf bytes.Buffer
 	goc.Stdout = &gocBuf
 	if err := uexec.ExecCmd(le, goc); err != nil {
@@ -116,13 +115,13 @@ func GetWasmExecPath(ctx context.Context, le *logrus.Entry, useTinygo bool) (str
 	}
 	goRootDir, _, _ := strings.Cut(gocBuf.String(), "\n")
 
+	// Resolve the runtime adapter and require it to exist in that installation.
 	var wasmExecFile string
 	if useTinygo {
 		wasmExecFile = filepath.Join(goRootDir, "targets/wasm_exec.js")
 	} else {
 		wasmExecFile = filepath.Join(goRootDir, "lib/wasm/wasm_exec.js")
 	}
-
 	if _, err := os.Stat(wasmExecFile); err != nil {
 		return wasmExecFile, errors.Wrapf(err, "cannot find wasm_exec.js in goroot: %s", wasmExecFile)
 	}


### PR DESCRIPTION
Compiler helpers forced `GOPROXY=direct`, bypassing the configured proxy and causing fresh npm release builds to fail while fetching a transitive dependency through Git. Preserve the caller's proxy setting or Go's default while retaining module mode and workspace isolation.

The regression test runs a real Go child process: `GOPROXY=off` previously became `direct` and now stays `off`. The focused compiler environment and GoScript binding-root checks pass.
