### PR TITLE
fix(bldr): select browser runtime capabilities

### DIFF
--- a/.protoc-manifest.json
+++ b/.protoc-manifest.json
@@ -68,7 +68,7 @@
       ]
     },
     "github.com/s4wave/spacewave/bldr/devtool/web": {
-      "hash": "5c769040e039f1ffb10193454ee1ee6d8c732be26cdaaf2236be7dc0fb27208a",
+      "hash": "3eadfd64c28a8a38a0b797af2818e5a3f463252276597bf3bd906c6a67cdec30",
       "generatedFiles": [
         "bldr/devtool/web/web.pb.go",
         "bldr/devtool/web/web.pb.ts"
@@ -317,7 +317,7 @@
       ]
     },
     "github.com/s4wave/spacewave/bldr/plugin/host/scheduler": {
-      "hash": "6c226910d7f3e3667893865829fefbb974742d0836e98aeddd911facfcf2f2cc",
+      "hash": "9614b74b193c6ac5b833e5b37fe94041017db2fe8ed6e9e3abf192c4dcfd79fc",
       "generatedFiles": [
         "bldr/plugin/host/scheduler/config.pb.go",
         "bldr/plugin/host/scheduler/config.pb.ts"

--- a/bldr/devtool/start-web-wasm.go
+++ b/bldr/devtool/start-web-wasm.go
@@ -39,7 +39,7 @@ import (
 // GoScript as the default Go compiler.
 func (a *DevtoolArgs) ExecuteWebGoScriptProject(ctx context.Context) error {
 	return withGoCompiler(gocompiler.GoCompilerGoScript, func() error {
-		return a.ExecuteWebWasmProject(ctx)
+		return a.executeWebProject(ctx, "GoScript", "js")
 	})
 }
 
@@ -60,8 +60,17 @@ func withGoCompiler(mode gocompiler.GoCompiler, fn func() error) error {
 	return fn()
 }
 
-// ExecuteWebWasmProject starts the project as a web server in Wasm mode.
-func (a *DevtoolArgs) ExecuteWebWasmProject(ctx context.Context) (err error) {
+// ExecuteWebWasmProject starts the browser-hosted devtool path with the
+// standard Go WebAssembly compiler.
+func (a *DevtoolArgs) ExecuteWebWasmProject(ctx context.Context) error {
+	return withGoCompiler(gocompiler.GoCompilerGo, func() error {
+		return a.executeWebProject(ctx, "Go/Wasm", "web/js/wasm")
+	})
+}
+
+// executeWebProject starts the browser host and labels the selected Go plugin
+// compiler in user-facing status.
+func (a *DevtoolArgs) executeWebProject(ctx context.Context, compilerName, goPluginPlatformID string) (err error) {
 	// Initialize the repo root and storage directories.
 	le := a.Logger
 	repoRoot, stateDir, err := a.InitRepoRoot()
@@ -79,7 +88,11 @@ func (a *DevtoolArgs) ExecuteWebWasmProject(ctx context.Context) (err error) {
 
 	// Start the command status log and the devtool TUI.
 	commandLogFile := a.commandLogFile()
-	d.setCommandStartingWithLogFile("start web", "initializing wasm web runtime", commandLogFile)
+	d.setCommandStartingWithLogFile(
+		"start web",
+		"initializing web runtime with "+compilerName+" plugins",
+		commandLogFile,
+	)
 	ctx, stopTUI := a.startDevtoolTUI(ctx, d.GetStatusProducer(), "http://"+a.WebListenAddr)
 	defer func() {
 		d.finishCommandWithLogFile(ctx, "start web", commandLogFile, err)
@@ -115,7 +128,11 @@ func (a *DevtoolArgs) ExecuteWebWasmProject(ctx context.Context) (err error) {
 	appID := currProjConf.GetId()
 	startConf := currProjConf.GetStart()
 	startupPlugins := startConf.GetPlugins()
-	startupManifestPreflights := ProjectOwnedStartupManifestPreflights(currProjConf, "web/js/wasm")
+	startupManifestPreflights := projectOwnedStartupManifestPreflightsForPlatforms(
+		currProjConf,
+		goPluginPlatformID,
+		"web/js/wasm",
+	)
 	webStartupSrcPath, _ := startConf.ParseWebStartupPath()
 
 	buildType := bldr_manifest.BuildType(a.BuildType)
@@ -132,7 +149,11 @@ func (a *DevtoolArgs) ExecuteWebWasmProject(ctx context.Context) (err error) {
 		webStartupSrcPath,
 		false,
 		func(string) error {
-			d.setCommandRunningWithLogFile("start web", "wasm web runtime active on "+a.WebListenAddr, commandLogFile)
+			d.setCommandRunningWithLogFile(
+				"start web",
+				"web dev server active on "+a.WebListenAddr+" with "+compilerName+" plugins",
+				commandLogFile,
+			)
 			return nil
 		},
 	)
@@ -365,11 +386,12 @@ func (d *DevtoolBus) executeWebWasm(
 
 	// Encode the init info for the browser devtool entrypoint.
 	browserInit := &devtool_web.DevtoolInitBrowser{
-		AppId:                 appID,
-		DevtoolPeerId:         wsPeerID,
-		DevtoolVolumeInfo:     d.GetVolumeInfo(),
-		StartPlugins:          startPlugins,
-		ForceDedicatedWorkers: forceDedicatedWorkers,
+		AppId:                     appID,
+		DevtoolPeerId:             wsPeerID,
+		DevtoolVolumeInfo:         d.GetVolumeInfo(),
+		StartPlugins:              startPlugins,
+		ForceDedicatedWorkers:     forceDedicatedWorkers,
+		PlatformSelectionPolicies: startupManifestPlatformSelectionPolicies(startupManifestPreflights),
 	}
 	if err := browserInit.Validate(); err != nil {
 		return err

--- a/bldr/devtool/startup_manifests.go
+++ b/bldr/devtool/startup_manifests.go
@@ -3,8 +3,11 @@
 package devtool
 
 import (
+	"slices"
+
 	bldr_plugin_compiler_go "github.com/s4wave/spacewave/bldr/plugin/compiler/go"
 	bldr_plugin_compiler_js "github.com/s4wave/spacewave/bldr/plugin/compiler/js"
+	plugin_host_scheduler "github.com/s4wave/spacewave/bldr/plugin/host/scheduler"
 	bldr_project "github.com/s4wave/spacewave/bldr/project"
 	web_plugin_compiler "github.com/s4wave/spacewave/bldr/web/plugin/compiler"
 )
@@ -13,6 +16,39 @@ import (
 type StartupManifestPreflight struct {
 	PluginID    string
 	PlatformIDs []string
+}
+
+// startupManifestPlatformSelectionPolicies prevents each exact preflight from
+// being rebuilt for the other plugin platform after the browser connects.
+func startupManifestPlatformSelectionPolicies(
+	preflights []StartupManifestPreflight,
+) []*plugin_host_scheduler.PlatformSelectionPolicy {
+	var platformIDs []string
+	for _, preflight := range preflights {
+		platformIDs = append(platformIDs, preflight.PlatformIDs...)
+	}
+	slices.Sort(platformIDs)
+	platformIDs = slices.Compact(platformIDs)
+
+	policies := make([]*plugin_host_scheduler.PlatformSelectionPolicy, 0, len(platformIDs))
+	for _, platformID := range platformIDs {
+		var deniedPluginIDs []string
+		for _, preflight := range preflights {
+			if !slices.Contains(preflight.PlatformIDs, platformID) {
+				deniedPluginIDs = append(deniedPluginIDs, preflight.PluginID)
+			}
+		}
+		if len(deniedPluginIDs) == 0 {
+			continue
+		}
+		slices.Sort(deniedPluginIDs)
+		deniedPluginIDs = slices.Compact(deniedPluginIDs)
+		policies = append(policies, &plugin_host_scheduler.PlatformSelectionPolicy{
+			PlatformId:      platformID,
+			DeniedPluginIds: deniedPluginIDs,
+		})
+	}
+	return policies
 }
 
 // projectOwnedStartupPlugins returns the plugin ids owned by the project's
@@ -45,7 +81,7 @@ func ProjectOwnedStartupManifestPreflight(
 	}
 	return StartupManifestPreflight{
 		PluginID:    pluginID,
-		PlatformIDs: startupManifestPlatformIDs(pluginID, manifest, wasmPlatformID),
+		PlatformIDs: startupManifestPlatformIDs(manifest, "", wasmPlatformID),
 	}, true
 }
 
@@ -67,20 +103,49 @@ func ProjectOwnedStartupManifestPreflights(projectConfig *bldr_project.ProjectCo
 	return preflights
 }
 
+// projectOwnedStartupManifestPreflightsForPlatforms narrows known builders to
+// the single platform used by the active browser development mode.
+func projectOwnedStartupManifestPreflightsForPlatforms(
+	projectConfig *bldr_project.ProjectConfig,
+	goPluginPlatformID,
+	wasmPlatformID string,
+) []StartupManifestPreflight {
+	pluginIDs := projectOwnedStartupPlugins(projectConfig)
+	preflights := make([]StartupManifestPreflight, 0, len(pluginIDs))
+	for _, pluginID := range pluginIDs {
+		manifest := projectConfig.GetManifests()[pluginID]
+		if manifest == nil {
+			continue
+		}
+		preflights = append(preflights, StartupManifestPreflight{
+			PluginID:    pluginID,
+			PlatformIDs: startupManifestPlatformIDs(manifest, goPluginPlatformID, wasmPlatformID),
+		})
+	}
+	return preflights
+}
+
 // startupManifestPlatformIDs returns the platform ids a manifest builds
 // for, given the resolved wasm platform id.
-func startupManifestPlatformIDs(pluginID string, manifest *bldr_project.ManifestConfig, wasmPlatformID string) []string {
+func startupManifestPlatformIDs(
+	manifest *bldr_project.ManifestConfig,
+	goPluginPlatformID,
+	wasmPlatformID string,
+) []string {
 	switch manifest.GetBuilder().GetId() {
 	case bldr_plugin_compiler_js.ConfigID:
-		if wasmPlatformID != "" && wasmPlatformID != "js" {
+		if goPluginPlatformID == "" && wasmPlatformID != "" && wasmPlatformID != "js" {
 			return []string{"js", wasmPlatformID}
 		}
 		return []string{"js"}
 	case bldr_plugin_compiler_go.ConfigID:
-		if wasmPlatformID != "" && wasmPlatformID != "js" {
-			return []string{"js", wasmPlatformID}
+		if goPluginPlatformID == "" {
+			if wasmPlatformID != "" && wasmPlatformID != "js" {
+				return []string{"js", wasmPlatformID}
+			}
+			return []string{"js"}
 		}
-		return []string{"js"}
+		return []string{goPluginPlatformID}
 	case web_plugin_compiler.ConfigID:
 		return []string{wasmPlatformID}
 	default:

--- a/bldr/devtool/startup_manifests_test.go
+++ b/bldr/devtool/startup_manifests_test.go
@@ -9,6 +9,7 @@ import (
 	configset_proto "github.com/aperturerobotics/controllerbus/controller/configset/proto"
 	bldr_plugin_compiler_go "github.com/s4wave/spacewave/bldr/plugin/compiler/go"
 	bldr_plugin_compiler_js "github.com/s4wave/spacewave/bldr/plugin/compiler/js"
+	plugin_host_scheduler "github.com/s4wave/spacewave/bldr/plugin/host/scheduler"
 	bldr_project "github.com/s4wave/spacewave/bldr/project"
 	web_plugin_compiler "github.com/s4wave/spacewave/bldr/web/plugin/compiler"
 )
@@ -71,6 +72,35 @@ func TestProjectOwnedStartupManifestPreflightsSelectBuilderPlatforms(t *testing.
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("ProjectOwnedStartupManifestPreflights() = %#v, want %#v", got, want)
+	}
+}
+
+func TestProjectOwnedStartupManifestPreflightsSelectActivePlatforms(t *testing.T) {
+	projectConfig := &bldr_project.ProjectConfig{
+		Start: &bldr_project.StartConfig{Plugins: []string{"web", "frontend", "core"}},
+		Manifests: map[string]*bldr_project.ManifestConfig{
+			"web":      {Builder: &configset_proto.ControllerConfig{Id: web_plugin_compiler.ConfigID}},
+			"frontend": {Builder: &configset_proto.ControllerConfig{Id: bldr_plugin_compiler_js.ConfigID}},
+			"core":     {Builder: &configset_proto.ControllerConfig{Id: bldr_plugin_compiler_go.ConfigID}},
+		},
+	}
+
+	got := projectOwnedStartupManifestPreflightsForPlatforms(projectConfig, "js", "web/js/wasm")
+	want := []StartupManifestPreflight{
+		{PluginID: "web", PlatformIDs: []string{"web/js/wasm"}},
+		{PluginID: "frontend", PlatformIDs: []string{"js"}},
+		{PluginID: "core", PlatformIDs: []string{"js"}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ProjectOwnedStartupManifestPreflights() = %#v, want %#v", got, want)
+	}
+	policies := startupManifestPlatformSelectionPolicies(got)
+	wantPolicies := []*plugin_host_scheduler.PlatformSelectionPolicy{
+		{PlatformId: "js", DeniedPluginIds: []string{"web"}},
+		{PlatformId: "web/js/wasm", DeniedPluginIds: []string{"core", "frontend"}},
+	}
+	if !reflect.DeepEqual(policies, wantPolicies) {
+		t.Fatalf("startupManifestPlatformSelectionPolicies() = %#v, want %#v", policies, wantPolicies)
 	}
 }
 

--- a/bldr/devtool/web/entrypoint/controller/controller.go
+++ b/bldr/devtool/web/entrypoint/controller/controller.go
@@ -298,6 +298,12 @@ func (c *Controller) Execute(ctx context.Context) (rerr error) {
 		true, // fetched manifest refs point at the devtool bucket
 		true, // no need to copy into browser storage in devtool mode
 	)
+	for _, policy := range devtoolInfo.GetPlatformSelectionPolicies() {
+		pluginSchedConf.PlatformSelectionPolicies = append(
+			pluginSchedConf.PlatformSelectionPolicies,
+			policy.CloneVT(),
+		)
+	}
 	pluginSchedCtrl := plugin_host_scheduler.NewController(le, b, pluginSchedConf)
 	pluginSchecCtrlRel, err := b.AddController(ctx, pluginSchedCtrl, func(err error) {
 		le.WithError(err).Error("plugin scheduler controller failed")

--- a/bldr/devtool/web/web.pb.go
+++ b/bldr/devtool/web/web.pb.go
@@ -11,6 +11,7 @@ import (
 
 	protobuf_go_lite "github.com/aperturerobotics/protobuf-go-lite"
 	json "github.com/aperturerobotics/protobuf-go-lite/json"
+	scheduler "github.com/s4wave/spacewave/bldr/plugin/host/scheduler"
 	volume "github.com/s4wave/spacewave/db/volume"
 )
 
@@ -30,6 +31,9 @@ type DevtoolInitBrowser struct {
 	// dedicated Workers for plugins. Useful for testing with Playwright
 	// which can capture console output from dedicated workers but not shared.
 	ForceDedicatedWorkers bool `protobuf:"varint,5,opt,name=force_dedicated_workers,json=forceDedicatedWorkers,proto3" json:"forceDedicatedWorkers,omitempty"`
+	// PlatformSelectionPolicies bind project-owned startup plugins to the
+	// platform selected by the active development compiler.
+	PlatformSelectionPolicies []*scheduler.PlatformSelectionPolicy `protobuf:"bytes,6,rep,name=platform_selection_policies,json=platformSelectionPolicies,proto3" json:"platformSelectionPolicies,omitempty"`
 }
 
 func (x *DevtoolInitBrowser) Reset() {
@@ -73,6 +77,13 @@ func (x *DevtoolInitBrowser) GetForceDedicatedWorkers() bool {
 	return false
 }
 
+func (x *DevtoolInitBrowser) GetPlatformSelectionPolicies() []*scheduler.PlatformSelectionPolicy {
+	if x != nil {
+		return x.PlatformSelectionPolicies
+	}
+	return nil
+}
+
 func (m *DevtoolInitBrowser) CloneVT() *DevtoolInitBrowser {
 	if m == nil {
 		return (*DevtoolInitBrowser)(nil)
@@ -83,6 +94,7 @@ func (m *DevtoolInitBrowser) CloneVT() *DevtoolInitBrowser {
 	r.ForceDedicatedWorkers = m.ForceDedicatedWorkers
 	r.DevtoolVolumeInfo = protobuf_go_lite.CloneVTValue(m.DevtoolVolumeInfo)
 	r.StartPlugins = protobuf_go_lite.CloneSlice(m.StartPlugins)
+	r.PlatformSelectionPolicies = protobuf_go_lite.CloneVTSlice(m.PlatformSelectionPolicies)
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = slices.Clone(m.unknownFields)
 	}
@@ -112,6 +124,9 @@ func (this *DevtoolInitBrowser) EqualVT(that *DevtoolInitBrowser) bool {
 		return false
 	}
 	if this.ForceDedicatedWorkers != that.ForceDedicatedWorkers {
+		return false
+	}
+	if !protobuf_go_lite.EqualVTSliceImplicit(this.PlatformSelectionPolicies, that.PlatformSelectionPolicies, func() *scheduler.PlatformSelectionPolicy { return &scheduler.PlatformSelectionPolicy{} }) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -158,6 +173,17 @@ func (x *DevtoolInitBrowser) MarshalProtoJSON(s *json.MarshalState) {
 		s.WriteObjectField("forceDedicatedWorkers")
 		s.WriteBool(x.ForceDedicatedWorkers)
 	}
+	if len(x.PlatformSelectionPolicies) > 0 || s.HasField("platformSelectionPolicies") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("platformSelectionPolicies")
+		s.WriteArrayStart()
+		var wroteElement bool
+		for _, element := range x.PlatformSelectionPolicies {
+			s.WriteMoreIf(&wroteElement)
+			element.MarshalProtoJSON(s.WithField("platformSelectionPolicies"))
+		}
+		s.WriteArrayEnd()
+	}
 	s.WriteObjectEnd()
 }
 
@@ -198,6 +224,24 @@ func (x *DevtoolInitBrowser) UnmarshalProtoJSON(s *json.UnmarshalState) {
 		case "force_dedicated_workers", "forceDedicatedWorkers":
 			s.AddField("force_dedicated_workers")
 			x.ForceDedicatedWorkers = s.ReadBool()
+		case "platform_selection_policies", "platformSelectionPolicies":
+			s.AddField("platform_selection_policies")
+			if s.ReadNil() {
+				x.PlatformSelectionPolicies = nil
+				return
+			}
+			s.ReadArray(func() {
+				if s.ReadNil() {
+					x.PlatformSelectionPolicies = append(x.PlatformSelectionPolicies, nil)
+					return
+				}
+				v := &scheduler.PlatformSelectionPolicy{}
+				v.UnmarshalProtoJSON(s.WithField("platform_selection_policies", false))
+				if s.Err() != nil {
+					return
+				}
+				x.PlatformSelectionPolicies = append(x.PlatformSelectionPolicies, v)
+			})
 		}
 	})
 }
@@ -235,6 +279,18 @@ func (m *DevtoolInitBrowser) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	_ = l
 	if m.unknownFields != nil {
 		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	if len(m.PlatformSelectionPolicies) > 0 {
+		for iNdEx := len(m.PlatformSelectionPolicies) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.PlatformSelectionPolicies[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x32
+		}
 	}
 	if m.ForceDedicatedWorkers {
 		i = protobuf_go_lite.EncodeBool(dAtA, i, m.ForceDedicatedWorkers)
@@ -285,6 +341,10 @@ func (m *DevtoolInitBrowser) SizeVT() (n int) {
 	}
 	n += protobuf_go_lite.SizeStringSlice(1, m.StartPlugins)
 	n += protobuf_go_lite.SizeBoolNonZero(1, m.ForceDedicatedWorkers)
+	for _, e := range m.PlatformSelectionPolicies {
+		l = e.SizeVT()
+		n += protobuf_go_lite.SizeMessage(1, l)
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -315,6 +375,18 @@ func (x *DevtoolInitBrowser) MarshalProtoText() string {
 	if x.ForceDedicatedWorkers != false {
 		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "force_dedicated_workers")
 		protobuf_go_lite.TextWriteBool(&sb, x.ForceDedicatedWorkers)
+	}
+	if len(x.PlatformSelectionPolicies) > 0 {
+		protobuf_go_lite.TextWriteListStart(&sb, initialLen, "platform_selection_policies")
+		for i, v := range x.PlatformSelectionPolicies {
+			protobuf_go_lite.TextWriteListSeparator(&sb, i)
+			if v == nil {
+				protobuf_go_lite.TextWriteTextMarshaler(&sb, &scheduler.PlatformSelectionPolicy{})
+			} else {
+				protobuf_go_lite.TextWriteTextMarshaler(&sb, v)
+			}
+		}
+		protobuf_go_lite.TextWriteListEnd(&sb)
 	}
 	return protobuf_go_lite.TextFinishMessage(&sb)
 }
@@ -398,6 +470,19 @@ func (m *DevtoolInitBrowser) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			m.ForceDedicatedWorkers = bool(v)
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PlatformSelectionPolicies", wireType)
+			}
+			msgStart, postIndex, err := protobuf_go_lite.DecodeLengthDelimited(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.PlatformSelectionPolicies = append(m.PlatformSelectionPolicies, &scheduler.PlatformSelectionPolicy{})
+			if err := m.PlatformSelectionPolicies[len(m.PlatformSelectionPolicies)-1].UnmarshalVT(dAtA[msgStart:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])

--- a/bldr/devtool/web/web.pb.ts
+++ b/bldr/devtool/web/web.pb.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import { VolumeInfo } from '@go/github.com/s4wave/spacewave/db/volume/volume.pb.js'
+import { PlatformSelectionPolicy } from '../../plugin/host/scheduler/config.pb.js'
 import type { MessageType } from '@aptre/protobuf-es-lite/message'
 import { createMessageType } from '@aptre/protobuf-es-lite/message'
 import { ScalarType } from '@aptre/protobuf-es-lite/scalar'
@@ -49,6 +50,13 @@ export interface DevtoolInitBrowser {
    * @generated from field: bool force_dedicated_workers = 5;
    */
   forceDedicatedWorkers?: boolean
+  /**
+   * PlatformSelectionPolicies bind project-owned startup plugins to the
+   * platform selected by the active development compiler.
+   *
+   * @generated from field: repeated plugin.host.scheduler.PlatformSelectionPolicy platform_selection_policies = 6;
+   */
+  platformSelectionPolicies?: PlatformSelectionPolicy[]
 }
 
 export const DevtoolInitBrowser: MessageType<DevtoolInitBrowser> =
@@ -75,6 +83,13 @@ export const DevtoolInitBrowser: MessageType<DevtoolInitBrowser> =
         name: 'force_dedicated_workers',
         kind: 'scalar',
         T: ScalarType.BOOL,
+      },
+      {
+        no: 6,
+        name: 'platform_selection_policies',
+        kind: 'message',
+        T: () => PlatformSelectionPolicy,
+        repeated: true,
       },
     ] satisfies readonly PartialFieldInfo[],
     packedByDefault: true,

--- a/bldr/devtool/web/web.proto
+++ b/bldr/devtool/web/web.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package devtool.web;
 
+import "github.com/s4wave/spacewave/bldr/plugin/host/scheduler/config.proto";
 import "github.com/s4wave/spacewave/db/volume/volume.proto";
 
 // DevtoolInitBrowser is the message initializing the browser from the devtool.
@@ -18,4 +19,7 @@ message DevtoolInitBrowser {
   // dedicated Workers for plugins. Useful for testing with Playwright
   // which can capture console output from dedicated workers but not shared.
   bool force_dedicated_workers = 5;
+  // PlatformSelectionPolicies bind project-owned startup plugins to the
+  // platform selected by the active development compiler.
+  repeated .plugin.host.scheduler.PlatformSelectionPolicy platform_selection_policies = 6;
 }

--- a/bldr/plugin/host/scheduler/config.go
+++ b/bldr/plugin/host/scheduler/config.go
@@ -69,6 +69,17 @@ func (c *Config) Validate() error {
 		if slices.Contains(policy.GetAllowedPluginIds(), "") {
 			return errors.New("platform_selection_policies: allowed_plugin_ids cannot contain empty values")
 		}
+		if slices.Contains(policy.GetDeniedPluginIds(), "") {
+			return errors.New("platform_selection_policies: denied_plugin_ids cannot contain empty values")
+		}
+		for _, pluginID := range policy.GetDeniedPluginIds() {
+			if slices.Contains(policy.GetAllowedPluginIds(), pluginID) {
+				return errors.Errorf(
+					"platform_selection_policies: plugin %q cannot be both allowed and denied",
+					pluginID,
+				)
+			}
+		}
 	}
 	if err := bldr_plugin.ValidatePluginID(c.GetMaterializerPluginId(), true); err != nil {
 		return errors.Wrap(err, "materializer_plugin_id")
@@ -146,7 +157,11 @@ func (c *Config) pluginPlatformAllowed(pluginID, platformID string) bool {
 		if policy.GetPlatformId() != platformID {
 			continue
 		}
-		return slices.Contains(policy.GetAllowedPluginIds(), pluginID)
+		if slices.Contains(policy.GetDeniedPluginIds(), pluginID) {
+			return false
+		}
+		allowed := policy.GetAllowedPluginIds()
+		return len(allowed) == 0 || slices.Contains(allowed, pluginID)
 	}
 	return true
 }

--- a/bldr/plugin/host/scheduler/config.pb.go
+++ b/bldr/plugin/host/scheduler/config.pb.go
@@ -58,9 +58,9 @@ type Config struct {
 	DisableCopyManifest bool `protobuf:"varint,10,opt,name=disable_copy_manifest,json=disableCopyManifest,proto3" json:"disableCopyManifest,omitempty"`
 	// Verbose enables verbose logging for world ops (slower).
 	Verbose bool `protobuf:"varint,11,opt,name=verbose,proto3" json:"verbose,omitempty"`
-	// PlatformSelectionPolicies restrict selected platform IDs to selected
-	// plugin IDs. If empty, every discovered plugin host platform is selectable
-	// for every plugin.
+	// PlatformSelectionPolicies restrict selected platform IDs by plugin ID. If
+	// empty, every discovered plugin host platform is selectable for every
+	// plugin.
 	PlatformSelectionPolicies []*PlatformSelectionPolicy `protobuf:"bytes,12,rep,name=platform_selection_policies,json=platformSelectionPolicies,proto3" json:"platformSelectionPolicies,omitempty"`
 	// NoCopyBucketIds lists source buckets that remain authoritative without a
 	// full-DAG copy.
@@ -218,14 +218,18 @@ func (x *Config) GetHostStorageId() string {
 	return ""
 }
 
-// PlatformSelectionPolicy restricts a plugin host platform to a plugin ID list.
+// PlatformSelectionPolicy restricts one plugin host platform by plugin ID.
 type PlatformSelectionPolicy struct {
 	unknownFields []byte
 	// PlatformId is the plugin host platform ID to restrict, such as
 	// "web/js/wasm".
 	PlatformId string `protobuf:"bytes,1,opt,name=platform_id,json=platformId,proto3" json:"platformId,omitempty"`
-	// AllowedPluginIds are the plugin IDs that may select PlatformId.
+	// AllowedPluginIds are the only plugin IDs that may select PlatformId when
+	// nonempty.
 	AllowedPluginIds []string `protobuf:"bytes,2,rep,name=allowed_plugin_ids,json=allowedPluginIds,proto3" json:"allowedPluginIds,omitempty"`
+	// DeniedPluginIds are the plugin IDs that cannot select PlatformId. This
+	// leaves unlisted and externally supplied plugins eligible.
+	DeniedPluginIds []string `protobuf:"bytes,3,rep,name=denied_plugin_ids,json=deniedPluginIds,proto3" json:"deniedPluginIds,omitempty"`
 }
 
 func (x *PlatformSelectionPolicy) Reset() {
@@ -244,6 +248,13 @@ func (x *PlatformSelectionPolicy) GetPlatformId() string {
 func (x *PlatformSelectionPolicy) GetAllowedPluginIds() []string {
 	if x != nil {
 		return x.AllowedPluginIds
+	}
+	return nil
+}
+
+func (x *PlatformSelectionPolicy) GetDeniedPluginIds() []string {
+	if x != nil {
+		return x.DeniedPluginIds
 	}
 	return nil
 }
@@ -288,6 +299,7 @@ func (m *PlatformSelectionPolicy) CloneVT() *PlatformSelectionPolicy {
 	r := new(PlatformSelectionPolicy)
 	r.PlatformId = m.PlatformId
 	r.AllowedPluginIds = protobuf_go_lite.CloneSlice(m.AllowedPluginIds)
+	r.DeniedPluginIds = protobuf_go_lite.CloneSlice(m.DeniedPluginIds)
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = slices.Clone(m.unknownFields)
 	}
@@ -379,6 +391,9 @@ func (this *PlatformSelectionPolicy) EqualVT(that *PlatformSelectionPolicy) bool
 		return false
 	}
 	if !protobuf_go_lite.EqualSlice(this.AllowedPluginIds, that.AllowedPluginIds) {
+		return false
+	}
+	if !protobuf_go_lite.EqualSlice(this.DeniedPluginIds, that.DeniedPluginIds) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -625,6 +640,11 @@ func (x *PlatformSelectionPolicy) MarshalProtoJSON(s *json.MarshalState) {
 		s.WriteObjectField("allowedPluginIds")
 		s.WriteStringArray(x.AllowedPluginIds)
 	}
+	if len(x.DeniedPluginIds) > 0 || s.HasField("deniedPluginIds") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("deniedPluginIds")
+		s.WriteStringArray(x.DeniedPluginIds)
+	}
 	s.WriteObjectEnd()
 }
 
@@ -652,6 +672,13 @@ func (x *PlatformSelectionPolicy) UnmarshalProtoJSON(s *json.UnmarshalState) {
 				return
 			}
 			x.AllowedPluginIds = s.ReadStringArray()
+		case "denied_plugin_ids", "deniedPluginIds":
+			s.AddField("denied_plugin_ids")
+			if s.ReadNil() {
+				x.DeniedPluginIds = nil
+				return
+			}
+			x.DeniedPluginIds = s.ReadStringArray()
 		}
 	})
 }
@@ -839,6 +866,13 @@ func (m *PlatformSelectionPolicy) MarshalToSizedBufferVT(dAtA []byte) (int, erro
 	if m.unknownFields != nil {
 		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
 	}
+	if len(m.DeniedPluginIds) > 0 {
+		for iNdEx := len(m.DeniedPluginIds) - 1; iNdEx >= 0; iNdEx-- {
+			i = protobuf_go_lite.EncodeString(dAtA, i, m.DeniedPluginIds[iNdEx])
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
 	if len(m.AllowedPluginIds) > 0 {
 		for iNdEx := len(m.AllowedPluginIds) - 1; iNdEx >= 0; iNdEx-- {
 			i = protobuf_go_lite.EncodeString(dAtA, i, m.AllowedPluginIds[iNdEx])
@@ -899,6 +933,7 @@ func (m *PlatformSelectionPolicy) SizeVT() (n int) {
 	_ = l
 	n += protobuf_go_lite.SizeStringNonEmpty(1, m.PlatformId)
 	n += protobuf_go_lite.SizeStringSlice(1, m.AllowedPluginIds)
+	n += protobuf_go_lite.SizeStringSlice(1, m.DeniedPluginIds)
 	n += len(m.unknownFields)
 	return n
 }
@@ -1011,6 +1046,14 @@ func (x *PlatformSelectionPolicy) MarshalProtoText() string {
 	if len(x.AllowedPluginIds) > 0 {
 		protobuf_go_lite.TextWriteListStart(&sb, initialLen, "allowed_plugin_ids")
 		for i, v := range x.AllowedPluginIds {
+			protobuf_go_lite.TextWriteListSeparator(&sb, i)
+			protobuf_go_lite.TextWriteString(&sb, v)
+		}
+		protobuf_go_lite.TextWriteListEnd(&sb)
+	}
+	if len(x.DeniedPluginIds) > 0 {
+		protobuf_go_lite.TextWriteListStart(&sb, initialLen, "denied_plugin_ids")
+		for i, v := range x.DeniedPluginIds {
 			protobuf_go_lite.TextWriteListSeparator(&sb, i)
 			protobuf_go_lite.TextWriteString(&sb, v)
 		}
@@ -1298,6 +1341,16 @@ func (m *PlatformSelectionPolicy) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			m.AllowedPluginIds = append(m.AllowedPluginIds, v)
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DeniedPluginIds", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.DeniedPluginIds = append(m.DeniedPluginIds, v)
 		default:
 			iNdEx = preIndex
 			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])

--- a/bldr/plugin/host/scheduler/config.pb.ts
+++ b/bldr/plugin/host/scheduler/config.pb.ts
@@ -11,7 +11,7 @@ import { Backoff } from '@go/github.com/aperturerobotics/util/backoff/backoff.pb
 export const protobufPackage = 'plugin.host.scheduler'
 
 /**
- * PlatformSelectionPolicy restricts a plugin host platform to a plugin ID list.
+ * PlatformSelectionPolicy restricts one plugin host platform by plugin ID.
  *
  * @generated from message plugin.host.scheduler.PlatformSelectionPolicy
  */
@@ -24,11 +24,19 @@ export interface PlatformSelectionPolicy {
    */
   platformId?: string
   /**
-   * AllowedPluginIds are the plugin IDs that may select PlatformId.
+   * AllowedPluginIds are the only plugin IDs that may select PlatformId when
+   * nonempty.
    *
    * @generated from field: repeated string allowed_plugin_ids = 2;
    */
   allowedPluginIds?: string[]
+  /**
+   * DeniedPluginIds are the plugin IDs that cannot select PlatformId. This
+   * leaves unlisted and externally supplied plugins eligible.
+   *
+   * @generated from field: repeated string denied_plugin_ids = 3;
+   */
+  deniedPluginIds?: string[]
 }
 
 export const PlatformSelectionPolicy: MessageType<PlatformSelectionPolicy> =
@@ -39,6 +47,13 @@ export const PlatformSelectionPolicy: MessageType<PlatformSelectionPolicy> =
       {
         no: 2,
         name: 'allowed_plugin_ids',
+        kind: 'scalar',
+        T: ScalarType.STRING,
+        repeated: true,
+      },
+      {
+        no: 3,
+        name: 'denied_plugin_ids',
         kind: 'scalar',
         T: ScalarType.STRING,
         repeated: true,
@@ -139,9 +154,9 @@ export interface Config {
    */
   verbose?: boolean
   /**
-   * PlatformSelectionPolicies restrict selected platform IDs to selected
-   * plugin IDs. If empty, every discovered plugin host platform is selectable
-   * for every plugin.
+   * PlatformSelectionPolicies restrict selected platform IDs by plugin ID. If
+   * empty, every discovered plugin host platform is selectable for every
+   * plugin.
    *
    * @generated from field: repeated plugin.host.scheduler.PlatformSelectionPolicy platform_selection_policies = 12;
    */

--- a/bldr/plugin/host/scheduler/config.proto
+++ b/bldr/plugin/host/scheduler/config.proto
@@ -46,9 +46,9 @@ message Config {
   bool disable_copy_manifest = 10;
   // Verbose enables verbose logging for world ops (slower).
   bool verbose = 11;
-  // PlatformSelectionPolicies restrict selected platform IDs to selected
-  // plugin IDs. If empty, every discovered plugin host platform is selectable
-  // for every plugin.
+  // PlatformSelectionPolicies restrict selected platform IDs by plugin ID. If
+  // empty, every discovered plugin host platform is selectable for every
+  // plugin.
   repeated PlatformSelectionPolicy platform_selection_policies = 12;
   // NoCopyBucketIds lists source buckets that remain authoritative without a
   // full-DAG copy.
@@ -74,11 +74,15 @@ message Config {
   string host_storage_id = 18;
 }
 
-// PlatformSelectionPolicy restricts a plugin host platform to a plugin ID list.
+// PlatformSelectionPolicy restricts one plugin host platform by plugin ID.
 message PlatformSelectionPolicy {
   // PlatformId is the plugin host platform ID to restrict, such as
   // "web/js/wasm".
   string platform_id = 1;
-  // AllowedPluginIds are the plugin IDs that may select PlatformId.
+  // AllowedPluginIds are the only plugin IDs that may select PlatformId when
+  // nonempty.
   repeated string allowed_plugin_ids = 2;
+  // DeniedPluginIds are the plugin IDs that cannot select PlatformId. This
+  // leaves unlisted and externally supplied plugins eligible.
+  repeated string denied_plugin_ids = 3;
 }

--- a/bldr/plugin/host/scheduler/fetch-world-manifest_test.go
+++ b/bldr/plugin/host/scheduler/fetch-world-manifest_test.go
@@ -3,6 +3,7 @@ package plugin_host_scheduler
 import (
 	"context"
 	"errors"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -291,6 +292,20 @@ func TestFilterPluginPlatformIDsHonorsPlatformPolicy(t *testing.T) {
 		if got[i] != want[i] {
 			t.Fatalf("allowed platform ids: got %v, want %v", got, want)
 		}
+	}
+}
+
+func TestFilterPluginPlatformIDsHonorsDeniedPlugins(t *testing.T) {
+	conf := &Config{PlatformSelectionPolicies: []*PlatformSelectionPolicy{{
+		PlatformId:      "web/js/wasm",
+		DeniedPluginIds: []string{"core"},
+	}}}
+	platforms := []string{"js", "web/js/wasm"}
+	if got, want := conf.FilterPluginPlatformIDs("core", platforms), []string{"js"}; !slices.Equal(got, want) {
+		t.Fatalf("denied plugin platforms = %v, want %v", got, want)
+	}
+	if got := conf.FilterPluginPlatformIDs("external", platforms); !slices.Equal(got, platforms) {
+		t.Fatalf("unlisted plugin platforms = %v, want %v", got, platforms)
 	}
 }
 

--- a/bldr/storage/browser/indexeddb.go
+++ b/bldr/storage/browser/indexeddb.go
@@ -1,4 +1,4 @@
-//go:build js && bldr_indexeddb
+//go:build js
 
 package browser_storage
 
@@ -58,12 +58,6 @@ func (i *IndexedDB) DeleteVolume(id string) error {
 		return err
 	}
 	return req.Await(context.Background())
-}
-
-func init() {
-	storageMethods = append(storageMethods, func(b bus.Bus, prefix string) []storage.Storage {
-		return []storage.Storage{NewIndexedDB(prefix, false)}
-	})
 }
 
 // _ is a type assertion

--- a/bldr/storage/browser/opfs.go
+++ b/bldr/storage/browser/opfs.go
@@ -1,4 +1,4 @@
-//go:build js && !bldr_indexeddb
+//go:build js
 
 package browser_storage
 
@@ -47,13 +47,6 @@ func (s *OpfsStorage) BuildVolumeConfig(id string, baseVolCtrlConf *volume_contr
 // DeleteVolume removes the active OPFS volume while retaining replaced legacy data.
 func (s *OpfsStorage) DeleteVolume(id string) error {
 	return volume_opfs.DeleteRoot(s.prefix + id)
-}
-
-// init registers the OPFS storage provider for browser builds.
-func init() {
-	storageMethods = append(storageMethods, func(b bus.Bus, prefix string) []storage.Storage {
-		return []storage.Storage{NewOpfsStorage(prefix)}
-	})
 }
 
 // _ is a type assertion.

--- a/bldr/storage/browser/opfs_test.go
+++ b/bldr/storage/browser/opfs_test.go
@@ -1,4 +1,4 @@
-//go:build js && !bldr_indexeddb
+//go:build js
 
 package browser_storage
 

--- a/bldr/storage/browser/storage.go
+++ b/bldr/storage/browser/storage.go
@@ -1,23 +1,24 @@
+//go:build js
+
 package browser_storage
 
 import (
+	"os"
+
 	"github.com/aperturerobotics/controllerbus/bus"
 	"github.com/s4wave/spacewave/bldr/storage"
 )
 
-// storageMethodCtor constructs a storage method.
-type storageMethodCtor func(b bus.Bus, prefix string) []storage.Storage
-
-// storageMethods is the list of available storage methods.
-var storageMethods []storageMethodCtor
+// StorageModeEnv selects the browser storage backend after the browser probes
+// its actual capabilities.
+const StorageModeEnv = "BLDR_BROWSER_STORAGE"
 
 // BuildStorage builds all available storage methods.
 //
 // prefix is used as the IndexedDB prefix in the browser.
-func BuildStorage(b bus.Bus, prefix string) []storage.Storage {
-	r := make([]storage.Storage, 0, len(storageMethods))
-	for _, ctor := range storageMethods {
-		r = append(r, ctor(b, prefix)...)
+func BuildStorage(_ bus.Bus, prefix string) []storage.Storage {
+	if os.Getenv(StorageModeEnv) == "indexeddb" {
+		return []storage.Storage{NewIndexedDB(prefix, false)}
 	}
-	return r
+	return []storage.Storage{NewOpfsStorage(prefix)}
 }

--- a/bldr/web/bldr/web-document.test.ts
+++ b/bldr/web/bldr/web-document.test.ts
@@ -15,6 +15,7 @@ import {
 import {
   WebDocument,
   registerUpdatedServiceWorker,
+  runtimeWasmEnvForCapabilities,
   shouldForceDedicatedWorkers,
 } from './web-document.js'
 import {
@@ -629,6 +630,51 @@ describe('WebDocument service worker startup', () => {
     controllerChangeListeners[0](new Event('controllerchange'))
     await new Promise((resolve) => setTimeout(resolve, 0))
     expect(waitConn).toHaveBeenCalledOnce()
+  })
+})
+
+describe('runtimeWasmEnvForCapabilities', () => {
+  afterEach(() => {
+    delete (
+      globalThis as typeof globalThis & {
+        BLDR_RUNTIME_WASM_ENV?: Record<string, string>
+      }
+    ).BLDR_RUNTIME_WASM_ENV
+  })
+
+  it('selects IndexedDB when the active browser profile cannot open OPFS', () => {
+    expect(
+      runtimeWasmEnvForCapabilities({
+        config: 'B',
+        caps: {
+          crossOriginIsolated: true,
+          sabAvailable: true,
+          opfsAvailable: false,
+          webLocksAvailable: true,
+          broadcastChannelAvailable: true,
+        },
+      }),
+    ).toEqual({ BLDR_BROWSER_STORAGE: 'indexeddb' })
+  })
+
+  it('preserves an explicit browser storage selection', () => {
+    ;(
+      globalThis as typeof globalThis & {
+        BLDR_RUNTIME_WASM_ENV?: Record<string, string>
+      }
+    ).BLDR_RUNTIME_WASM_ENV = { BLDR_BROWSER_STORAGE: 'custom' }
+    expect(
+      runtimeWasmEnvForCapabilities({
+        config: 'C',
+        caps: {
+          crossOriginIsolated: true,
+          sabAvailable: true,
+          opfsAvailable: true,
+          webLocksAvailable: true,
+          broadcastChannelAvailable: true,
+        },
+      }),
+    ).toEqual({ BLDR_BROWSER_STORAGE: 'custom' })
   })
 })
 

--- a/bldr/web/bldr/web-document.ts
+++ b/bldr/web/bldr/web-document.ts
@@ -651,6 +651,18 @@ function readRuntimeWasmEnv(): Record<string, string> | undefined {
   return Object.keys(env).length > 0 ? env : undefined
 }
 
+// runtimeWasmEnvForCapabilities selects IndexedDB only when the browser's
+// active profile cannot open OPFS. Explicit runtime configuration wins.
+export function runtimeWasmEnvForCapabilities(
+  detect?: WorkerCommsDetectResult,
+): Record<string, string> | undefined {
+  const env = readRuntimeWasmEnv() ?? {}
+  if (!detect?.caps.opfsAvailable && env.BLDR_BROWSER_STORAGE === undefined) {
+    env.BLDR_BROWSER_STORAGE = 'indexeddb'
+  }
+  return Object.keys(env).length > 0 ? env : undefined
+}
+
 export interface WebDocumentResumeReadyState {
   ready: true
   documentId: string
@@ -1088,7 +1100,7 @@ export class WebDocument extends SimpleEventEmitter<WebDocumentEvents> {
       this.enablePluginSingletonLock()
     }
 
-    const startWebRuntimeWorker = () => {
+    const startWebRuntimeWorker = (detect?: WorkerCommsDetectResult) => {
       if (this.webRuntimePort || this.closed) {
         return
       }
@@ -1123,7 +1135,7 @@ export class WebDocument extends SimpleEventEmitter<WebDocumentEvents> {
         type: 'module',
       }
 
-      const runtimeWasmEnv = readRuntimeWasmEnv()
+      const runtimeWasmEnv = runtimeWasmEnvForCapabilities(detect)
       const initMsg: WebDocumentToWebRuntime = {
         from: this.webDocumentUuid,
         initWebRuntime: {
@@ -1193,25 +1205,25 @@ export class WebDocument extends SimpleEventEmitter<WebDocumentEvents> {
       this.webRuntimePort.start()
     }
 
-    const startDedicatedRuntime = () => {
+    const startDedicatedRuntime = (detect?: WorkerCommsDetectResult) => {
       if (this.closed) {
         return
       }
       if (!this.dedicatedRuntimeHost) {
-        startWebRuntimeWorker()
+        startWebRuntimeWorker(detect)
         this.startWebRuntimeConnection()
         return
       }
       this.dedicatedRuntimeHost.start({
         startHost: () => {
-          startWebRuntimeWorker()
+          startWebRuntimeWorker(detect)
           this.startWebRuntimeConnection()
         },
         startAttached: () => {
           this.startWebRuntimeConnection()
         },
         promoteToHost: () => {
-          startWebRuntimeWorker()
+          startWebRuntimeWorker(detect)
           // Promoted hosts own a new DedicatedWorker generation; publish it
           // through the normal connection path so runtime and resume-ready
           // state belong to the new worker, not the stale attached relay.
@@ -1234,7 +1246,7 @@ export class WebDocument extends SimpleEventEmitter<WebDocumentEvents> {
           this.startWebRuntimeConnection()
         },
         startUnavailable: () => {
-          startWebRuntimeWorker()
+          startWebRuntimeWorker(detect)
           this.startWebRuntimeConnection()
         },
       })
@@ -1289,14 +1301,19 @@ export class WebDocument extends SimpleEventEmitter<WebDocumentEvents> {
         return
       }
       runtimeStarted = true
-      if (useDedicatedRuntime) {
-        // The dedicated host election reads the ServiceWorker tracker, so let
-        // the caller finish binding its port before the election starts.
-        queueMicrotask(startDedicatedRuntime)
-        return
-      }
-      startWebRuntimeWorker()
-      this.startWebRuntimeConnection()
+      void this.workerCommsDetect.then((detect) => {
+        if (this.closed) {
+          return
+        }
+        if (useDedicatedRuntime) {
+          // The dedicated host election reads the ServiceWorker tracker, so let
+          // the caller finish binding its port before the election starts.
+          queueMicrotask(() => startDedicatedRuntime(detect))
+          return
+        }
+        startWebRuntimeWorker(detect)
+        this.startWebRuntimeConnection()
+      })
     }
     this.startRuntimeOnce = startRuntimeOnce
     const controlFallback = globalThis.setTimeout(
@@ -1562,7 +1579,7 @@ export class WebDocument extends SimpleEventEmitter<WebDocumentEvents> {
       shared,
       this.onWebWorkerMessage.bind(this, request.id),
       detect,
-      readRuntimeWasmEnv(),
+      runtimeWasmEnvForCapabilities(detect),
     )
     this.webWorkers[request.id] = worker
     this.notifyResumeReadyClient(worker.port)


### PR DESCRIPTION
GoScript browser start compiled project-owned Go plugins for both `js` and `web/js/wasm`, then rediscovered the extra targets after the browser connected. WebKit also failed when OPFS was unavailable.

This change binds project-owned startup plugins to the active compiler platform, carries that policy into the browser scheduler, and selects IndexedDB only when the browser capability probe cannot open OPFS. Chromium keeps OPFS; WebKit gets the IndexedDB fallback. The startup dashboard now names the selected compiler.

Validation:
- `go test ./bldr/plugin/host/scheduler ./bldr/devtool ./bldr/devtool/web/... ./bldr/plugin/host/default ./bldr/e2e/downstreamapp ./e2e/wasm`
- `bunx vitest run --config bldr/vitest.config.ts bldr/web/bldr/web-document.test.ts` (52 tests)
- `GOOS=js GOARCH=wasm go test -c ./bldr/storage/browser`
- `bun run typecheck`
- Live Praxi GoScript start in Chromium and WebKit; after browser connection and a source edit, the dashboard remained at three targets and rebuilt only `fraglands-web`.
