### PR TITLE
feat(webrtc): resolve fresh peer-scoped ICE credentials

### DIFF
--- a/net/transport/webrtc/ice-provider.go
+++ b/net/transport/webrtc/ice-provider.go
@@ -1,0 +1,84 @@
+package webrtc
+
+import (
+	"context"
+
+	"github.com/aperturerobotics/controllerbus/bus"
+	"github.com/aperturerobotics/controllerbus/directive"
+	"github.com/s4wave/spacewave/net/peer"
+)
+
+// ICEProvider supplies fresh ICE credentials for each new peer connection.
+// Credentials remain local and must not be included in directive diagnostics.
+type ICEProvider interface {
+	// ICEConfig returns fresh local credentials for one connection attempt.
+	ICEConfig(context.Context) (*WebRtcConfig, error)
+}
+
+// LookupICEProvider resolves the optional credential provider for one local peer.
+// Value: ICEProvider. An idle lookup with no value uses the transport config.
+type LookupICEProvider interface {
+	directive.Directive
+	// ICEPeerID identifies the local session whose credentials are requested.
+	ICEPeerID() peer.ID
+}
+
+// lookupICEProvider identifies one local peer's credential source.
+type lookupICEProvider struct {
+	// peerID is the local session identity.
+	peerID peer.ID
+}
+
+// NewLookupICEProvider constructs a lookup scoped to one local peer.
+func NewLookupICEProvider(id peer.ID) LookupICEProvider {
+	return &lookupICEProvider{peerID: id}
+}
+
+// ExLookupICEProvider retains the provider until the returned release is called.
+func ExLookupICEProvider(ctx context.Context, b bus.Bus, id peer.ID) (ICEProvider, func(), error) {
+	value, _, ref, err := bus.ExecOneOffTyped[ICEProvider](ctx, b, NewLookupICEProvider(id), bus.ReturnIfIdle(true), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	if value == nil {
+		if ref != nil {
+			ref.Release()
+		}
+		return nil, nil, nil
+	}
+	return value.GetValue(), ref.Release, nil
+}
+
+// ICEPeerID returns the local credential identity.
+func (d *lookupICEProvider) ICEPeerID() peer.ID { return d.peerID }
+
+// Validate requires a local peer identity.
+func (d *lookupICEProvider) Validate() error {
+	if d.peerID == "" {
+		return peer.ErrEmptyPeerID
+	}
+	return nil
+}
+
+// GetValueOptions disposes credential lookups when their caller releases them.
+func (d *lookupICEProvider) GetValueOptions() directive.ValueOptions { return directive.ValueOptions{} }
+
+// IsEquivalent merges lookups for the same local peer.
+func (d *lookupICEProvider) IsEquivalent(other directive.Directive) bool {
+	o, ok := other.(LookupICEProvider)
+	return ok && o.ICEPeerID() == d.peerID
+}
+
+// Superceeds preserves other credential lookups.
+func (d *lookupICEProvider) Superceeds(directive.Directive) bool { return false }
+
+// GetName identifies credential lookups without exposing credentials.
+func (d *lookupICEProvider) GetName() string { return "LookupICEProvider" }
+
+// GetDebugVals contains only the public peer identity.
+func (d *lookupICEProvider) GetDebugVals() directive.DebugValues {
+	return directive.DebugValues{"peer": []string{d.peerID.String()}}
+}
+
+// _ is a type assertion
+var _ LookupICEProvider = (*lookupICEProvider)(nil)

--- a/net/transport/webrtc/ice-provider_test.go
+++ b/net/transport/webrtc/ice-provider_test.go
@@ -1,0 +1,112 @@
+package webrtc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aperturerobotics/controllerbus/controller"
+	"github.com/aperturerobotics/controllerbus/directive"
+	pion "github.com/pion/webrtc/v4"
+	"github.com/s4wave/spacewave/net/peer"
+	"github.com/s4wave/spacewave/net/testbed"
+	"github.com/sirupsen/logrus"
+)
+
+// testICEProvider serves mutable credentials to one test peer.
+type testICEProvider struct {
+	// peerID restricts the provider to the intended local identity.
+	peerID peer.ID
+	// password is the next credential returned during a synchronous request.
+	password string
+	// err refuses the next credential request when set.
+	err error
+}
+
+// GetControllerInfo identifies the fixture adapter.
+func (p *testICEProvider) GetControllerInfo() *controller.Info {
+	return controller.NewInfo("test/ice", controller.MustParseVersion("0.0.1"), "ICE test")
+}
+
+// Execute leaves the fixture attached until cleanup.
+func (p *testICEProvider) Execute(context.Context) error { return nil }
+
+// Close releases no external resources.
+func (p *testICEProvider) Close() error { return nil }
+
+// HandleDirective confines credentials to the fixture peer.
+func (p *testICEProvider) HandleDirective(_ context.Context, inst directive.Instance) ([]directive.Resolver, error) {
+	d, ok := inst.GetDirective().(LookupICEProvider)
+	if !ok || d.ICEPeerID() != p.peerID {
+		return nil, nil
+	}
+	return directive.Resolvers(directive.NewValueResolver([]ICEProvider{p})), nil
+}
+
+// ICEConfig returns the current credential or a deliberate refusal.
+func (p *testICEProvider) ICEConfig(context.Context) (*WebRtcConfig, error) {
+	if p.err != nil {
+		return nil, p.err
+	}
+	return &WebRtcConfig{IceServers: []*IceServerConfig{{
+		Urls: []string{"turn:127.0.0.1:3478"}, Username: "tester",
+		Credential: &IceServerConfig_Password{Password: p.password},
+	}}}, nil
+}
+
+// TestICEProviderRefreshAndIsolation exercises the real Pion construction boundary.
+func TestICEProviderRefreshAndIsolation(t *testing.T) {
+	// Attach an application provider to the actual controller bus.
+	tb, err := testbed.NewTestbed(t.Context(), logrus.NewEntry(logrus.New()), testbed.TestbedOpts{NoEcho: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(tb.Release)
+	provider := &testICEProvider{peerID: tb.PeerID, password: "first"}
+	release, err := tb.Bus.AddController(t.Context(), provider, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(release)
+	w := &WebRTC{b: tb.Bus, peerID: tb.PeerID, webrtcApi: pion.NewAPI(), webrtcConf: &pion.Configuration{}}
+
+	// Every new connection uses fresh credentials without mutating the prior one.
+	first, err := w.newPeerConnection(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = first.Close() })
+	provider.password = "second"
+	second, err := w.newPeerConnection(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = second.Close() })
+	if first.GetConfiguration().ICEServers[0].Credential != "first" || second.GetConfiguration().ICEServers[0].Credential != "second" {
+		t.Fatal("credentials were retained across independent connection attempts")
+	}
+
+	// A provider refusal must not silently fall back to direct-only transport.
+	provider.err = errors.New("credentials unavailable")
+	if conn, err := w.newPeerConnection(t.Context()); err == nil || conn != nil {
+		t.Fatal("credential refusal created a connection")
+	}
+
+	// Other session identities retain their configured transport without this provider.
+	other, err := peer.NewPeer(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.peerID = other.GetPeerID()
+	conn, err := w.newPeerConnection(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if len(conn.GetConfiguration().ICEServers) != 0 {
+		t.Fatal("another peer inherited application credentials")
+	}
+}
+
+// _ is a type assertion
+var _ controller.Controller = (*testICEProvider)(nil)

--- a/net/transport/webrtc/peer-connection.go
+++ b/net/transport/webrtc/peer-connection.go
@@ -1,0 +1,36 @@
+package webrtc
+
+import (
+	"context"
+	"errors"
+
+	pion "github.com/pion/webrtc/v4"
+)
+
+// newPeerConnection obtains fresh credentials without changing established links.
+func (w *WebRTC) newPeerConnection(ctx context.Context) (*pion.PeerConnection, error) {
+	// Keep static configuration when no application credential source is present.
+	config := w.webrtcConf
+	if w.b != nil {
+		provider, release, err := ExLookupICEProvider(ctx, w.b, w.peerID)
+		if err != nil {
+			return nil, err
+		}
+		if release != nil {
+			defer release()
+		}
+		if provider != nil {
+			fresh, err := provider.ICEConfig(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if fresh == nil {
+				return nil, errors.New("ICE provider returned no configuration")
+			}
+			config = fresh.ToWebRtcConfiguration()
+		}
+	}
+
+	// Pion retains the selected configuration for this connection's lifetime.
+	return w.webrtcApi.NewPeerConnection(*config)
+}

--- a/net/transport/webrtc/session.go
+++ b/net/transport/webrtc/session.go
@@ -407,7 +407,7 @@ type session struct {
 }
 
 // newSession constructs a new session.
-func (s *sessionTracker) newSession() (*session, <-chan struct{}, error) {
+func (s *sessionTracker) newSession(ctx context.Context) (*session, <-chan struct{}, error) {
 	setCallback := func(name string, cb func()) (err error) {
 		defer func() {
 			if e := recover(); e != nil {
@@ -423,7 +423,7 @@ func (s *sessionTracker) newSession() (*session, <-chan struct{}, error) {
 	}
 
 	// Create the peer connection.
-	pc, err := s.w.webrtcApi.NewPeerConnection(*s.w.webrtcConf)
+	pc, err := s.w.newPeerConnection(ctx)
 	if err != nil {
 		return nil, nil, pkgerrors.Wrap(err, "create peer connection")
 	}
@@ -802,7 +802,7 @@ func (s *sessionTracker) execute(ctx context.Context) (err error) {
 		waitCh = s.adoptSession(sess)
 		s.le.Debug("adopted in-flight negotiation session from retired predecessor")
 	} else {
-		sess, waitCh, err = s.newSession()
+		sess, waitCh, err = s.newSession(ctx)
 		if err != nil {
 			return pkgerrors.Wrap(err, phase)
 		}

--- a/net/transport/webrtc/signal_hostedflow_test.go
+++ b/net/transport/webrtc/signal_hostedflow_test.go
@@ -179,7 +179,7 @@ func runHostedFlowGeneration(
 ) error {
 	execution := tkr.beginExecution()
 	defer tkr.retireExecution(execution)
-	sess, _, err := tkr.newSession()
+	sess, _, err := tkr.newSession(ctx)
 	if err != nil {
 		return pkgerrors.Wrap(err, "construct hosted-flow session")
 	}


### PR DESCRIPTION
Native applications can now provide fresh ICE configuration for each new WebRTC connection through a local-peer-scoped controller directive. Existing static configuration remains the default without a provider, and provider errors refuse the attempt. Established connections retain their original configuration.

Validation: focused provider tests cover refresh, failure, and peer isolation and pass under the race detector. The existing hosted tracker-regeneration test passes individually on base and head. One broader hosted-test run timed out in that test; the isolated checks did not reproduce the failure. The package commit-hook lint passed.
